### PR TITLE
Fix "Star on Github" Link in dashboard

### DIFF
--- a/cli-tool/src/analytics-web/components/DashboardPage.js
+++ b/cli-tool/src/analytics-web/components/DashboardPage.js
@@ -147,7 +147,7 @@ class DashboardPage {
                   </div>
                 </div>
               </div>
-              <a href="https://github.com/anthropics/claude-code-templates" target="_blank" class="github-link" title="Star on GitHub">
+              <a href="https://github.com/davila7/claude-code-templates" target="_blank" class="github-link" title="Star on GitHub">
                 <span class="github-icon">⭐</span>
                 Star on GitHub
               </a>


### PR DESCRIPTION
Updated the hyperlink in the DashboardPage component to point to this repo instead of the the non-existent/private one at anthropics.