### PR TITLE
chore: add permissive Claude Code permissions config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash",
+      "Read",
+      "Edit",
+      "Write",
+      "WebFetch",
+      "Task"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./.env.local)",
+      "Read(./secrets/**)",
+      "Read(./.aws/**)",
+      "Read(./.ssh/**)",
+      "Read(./credentials*)",
+      "Read(./**/credentials*)",
+      "Read(./**/*.pem)",
+      "Read(./**/*.key)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with permissive permissions configuration
- Auto-approves common dev commands (Bash, Read, Edit, Write, WebFetch, Task)
- Protects sensitive files (.env, credentials, keys) via deny rules

## Test plan
- [ ] Verify settings are applied when opening project in Claude Code
- [ ] Confirm protected files (.env, etc.) are blocked from reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add project-level Claude Code permissions to streamline dev workflows and protect secrets. Auto-approves Bash, Read/Edit/Write, WebFetch, and Task operations by default, and denies reads of .env files, credentials, AWS/SSH directories, and .pem/.key files.

<sup>Written for commit 758e5d66fb41751da69089e5e135644b688f8a11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

