### PR TITLE
refactor: extract AgentInstaller module from agents.js

### DIFF
--- a/cli-tool/src/agents/AgentInstaller.js
+++ b/cli-tool/src/agents/AgentInstaller.js
@@ -1,0 +1,127 @@
+/**
+ * AgentInstaller - Handles installation of Claude Code agents
+ * 
+ * Responsible for copying agent files to project's .claude/agents directory
+ * and tracking which agents are already installed.
+ */
+const fs = require('fs-extra');
+const path = require('path');
+const chalk = require('chalk');
+
+/**
+ * Ensure the .claude/agents directory exists
+ * @param {string} projectPath - Project root directory
+ * @returns {Promise<string>} Path to agents directory
+ */
+async function ensureAgentsDirectory(projectPath) {
+  const agentsDir = path.join(projectPath, '.claude', 'agents');
+  await fs.ensureDir(agentsDir);
+  return agentsDir;
+}
+
+/**
+ * Install a single agent to the target directory
+ * @param {Object} agent - Agent object with name, filePath, language, framework
+ * @param {string} agentsDir - Target directory for agent files
+ * @returns {Promise<Object>} Result object with success status
+ */
+async function installSingleAgent(agent, agentsDir) {
+  if (!agent?.filePath) {
+    return { success: false, name: agent?.name, reason: 'not_found' };
+  }
+  
+  if (!await fs.pathExists(agent.filePath)) {
+    return { success: false, name: agent.name, reason: 'source_missing' };
+  }
+  
+  const targetFile = path.join(agentsDir, `${agent.name}.md`);
+  await fs.copy(agent.filePath, targetFile);
+  return { success: true, name: agent.name, agent };
+}
+
+/**
+ * Log installation results to console
+ * @param {Array} results - Array of installation result objects
+ * @returns {boolean} True if at least one agent was installed
+ */
+function logInstallResults(results) {
+  const installed = results.filter(r => r.success);
+  const failed = results.filter(r => !r.success);
+  
+  for (const result of installed) {
+    console.log(chalk.green(`✓ Installed agent: ${result.name} (${result.agent.language}/${result.agent.framework})`));
+  }
+  
+  for (const result of failed) {
+    const msg = result.reason === 'source_missing' 
+      ? `Agent source file not found: ${result.name}`
+      : `Agent not found: ${result.name}`;
+    console.log(chalk.yellow(`⚠️  ${msg}`));
+  }
+  
+  if (installed.length > 0) {
+    console.log(chalk.green(`\n🎉 Successfully installed ${installed.length} agent(s) to .claude/agents/`));
+    console.log(chalk.blue('   You can now use these agents in your Claude Code conversations!'));
+  } else {
+    console.log(chalk.yellow('⚠️  No agents were installed'));
+  }
+  
+  return installed.length > 0;
+}
+
+/**
+ * Install selected agents to the project's .claude/agents directory
+ * @param {Array} selectedAgents - Array of agent names to install
+ * @param {string} projectPath - Project directory path
+ * @param {Function} getAvailableAgentsFn - Function to retrieve available agents
+ * @returns {Promise<boolean>} Success status
+ */
+async function installAgents(selectedAgents, projectPath = process.cwd(), getAvailableAgentsFn) {
+  try {
+    const agentsDir = await ensureAgentsDirectory(projectPath);
+    const allAgents = getAvailableAgentsFn();
+    
+    const results = await Promise.all(
+      selectedAgents.map(name => {
+        const agent = allAgents.find(a => a.name === name);
+        return installSingleAgent(agent, agentsDir);
+      })
+    );
+    
+    return logInstallResults(results);
+  } catch (error) {
+    console.error(chalk.red('❌ Failed to install agents:'), error.message);
+    return false;
+  }
+}
+
+/**
+ * Check if project already has agents installed
+ * @param {string} projectPath - Project directory path
+ * @returns {Promise<Array>} Array of installed agent names
+ */
+async function getInstalledAgents(projectPath = process.cwd()) {
+  try {
+    const agentsDir = path.join(projectPath, '.claude', 'agents');
+    
+    if (!await fs.pathExists(agentsDir)) {
+      return [];
+    }
+    
+    const agentFiles = await fs.readdir(agentsDir);
+    return agentFiles
+      .filter(file => file.endsWith('.md'))
+      .map(file => path.basename(file, '.md'));
+  } catch (error) {
+    return [];
+  }
+}
+
+module.exports = {
+  installAgents,
+  getInstalledAgents,
+  // Expose internals for testing
+  ensureAgentsDirectory,
+  installSingleAgent,
+  logInstallResults
+};

