### PR TITLE
fix: shorten MCP server names to avoid 64-char API limit

### DIFF
--- a/cli-tool/components/mcps/browser_automation/mcp-server-playwright.json
+++ b/cli-tool/components/mcps/browser_automation/mcp-server-playwright.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "automatalabs-playwright-server": {
+    "playwright-server": {
       "description": "A Model Context Protocol server that provides browser automation capabilities using Playwright",
       "command": "npx",
       "args": ["-y", "@automatalabs/mcp-server-playwright"]

--- a/cli-tool/components/mcps/browser_automation/playwright-mcp-server.json
+++ b/cli-tool/components/mcps/browser_automation/playwright-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "executeautomation-playwright-server": {
+    "ea-playwright-server": {
       "description": "A Model Context Protocol server that provides browser automation capabilities using Playwright. This server enables LLMs to interact with web pages, take screenshots, generate test code, web scraps the page and execute JavaScript in a real browser environment.",
       "command": "npx",
       "args": ["-y", "@executeautomation/playwright-mcp-server"]

--- a/cli-tool/components/mcps/browser_automation/playwright-mcp.json
+++ b/cli-tool/components/mcps/browser_automation/playwright-mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "playwright-server": {
+    "pw": {
       "description": "A Model Context Protocol (MCP) server that provides browser automation capabilities using Playwright. This server enables LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models.",
       "command": "npx",
       "args": [


### PR DESCRIPTION
## Summary

- Fixes #318 - MCP server name 'playwright-server' causes tool names to exceed 64-char API limit
- Shortened server keys in three Playwright MCP files to prevent overflow when bundled in plugins

## Changes

| File | Before | After |
|------|--------|-------|
| playwright-mcp.json | `playwright-server` | `pw` |
| playwright-mcp-server.json | `executeautomation-playwright-server` | `ea-playwright-server` |
| mcp-server-playwright.json | `automatalabs-playwright-server` | `playwright-server` |

## Test plan

- [ ] Install `testing-suite` plugin and verify Playwright MCP tools work without API errors
- [x] Verify tool names are under 64 characters: `mcp__plugin_testing-suite_pw__browser_console_messages` (55 chars)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened Playwright MCP server keys so generated tool names stay under the 64‑char API limit when loaded via plugins. Fixes #318 with no behavior changes.

- **Bug Fixes**
  - playwright-mcp.json: playwright-server → pw
  - playwright-mcp-server.json: executeautomation-playwright-server → ea-playwright-server
  - mcp-server-playwright.json: automatalabs-playwright-server → playwright-server

<sup>Written for commit 55154122e5472df1db5f60128c16732c00dde708. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

