### PR TITLE
Fix domain URLs: remove www subdomain and update image paths

### DIFF
--- a/docs/blog/code-reviewer-agent/index.html
+++ b/docs/blog/code-reviewer-agent/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/code-reviewer-agent/">
     <meta property="og:title" content="Code Reviewer Agent for Claude Code: Automated Code Quality & Security">
     <meta property="og:description" content="Install the Code Reviewer Agent for Claude Code to automate code reviews, detect security vulnerabilities, and enforce best practices. AI-powered code quality analysis with actionable feedback.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/code-reviewer-agent-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/code-reviewer-agent-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:article:published_time" content="2025-01-15T10:00:00Z">
@@ -42,11 +42,11 @@
     <meta property="og:article:tag" content="Code Quality">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/code-reviewer-agent/">
-    <meta property="twitter:title" content="Code Reviewer Agent for Claude Code: Automated Code Quality & Security">
-    <meta property="twitter:description" content="Install the Code Reviewer Agent for Claude Code to automate code reviews, detect security vulnerabilities, and enforce best practices. AI-powered code quality analysis with actionable feedback.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/code-reviewer-agent-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/code-reviewer-agent/">
+    <meta name="twitter:title" content="Code Reviewer Agent for Claude Code: Automated Code Quality & Security">
+    <meta name="twitter:description" content="Install the Code Reviewer Agent for Claude Code to automate code reviews, detect security vulnerabilities, and enforce best practices. AI-powered code quality analysis with actionable feedback.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/code-reviewer-agent-cover.png">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code agent, Code Reviewer Agent, Claude Code code review, automated code review, security scanning, code quality, AI code review, vulnerability detection, best practices, OWASP, code audit, static analysis, Claude Code security">
@@ -78,7 +78,7 @@
         "@type": "BlogPosting",
         "headline": "Code Reviewer Agent for Claude Code: Automated Code Quality & Security Expert",
         "description": "Install the Code Reviewer Agent for Claude Code to automate code reviews, detect security vulnerabilities, and enforce best practices. AI-powered code quality analysis with actionable feedback.",
-        "image": "https://www.aitmpl.com/blog/assets/code-reviewer-agent-cover.png",
+        "image": "https://aitmpl.com/blog/assets/code-reviewer-agent-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -88,7 +88,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/context7-mcp/index.html
+++ b/docs/blog/context7-mcp/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/context7-mcp/">
     <meta property="og:title" content="Context7 MCP for Claude Code: Real-Time Documentation & Library Integration">
     <meta property="og:description" content="Install the Context7 MCP for Claude Code to access real-time library documentation. AI-powered MCP for React, Next.js, Supabase, and 1000+ libraries.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/context7-mcp-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/context7-mcp-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -42,11 +42,11 @@
     <meta property="article:tag" content="Libraries">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/context7-mcp/">
-    <meta property="twitter:title" content="Context7 MCP for Claude Code: Real-Time Documentation & Library Integration">
-    <meta property="twitter:description" content="Install the Context7 MCP for Claude Code to access real-time library documentation. AI-powered MCP for React, Next.js, Supabase, and 1000+ libraries.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/context7-mcp-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/context7-mcp/">
+    <meta name="twitter:title" content="Context7 MCP for Claude Code: Real-Time Documentation & Library Integration">
+    <meta name="twitter:description" content="Install the Context7 MCP for Claude Code to access real-time library documentation. AI-powered MCP for React, Next.js, Supabase, and 1000+ libraries.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/context7-mcp-cover.png">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code MCP, Context7 MCP, Claude Code documentation, real-time library docs, React documentation Claude Code, Next.js docs, Supabase documentation, MCP integration, API documentation, up-to-date documentation, library integration">
@@ -78,7 +78,7 @@
         "@type": "BlogPosting",
         "headline": "Context7 MCP for Claude Code: Real-Time Documentation & Library Integration",
         "description": "Install the Context7 MCP for Claude Code to access real-time library documentation. AI-powered MCP for React, Next.js, Supabase, and 1000+ libraries with up-to-date API references.",
