### PR TITLE
fix: improve network error messages for SSL/certificate issues

### DIFF
--- a/cli-tool/jest.config.js
+++ b/cli-tool/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/analytics/**/*.js',
     'src/analytics-web/**/*.js',
+    'src/network.js',
     '!src/analytics.log',
     '!src/analytics-web/index.html*',
     '!**/node_modules/**',

--- a/cli-tool/src/file-operations.js
+++ b/cli-tool/src/file-operations.js
@@ -3,6 +3,7 @@ const path = require('path');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
 const { getHooksForLanguage, filterHooksBySelection, getMCPsForLanguage, filterMCPsBySelection } = require('./hook-scanner');
+const { fetchFromGitHub } = require('./network');
 
 // GitHub configuration for downloading templates
 const GITHUB_CONFIG = {
@@ -27,7 +28,7 @@ async function downloadFileFromGitHub(filePath, retryCount = 0) {
   const githubUrl = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.templatesPath}/${filePath}`;
   
   try {
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     
     // Handle rate limiting for raw.githubusercontent.com (though less common)
     if (response.status === 403 && retryCount < maxRetries) {
@@ -81,7 +82,7 @@ async function downloadDirectoryFromGitHub(dirPath, retryCount = 0) {
   const apiUrl = `https://api.github.com/repos/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/contents/${GITHUB_CONFIG.templatesPath}/${dirPath}?ref=${GITHUB_CONFIG.branch}`;
   
   try {
-    const response = await fetch(apiUrl);
+    const response = await fetchFromGitHub(apiUrl);
     
     // Handle rate limiting with more sophisticated detection
     if (response.status === 403) {

--- a/cli-tool/src/index.js
+++ b/cli-tool/src/index.js
@@ -19,6 +19,7 @@ const { runPluginDashboard } = require('./plugin-dashboard');
 const { runSkillDashboard } = require('./skill-dashboard');
 const { trackingService } = require('./tracking-service');
 const { createGlobalAgent, listGlobalAgents, removeGlobalAgent, updateGlobalAgent } = require('./sdk/global-agent-manager');
+const { fetchFromGitHub } = require('./network');
 const SessionSharing = require('./session-sharing');
 const ConversationAnalyzer = require('./analytics/core/ConversationAnalyzer');
 
@@ -517,7 +518,7 @@ async function installIndividualAgent(agentName, targetDir, options) {
     
     console.log(chalk.gray(`📥 Downloading from GitHub (main branch)...`));
     
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     if (!response.ok) {
       if (response.status === 404) {
         console.log(chalk.red(`❌ Agent "${agentName}" not found`));
@@ -582,7 +583,7 @@ async function installIndividualCommand(commandName, targetDir, options) {
     
     console.log(chalk.gray(`📥 Downloading from GitHub (main branch)...`));
     
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     if (!response.ok) {
       if (response.status === 404) {
         console.log(chalk.red(`❌ Command "${commandName}" not found`));
@@ -648,7 +649,7 @@ async function installIndividualMCP(mcpName, targetDir, options) {
     
     console.log(chalk.gray(`📥 Downloading from GitHub (main branch)...`));
     
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     if (!response.ok) {
       if (response.status === 404) {
         console.log(chalk.red(`❌ MCP "${mcpName}" not found`));
@@ -734,7 +735,7 @@ async function installIndividualSetting(settingName, targetDir, options) {
     
     console.log(chalk.gray(`📥 Downloading from GitHub (main branch)...`));
     
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     if (!response.ok) {
       if (response.status === 404) {
         console.log(chalk.red(`❌ Setting "${settingName}" not found`));
@@ -761,7 +762,7 @@ async function installIndividualSetting(settingName, targetDir, options) {
       
       try {
         console.log(chalk.gray(`📥 Downloading Python script: ${pythonFileName}...`));
-        const pythonResponse = await fetch(pythonUrl);
+        const pythonResponse = await fetchFromGitHub(pythonUrl);
         if (pythonResponse.ok) {
           const pythonContent = await pythonResponse.text();
           additionalFiles['.claude/scripts/' + pythonFileName] = {
@@ -1067,7 +1068,7 @@ async function installIndividualHook(hookName, targetDir, options) {
     
     console.log(chalk.gray(`📥 Downloading from GitHub (main branch)...`));
     
-    const response = await fetch(githubUrl);
+    const response = await fetchFromGitHub(githubUrl);
     if (!response.ok) {
       if (response.status === 404) {
         console.log(chalk.red(`❌ Hook "${hookName}" not found`));
@@ -1092,7 +1093,7 @@ async function installIndividualHook(hookName, targetDir, options) {
 
     try {
       console.log(chalk.gray(`📥 Checking for additional Python script...`));
-      const pythonResponse = await fetch(pythonUrl);
+      const pythonResponse = await fetchFromGitHub(pythonUrl);
       if (pythonResponse.ok) {
         const pythonContent = await pythonResponse.text();
         additionalFiles[`.claude/hooks/${hookBaseName}.py`] = {
@@ -1110,7 +1111,7 @@ async function installIndividualHook(hookName, targetDir, options) {
 
     try {
       console.log(chalk.gray(`📥 Checking for additional bash script...`));
-      const bashResponse = await fetch(bashUrl);
+      const bashResponse = await fetchFromGitHub(bashUrl);
       if (bashResponse.ok) {
         const bashContent = await bashResponse.text();
         additionalFiles[`.claude/hooks/${hookBaseName}.sh`] = {
@@ -1432,7 +1433,7 @@ async function getAvailableAgentsFromGitHub() {
     // Fallback to aitmpl.com API if local file not found
     try {
       // Try aitmpl.com API first
-      const apiResponse = await fetch('https://aitmpl.com/api/agents.json');
+      const apiResponse = await fetchFromGitHub('https://aitmpl.com/api/agents.json');
       if (apiResponse.ok) {
         const apiData = await apiResponse.json();
         
@@ -1447,7 +1448,7 @@ async function getAvailableAgentsFromGitHub() {
     
     // If aitmpl.com API fails, try GitHub API as secondary fallback
     console.log(chalk.yellow('⚠️  Falling back to GitHub API...'));
-    const response = await fetch('https://api.github.com/repos/davila7/claude-code-templates/contents/cli-tool/components/agents');
+    const response = await fetchFromGitHub('https://api.github.com/repos/davila7/claude-code-templates/contents/cli-tool/components/agents');
     if (!response.ok) {
       // Check for rate limit error
       if (response.status === 403) {
@@ -1491,7 +1492,7 @@ async function getAvailableAgentsFromGitHub() {
       } else if (item.type === 'dir') {
         // Category directory, fetch its contents
         try {
-          const categoryResponse = await fetch(`https://api.github.com/repos/davila7/claude-code-templates/contents/cli-tool/components/agents/${item.name}`);
+          const categoryResponse = await fetchFromGitHub(`https://api.github.com/repos/davila7/claude-code-templates/contents/cli-tool/components/agents/${item.name}`);
           if (categoryResponse.ok) {
             const categoryContents = await categoryResponse.json();
             for (const categoryItem of categoryContents) {
@@ -1543,10 +1544,9 @@ async function installIndividualSkill(skillName, targetDir, options) {
     // Recursive function to download all files and directories
     async function downloadDirectory(apiUrl, relativePath = '') {
       try {
-        const response = await fetch(apiUrl, {
+        const response = await fetchFromGitHub(apiUrl, {
           headers: {
-            'Accept': 'application/vnd.github.v3+json',
-            'User-Agent': 'claude-code-templates'
+            'Accept': 'application/vnd.github.v3+json'
           }
         });
 
@@ -1568,7 +1568,7 @@ async function installIndividualSkill(skillName, targetDir, options) {
           if (item.type === 'file') {
             // Download file
             try {
-              const fileResponse = await fetch(item.download_url);
+              const fileResponse = await fetchFromGitHub(item.download_url);
               if (fileResponse.ok) {
                 const fileContent = await fileResponse.text();
                 const isExecutable = item.name.endsWith('.py') || item.name.endsWith('.sh');
@@ -3192,7 +3192,7 @@ async function executeE2BSandbox(options, targetDir) {
         const baseUrl = 'https://raw.githubusercontent.com/davila7/claude-code-templates/main/cli-tool/components/sandbox/e2b';
         
         // Download launcher script
-        const launcherResponse = await fetch(`${baseUrl}/e2b-launcher.py`);
+        const launcherResponse = await fetchFromGitHub(`${baseUrl}/e2b-launcher.py`);
         if (!launcherResponse.ok) {
           throw new Error(`Failed to download e2b-launcher.py: ${launcherResponse.status} ${launcherResponse.statusText}`);
         }
@@ -3200,7 +3200,7 @@ async function executeE2BSandbox(options, targetDir) {
         await fs.writeFile(path.join(sandboxDir, 'e2b-launcher.py'), launcherContent, { mode: 0o755 });
         
         // Download requirements.txt
-        const requirementsResponse = await fetch(`${baseUrl}/requirements.txt`);
+        const requirementsResponse = await fetchFromGitHub(`${baseUrl}/requirements.txt`);
         if (!requirementsResponse.ok) {
           throw new Error(`Failed to download requirements.txt: ${requirementsResponse.status} ${requirementsResponse.statusText}`);
         }
@@ -3208,7 +3208,7 @@ async function executeE2BSandbox(options, targetDir) {
         await fs.writeFile(path.join(sandboxDir, 'requirements.txt'), requirementsContent);
         
         // Download .env.example
-        const envExampleResponse = await fetch(`${baseUrl}/.env.example`);
+        const envExampleResponse = await fetchFromGitHub(`${baseUrl}/.env.example`);
         if (!envExampleResponse.ok) {
           throw new Error(`Failed to download .env.example: ${envExampleResponse.status} ${envExampleResponse.statusText}`);
         }

--- a/cli-tool/src/network.js
+++ b/cli-tool/src/network.js
@@ -1,0 +1,87 @@
+const chalk = require('chalk');
+
+/**
+ * Fetch from GitHub with proper headers, timeout, and error handling
+ * Provides helpful error messages for common issues like SSL certificate problems
+ * @param {string} url - URL to fetch
+ * @param {Object} options - Additional fetch options
+ * @returns {Promise<Response>} Fetch response
+ */
+async function fetchFromGitHub(url, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000); // 30 second timeout
+  
+  try {
+    const { headers: customHeaders, ...restOptions } = options;
+    const response = await fetch(url, {
+      ...restOptions,
+      headers: {
+        'User-Agent': 'claude-code-templates-cli',
+        ...customHeaders
+      },
+      redirect: 'follow',
+      signal: controller.signal
+    });
+    return response;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    
+    // Provide helpful error messages for common issues
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timed out after 30 seconds. Check your network connection.`);
+    }
+    
+    // Extract the underlying cause for better error messages
+    const cause = error.cause;
+    if (cause) {
+      const causeMessage = cause.message || cause.code || '';
+      
+      // SSL/TLS certificate errors
+      if (causeMessage.includes('unable to get local issuer certificate') ||
+          causeMessage.includes('UNABLE_TO_GET_ISSUER_CERT_LOCALLY') ||
+          causeMessage.includes('certificate') ||
+          causeMessage.includes('SSL') ||
+          causeMessage.includes('TLS')) {
+        throw new Error(
+          `SSL certificate error: ${causeMessage}\n` +
+          chalk.yellow('   This is usually caused by:\n') +
+          chalk.yellow('   • Corporate proxy/firewall intercepting HTTPS\n') +
+          chalk.yellow('   • Outdated Node.js CA certificates\n') +
+          chalk.yellow('   • VPN or network security software\n\n') +
+          chalk.cyan('   Possible fixes:\n') +
+          chalk.cyan('   • Update Node.js: nvm install --lts --reinstall-packages-from=current\n') +
+          chalk.cyan('   • Update CA certs: brew install ca-certificates (macOS)\n') +
+          chalk.cyan('   • Temporary workaround: NODE_TLS_REJECT_UNAUTHORIZED=0 npx claude-code-templates ...')
+        );
+      }
+      
+      // DNS/Network errors
+      if (causeMessage.includes('ENOTFOUND') || causeMessage.includes('EAI_AGAIN')) {
+        throw new Error(
+          `DNS resolution failed: ${causeMessage}\n` +
+          chalk.yellow('   Cannot resolve github.com. Check your internet connection.')
+        );
+      }
+      
+      // Connection errors
+      if (causeMessage.includes('ECONNREFUSED') || causeMessage.includes('ECONNRESET')) {
+        throw new Error(
+          `Connection failed: ${causeMessage}\n` +
+          chalk.yellow('   Unable to connect to GitHub. Check your network or firewall settings.')
+        );
+      }
+      
+      // Generic network error with cause
+      throw new Error(`Network error: ${causeMessage}`);
+    }
+    
+    // Re-throw original error if no cause
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+module.exports = {
+  fetchFromGitHub
+};

--- a/cli-tool/tests/unit/network.test.js
+++ b/cli-tool/tests/unit/network.test.js
@@ -1,0 +1,258 @@
+/**
+ * Unit Tests for network.js
+ * Tests fetchFromGitHub helper with proper error handling
+ */
+
+const { fetchFromGitHub } = require('../../src/network');
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock chalk to avoid ANSI codes in tests
+jest.mock('chalk', () => ({
+  yellow: (str) => str,
+  cyan: (str) => str
+}));
+
+describe('fetchFromGitHub', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('successful requests', () => {
+    it('should return response on successful fetch', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue('content')
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const response = await fetchFromGitHub('https://example.com/file.md');
+
+      expect(response).toBe(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/file.md',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': 'claude-code-templates-cli'
+          }),
+          redirect: 'follow'
+        })
+      );
+    });
+
+    it('should merge custom headers with default User-Agent', async () => {
+      const mockResponse = { ok: true, status: 200 };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchFromGitHub('https://example.com', {
+        headers: { 'Accept': 'application/json' }
+      });
+
+      // Verify User-Agent is present in the call
+      expect(mockFetch).toHaveBeenCalled();
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers['User-Agent']).toBe('claude-code-templates-cli');
+      expect(callArgs[1].headers['Accept']).toBe('application/json');
+    });
+
+    it('should pass through additional fetch options', async () => {
+      const mockResponse = { ok: true, status: 200 };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchFromGitHub('https://example.com', {
+        method: 'POST',
+        body: JSON.stringify({ test: true })
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ test: true })
+        })
+      );
+    });
+  });
+
+  describe('SSL certificate errors', () => {
+    it('should provide helpful message for "unable to get local issuer certificate"', async () => {
+      const sslError = new Error('fetch failed');
+      sslError.cause = { message: 'unable to get local issuer certificate' };
+      mockFetch.mockRejectedValue(sslError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/SSL certificate error/);
+    });
+
+    it('should provide helpful message for UNABLE_TO_GET_ISSUER_CERT_LOCALLY', async () => {
+      const sslError = new Error('fetch failed');
+      sslError.cause = { code: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY' };
+      mockFetch.mockRejectedValue(sslError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/SSL certificate error/);
+    });
+
+    it('should include troubleshooting suggestions for SSL errors', async () => {
+      const sslError = new Error('fetch failed');
+      sslError.cause = { message: 'certificate has expired' };
+      mockFetch.mockRejectedValue(sslError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/Corporate proxy|Outdated Node.js|VPN/);
+    });
+
+    it('should include fix suggestions for SSL errors', async () => {
+      const sslError = new Error('fetch failed');
+      sslError.cause = { message: 'SSL routines' };
+      mockFetch.mockRejectedValue(sslError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/nvm install|brew install|NODE_TLS_REJECT_UNAUTHORIZED/);
+    });
+  });
+
+  describe('DNS errors', () => {
+    it('should provide helpful message for ENOTFOUND', async () => {
+      const dnsError = new Error('fetch failed');
+      dnsError.cause = { code: 'ENOTFOUND' };
+      mockFetch.mockRejectedValue(dnsError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/DNS resolution failed/);
+    });
+
+    it('should provide helpful message for EAI_AGAIN', async () => {
+      const dnsError = new Error('fetch failed');
+      dnsError.cause = { message: 'EAI_AGAIN' };
+      mockFetch.mockRejectedValue(dnsError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/DNS resolution failed/);
+    });
+
+    it('should suggest checking internet connection for DNS errors', async () => {
+      const dnsError = new Error('fetch failed');
+      dnsError.cause = { code: 'ENOTFOUND' };
+      mockFetch.mockRejectedValue(dnsError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/Check your internet connection/);
+    });
+  });
+
+  describe('connection errors', () => {
+    it('should provide helpful message for ECONNREFUSED', async () => {
+      const connError = new Error('fetch failed');
+      connError.cause = { code: 'ECONNREFUSED' };
+      mockFetch.mockRejectedValue(connError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/Connection failed/);
+    });
+
+    it('should provide helpful message for ECONNRESET', async () => {
+      const connError = new Error('fetch failed');
+      connError.cause = { message: 'ECONNRESET' };
+      mockFetch.mockRejectedValue(connError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/Connection failed/);
+    });
+
+    it('should suggest checking firewall for connection errors', async () => {
+      const connError = new Error('fetch failed');
+      connError.cause = { code: 'ECONNREFUSED' };
+      mockFetch.mockRejectedValue(connError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/firewall/);
+    });
+  });
+
+  describe('timeout handling', () => {
+    it('should set up AbortController with signal', async () => {
+      const mockResponse = { ok: true, status: 200 };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchFromGitHub('https://github.com/test');
+
+      // Verify AbortSignal was passed to fetch
+      expect(mockFetch).toHaveBeenCalled();
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].signal).toBeDefined();
+      expect(callArgs[1].signal.constructor.name).toBe('AbortSignal');
+    });
+
+    it('should provide helpful message for timeout/abort', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValue(abortError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/timed out after 30 seconds/);
+    });
+  });
+
+  describe('generic errors', () => {
+    it('should wrap unknown errors with cause in Network error', async () => {
+      const unknownError = new Error('fetch failed');
+      unknownError.cause = { message: 'some unknown network issue' };
+      mockFetch.mockRejectedValue(unknownError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow(/Network error: some unknown network issue/);
+    });
+
+    it('should re-throw errors without cause as-is', async () => {
+      const plainError = new Error('plain error');
+      mockFetch.mockRejectedValue(plainError);
+
+      await expect(fetchFromGitHub('https://github.com/test'))
+        .rejects
+        .toThrow('plain error');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should clear timeout on successful response', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const mockResponse = { ok: true, status: 200 };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetchFromGitHub('https://example.com');
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should clear timeout on error', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const error = new Error('test error');
+      mockFetch.mockRejectedValue(error);
+
+      await expect(fetchFromGitHub('https://example.com')).rejects.toThrow();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `fetchFromGitHub` helper with proper User-Agent header, timeout handling, and detailed error messages
- Replace generic "fetch failed" with actionable guidance for common network issues:
  - SSL certificate errors (corporate proxy, outdated CA certs, VPN)
  - DNS resolution failures
  - Connection refused/reset errors
  - Request timeouts

Fixes #135

## Problem

Users experiencing SSL certificate issues (common in corporate environments) see only:
```
❌ Error installing agent: fetch failed
```

## Solution

Now users see helpful diagnostics:
```
❌ Error installing agent: SSL certificate error: unable to get local issuer certificate
   This is usually caused by:
   • Corporate proxy/firewall intercepting HTTPS
   • Outdated Node.js CA certificates
   • VPN or network security software

   Possible fixes:
   • Update Node.js: nvm install --lts --reinstall-packages-from=current
   • Update CA certs: brew install ca-certificates (macOS)
   • Temporary workaround: NODE_TLS_REJECT_UNAUTHORIZED=0 npx claude-code-templates ...
```

## Changes

- New `cli-tool/src/network.js` module with `fetchFromGitHub` helper
- Updated `cli-tool/src/index.js` and `cli-tool/src/file-operations.js` to use the helper
- Added 19 unit tests for error handling scenarios

## Test plan

- [x] Unit tests pass (`npm test -- --testPathPatterns="network.test.js"`)
- [x] Manual test with SSL error reproduces helpful message