### PR TITLE
[Bug] Prompts for the testing plugin are scoped to a non-existent model and returns a 404.

### DIFF
--- a/cli-tool/components/commands/testing/add-mutation-testing.md
+++ b/cli-tool/components/commands/testing/add-mutation-testing.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [language] | --javascript | --java | --python | --rust | --go | --csharp
 description: Setup comprehensive mutation testing with framework selection and CI integration
-model: sonnet
 ---
 
 # Add Mutation Testing
@@ -23,6 +22,7 @@ Implement comprehensive mutation testing with framework optimization and quality
 **Language Focus**: Use $ARGUMENTS to specify JavaScript, Java, Python, Rust, Go, C#, or auto-detect from codebase
 
 **Mutation Testing Framework**:
+
 1. **Tool Selection & Setup** - Choose framework (Stryker, PIT, mutmut, cargo-mutants), install dependencies, configure basic settings, validate installation
 2. **Mutation Operator Configuration** - Configure arithmetic operators, relational operators, logical operators, conditional boundaries, statement mutations
 3. **Performance Optimization** - Setup parallel execution, configure incremental testing, optimize file filtering, implement caching strategies

--- a/cli-tool/components/commands/testing/add-property-based-testing.md
+++ b/cli-tool/components/commands/testing/add-property-based-testing.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [language] | --javascript | --python | --java | --haskell | --rust | --clojure
 description: Implement property-based testing with framework selection and invariant identification
-model: sonnet
 ---
 
 # Add Property-Based Testing
@@ -23,6 +22,7 @@ Implement comprehensive property-based testing with invariant analysis and autom
 **Language Focus**: Use $ARGUMENTS to specify JavaScript, Python, Java, Haskell, Rust, Clojure, or auto-detect from codebase
 
 **Property-Based Testing Framework**:
+
 1. **Framework Selection** - Choose appropriate tool (fast-check, Hypothesis, QuickCheck, proptest), install dependencies, configure integration
 2. **Property Identification** - Analyze mathematical properties, identify business invariants, discover symmetries, evaluate round-trip properties
 3. **Generator Design** - Create custom data generators, implement constraint-based generation, design composite generators, optimize generation strategies

--- a/cli-tool/components/commands/testing/e2e-setup.md
+++ b/cli-tool/components/commands/testing/e2e-setup.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [framework] | --cypress | --playwright | --webdriver | --puppeteer | --mobile
 description: Configure comprehensive end-to-end testing suite with framework selection and CI integration
-model: sonnet
 ---
 
 # E2E Setup
@@ -23,6 +22,7 @@ Implement comprehensive end-to-end testing with framework selection and optimiza
 **Framework Focus**: Use $ARGUMENTS to specify Cypress, Playwright, WebDriver, Puppeteer, mobile testing, or auto-detect best fit
 
 **E2E Testing Framework**:
+
 1. **Framework Selection & Setup** - Choose optimal E2E tool, install dependencies, configure basic settings, setup project structure
 2. **Test Environment Configuration** - Setup test environments, configure base URLs, implement environment switching, optimize test isolation
 3. **Page Object Patterns** - Design page object model, create reusable components, implement element selectors, optimize maintainability

--- a/cli-tool/components/commands/testing/generate-test-cases.md
+++ b/cli-tool/components/commands/testing/generate-test-cases.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [target] | [scope] | --unit | --integration | --edge-cases | --automatic
 description: Generate comprehensive test cases with automatic analysis and coverage optimization
-model: sonnet
 ---
 
 # Generate Test Cases
@@ -23,6 +22,7 @@ Execute intelligent test case generation with comprehensive coverage and optimiz
 **Generation Scope**: Use $ARGUMENTS to specify target file, unit tests, integration tests, edge cases, or automatic comprehensive generation
 
 **Test Case Generation Framework**:
