### PR TITLE
feat: Add console-log-cleaner pre-tool hook

### DIFF
--- a/cli-tool/components/hooks/pre-tool/console-log-cleaner.json
+++ b/cli-tool/components/hooks/pre-tool/console-log-cleaner.json
@@ -1,0 +1,16 @@
+{
+  "description": "Warns about console.log statements when editing files on production branches (main/master). Helps prevent debug code from reaching production.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if git rev-parse --git-dir >/dev/null 2>&1 && [[ -n \"$CLAUDE_TOOL_FILE_PATH\" ]]; then BRANCH=$(git branch --show-current 2>/dev/null); if [[ \"$BRANCH\" =~ ^(main|master|production|prod)$ ]]; then EXT=\"${CLAUDE_TOOL_FILE_PATH##*.}\"; if [[ \"$EXT\" =~ ^(js|ts|jsx|tsx|mjs|cjs)$ ]]; then LOGS=$(grep -n 'console\\.' \"$CLAUDE_TOOL_FILE_PATH\" 2>/dev/null); if [[ -n \"$LOGS\" ]]; then echo \"⚠️  WARNING: console statements found on '$BRANCH' branch:\"; echo \"$LOGS\" | head -5; COUNT=$(echo \"$LOGS\" | wc -l); if [[ $COUNT -gt 5 ]]; then echo \"... and $((COUNT-5)) more\"; fi; echo \"Consider removing debug statements before merging.\"; fi; fi; fi; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

  - Add a new pre-tool hook that warns about `console.*` statements when editing JS/TS files on production branches
  - Helps prevent debug code from accidentally reaching production

  ## Features

  - **Branch detection**: Only activates on `main`, `master`, `production`, `prod` branches
  - **File filtering**: Targets JavaScript/TypeScript files (`.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, `.cjs`)
  - **Console detection**: Finds `console.log`, `console.warn`, `console.error`, etc.
  - **Clear output**: Shows line numbers with a limit of 5 matches to avoid noise

  ## Example Output

  ⚠️  WARNING: console statements found on 'main' branch:
  12:  console.log('debug:', data)
  45:  console.warn('deprecated')
  Consider removing debug statements before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-tool hook that warns about console.* statements when editing files on production branches. Helps prevent debug logs from shipping.

- **New Features**
  - Branch-aware: runs on main, master, production, prod.
  - Targets JS/TS files (.js, .ts, .jsx, .tsx, .mjs, .cjs).
  - Flags console.* with line numbers; shows up to 5 matches and a reminder to remove.

<sup>Written for commit 4d94ecc74ff74988575541b96e4842c53413a75e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