-        "image": "https://www.aitmpl.com/blog/assets/context7-mcp-cover.png",
+        "image": "https://aitmpl.com/blog/assets/context7-mcp-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -88,7 +88,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/e2b-claude-code-sandbox/index.html
+++ b/docs/blog/e2b-claude-code-sandbox/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
     <meta property="og:title" content="E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide">
     <meta property="og:description" content="Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -49,11 +49,11 @@
     <meta property="article:tag" content="Remote Development">
     
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
-    <meta property="twitter:title" content="E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide">
-    <meta property="twitter:description" content="Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/e2b-claude-code-sandbox/">
+    <meta name="twitter:title" content="E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide">
+    <meta name="twitter:description" content="Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="E2B Claude Code sandbox, cloud development environment, secure code execution, isolated development, Claude Code safety, E2B Python SDK, remote development, AI sandbox, secure AI development, cloud sandbox, development isolation, safe code generation">
@@ -85,7 +85,7 @@
         "@type": "BlogPosting",
         "headline": "E2B + Claude Code Sandbox: Secure Cloud Development Environment Guide",
         "description": "Complete guide to run Claude Code in isolated E2B cloud sandbox. Install components safely, execute prompts in secure environment, and develop without local system risks.",
-        "image": "https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png",
+        "image": "https://aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -95,7 +95,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {
@@ -203,7 +203,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png" alt="E2B and Claude Code Sandbox Integration" class="article-cover" loading="lazy">
+            <img src="https://aitmpl.com/blog/assets/e2b-claude-code-sandbox-cover.png" alt="E2B and Claude Code Sandbox Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Benefits of Secure Sandbox Execution</h2>

--- a/docs/blog/frontend-developer-agent/index.html
+++ b/docs/blog/frontend-developer-agent/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/frontend-developer-agent/">
     <meta property="og:title" content="Frontend Developer Agent for Claude Code: React, Vue & Vite Expert">
     <meta property="og:description" content="Install the Frontend Developer Agent for Claude Code to build React, Vue, and Vite applications faster. AI-powered agent for UI components, state management, and performance optimization.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/frontend-developer-agent-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/frontend-developer-agent-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -47,11 +47,11 @@
     <meta property="article:tag" content="Performance Optimization">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/frontend-developer-agent/">
-    <meta property="twitter:title" content="Frontend Developer Agent for Claude Code: React, Vue & Vite Expert">
-    <meta property="twitter:description" content="Install the Frontend Developer Agent for Claude Code to build React, Vue, and Vite applications faster. AI-powered agent for UI components, state management, and performance optimization.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/frontend-developer-agent-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/frontend-developer-agent/">
+    <meta name="twitter:title" content="Frontend Developer Agent for Claude Code: React, Vue & Vite Expert">
+    <meta name="twitter:description" content="Install the Frontend Developer Agent for Claude Code to build React, Vue, and Vite applications faster. AI-powered agent for UI components, state management, and performance optimization.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/frontend-developer-agent-cover.png">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code agent, Frontend Developer Agent, Claude Code frontend, React agent, Vue agent, Vite development, Claude Code React, AI frontend development, React components, Vue components, state management, Tailwind CSS, TypeScript agent, frontend performance, Claude Code templates, AI coding assistant, React hooks, Vue Composition API, UI components, responsive design">
@@ -83,7 +83,7 @@
         "@type": "BlogPosting",
         "headline": "Frontend Developer Agent for Claude Code: React, Vue & Vite Expert AI Assistant",
         "description": "Install the Frontend Developer Agent for Claude Code to build React, Vue, and Vite applications faster. AI-powered agent for UI components, state management, and performance optimization.",
-        "image": "https://www.aitmpl.com/blog/assets/frontend-developer-agent-cover.png",
+        "image": "https://aitmpl.com/blog/assets/frontend-developer-agent-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -93,7 +93,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/heygen-best-practices-skill/index.html
+++ b/docs/blog/heygen-best-practices-skill/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/heygen-best-practices-skill/">
     <meta property="og:title" content="HeyGen Best Practices Skill: AI Avatar Video Creation Guide">
     <meta property="og:description" content="Master HeyGen API integration with 18+ best practice rules. Learn to create AI avatar videos, manage voices, and handle video generation workflows.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -43,11 +43,11 @@
     <meta property="article:tag" content="Video Generation">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/heygen-best-practices-skill/">
