### PR TITLE
feat: Add fullscreen toggle with sidebar control for chat interface

### DIFF
--- a/cli-tool/src/analytics-web/components/AgentsPage.js
+++ b/cli-tool/src/analytics-web/components/AgentsPage.js
@@ -742,6 +742,14 @@ class AgentsPage {
                 <div class="selected-conversation-meta" id="selected-conversation-meta"></div>
               </div>
               <div class="messages-actions">
+                <button class="action-btn-small sidebar-toggle" id="sidebar-toggle" title="Toggle sidebar">
+                  <span class="btn-icon-small">☰</span>
+                  Hide Sidebar
+                </button>
+                <button class="action-btn-small" id="fullscreen-toggle" title="Toggle fullscreen">
+                  <span class="btn-icon-small">⛶</span>
+                  Fullscreen
+                </button>
                 <button class="action-btn-small" id="test-console-interaction" title="Test console interaction">🧪 Test Console</button>
                 <button class="action-btn-small" id="export-conversation" title="Export conversation">
                   <span class="btn-icon-small">📁</span>
@@ -845,6 +853,55 @@ class AgentsPage {
     if (testConsoleBtn) {
       testConsoleBtn.addEventListener('click', () => this.testConsoleInteraction());
     }
+
+    // Fullscreen toggle
+    const fullscreenBtn = this.container.querySelector('#fullscreen-toggle');
+    if (fullscreenBtn) {
+      fullscreenBtn.addEventListener('click', () => this.toggleFullscreen());
+    }
+
+    // Sidebar toggle (only visible in fullscreen)
+    const sidebarBtn = this.container.querySelector('#sidebar-toggle');
+    if (sidebarBtn) {
+      sidebarBtn.addEventListener('click', () => this.toggleSidebar());
+    }
+
+    // Listen for fullscreen changes (ESC key, browser controls)
+    this.bindFullscreenEvents();
+  }
+
+  /**
+   * Bind fullscreen change events with cross-browser support
+   */
+  bindFullscreenEvents() {
+    const events = [
+      'fullscreenchange',
+      'webkitfullscreenchange',
+      'mozfullscreenchange',
+      'MSFullscreenChange'
+    ];
+
+    this.fullscreenChangeHandler = () => {
+      const agentsPage = this.container.querySelector('.agents-page');
+      
+      if (this.isFullscreen()) {
+        // Entered fullscreen - hide UI elements, keep sidebar visible
+        agentsPage.classList.add('fullscreen-mode');
+      } else {
+        // Exited fullscreen - restore UI elements and sidebar
+        agentsPage.classList.remove('fullscreen-mode');
+        agentsPage.classList.remove('sidebar-hidden');
+      }
+      
+      // Update button states
+      this.updateFullscreenButton();
+      this.updateSidebarButton();
+    };
+
+    // Add listeners for all browser prefixes
+    events.forEach(event => {
+      document.addEventListener(event, this.fullscreenChangeHandler);
+    });
   }
   
   /**
@@ -2505,6 +2562,158 @@ class AgentsPage {
   }
 
   /**
+   * Check if fullscreen is supported
+   */
+  isFullscreenSupported() {
+    return !!(
+      document.fullscreenEnabled ||
+      document.webkitFullscreenEnabled ||
+      document.mozFullScreenEnabled ||
+      document.msFullscreenEnabled
+    );
+  }
+
+  /**
+   * Check if currently in fullscreen mode
+   */
+  isFullscreen() {
+    return !!(
+      document.fullscreenElement ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement ||
+      document.msFullscreenElement
+    );
+  }
+
+  /**
+   * Request fullscreen on an element with cross-browser support
+   */
+  requestFullscreen(element) {
+    if (element.requestFullscreen) {
+      return element.requestFullscreen();
+    } else if (element.webkitRequestFullscreen) {
+      return element.webkitRequestFullscreen();
+    } else if (element.mozRequestFullScreen) {
+      return element.mozRequestFullScreen();
+    } else if (element.msRequestFullscreen) {
+      return element.msRequestFullscreen();
+    }
+    return Promise.reject(new Error('Fullscreen not supported'));
+  }
+
+  /**
+   * Exit fullscreen with cross-browser support
+   */
+  exitFullscreen() {
+    if (document.exitFullscreen) {
+      return document.exitFullscreen();
+    } else if (document.webkitExitFullscreen) {
+      return document.webkitExitFullscreen();
+    } else if (document.mozCancelFullScreen) {
+      return document.mozCancelFullScreen();
+    } else if (document.msExitFullscreen) {
+      return document.msExitFullscreen();
+    }
+    return Promise.reject(new Error('Exit fullscreen not supported'));
+  }
+
+  /**
+   * Update fullscreen button state
+   */
+  updateFullscreenButton() {
+    const fullscreenBtn = this.container.querySelector('#fullscreen-toggle');
+    if (!fullscreenBtn) return;
+
+    if (this.isFullscreen()) {
+      fullscreenBtn.innerHTML = '<span class="btn-icon-small">⛷</span> Exit Fullscreen';
+      fullscreenBtn.title = 'Exit fullscreen';
+    } else {
+      fullscreenBtn.innerHTML = '<span class="btn-icon-small">⛶</span> Fullscreen';
+      fullscreenBtn.title = 'Toggle fullscreen';
+    }
+  }
+
+  /**
+   * Update sidebar toggle button state
+   */
+  updateSidebarButton() {
+    const agentsPage = this.container.querySelector('.agents-page');
+    const sidebarBtn = this.container.querySelector('#sidebar-toggle');
+    if (!sidebarBtn) return;
+
+    if (agentsPage.classList.contains('sidebar-hidden')) {
+      sidebarBtn.innerHTML = '<span class="btn-icon-small">⚞</span> Show Sidebar';
+      sidebarBtn.title = 'Show sidebar';
+    } else {
+      sidebarBtn.innerHTML = '<span class="btn-icon-small">☰</span> Hide Sidebar';
+      sidebarBtn.title = 'Hide sidebar';
+    }
+  }
+
+  /**
+   * Toggle sidebar visibility within fullscreen mode
+   */
+  toggleSidebar() {
+    const agentsPage = this.container.querySelector('.agents-page');
+    
+    if (agentsPage.classList.contains('sidebar-hidden')) {
+      // Show sidebar
+      agentsPage.classList.remove('sidebar-hidden');
+    } else {
+      // Hide sidebar
+      agentsPage.classList.add('sidebar-hidden');
+    }
+    
+    // Update button state
+    this.updateSidebarButton();
+  }
+
+  /**
+   * Toggle fullscreen mode for chat window
+   */
+  async toggleFullscreen() {
+    const agentsPage = this.container.querySelector('.agents-page');
+
+    try {
+      if (this.isFullscreen()) {
+        // Exit fullscreen
+        await this.exitFullscreen();
+        // Remove fullscreen class (UI elements will reappear)
+        agentsPage.classList.remove('fullscreen-mode');
+        // Also remove sidebar-hidden class when exiting fullscreen
+        agentsPage.classList.remove('sidebar-hidden');
+      } else {
+        // Check if fullscreen is supported
+        if (this.isFullscreenSupported()) {
+          // Enter browser fullscreen
+          await this.requestFullscreen(document.documentElement);
+          // Add fullscreen class (hide UI elements, keep sidebar visible)
+          agentsPage.classList.add('fullscreen-mode');
+        } else {
+          // Fallback: hide UI elements if fullscreen not supported
+          if (agentsPage.classList.contains('fullscreen-mode')) {
+            agentsPage.classList.remove('fullscreen-mode');
+            agentsPage.classList.remove('sidebar-hidden');
+          } else {
+            agentsPage.classList.add('fullscreen-mode');
+          }
+          this.updateFullscreenButton();
+        }
+      }
+    } catch (error) {
+      console.warn('Fullscreen operation failed:', error);
+      // Fallback to UI hiding behavior
+      if (agentsPage.classList.contains('fullscreen-mode')) {
+        agentsPage.classList.remove('fullscreen-mode');
+        agentsPage.classList.remove('sidebar-hidden');
+      } else {
+        agentsPage.classList.add('fullscreen-mode');
+      }
+      this.updateFullscreenButton();
+    }
+  }
+
+  /**
    * Destroy agents page
    */
   destroy() {
@@ -2519,6 +2728,19 @@ class AgentsPage {
     const messagesContent = this.container.querySelector('#messages-content');
     if (messagesContent && this.messagesScrollListener) {
       messagesContent.removeEventListener('scroll', this.messagesScrollListener);
+    }
+
+    // Cleanup fullscreen event listeners
+    if (this.fullscreenChangeHandler) {
+      const events = [
+        'fullscreenchange',
+        'webkitfullscreenchange',
+        'mozfullscreenchange',
+        'MSFullscreenChange'
+      ];
+      events.forEach(event => {
+        document.removeEventListener(event, this.fullscreenChangeHandler);
+      });
     }
     
     // Unsubscribe from state changes

--- a/cli-tool/src/analytics-web/index.html
+++ b/cli-tool/src/analytics-web/index.html
@@ -407,60 +407,43 @@
             /* Custom styles */
             background: var(--bg-tertiary);
             color: var(--text-secondary);
-            padding: 4px 8px;
-            border-radius: 4px;
+            padding: 8px 12px;
+            border-radius: 6px;
             cursor: pointer;
             font-family: inherit;
-            font-size: 0.75rem;
-            transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: all 0.2s ease;
             display: flex;
             align-items: center;
-            gap: 4px;
-            min-width: 80px;
+            gap: 6px;
+            min-width: auto;
             width: auto;
-            height: 24px;
+            height: 32px;
             white-space: nowrap;
             box-sizing: border-box;
-            
-            /* Force fixed dimensions */
-            max-width: 80px;
-            overflow: hidden;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
         }
 
         .action-btn-small:hover {
             border-color: var(--text-accent);
             color: var(--text-accent);
             background: var(--bg-secondary);
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
 
         .action-btn-small:active {
             opacity: 0.8;
-            transform: none !important;
-            scale: none !important;
+            transform: translateY(0px);
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
         }
 
         .action-btn-small:disabled {
             opacity: 0.5;
             cursor: not-allowed;
-            transform: none !important;
-        }
-
-        /* Prevent any size changes on action buttons */
-        .action-btn-small,
-        .action-btn-small:hover,
-        .action-btn-small:active,
-        .action-btn-small:focus,
-        .action-btn-small.loading {
-            transform: none !important;
-            scale: none !important;
-            height: 24px !important;
-            min-width: 80px !important;
-            max-width: 80px !important;
-            padding: 4px 8px !important;
-            border-width: 1px !important;
-            box-sizing: border-box !important;
-            white-space: nowrap !important;
-            overflow: hidden !important;
+            transform: none;
+            box-shadow: none;
         }
 
         .action-btn-small.loading {
@@ -469,10 +452,10 @@
         }
 
         .btn-icon-small {
-            font-size: 0.7rem;
+            font-size: 0.875rem;
             line-height: 1;
             display: inline-block;
-            width: 10px;
+            width: auto;
             text-align: center;
         }
 
@@ -3319,6 +3302,71 @@
             gap: 20px;
             height: calc(100vh - 400px);
             min-height: 600px;
+            transition: grid-template-columns 0.3s ease;
+        }
+
+        /* Fullscreen Mode - Clean Chat Experience */
+        .fullscreen-mode .page-header,
+        .fullscreen-mode .conversations-filters {
+            display: none;
+        }
+
+        .fullscreen-mode .conversations-layout {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: 9999;
+            grid-template-columns: 350px 1fr;
+            gap: 20px;
+            padding: 20px;
+            box-sizing: border-box;
+            background: var(--bg-primary);
+        }
+
+        /* Sidebar toggle within fullscreen */
+        .fullscreen-mode.sidebar-hidden .conversations-layout {
+            grid-template-columns: 1fr;
+            gap: 0;
+            padding: 0;
+        }
+
+        .fullscreen-mode.sidebar-hidden .conversations-sidebar {
+            display: none;
+        }
+
+        .fullscreen-mode.sidebar-hidden .messages-panel {
+            width: 100vw;
+            height: 100vh;
+            border-radius: 0;
+            border: none;
+        }
+
+        .fullscreen-mode.sidebar-hidden .messages-content {
+            background: var(--bg-secondary);
+            height: 100vh;
+            width: 100vw;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+
+        .fullscreen-mode.sidebar-hidden .no-conversation-selected {
+            background: var(--bg-secondary);
+            height: 100vh;
+            width: 100vw;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        /* Sidebar toggle button - only visible in fullscreen */
+        .sidebar-toggle {
+            display: none;
+        }
+
+        .fullscreen-mode .sidebar-toggle {
+            display: flex;
         }
 
         /* Left Sidebar */
@@ -3513,7 +3561,8 @@
 
         .messages-actions {
             display: flex;
-            gap: 8px;
+            gap: 12px;
+            align-items: center;
         }
 
         .messages-content {


### PR DESCRIPTION
## Summary
- Add fullscreen toggle button next to "Select a chat" label in analytics dashboard
- Implement true browser fullscreen functionality using Fullscreen API
- Add sidebar toggle control that only appears in fullscreen mode
- Clean, modern button styling with improved spacing and visibility

## Key Features
- **True Fullscreen Mode**: Uses browser Fullscreen API instead of CSS-only fullscreen
- **Sidebar Control**: Independent toggle to show/hide sidebar when in fullscreen
- **Cross-browser Support**: Includes webkit, moz, and ms prefixes for compatibility
- **Clean UI**: Improved button styling with consistent spacing and modern appearance
- **Seamless Experience**: Proper background colors and layout handling for all states

## Technical Details
- Added fullscreen toggle button HTML in AgentsPage.js messages-actions div
- Implemented Fullscreen API helper methods with cross-browser compatibility
- Added CSS for fullscreen mode that hides header/filters, shows only sidebar + chat
- Fixed black screen issue by ensuring proper backgrounds in all fullscreen states
- Added ESC key handling for natural fullscreen exit behavior

## Test Instructions
1. Start analytics dashboard: `npm run analytics:start`
2. Navigate to chat interface
3. Click fullscreen button next to "Select a chat"
4. Verify true browser fullscreen activates
5. Test sidebar toggle (hide/show) while in fullscreen
6. Press ESC to exit fullscreen
7. Verify all states work without black screens or layout issues

## Files Modified
- `cli-tool/src/analytics-web/components/AgentsPage.js` - Added fullscreen functionality
- `cli-tool/src/analytics-web/index.html` - Updated CSS for fullscreen mode and button styling