### PR TITLE
fix(commands): Quote argument-hint to prevent YAML parsing error

### DIFF
--- a/cli-tool/components/commands/documentation/create-architecture-documentation.md
+++ b/cli-tool/components/commands/documentation/create-architecture-documentation.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [framework] | --c4-model | --arc42 | --adr | --plantuml | --full-suite
+argument-hint: "[framework] | --c4-model | --arc42 | --adr | --plantuml | --full-suite"
 description: Generate comprehensive architecture documentation with diagrams, ADRs, and interactive visualization
 ---
 


### PR DESCRIPTION
 ## Summary
  Fix STRUCT_E002 validation error caused by unquoted special characters in argument-hint.

  ## Changes
  - Quote `argument-hint` value containing `|` and `[]` characters
  - Prevents YAML parser from misinterpreting pipe as multiline indicator

  ## File
  - cli-tool/components/commands/documentation/create-architecture-documentation.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quoted the argument-hint in the create-architecture-documentation command docs to prevent YAML STRUCT_E002 errors from special characters. This avoids the pipe being parsed as a multiline indicator and fixes front matter validation.

<sup>Written for commit 655082fa0a0776554ce993ab2c38821683cd66a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