-    <meta property="twitter:title" content="HeyGen Best Practices Skill: AI Avatar Video Creation Guide">
-    <meta property="twitter:description" content="Master HeyGen API integration with 18+ best practice rules. Learn to create AI avatar videos, manage voices, and handle video generation workflows.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/heygen-best-practices-skill/">
+    <meta name="twitter:title" content="HeyGen Best Practices Skill: AI Avatar Video Creation Guide">
+    <meta name="twitter:description" content="Master HeyGen API integration with 18+ best practice rules. Learn to create AI avatar videos, manage voices, and handle video generation workflows.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="HeyGen API, AI avatar, video generation, text-to-video, avatar video, Claude Code, HeyGen skill, video automation, AI presenter, talking head video, streaming avatar, video translation, webhook integration">
@@ -79,7 +79,7 @@
         "@type": "BlogPosting",
         "headline": "HeyGen Best Practices Skill for Claude Code: AI Avatar Video Creation Guide",
         "description": "Master HeyGen API integration with 18+ best practice rules. Learn to create AI avatar videos, manage voices, and handle video generation workflows.",
-        "image": "https://www.aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg",
+        "image": "https://aitmpl.com/blog/assets/heygen-best-practices-skill-cover.svg",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -89,7 +89,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://aitmpl.com/blog/">
     <meta property="og:title" content="Blog - Claude Code Templates">
     <meta property="og:description" content="Latest articles about Claude Code, AI development, and automation tools. Learn how to supercharge your development workflow with Anthropic's Claude Code.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
     
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/">
-    <meta property="twitter:title" content="Blog - Claude Code Templates">
-    <meta property="twitter:description" content="Latest articles about Claude Code, AI development, and automation tools.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/">
+    <meta name="twitter:title" content="Blog - Claude Code Templates">
+    <meta name="twitter:description" content="Latest articles about Claude Code, AI development, and automation tools.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
     
     <link rel="canonical" href="https://aitmpl.com/blog/">
 

--- a/docs/blog/nextjs-vercel-claude-code-integration/index.html
+++ b/docs/blog/nextjs-vercel-claude-code-integration/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
     <meta property="og:title" content="Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks">
     <meta property="og:description" content="Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -49,11 +49,11 @@
     <meta property="article:tag" content="Edge Computing">
     
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
-    <meta property="twitter:title" content="Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks">
-    <meta property="twitter:description" content="Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/nextjs-vercel-claude-code-integration/">
+    <meta name="twitter:title" content="Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks">
+    <meta name="twitter:description" content="Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="Next.js Claude Code integration, Vercel Claude Code, Next.js AI development, Claude Code agents, Next.js automation, Vercel deployment hooks, React Claude Code, TypeScript automation, Next.js performance optimization, Vercel monitoring, AI-powered frontend development, Next.js best practices, Claude Code templates, Next.js deployment automation, Vercel error monitoring">
@@ -84,7 +84,7 @@
         "@type": "BlogPosting",
         "headline": "Next.js + Vercel + Claude Code Integration: Complete Guide with Agents, Commands and Hooks",
         "description": "Complete guide to integrate Next.js and Vercel with Claude Code. Install 10 development commands, 3 specialized AI agents, and 5 automated hooks for Next.js deployment, optimization, and monitoring.",
-        "image": "https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png",
+        "image": "https://aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -94,7 +94,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {
@@ -207,7 +207,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" class="article-cover" loading="lazy">
+            <img src="https://aitmpl.com/blog/assets/nextjs-vercel-claude-code-templates-cover.png" alt="Next.js, Vercel and Claude Code Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Claude Code stack for Next.js and Vercel</h2>
@@ -368,7 +368,7 @@
 
                 <p>Visit <strong><a href="https://aitmpl.com" target="_blank" rel="noopener">aitmpl.com</a></strong> and search for "nextjs" or "vercel" to see:</p>
 
-                <img src="https://www.aitmpl.com/blog/assets/aitmpl-nextjs-search.png" alt="Searching for Next.js components on AITMPL.com" loading="lazy">
+                <img src="https://aitmpl.com/blog/assets/aitmpl-nextjs-search.png" alt="Searching for Next.js components on AITMPL.com" loading="lazy">
                 
                 <!-- Newsletter CTA - Middle -->
                 <div class="newsletter-cta middle-newsletter">

--- a/docs/blog/react-best-practices-skill/index.html
+++ b/docs/blog/react-best-practices-skill/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/react-best-practices-skill/">
     <meta property="og:title" content="React Best Practices Skill: 40+ Performance Optimization Rules">
     <meta property="og:description" content="Master React and Next.js performance optimization with 40+ proven rules. Learn to eliminate waterfalls, optimize bundles, and improve rendering performance.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/react-best-practices-skill-cover.svg">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/react-best-practices-skill-cover.svg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -45,11 +45,11 @@
     <meta property="article:tag" content="Server Components">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/react-best-practices-skill/">