+
 1. **Code Structure Analysis** - Parse function signatures, analyze control flow, identify branching paths, assess complexity metrics
 2. **Test Pattern Recognition** - Analyze existing test patterns, identify testing conventions, extract reusable patterns, optimize consistency
 3. **Input Space Analysis** - Identify parameter domains, analyze boundary conditions, discover edge cases, evaluate error conditions

--- a/cli-tool/components/commands/testing/generate-tests.md
+++ b/cli-tool/components/commands/testing/generate-tests.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [file-path] | [component-name]
 description: Generate comprehensive test suite with unit, integration, and edge case coverage
-model: sonnet
 ---
 
 # Generate Tests
@@ -21,7 +20,7 @@ Generate comprehensive test suite for: $ARGUMENTS
 I'll analyze the target code and create complete test coverage including:
 
 1. Unit tests for individual functions and methods
-2. Integration tests for component interactions  
+2. Integration tests for component interactions
 3. Edge case and error handling tests
 4. Mock implementations for external dependencies
 5. Test utilities and helpers as needed
@@ -42,18 +41,21 @@ I'll follow these steps:
 ## Test Types
 
 ### Unit Tests
+
 - Individual function testing with various inputs
 - Component rendering and prop handling
 - State management and lifecycle methods
 - Utility function edge cases and error conditions
 
 ### Integration Tests
+
 - Component interaction testing
 - API integration with mocked responses
 - Service layer integration
 - End-to-end user workflows
 
 ### Framework-Specific Tests
+
 - **React**: Component testing with React Testing Library
 - **Vue**: Component testing with Vue Test Utils
 - **Angular**: Component and service testing with TestBed
@@ -62,18 +64,21 @@ I'll follow these steps:
 ## Testing Best Practices
 
 ### Test Structure
+
 - Use descriptive test names that explain the behavior
 - Follow AAA pattern (Arrange, Act, Assert)
 - Group related tests with describe blocks
 - Use proper setup and teardown for test isolation
 
 ### Mock Strategy
+
 - Mock external dependencies and API calls
 - Use factories for test data generation
 - Implement proper cleanup for async operations
 - Mock timers and dates for deterministic tests
 
 ### Coverage Goals
+
 - Aim for 80%+ code coverage
 - Focus on critical business logic paths
 - Test both happy path and error scenarios

--- a/cli-tool/components/commands/testing/setup-comprehensive-testing.md
+++ b/cli-tool/components/commands/testing/setup-comprehensive-testing.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [scope] | --unit | --integration | --e2e | --visual | --performance | --full-stack
 description: Setup complete testing infrastructure with framework configuration and CI integration
-model: sonnet
 ---
 
 # Setup Comprehensive Testing
@@ -23,6 +22,7 @@ Implement comprehensive testing infrastructure with multi-layer testing strategy
 **Setup Scope**: Use $ARGUMENTS to focus on unit, integration, e2e, visual, performance testing, or full-stack implementation
 
 **Comprehensive Testing Framework**:
+
 1. **Testing Strategy Design** - Analyze project requirements, define testing pyramid, plan coverage goals, optimize testing investment
 2. **Unit Testing Setup** - Configure primary framework (Jest, Vitest, pytest), setup test runners, implement test utilities, optimize execution
 3. **Integration Testing** - Setup integration test framework, configure test databases, implement API testing, optimize test isolation

--- a/cli-tool/components/commands/testing/setup-load-testing.md
+++ b/cli-tool/components/commands/testing/setup-load-testing.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [testing-type] | --capacity | --stress | --spike | --endurance | --volume
 description: Configure comprehensive load testing with performance metrics and bottleneck identification
-model: sonnet
 ---
 
 # Setup Load Testing
@@ -23,6 +22,7 @@ Implement comprehensive load testing with performance optimization and bottlenec
 **Testing Type**: Use $ARGUMENTS to focus on capacity planning, stress testing, spike testing, endurance testing, or volume testing
 
 **Load Testing Framework**:
