### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 
 # Claude Code Templates ([aitmpl.com](https://aitmpl.com))
 
+[![Run in Smithery](https://smithery.ai/badge/skills/davila7)](https://smithery.ai/skills?ns=davila7&utm_source=github&utm_medium=badge)
+
+
 **Ready-to-use configurations for Anthropic's Claude Code.** A comprehensive collection of AI agents, custom commands, settings, hooks, external integrations (MCPs), and project templates to enhance your development workflow.
 
 ## Browse & Install Components and Templates


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/davila7)](https://smithery.ai/skills?ns=davila7&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 10 skills have been installed **9 times** by **6 users** in the last 30 days.

### Top Skills
- **excel-analysis** (8 activations, 5 users)
- **email-composer** (1 activations, 1 users)
- **git-commit-helper** (0 activations, 0 users)
- **pdf-processing-pro** (0 activations, 0 users)
- **skill-creator** (0 activations, 0 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Run in Smithery” badge to the README so users can quickly browse and install the project’s skills on Smithery. Placed directly below the title for visibility.

<sup>Written for commit 672f631998ff80217605c90ee13e78509ef147f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