-    <meta property="twitter:title" content="React Best Practices Skill: 40+ Performance Optimization Rules">
-    <meta property="twitter:description" content="Master React and Next.js performance optimization with 40+ proven rules. Learn to eliminate waterfalls, optimize bundles, and improve rendering performance.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/react-best-practices-skill-cover.svg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/react-best-practices-skill/">
+    <meta name="twitter:title" content="React Best Practices Skill: 40+ Performance Optimization Rules">
+    <meta name="twitter:description" content="Master React and Next.js performance optimization with 40+ proven rules. Learn to eliminate waterfalls, optimize bundles, and improve rendering performance.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/react-best-practices-skill-cover.svg">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="React performance, Next.js optimization, bundle size, React best practices, waterfalls, rendering optimization, Server Components, Claude Code, React skills, performance optimization, web performance, JavaScript optimization, React hooks, memoization, code splitting">
@@ -81,7 +81,7 @@
         "@type": "BlogPosting",
         "headline": "React Best Practices Skill for Claude Code: 40+ Performance Optimization Rules",
         "description": "Master React and Next.js performance optimization with 40+ proven rules. Learn to eliminate waterfalls, optimize bundles, and improve rendering performance.",
-        "image": "https://www.aitmpl.com/blog/assets/react-best-practices-skill-cover.svg",
+        "image": "https://aitmpl.com/blog/assets/react-best-practices-skill-cover.svg",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -91,7 +91,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/security-hooks-secrets/index.html
+++ b/docs/blog/security-hooks-secrets/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/security-hooks-secrets/">
     <meta property="og:title" content="Block API Keys & Secrets from Your Commits with Claude Code Hooks">
     <meta property="og:description" content="Learn how to set up a PreToolUse hook in Claude Code that automatically detects and blocks commits containing API keys, passwords, and secrets.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/security-hooks-secrets-cover.svg">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/security-hooks-secrets-cover.svg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -42,11 +42,11 @@
     <meta property="article:tag" content="Claude Code">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/security-hooks-secrets/">
-    <meta property="twitter:title" content="Block API Keys & Secrets from Your Commits with Claude Code Hooks">
-    <meta property="twitter:description" content="Learn how to set up a PreToolUse hook in Claude Code that automatically detects and blocks commits containing API keys, passwords, and secrets.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/security-hooks-secrets-cover.svg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/security-hooks-secrets/">
+    <meta name="twitter:title" content="Block API Keys & Secrets from Your Commits with Claude Code Hooks">
+    <meta name="twitter:description" content="Learn how to set up a PreToolUse hook in Claude Code that automatically detects and blocks commits containing API keys, passwords, and secrets.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/security-hooks-secrets-cover.svg">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code Hooks, Secret Detection, API Key Protection, Git Security, PreToolUse Hook, Claude Code Security, Credential Leak Prevention, Secrets Scanner, Claude Code Templates, DevSecOps">
@@ -78,7 +78,7 @@
         "@type": "BlogPosting",
         "headline": "Block API Keys & Secrets from Your Commits with Claude Code Hooks",
         "description": "Learn how to set up a PreToolUse hook in Claude Code that automatically detects and blocks commits containing API keys, passwords, and secrets.",
-        "image": "https://www.aitmpl.com/blog/assets/security-hooks-secrets-cover.svg",
+        "image": "https://aitmpl.com/blog/assets/security-hooks-secrets-cover.svg",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -88,7 +88,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/simple-notifications-hook/index.html
+++ b/docs/blog/simple-notifications-hook/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/simple-notifications-hook/">
     <meta property="og:title" content="Simple Notifications Hook for Claude Code: Desktop Alerts">
     <meta property="og:description" content="Get instant desktop notifications when Claude Code operations complete. Cross-platform hook for macOS and Linux.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/simple-notifications-hook-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/simple-notifications-hook-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -42,11 +42,11 @@
     <meta property="article:tag" content="Desktop Alerts">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/simple-notifications-hook/">
-    <meta property="twitter:title" content="Simple Notifications Hook for Claude Code: Desktop Alerts">
-    <meta property="twitter:description" content="Get instant desktop notifications when Claude Code operations complete.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/simple-notifications-hook-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/simple-notifications-hook/">
+    <meta name="twitter:title" content="Simple Notifications Hook for Claude Code: Desktop Alerts">
+    <meta name="twitter:description" content="Get instant desktop notifications when Claude Code operations complete.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/simple-notifications-hook-cover.png">
 
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code Hook, Simple Notifications, Claude Code Desktop Alerts, macOS Notifications, Linux Notifications, AI Automation, Claude Code Hooks, Desktop Notifications, PostToolUse Hook, Claude Code Alerts">
@@ -78,7 +78,7 @@
         "@type": "BlogPosting",
         "headline": "Simple Notifications Hook for Claude Code: Desktop Alerts for macOS & Linux",
         "description": "Install the Simple Notifications Hook for Claude Code to get instant desktop notifications when operations complete. AI-powered automation hook for macOS and Linux systems.",