+
 1. **Strategy & Requirements** - Analyze application architecture, define testing objectives, determine scenarios, identify performance metrics
 2. **Tool Selection & Setup** - Choose appropriate tools (k6, Artillery, JMeter, Gatling), install dependencies, configure environments
 3. **Test Scenario Design** - Create realistic user scenarios, implement API test scripts, configure data generation, design load patterns

--- a/cli-tool/components/commands/testing/setup-visual-testing.md
+++ b/cli-tool/components/commands/testing/setup-visual-testing.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [testing-scope] | --components | --pages | --responsive | --cross-browser | --accessibility
 description: Setup comprehensive visual regression testing with cross-browser and responsive testing
-model: sonnet
 ---
 
 # Setup Visual Testing
@@ -23,6 +22,7 @@ Implement comprehensive visual testing with regression detection and accessibili
 **Testing Scope**: Use $ARGUMENTS to focus on component testing, page testing, responsive testing, cross-browser testing, or accessibility testing
 
 **Visual Testing Framework**:
+
 1. **Tool Selection & Setup** - Choose visual testing tools (Percy, Chromatic, BackstopJS, Playwright), configure integration, setup environments
 2. **Baseline Creation** - Capture visual baselines, organize screenshot structure, implement version control, optimize image management
 3. **Test Scenario Design** - Create component tests, design page workflows, implement responsive breakpoints, configure browser matrix

--- a/cli-tool/components/commands/testing/test-automation-orchestrator.md
+++ b/cli-tool/components/commands/testing/test-automation-orchestrator.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [orchestration-type] | --parallel | --sequential | --conditional | --pipeline-optimization
 description: Orchestrate comprehensive test automation with intelligent execution and optimization
-model: sonnet
 ---
 
 # Test Automation Orchestrator
@@ -23,6 +22,7 @@ Implement intelligent test orchestration with execution optimization and resourc
 **Orchestration Type**: Use $ARGUMENTS to focus on parallel execution, sequential execution, conditional testing, or pipeline optimization
 
 **Test Orchestration Framework**:
+
 1. **Test Discovery & Classification** - Analyze test suites, classify test types, assess execution requirements, optimize categorization
 2. **Execution Strategy Design** - Design parallel execution strategies, implement intelligent batching, optimize resource allocation, configure conditional execution
 3. **Dependency Management** - Analyze test dependencies, implement execution ordering, configure prerequisite validation, optimize dependency resolution

--- a/cli-tool/components/commands/testing/test-changelog-automation.md
+++ b/cli-tool/components/commands/testing/test-changelog-automation.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [automation-type] | --changelog | --workflow-demo | --ci-integration | --validation
 description: Automate changelog testing workflow with CI integration and validation
-model: sonnet
 ---
 
 # Test Changelog Automation
@@ -23,6 +22,7 @@ Implement comprehensive changelog automation with testing and validation workflo
 **Automation Type**: Use $ARGUMENTS to focus on changelog automation, workflow demonstration, CI integration, or validation testing
 
 **Changelog Automation Framework**:
+
 1. **Automation Setup** - Configure changelog generation, setup version control integration, implement automated updates, design validation rules
 2. **Workflow Integration** - Design CI/CD integration, configure automated triggers, implement validation checks, optimize execution performance
 3. **Testing Strategy** - Create changelog validation tests, implement format verification, design content validation, setup regression testing

--- a/cli-tool/components/commands/testing/test-coverage.md
+++ b/cli-tool/components/commands/testing/test-coverage.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [coverage-type] | --line | --branch | --function | --statement | --report
 description: Analyze and improve test coverage with comprehensive reporting and gap identification
-model: sonnet
 ---
 
 # Test Coverage
@@ -23,6 +22,7 @@ Execute comprehensive coverage analysis with improvement recommendations and rep
 **Coverage Type**: Use $ARGUMENTS to focus on line coverage, branch coverage, function coverage, statement coverage, or comprehensive reporting
 
 **Coverage Analysis Framework**:
