### PR TITLE
Remove GLM Z.AI partnership banner from main website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,6 @@
     <link rel="icon" type="image/png" sizes="512x512" href="static/favicon/android-chrome-512x512.png">
 
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="css/partnership-banner.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -152,19 +151,6 @@
             </div>
         </div>
     </header>
-
-    <!-- Partnership Banner - GLM Z.AI -->
-    <section class="partnership-banner" id="partnershipBanner">
-        <a href="https://z.ai/subscribe?ic=8JVLJQFSKB&utm_source=aitmpl.com&utm_medium=banner&utm_campaign=partnership"
-           target="_blank"
-           rel="noopener noreferrer"
-           id="partnershipPrimaryCTA"
-           style="display: block; position: relative;">
-            <img src="static/img/image.png"
-                 alt="GLM Coding Plan - Get 10% OFF"
-                 style="width: 100%; height: auto; display: block;" />
-        </a>
-    </section>
 
     <main class="terminal">
         <section class="stats-section">
@@ -717,6 +703,5 @@
     <script src="js/modal-helpers.js"></script>
     <script src="js/generate-search-data.js"></script>
     <script src="js/search-functionality.js"></script>
-    <script src="js/partnership-banner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Remove the banner section, its CSS stylesheet link, and JS script
reference from docs/index.html.

https://claude.ai/code/session_01FWLru1iJV8gcmsf5r8mt2k

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the GLM Z.AI partnership banner from the homepage to clean up the UI and stop loading unused assets. Deleted the banner section and its CSS/JS references in docs/index.html.

<sup>Written for commit 9f2e4438b24b514a260f1c5ea051facdce56c2fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

