### PR TITLE
fix: Add UTF-8 encoding for cross-platform file reading in context-monitor

### DIFF
--- a/cli-tool/components/settings/statusline/context-monitor.py
+++ b/cli-tool/components/settings/statusline/context-monitor.py
@@ -15,7 +15,7 @@ def parse_context_from_transcript(transcript_path):
         return None
     
     try:
-        with open(transcript_path, 'r') as f:
+        with open(transcript_path, 'r', encoding='utf-8', errors='replace') as f:
             lines = f.readlines()
         
         # Check last 15 lines for context information


### PR DESCRIPTION
Fixes #106

  ## Problem
  The context-monitor fails to read transcript files on Windows due to encoding mismatch. The script doesn't specify
   encoding, so it defaults to cp949 on Windows, which can't handle UTF-8 content.

  ## Solution
  Added explicit UTF-8 encoding to the file open call:
  ```python
  with open(transcript_path, 'r', encoding='utf-8', errors='replace') as f:
```
  This follows Python best practices and ensures the code works across all platforms.

  Testing

  Tested on Windows 11 with Python 3.13. The statusline now correctly displays context information instead of "???".

  Changes

  - Modified line 18 in cli-tool/components/settings/statusline/context-monitor.py
  - 1 file changed, 1 insertion(+), 1 deletion(-)

  Image
 
 - Before
<img width="594" height="98" alt="image" src="https://github.com/user-attachments/assets/c81875bd-7a7e-43de-9016-92f060f209e5" />


 - After
<img width="716" height="101" alt="image" src="https://github.com/user-attachments/assets/7a3c8343-d63e-49c0-a9bc-33c242059107" />
