### PR TITLE
fix: prevent unbounded Map growth in chats server

### DIFF
--- a/cli-tool/src/analytics/data/DataCache.js
+++ b/cli-tool/src/analytics/data/DataCache.js
@@ -34,13 +34,14 @@ class DataCache {
     };
     
     // Cache configuration - balanced for performance vs memory
+    // Sized to handle large conversation counts (1000+) without excessive eviction
     this.config = {
-      fileContentTTL: 60000, // 1 minute for file content
-      parsedDataTTL: 30000, // 30 seconds for parsed data
-      computationTTL: 20000, // 20 seconds for expensive computations
-      metadataTTL: 10000, // 10 seconds for metadata
+      fileContentTTL: 120000, // 2 minutes for file content
+      parsedDataTTL: 60000, // 1 minute for parsed data (was 30 seconds)
+      computationTTL: 30000, // 30 seconds for expensive computations (was 20 seconds)
+      metadataTTL: 15000, // 15 seconds for metadata (was 10 seconds)
       processTTL: 1000, // 1 second for process data
-      maxCacheSize: 50, // Increased to reduce evictions
+      maxCacheSize: 500, // Increased from 50 to handle 1000+ conversations without thrashing
     };
     
     // Dependency tracking for smart invalidation


### PR DESCRIPTION
## Summary

Three Maps in the chats server grow without bounds, causing memory exhaustion in long-running deployments:

- `conversationMessageCounts` and `conversationMessageSnapshots` in `chats-mobile.js` retain entries for deleted conversations
- `fileActivity` and `typingTimeout` in `FileWatcher.js` accumulate stale entries
- `DataCache.js` cache size (50) causes thrashing with 800+ conversations

## Changes

**chats-mobile.js:** Remove Map entries for conversations that no longer exist during `loadInitialData()`.

**DataCache.js:** Increase `maxCacheSize` from 50 to 500. Extend TTLs to reduce cache misses.

**FileWatcher.js:** Add periodic cleanup (every 5 minutes) of file activity entries older than 10 minutes.

## Test Plan

- [ ] Start server with 500+ conversations
- [ ] Monitor memory usage over 30+ minutes
- [ ] Delete several conversations while server runs
- [ ] Verify Map sizes stabilize (check via `conversationMessageCounts.size` in logs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded Map growth in the chats server to stop memory leaks and stabilize long-running deployments. Adds cleanup for stale entries and tunes cache settings to reduce eviction thrash.

- **Bug Fixes**
  - Remove conversationMessageCounts and conversationMessageSnapshots entries for deleted conversations during loadInitialData().
  - Add a 5-minute cleanup to purge stale fileActivity (>10 min) and clear orphaned typingTimeouts.

- **Performance**
  - Increase DataCache maxCacheSize to 500 and extend TTLs to reduce cache evictions with large (800+ ) conversation sets.

<sup>Written for commit debc6452fc3f3ee0ed31d9939a3083cf50a5f86b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

