### PR TITLE
Remove plugins filter chip from search interface

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -248,9 +248,6 @@
                         <a href="/mcps" class="filter-chip" data-filter="mcps" onclick="handleFilterClick(event, 'mcps')">
                             <span class="chip-icon">🔌</span>mcps
                         </a>
-                        <a href="/plugins" class="filter-chip" data-filter="plugins" onclick="handleFilterClick(event, 'plugins')">
-                            <span class="chip-icon">🧩</span>plugins
-                        </a>
                         <a href="/skills" class="filter-chip" data-filter="skills" onclick="handleFilterClick(event, 'skills')">
                             <span class="new-label">NEW</span>
                             <span class="chip-icon">🎨</span>skills


### PR DESCRIPTION
## Summary
Removed the plugins filter chip from the search interface in the documentation homepage.

## Changes
- Removed the plugins filter chip element (`<a href="/plugins" class="filter-chip">`) from the search filter options
- The chip displayed a puzzle piece emoji (🧩) and allowed filtering by "plugins"
- Other filter options (mcps, skills) remain intact

## Details
This change simplifies the search filter interface by removing the plugins category filter. The skills filter now directly follows the mcps filter in the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the plugins filter chip from the documentation homepage search to simplify the filters and remove plugin-based results. mcps and skills chips remain; skills now appears directly after mcps.

<sup>Written for commit fd534a01b300908e3242a739cda4743ee1eb296e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