--- a/cli-tool/src/agents/index.js
+++ b/cli-tool/src/agents/index.js
@@ -1,0 +1,18 @@
+/**
+ * Agents module - re-exports all agent-related functionality
+ */
+const {
+  installAgents,
+  getInstalledAgents,
+  ensureAgentsDirectory,
+  installSingleAgent,
+  logInstallResults
+} = require('./AgentInstaller');
+
+module.exports = {
+  installAgents,
+  getInstalledAgents,
+  ensureAgentsDirectory,
+  installSingleAgent,
+  logInstallResults
+};

--- a/cli-tool/tests/AgentInstaller.test.js
+++ b/cli-tool/tests/AgentInstaller.test.js
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for AgentInstaller module
+ */
+const path = require('path');
+
+// Mock fs-extra before requiring the module
+jest.mock('fs-extra', () => ({
+  ensureDir: jest.fn(),
+  pathExists: jest.fn(),
+  copy: jest.fn(),
+  readdir: jest.fn()
+}));
+
+const fs = require('fs-extra');
+const {
+  ensureAgentsDirectory,
+  installSingleAgent,
+  logInstallResults,
+  installAgents,
+  getInstalledAgents
+} = require('../src/agents/AgentInstaller');
+
+describe('AgentInstaller', () => {
+  const mockProjectPath = '/test/project';
+  const mockAgentsDir = path.join(mockProjectPath, '.claude', 'agents');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ensureAgentsDirectory', () => {
+    it('should create .claude/agents directory', async () => {
+      fs.ensureDir.mockResolvedValue();
+
+      const result = await ensureAgentsDirectory(mockProjectPath);
+
+      expect(fs.ensureDir).toHaveBeenCalledWith(mockAgentsDir);
+      expect(result).toBe(mockAgentsDir);
+    });
+
+    it('should propagate errors from fs.ensureDir', async () => {
+      const error = new Error('Permission denied');
+      fs.ensureDir.mockRejectedValue(error);
+
+      await expect(ensureAgentsDirectory(mockProjectPath)).rejects.toThrow('Permission denied');
+    });
+  });
+
+  describe('installSingleAgent', () => {
+    const mockAgent = {
+      name: 'test-agent',
+      filePath: '/templates/test-agent.md',
+      language: 'javascript',
+      framework: 'react'
+    };
+
+    it('should return failure when agent is null', async () => {
+      const result = await installSingleAgent(null, mockAgentsDir);
+
+      expect(result).toEqual({ success: false, name: undefined, reason: 'not_found' });
+    });
+
+    it('should return failure when agent has no filePath', async () => {
+      const result = await installSingleAgent({ name: 'no-path' }, mockAgentsDir);
+
+      expect(result).toEqual({ success: false, name: 'no-path', reason: 'not_found' });
+    });
+
+    it('should return failure when source file does not exist', async () => {
+      fs.pathExists.mockResolvedValue(false);
+
+      const result = await installSingleAgent(mockAgent, mockAgentsDir);
+
+      expect(result).toEqual({ success: false, name: 'test-agent', reason: 'source_missing' });
+    });
+
+    it('should copy agent file and return success', async () => {
+      fs.pathExists.mockResolvedValue(true);
+      fs.copy.mockResolvedValue();
+
+      const result = await installSingleAgent(mockAgent, mockAgentsDir);
+
+      expect(fs.copy).toHaveBeenCalledWith(
+        mockAgent.filePath,
+        path.join(mockAgentsDir, 'test-agent.md')
+      );
+      expect(result).toEqual({ success: true, name: 'test-agent', agent: mockAgent });
+    });
+  });
+
+  describe('logInstallResults', () => {
+    it('should return true when at least one agent installed', () => {
+      const results = [
+        { success: true, name: 'agent1', agent: { language: 'js', framework: 'react' } },
+        { success: false, name: 'agent2', reason: 'not_found' }
+      ];
+
+      const result = logInstallResults(results);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when no agents installed', () => {
+      const results = [
+        { success: false, name: 'agent1', reason: 'not_found' },
+        { success: false, name: 'agent2', reason: 'source_missing' }
+      ];
+
+      const result = logInstallResults(results);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for empty results', () => {
+      const result = logInstallResults([]);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('installAgents', () => {
+    const mockGetAvailableAgents = jest.fn();
+    const mockAgents = [
+      { name: 'agent1', filePath: '/path/agent1.md', language: 'js', framework: 'react' },
+      { name: 'agent2', filePath: '/path/agent2.md', language: 'python', framework: 'django' }
+    ];
+
+    beforeEach(() => {
+      mockGetAvailableAgents.mockReturnValue(mockAgents);
+      fs.ensureDir.mockResolvedValue();
+      fs.pathExists.mockResolvedValue(true);
+      fs.copy.mockResolvedValue();
+    });
+
+    it('should install selected agents', async () => {
+      const result = await installAgents(['agent1'], mockProjectPath, mockGetAvailableAgents);
+
+      expect(fs.ensureDir).toHaveBeenCalledWith(mockAgentsDir);
+      expect(mockGetAvailableAgents).toHaveBeenCalled();
+      expect(fs.copy).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+    });
+
+    it('should install multiple agents in parallel', async () => {
+      const result = await installAgents(['agent1', 'agent2'], mockProjectPath, mockGetAvailableAgents);
+
+      expect(fs.copy).toHaveBeenCalledTimes(2);
+      expect(result).toBe(true);
+    });
+
+    it('should handle agent not found in available agents', async () => {
+      const result = await installAgents(['nonexistent'], mockProjectPath, mockGetAvailableAgents);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false on error', async () => {
+      fs.ensureDir.mockRejectedValue(new Error('Failed'));
+
+      const result = await installAgents(['agent1'], mockProjectPath, mockGetAvailableAgents);
+
+      expect(result).toBe(false);
+    });
+
+    it('should use process.cwd() as default project path', async () => {
+      const originalCwd = process.cwd;
+      process.cwd = jest.fn().mockReturnValue('/default/path');
+
+      await installAgents(['agent1'], undefined, mockGetAvailableAgents);
+
+      expect(fs.ensureDir).toHaveBeenCalledWith(
+        path.join('/default/path', '.claude', 'agents')
+      );
+
+      process.cwd = originalCwd;
+    });
+  });
+
+  describe('getInstalledAgents', () => {
+    it('should return empty array when agents directory does not exist', async () => {
+      fs.pathExists.mockResolvedValue(false);
+
+      const result = await getInstalledAgents(mockProjectPath);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return list of installed agent names', async () => {
+      fs.pathExists.mockResolvedValue(true);
+      fs.readdir.mockResolvedValue(['agent1.md', 'agent2.md', 'readme.txt']);
+
+      const result = await getInstalledAgents(mockProjectPath);
+
+      expect(result).toEqual(['agent1', 'agent2']);
+    });
+
+    it('should filter out non-.md files', async () => {
+      fs.pathExists.mockResolvedValue(true);
+      fs.readdir.mockResolvedValue(['agent.md', 'config.json', 'notes.txt']);
+
+      const result = await getInstalledAgents(mockProjectPath);
+
+      expect(result).toEqual(['agent']);
+    });
+
+    it('should return empty array on error', async () => {
+      fs.pathExists.mockResolvedValue(true);
+      fs.readdir.mockRejectedValue(new Error('Read error'));
+
+      const result = await getInstalledAgents(mockProjectPath);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should use process.cwd() as default project path', async () => {
+      const originalCwd = process.cwd;
+      process.cwd = jest.fn().mockReturnValue('/default/path');
+      fs.pathExists.mockResolvedValue(false);
+
+      await getInstalledAgents();
+
+      expect(fs.pathExists).toHaveBeenCalledWith(
+        path.join('/default/path', '.claude', 'agents')
+      );
+
+      process.cwd = originalCwd;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract agent installation logic into dedicated `AgentInstaller` module for better testability and separation of concerns
- Add comprehensive unit tests covering all installation scenarios (19 tests)
- Use dependency injection pattern to decouple from `getAvailableAgents` function

## Test plan

- [x] All 19 AgentInstaller unit tests pass
- [ ] Manual test: `npx claude-code-templates@latest --agent frontend-developer` installs correctly
- [ ] Verify existing agent installation flows work unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted agent install logic into a dedicated AgentInstaller module for clearer separation and easier testing. agents.js now delegates to this module; CLI behavior is unchanged.

- **Refactors**
  - Added src/agents/AgentInstaller.js with installAgents, getInstalledAgents, ensureAgentsDirectory, installSingleAgent, and result logging.
  - agents.js now calls the module and injects getAvailableAgents for decoupling.
  - Added src/agents/index.js to re-export agent APIs from a single entry point.
  - Added 19 unit tests covering success, missing sources, not found, and directory setup.

<sup>Written for commit 7a9b5626b686c3f2930142fcec4fc6728ccd4a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

