### PR TITLE
feat: reorganize footer into columns and update year

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -968,7 +968,7 @@ body {
     background: var(--bg-secondary);
     border-top: 1px solid var(--border-primary);
     color: var(--text-secondary);
-    padding: 2rem 0 3rem 0;
+    padding: 2.5rem 0 3rem 0;
     margin-top: 2rem;
 }
 
@@ -980,23 +980,13 @@ body {
     gap: 2rem;
 }
 
-.footer-left {
+.footer-brand {
     flex: 1;
     min-width: 300px;
 }
 
-.footer-right {
-    flex: 1;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    margin-right: 4rem; /* Space to avoid cart button overlap */
-}
-
 .footer-ascii {
-    margin-bottom: 0.5rem;
+    margin-bottom: 1rem;
 }
 
 .footer-ascii-art {
@@ -1018,20 +1008,32 @@ body {
 
 .footer-copyright {
     color: var(--text-secondary);
-    font-size: 0.875rem;
+    font-size: 0.8rem;
     margin: 0;
 }
 
-.footer-links {
+.footer-columns {
     display: flex;
-    gap: 1.5rem;
-    justify-content: center;
+    gap: 3rem;
+    margin-right: 4rem;
+}
+
+.footer-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.footer-column-title {
+    color: var(--text-primary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0 0 0.25rem 0;
 }
 
 .footer-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
     color: var(--text-secondary);
     text-decoration: none;
     font-size: 0.875rem;
@@ -1040,10 +1042,6 @@ body {
 
 .footer-link:hover {
     color: var(--text-primary);
-}
-
-.footer-link svg {
-    flex-shrink: 0;
 }
 
 /* Loading and error states */
@@ -1223,17 +1221,22 @@ body {
         text-align: center;
         gap: 1.5rem;
     }
-    
-    .footer-left {
+
+    .footer-brand {
         min-width: unset;
         text-align: center;
     }
-    
-    .footer-right {
-        text-align: center;
-        align-items: center;
+
+    .footer-columns {
+        justify-content: center;
+        margin-right: 0;
+        gap: 2rem;
     }
-    
+
+    .footer-column {
+        text-align: left;
+    }
+
     .footer-ascii-art {
         font-size: 6px;
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -509,51 +509,35 @@
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
-                <div class="footer-left">
+                <div class="footer-brand">
                     <div class="footer-ascii">
-                        <pre class="footer-ascii-art"> █████╗ ██╗████████╗███╗   ███╗██████╗ ██╗     
-██╔══██╗██║╚══██╔══╝████╗ ████║██╔══██╗██║     
-███████║██║   ██║   ██╔████╔██║██████╔╝██║     
-██╔══██║██║   ██║   ██║╚██╔╝██║██╔═══╝ ██║     
+                        <pre class="footer-ascii-art"> █████╗ ██╗████████╗███╗   ███╗██████╗ ██╗
+██╔══██╗██║╚══██╔══╝████╗ ████║██╔══██╗██║
+███████║██║   ██║   ██╔████╔██║██████╔╝██║
+██╔══██║██║   ██║   ██║╚██╔╝██║██╔═══╝ ██║
 ██║  ██║██║   ██║   ██║ ╚═╝ ██║██║     ███████╗
 ╚═╝  ╚═╝╚═╝   ╚═╝   ╚═╝     ╚═╝╚═╝     ╚══════╝</pre>
                         <p class="footer-tagline">Supercharge Anthropic's Claude Code</p>
                     </div>
+                    <p class="footer-copyright">&copy; 2026 Claude Code Templates. Open source project.</p>
                 </div>
-                
-                <div class="footer-right">
-                    <p class="footer-copyright">&copy; 2025 Claude Code Templates. Open source project.</p>
-                    <div class="footer-links">
-                        <a href="trending.html" class="footer-link">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M16,6L18.29,8.29L13.41,13.17L9.41,9.17L2,16.59L3.41,18L9.41,12L13.41,16L19.71,9.71L22,12V6H16Z"/>
-                            </svg>
-                            Trending
-                        </a>
-                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
-                            </svg>
-                            Documentation
-                        </a>
-                        <a href="https://www.anthropic.com/claude-code?ref=aitmpl.com" target="_blank" class="footer-link">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-                            </svg>
-                            Claude Code
-                        </a>
-                        <a href="https://discord.gg/dyTTwzBhwY" target="_blank" class="footer-link">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-                            </svg>
-                            Discord
-                        </a>
-                        <a href="https://github.com/davila7/claude-code-templates" target="_blank" class="footer-link">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.30 3.297-1.30.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                            </svg>
-                            GitHub
-                        </a>
+
+                <div class="footer-columns">
+                    <div class="footer-column">
+                        <h4 class="footer-column-title">Product</h4>
+                        <a href="trending.html" class="footer-link">Trending</a>
+                        <a href="blog/" class="footer-link">Blog</a>
+                        <a href="https://www.anthropic.com/claude-code?ref=aitmpl.com" target="_blank" class="footer-link">Claude Code</a>
+                    </div>
+                    <div class="footer-column">
+                        <h4 class="footer-column-title">Community</h4>
+                        <a href="https://discord.gg/dyTTwzBhwY" target="_blank" class="footer-link">Discord</a>
+                        <a href="https://github.com/davila7/claude-code-templates" target="_blank" class="footer-link">GitHub</a>
+                    </div>
+                    <div class="footer-column">
+                        <h4 class="footer-column-title">Resources</h4>
+                        <a href="https://docs.aitmpl.com/" target="_blank" class="footer-link">Documentation</a>
+                        <a href="https://www.npmjs.com/package/claude-code-templates" target="_blank" class="footer-link">npm Package</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Restructure footer from flat link list into 3 categorized columns: **Product**, **Community**, **Resources**
- Update copyright year from 2025 to 2026
- Add new links: **Blog** and **npm Package**
- Remove inline SVG icons (column titles provide sufficient context)
- Clean up CSS with new `.footer-brand`, `.footer-columns`, `.footer-column` classes

## Test plan
- [ ] Verify footer renders correctly on desktop (3 columns next to ASCII brand)
- [ ] Verify footer stacks properly on mobile (< 768px)
- [ ] Verify all links work (Blog, npm, Discord, GitHub, Docs, Trending, Claude Code)
- [ ] Verify Catppuccin theme colors are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized the footer into three labeled columns and updated the copyright year to 2026. Added Blog and npm Package links and improved responsive layout.

- **New Features**
  - Three columns: Product, Community, Resources.
  - Added links: Blog and npm Package.

- **Refactors**
  - Removed inline SVG icons from links.
  - Introduced .footer-brand, .footer-columns, .footer-column, .footer-column-title; updated spacing.
  - Improved mobile layout: centered brand, stacked columns, reduced gaps.

<sup>Written for commit 737c1c6f2fed80553809597d984ddf192c649c89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