+
 1. **Coverage Tool Setup** - Configure appropriate tools (Jest, NYC, Istanbul, Coverage.py, JaCoCo), setup collection settings, optimize performance, enable reporting
 2. **Coverage Measurement** - Generate line coverage, branch coverage, function coverage, statement coverage reports, identify uncovered code paths
 3. **Gap Analysis** - Identify critical uncovered paths, analyze coverage quality, assess business logic coverage, evaluate edge case handling

--- a/cli-tool/components/commands/testing/test-quality-analyzer.md
+++ b/cli-tool/components/commands/testing/test-quality-analyzer.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [analysis-type] | --coverage-quality | --test-effectiveness | --maintainability | --performance-analysis
 description: Analyze test suite quality with comprehensive metrics and improvement recommendations
-model: sonnet
 ---
 
 # Test Quality Analyzer
@@ -23,6 +22,7 @@ Execute comprehensive test quality analysis with improvement recommendations and
 **Analysis Type**: Use $ARGUMENTS to focus on coverage quality, test effectiveness, maintainability analysis, or performance analysis
 
 **Test Quality Analysis Framework**:
+
 1. **Coverage Quality Assessment** - Analyze coverage depth, evaluate coverage quality, assess edge case handling, identify coverage gaps
 2. **Test Effectiveness Evaluation** - Measure defect detection capability, analyze test reliability, assess assertion quality, evaluate test value
 3. **Maintainability Analysis** - Evaluate test code quality, analyze test organization, assess refactoring needs, optimize test structure

--- a/cli-tool/components/commands/testing/testing_plan_integration.md
+++ b/cli-tool/components/commands/testing/testing_plan_integration.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [target-code] | [test-type] | --rust | --inline | --refactoring-suggestions
 description: Create comprehensive integration testing plan with inline tests and refactoring recommendations
-model: sonnet
 ---
 
 # Testing Plan Integration
@@ -23,6 +22,7 @@ Execute comprehensive integration testing plan with testability analysis:
 **Planning Focus**: Use $ARGUMENTS to specify target code, test type requirements, Rust inline testing, or refactoring suggestions
 
 **Integration Testing Framework**:
+
 1. **Code Testability Analysis** - Analyze target code structure, identify testing challenges, assess coupling levels, evaluate dependency injection
 2. **Test Strategy Design** - Design integration test approach, plan inline vs separate test files, identify test boundaries, optimize test isolation
 3. **Refactoring Assessment** - Identify testability improvements, suggest dependency injection, recommend interface abstractions, optimize component boundaries

--- a/cli-tool/components/commands/testing/write-tests.md
+++ b/cli-tool/components/commands/testing/write-tests.md
@@ -2,7 +2,6 @@
 allowed-tools: Read, Write, Edit, Bash
 argument-hint: [target-file] | [test-type] | --unit | --integration | --e2e | --component
 description: Write comprehensive unit and integration tests with proper mocking and coverage
-model: sonnet
 ---
 
 # Write Tests
@@ -23,6 +22,7 @@ Execute comprehensive test writing with framework-specific optimizations and bes
 **Test Focus**: Use $ARGUMENTS to specify target file, unit tests, integration tests, e2e tests, or component tests
 
 **Test Writing Framework**:
+
 1. **Code Analysis** - Analyze target code structure, identify testable functions, assess dependency complexity, evaluate edge cases
 2. **Test Strategy Design** - Plan test organization, design test hierarchies, identify mock requirements, optimize test isolation
 3. **Framework Integration** - Setup framework-specific patterns, configure test utilities, implement proper assertions, optimize test performance


### PR DESCRIPTION
Attempting to use the testing plugin with the latest version of Claude doesn't work due to the Sonnet model no longer being GA.

```
/testing-suite:test-quality-analyzer is running… 
  ⎿  Model: sonnet
  ⎿  Allowed 4 tools for this command
  ⎿  API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: sonnet"},"request_id":"req_011CTyHSYoC9n5hVotpRSoEw"}
```

Removing the Model fixes this issue and lets you use the plugin.