### PR TITLE
chore: remove unused functions from index.js

### DIFF
--- a/cli-tool/src/index.js
+++ b/cli-tool/src/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 const ora = require('ora');
 const { detectProject } = require('./utils');
 const { getTemplateConfig, TEMPLATES_CONFIG } = require('./templates');
-const { createPrompts, interactivePrompts } = require('./prompts');
+const { interactivePrompts } = require('./prompts');
 const { copyTemplateFiles, runPostInstallationValidation } = require('./file-operations');
 const { getHooksForLanguage, getMCPsForLanguage } = require('./hook-scanner');
 const { installAgents } = require('./agents');
@@ -1366,33 +1366,6 @@ async function installIndividualHook(hookName, targetDir, options) {
     console.log(chalk.red(`❌ Error installing hook: ${error.message}`));
     return 0;
   }
-}
-
-// Helper functions to extract language/framework from agent content
-function extractLanguageFromAgent(content, agentName) {
-  // Try to determine language from agent content or filename
-  if (agentName.includes('react') || content.includes('React')) return 'javascript-typescript';
-  if (agentName.includes('django') || content.includes('Django')) return 'python';
-  if (agentName.includes('fastapi') || content.includes('FastAPI')) return 'python';
-  if (agentName.includes('flask') || content.includes('Flask')) return 'python';
-  if (agentName.includes('rails') || content.includes('Rails')) return 'ruby';
-  if (agentName.includes('api-security') || content.includes('API security')) return 'javascript-typescript';
-  if (agentName.includes('database') || content.includes('database')) return 'javascript-typescript';
-  
-  // Default to javascript-typescript for general agents
-  return 'javascript-typescript';
-}
-
-function extractFrameworkFromAgent(content, agentName) {
-  // Try to determine framework from agent content or filename
-  if (agentName.includes('react') || content.includes('React')) return 'react';
-  if (agentName.includes('django') || content.includes('Django')) return 'django';
-  if (agentName.includes('fastapi') || content.includes('FastAPI')) return 'fastapi';
-  if (agentName.includes('flask') || content.includes('Flask')) return 'flask';
-  if (agentName.includes('rails') || content.includes('Rails')) return 'rails';
-  
-  // For general agents, return none to install the base template
-  return 'none';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `extractLanguageFromAgent` and `extractFrameworkFromAgent` helper functions that were defined but never called
- Remove unused `createPrompts` import

## Test plan
- [x] Verified functions have no callers via grep
- [ ] `npm test` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused helpers (extractLanguageFromAgent, extractFrameworkFromAgent) and the unused createPrompts import from cli-tool/src/index.js to clean up dead code.

<sup>Written for commit d3e7767da2faff2d8e59d71eaf0f0aa0329c7407. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