-        "image": "https://www.aitmpl.com/blog/assets/simple-notifications-hook-cover.png",
+        "image": "https://aitmpl.com/blog/assets/simple-notifications-hook-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -88,7 +88,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/skills-creator/index.html
+++ b/docs/blog/skills-creator/index.html
@@ -33,7 +33,7 @@
     <meta property="og:title" content="Claude Code Skills for Custom Workflows: AI Automation">
     <meta property="og:description"
         content="Install Claude Code Skills to create custom AI workflows with progressive context loading. Build reusable automation for your development workflow.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/skills-creator-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/skills-creator-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:article:published_time" content="2025-01-15T10:00:00Z">
@@ -45,12 +45,12 @@
     <meta property="og:article:tag" content="Automation">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/skills-creator/">
-    <meta property="twitter:title" content="Claude Code Skills for Custom Workflows: AI Automation">
-    <meta property="twitter:description"
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/skills-creator/">
+    <meta name="twitter:title" content="Claude Code Skills for Custom Workflows: AI Automation">
+    <meta name="twitter:description"
         content="Install Claude Code Skills to create custom AI workflows with progressive context loading. Build reusable automation for your development workflow.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/skills-creator-cover.png">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/skills-creator-cover.png">
 
     <!-- Additional SEO -->
     <meta name="keywords"
@@ -83,7 +83,7 @@
         "@type": "BlogPosting",
         "headline": "Claude Code Skills for Custom Workflows: AI Automation Expert 2025",
         "description": "Install Claude Code Skills to create custom AI workflows with progressive context loading. Build reusable automation for your development workflow with slash commands.",
-        "image": "https://www.aitmpl.com/blog/assets/skills-creator-cover.png",
+        "image": "https://aitmpl.com/blog/assets/skills-creator-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -93,7 +93,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {

--- a/docs/blog/supabase-claude-code-integration/index.html
+++ b/docs/blog/supabase-claude-code-integration/index.html
@@ -30,7 +30,7 @@
     <meta property="og:url" content="https://aitmpl.com/blog/supabase-claude-code-integration/">
     <meta property="og:title" content="Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server">
     <meta property="og:description" content="Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.">
-    <meta property="og:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta property="og:image" content="https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="article:author" content="Claude Code Templates">
@@ -49,11 +49,11 @@
     <meta property="article:tag" content="Real-time Database">
     
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/blog/supabase-claude-code-integration/">
-    <meta property="twitter:title" content="Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server">
-    <meta property="twitter:description" content="Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.">
-    <meta property="twitter:image" content="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/blog/supabase-claude-code-integration/">
+    <meta name="twitter:title" content="Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server">
+    <meta name="twitter:description" content="Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.">
+    <meta name="twitter:image" content="https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="Supabase Claude Code integration, MCP server Supabase, Claude Code agents, database development AI, Supabase schema architect, PostgreSQL Claude Code, AI database tools, Supabase automation, Claude Code templates, database migration assistant, Supabase TypeScript generator, real-time database monitoring, Supabase backup automation, database security audit, Anthropic Claude Code, AI-powered database development">
@@ -84,7 +84,7 @@
         "@type": "BlogPosting",
         "headline": "Supabase Claude Code Integration Guide: 8 Commands + AI Agents + MCP Server",
         "description": "Complete guide to integrate Supabase with Claude Code. Install 8 database commands, 2 AI agents, and MCP server for automated schema design, migrations, and TypeScript generation.",
