### PR TITLE
docs(hooks/debug-window): description

### DIFF
--- a/cli-tool/components/hooks/development-tools/debug-window.json
+++ b/cli-tool/components/hooks/development-tools/debug-window.json
@@ -1,5 +1,5 @@
 {
-  "description": "Auto Debug Log Viewer. Opens a live-tailing debug log window when Claude Code starts with --debug or -d flag. The window closes automatically on session end. To keep the debug window open after session ends, set DEBUG_WINDOW_AUTO_CLOSE_DISABLE=1 in your settings.json. Tested on Intel Mac. Supports macOS, Linux, and Windows (Git Bash/Cygwin). Contributions from other platform users are welcome.",
+  "description": "Auto Debug Log Viewer. Opens a live-tailing debug log window when Claude Code starts with --debug or -d flag. The window closes automatically on session end. To keep the debug window open after the session ends, set the DEBUG_WINDOW_AUTO_CLOSE_DISABLE=1 environment variable in the env property of your settings.json. Supports macOS, Linux, and Windows (Git Bash/Cygwin). If you encounter any issues, please report them at https://github.com/davila7/claude-code-templates/issues",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Updated the debug window description to clarify the environment variable setting and added a link for issue reporting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified how to keep the debug window open after a session by setting the DEBUG_WINDOW_AUTO_CLOSE_DISABLE=1 environment variable in the env property of settings.json. Added a link for reporting issues.

<sup>Written for commit efecae79bba22ebcf0a32409d9792b6a0adf5150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