-        "image": "https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png",
+        "image": "https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png",
         "author": {
             "@type": "Organization",
             "name": "Claude Code Templates"
@@ -94,7 +94,7 @@
             "name": "Claude Code Templates",
             "logo": {
                 "@type": "ImageObject",
-                "url": "https://www.aitmpl.com/static/img/logo.svg"
+                "url": "https://aitmpl.com/static/img/logo.svg"
             }
         },
         "mainEntityOfPage": {
@@ -202,7 +202,7 @@
         </header>
 
         <article class="article-body">
-            <img src="https://www.aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" class="article-cover" loading="lazy">
+            <img src="https://aitmpl.com/blog/assets/supabase-claude-code-templates-cover.png" alt="Supabase and Claude Code Integration" class="article-cover" loading="lazy">
             
             <div class="article-content-full">
                 <h2>Claude Code stack for Supabase</h2>
@@ -295,7 +295,7 @@
 
                 <p>Visit <strong><a href="https://aitmpl.com" target="_blank" rel="noopener">aitmpl.com</a></strong> and search for "supabase" to see:</p>
 
-                <img src="https://www.aitmpl.com/blog/assets/aitmpl-supabase-search.png" alt="Searching for Supabase components on AITMPL.com" loading="lazy">
+                <img src="https://aitmpl.com/blog/assets/aitmpl-supabase-search.png" alt="Searching for Supabase components on AITMPL.com" loading="lazy">
                 
                 <!-- Newsletter CTA - Middle -->
                 <div class="newsletter-cta middle-newsletter">

--- a/docs/component.html
+++ b/docs/component.html
@@ -32,7 +32,7 @@
     <!-- Open Graph -->
     <meta property="og:title" content="Component - Claude Code Templates" id="og-title">
     <meta property="og:description" content="Explore Claude Code templates, agents, commands, and automation tools for enhanced development workflows." id="og-description">
-    <meta property="og:image" content="https://aitmpl.com/og-image.png">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
     <meta property="og:url" content="" id="og-url">
     <meta property="og:type" content="website">
     
@@ -40,7 +40,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Component - Claude Code Templates" id="twitter-title">
     <meta name="twitter:description" content="Explore Claude Code templates, agents, commands, and automation tools for enhanced development workflows." id="twitter-description">
-    <meta name="twitter:image" content="https://aitmpl.com/og-image.png">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
     <meta name="twitter:url" content="" id="twitter-url">
     
     <!-- Favicon -->

--- a/docs/download-stats.html
+++ b/docs/download-stats.html
@@ -23,7 +23,24 @@
     <link rel="icon" type="image/png" sizes="192x192" href="static/favicon/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
-    <meta name="description" content="Detailed download analytics and usage statistics for Claude Code Templates">
+    <meta name="description" content="Detailed download analytics and usage statistics for Claude Code Templates.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aitmpl.com/download-stats.html">
+    <meta property="og:title" content="Download Analytics - Claude Code Templates">
+    <meta property="og:description" content="Detailed download analytics and usage statistics for Claude Code Templates.">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Claude Code Templates">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Download Analytics - Claude Code Templates">
+    <meta name="twitter:description" content="Detailed download analytics and usage statistics for Claude Code Templates.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="fonts.gstatic.com" crossorigin>

--- a/docs/featured/braingrid/index.html
+++ b/docs/featured/braingrid/index.html
@@ -30,11 +30,11 @@
     <meta property="og:image" content="https://aitmpl.com/featured/braingrid/assets/braingrid-cover.svg">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aitmpl.com/featured/braingrid/">
-    <meta property="twitter:title" content="BrainGrid: Product Management Agent for Claude Code">
-    <meta property="twitter:description" content="Transform messy ideas into clear specifications and Claude Code-ready prompts with BrainGrid.">
-    <meta property="twitter:image" content="https://aitmpl.com/featured/braingrid/assets/braingrid-cover.svg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/featured/braingrid/">
+    <meta name="twitter:title" content="BrainGrid: Product Management Agent for Claude Code">
+    <meta name="twitter:description" content="Transform messy ideas into clear specifications and Claude Code-ready prompts with BrainGrid.">
+    <meta name="twitter:image" content="https://aitmpl.com/featured/braingrid/assets/braingrid-cover.svg">
 
     <meta name="keywords" content="BrainGrid, Claude Code, Product Management Agent, AI Planning, Software Planning, Claude Code Integration, AI Development, Product Strategy">
     <link rel="canonical" href="https://aitmpl.com/featured/braingrid/">

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
     <meta property="og:url" content="https://aitmpl.com/">
     <meta property="og:title" content="Claude Code Templates - Supercharge Your AI Development with Anthropic Claude">
     <meta property="og:description" content="Professional templates for Anthropic's Claude Code. Deep coding at terminal velocity with Claude Opus 4.1. Install 100+ agents, commands, settings & hooks. Transform your AI-powered development workflow.">
-    <meta property="og:image" content="https://aitmpl.com/social-preview.png">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="Claude Code Templates - Supercharge Your AI Development with Anthropic Claude">
@@ -32,7 +32,7 @@
     <meta name="twitter:url" content="https://aitmpl.com/">
     <meta name="twitter:title" content="Claude Code Templates - Supercharge Your AI Development">
     <meta name="twitter:description" content="Professional templates for Anthropic's Claude Code. Deep coding at terminal velocity with Claude Opus 4.1. Install 100+ agents, commands, settings & hooks.">
-    <meta name="twitter:image" content="https://aitmpl.com/social-preview.png">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
     <meta name="twitter:image:alt" content="Claude Code Templates - Supercharge Your AI Development with Anthropic Claude">
     <meta name="twitter:creator" content="@davila7">
     <meta name="twitter:site" content="@davila7">
@@ -89,7 +89,7 @@
       "description": "Professional templates and configurations for Anthropic's Claude Code. Transform your AI-powered development workflow with Claude Opus 4.1 at terminal velocity.",
       "operatingSystem": ["Windows", "macOS", "Linux"],
       "softwareVersion": "1.18.0",
-      "url": "https://davila7.github.io/claude-code-templates/",
+      "url": "https://aitmpl.com/",
       "downloadUrl": "https://www.npmjs.com/package/claude-code-templates",
       "author": {
         "@type": "Organization",

--- a/docs/jobs.html
+++ b/docs/jobs.html
@@ -27,30 +27,30 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://davila7.github.io/claude-code-templates/jobs.html">
+    <meta property="og:url" content="https://aitmpl.com/jobs.html">
     <meta property="og:title" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
     <meta property="og:description" content="Discover the latest job opportunities requiring Claude Code expertise. Find positions at Anthropic and other companies building the future of AI-powered development.">
-    <meta property="og:image" content="https://raw.githubusercontent.com/davila7/claude-code-templates/main/social-preview.png">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
     <meta property="og:site_name" content="Claude Code Templates">
-    
+
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://davila7.github.io/claude-code-templates/jobs.html">
-    <meta property="twitter:title" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
-    <meta property="twitter:description" content="Discover the latest job opportunities requiring Claude Code expertise. Find positions at Anthropic and other companies building the future of AI-powered development.">
-    <meta property="twitter:image" content="https://raw.githubusercontent.com/davila7/claude-code-templates/main/social-preview.png">
-    <meta property="twitter:image:alt" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
-    <meta property="twitter:creator" content="@davila7">
-    <meta property="twitter:site" content="@davila7">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://aitmpl.com/jobs.html">
+    <meta name="twitter:title" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
+    <meta name="twitter:description" content="Discover the latest job opportunities requiring Claude Code expertise. Find positions at Anthropic and other companies building the future of AI-powered development.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta name="twitter:image:alt" content="Claude Code Jobs - Find Your Next AI-Powered Development Role">
+    <meta name="twitter:creator" content="@davila7">
+    <meta name="twitter:site" content="@davila7">
     
     <!-- Additional SEO -->
     <meta name="keywords" content="Claude Code jobs, Anthropic careers, AI development jobs, Claude Code careers, AI engineer positions, developer jobs, AI-powered development, Claude Code opportunities">
     <meta name="author" content="Claude Code Templates Community">
     <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://davila7.github.io/claude-code-templates/jobs.html">
+    <link rel="canonical" href="https://aitmpl.com/jobs.html">
     
     <!-- Claude Code / Anthropic relation -->
     <meta name="product" content="Claude Code Jobs">

--- a/docs/plugin.html
+++ b/docs/plugin.html
@@ -23,7 +23,23 @@
     <link rel="icon" type="image/png" sizes="192x192" href="static/favicon/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
-    <meta name="description" content="Plugin details for Claude Code Templates">
+    <meta name="description" content="Plugin details for Claude Code Templates.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aitmpl.com/plugin.html">
+    <meta property="og:title" content="Plugin Details - Claude Code Templates">
+    <meta property="og:description" content="Plugin details for Claude Code Templates.">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Claude Code Templates">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Plugin Details - Claude Code Templates">
+    <meta name="twitter:description" content="Plugin details for Claude Code Templates.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
 
     <link rel="stylesheet" href="/css/styles.css">
     <link rel="stylesheet" href="/css/plugin-page.css">

--- a/docs/sandbox-interface.html
+++ b/docs/sandbox-interface.html
@@ -23,8 +23,24 @@
     <link rel="icon" type="image/png" sizes="192x192" href="static/favicon/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
-    <meta name="description" content="Execute Claude Code locally or in cloud sandbox environments with real-time task management">
-    
+    <meta name="description" content="Execute Claude Code locally or in cloud sandbox environments with real-time task management.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aitmpl.com/sandbox-interface.html">
+    <meta property="og:title" content="Claude Code Studio - AI Development Interface">
+    <meta property="og:description" content="Execute Claude Code locally or in cloud sandbox environments with real-time task management.">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Claude Code Templates">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Claude Code Studio - AI Development Interface">
+    <meta name="twitter:description" content="Execute Claude Code locally or in cloud sandbox environments with real-time task management.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/trending.html
+++ b/docs/trending.html
@@ -23,6 +23,24 @@
     <link rel="icon" type="image/png" sizes="192x192" href="static/favicon/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
+    <meta name="description" content="Discover the most popular Claude Code templates, agents, and status lines trending today.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aitmpl.com/trending.html">
+    <meta property="og:title" content="Trending - Claude Code Templates">
+    <meta property="og:description" content="Discover the most popular Claude Code templates, agents, and status lines trending today.">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Claude Code Templates">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Trending - Claude Code Templates">
+    <meta name="twitter:description" content="Discover the most popular Claude Code templates, agents, and status lines trending today.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/trending.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/workflows.html
+++ b/docs/workflows.html
@@ -23,6 +23,24 @@
     <link rel="icon" type="image/png" sizes="192x192" href="static/favicon/android-chrome-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
+    <meta name="description" content="Build and share automated workflows with Claude Code Templates.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://aitmpl.com/workflows.html">
+    <meta property="og:title" content="Workflow Builder - Claude Code Templates">
+    <meta property="og:description" content="Build and share automated workflows with Claude Code Templates.">
+    <meta property="og:image" content="https://aitmpl.com/images/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Claude Code Templates">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Workflow Builder - Claude Code Templates">
+    <meta name="twitter:description" content="Build and share automated workflows with Claude Code Templates.">
+    <meta name="twitter:image" content="https://aitmpl.com/images/social-preview.png">
+
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/workflows.css">
     <link rel="stylesheet" href="css/workflows-modal.css">


### PR DESCRIPTION
## Summary
This PR standardizes all domain URLs across the documentation and blog by removing the `www` subdomain prefix and updating image asset paths to use the correct domain structure.

## Key Changes

- **Domain URL Standardization**: Changed all `https://www.aitmpl.com` URLs to `https://aitmpl.com` throughout blog posts, featured content, and main pages
- **Twitter Meta Tags**: Updated Twitter meta tags from `property` to `name` attribute (correct HTML5 syntax for Twitter Card tags)
- **Image Asset Paths**: Updated all image URLs to use the non-www domain consistently
- **Social Preview Images**: Updated references to social preview images to use `/images/social-preview.png` path
- **Schema.org Updates**: Fixed JSON-LD structured data to use correct domain URLs
- **SEO Meta Tags**: Enhanced `download-stats.html` with proper Open Graph and Twitter Card meta tags

## Files Modified
- Blog articles (code-reviewer-agent, context7-mcp, e2b-claude-code-sandbox, frontend-developer-agent, heygen-best-practices-skill, nextjs-vercel-claude-code-integration, react-best-practices-skill, security-hooks-secrets, simple-notifications-hook, skills-creator, supabase-claude-code-integration)
- Blog index page
- Featured content (braingrid)
- Main pages (index.html, component.html, download-stats.html)

## Implementation Details
- All changes maintain backward compatibility with existing links
- Twitter Card meta tags now use correct `name` attribute instead of `property`
- Image paths consistently point to the non-www domain
- Schema.org structured data updated for proper SEO

https://claude.ai/code/session_01CXzS5mzoK3rZB6PW3QSPPd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all site URLs to the non-www domain and fixed broken social preview metadata and image paths. This restores correct link previews on X/Twitter and improves SEO consistency across pages.

- **SEO and Social Previews**
  - Switched twitter:* tags to name= and corrected preview image path to /images/social-preview.png.
  - Replaced incorrect OG/Twitter image URLs site-wide and fixed references like og-image.png.
  - Added complete Open Graph and Twitter Card tags to trending, download-stats, plugin, sandbox-interface, and workflows pages.

- **Domain Standardization**
  - Replaced https://www.aitmpl.com with https://aitmpl.com across blog posts, featured content, images, and logos.
  - Updated canonical and structured data URLs, including the homepage schema and jobs page.

<sup>Written for commit 8ea24a41aab81b8c334ac069690db807260ea482. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

