### PR TITLE
Add Telegram PR webhook for automated notifications

### DIFF
--- a/.claude/hooks/telegram-pr-webhook.py
+++ b/.claude/hooks/telegram-pr-webhook.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Telegram PR Webhook Hook
+Sends a Telegram notification when a new PR is created via `gh pr create`.
+Includes the PR URL and the Vercel preview URL.
+
+Required environment variables:
+  TELEGRAM_BOT_TOKEN  - Bot token from @BotFather
+  TELEGRAM_CHAT_ID    - Chat ID for notifications
+
+Optional environment variables:
+  VERCEL_PROJECT_NAME - Vercel project name (for preview URL)
+  VERCEL_TEAM_SLUG    - Vercel team slug (for preview URL)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.parse
+
+
+def get_input():
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def extract_pr_url(text):
+    """Extract GitHub PR URL from command output."""
+    match = re.search(r"https://github\.com/[^\s]+/pull/\d+", text)
+    return match.group(0) if match else None
+
+
+def get_branch_name():
+    """Get the current git branch name."""
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+
+def build_vercel_preview_url(branch):
+    """Build Vercel preview URL from branch name and env vars."""
+    project = os.environ.get("VERCEL_PROJECT_NAME", "")
+    team = os.environ.get("VERCEL_TEAM_SLUG", "")
+
+    if not project or not team:
+        return None
+
+    # Vercel slugifies branch names: lowercase, replace non-alphanumeric with -
+    slug = re.sub(r"[^a-z0-9]+", "-", branch.lower()).strip("-")
+    return f"https://{project}-git-{slug}-{team}.vercel.app"
+
+
+def send_telegram(message):
+    """Send a message via Telegram Bot API."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+
+    if not token or not chat_id:
+        print(
+            "Telegram notification skipped: "
+            "Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID",
+            file=sys.stderr,
+        )
+        return False
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode(
+        {"chat_id": chat_id, "text": message, "parse_mode": "HTML"}
+    ).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(url, data=data, method="POST")
+        urllib.request.urlopen(req, timeout=10)
+        return True
+    except Exception as e:
+        print(f"Failed to send Telegram notification: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    input_data = get_input()
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only act on gh pr create commands
+    if tool_name != "Bash" or "gh pr create" not in command:
+        sys.exit(0)
+
+    # Extract PR URL from tool response
+    tool_response = input_data.get("tool_response", "")
+    if isinstance(tool_response, dict):
+        tool_response = tool_response.get("stdout", "") or json.dumps(tool_response)
+
+    pr_url = extract_pr_url(str(tool_response))
+    if not pr_url:
+        # No PR URL found — the command may have failed
+        sys.exit(0)
+
+    # Build Vercel preview URL
+    branch = get_branch_name()
+    vercel_url = build_vercel_preview_url(branch) if branch else None
+
+    # Compose Telegram message
+    lines = [
+        "<b>New Pull Request Created</b>",
+        "",
+        f"<b>PR:</b> <a href=\"{pr_url}\">{pr_url}</a>",
+    ]
+
+    if vercel_url:
+        lines.append(f"<b>Preview:</b> <a href=\"{vercel_url}\">{vercel_url}</a>")
+    else:
+        lines.append(
+            "<b>Preview:</b> Check the PR checks tab for the Vercel deployment URL"
+        )
+
+    if branch:
+        lines.append(f"<b>Branch:</b> <code>{branch}</code>")
+
+    message = "\n".join(lines)
+    send_telegram(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/telegram-pr-webhook.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 
 # Claude Code local settings (may contain API keys)
 **/settings.local.json
-.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/telegram-pr-webhook.py
 .claude/commands/opsx/
 .claude/skills/
 

--- a/cli-tool/components/hooks/automation/telegram-pr-webhook.json
+++ b/cli-tool/components/hooks/automation/telegram-pr-webhook.json
@@ -1,0 +1,17 @@
+{
+  "description": "Send Telegram notification when a new PR is created via gh pr create. Includes PR URL and Vercel preview URL. Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID environment variables. Optionally set VERCEL_PROJECT_NAME and VERCEL_TEAM_SLUG to construct the Vercel preview URL automatically.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/telegram-pr-webhook.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli-tool/components/hooks/automation/telegram-pr-webhook.py
+++ b/cli-tool/components/hooks/automation/telegram-pr-webhook.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Telegram PR Webhook Hook
+Sends a Telegram notification when a new PR is created via `gh pr create`.
+Includes the PR URL and the Vercel preview URL.
+
+Required environment variables:
+  TELEGRAM_BOT_TOKEN  - Bot token from @BotFather
+  TELEGRAM_CHAT_ID    - Chat ID for notifications
+
+Optional environment variables:
+  VERCEL_PROJECT_NAME - Vercel project name (for preview URL)
+  VERCEL_TEAM_SLUG    - Vercel team slug (for preview URL)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.parse
+
+
+def get_input():
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def extract_pr_url(text):
+    """Extract GitHub PR URL from command output."""
+    match = re.search(r"https://github\.com/[^\s]+/pull/\d+", text)
+    return match.group(0) if match else None
+
+
+def get_branch_name():
+    """Get the current git branch name."""
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+
+def build_vercel_preview_url(branch):
+    """Build Vercel preview URL from branch name and env vars."""
+    project = os.environ.get("VERCEL_PROJECT_NAME", "")
+    team = os.environ.get("VERCEL_TEAM_SLUG", "")
+
+    if not project or not team:
+        return None
+
+    # Vercel slugifies branch names: lowercase, replace non-alphanumeric with -
+    slug = re.sub(r"[^a-z0-9]+", "-", branch.lower()).strip("-")
+    return f"https://{project}-git-{slug}-{team}.vercel.app"
+
+
+def send_telegram(message):
+    """Send a message via Telegram Bot API."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+
+    if not token or not chat_id:
+        print(
+            "Telegram notification skipped: "
+            "Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID",
+            file=sys.stderr,
+        )
+        return False
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode(
+        {"chat_id": chat_id, "text": message, "parse_mode": "HTML"}
+    ).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(url, data=data, method="POST")
+        urllib.request.urlopen(req, timeout=10)
+        return True
+    except Exception as e:
+        print(f"Failed to send Telegram notification: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    input_data = get_input()
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    # Only act on gh pr create commands
+    if tool_name != "Bash" or "gh pr create" not in command:
+        sys.exit(0)
+
+    # Extract PR URL from tool response
+    tool_response = input_data.get("tool_response", "")
+    if isinstance(tool_response, dict):
+        tool_response = tool_response.get("stdout", "") or json.dumps(tool_response)
+
+    pr_url = extract_pr_url(str(tool_response))
+    if not pr_url:
+        # No PR URL found — the command may have failed
+        sys.exit(0)
+
+    # Build Vercel preview URL
+    branch = get_branch_name()
+    vercel_url = build_vercel_preview_url(branch) if branch else None
+
+    # Compose Telegram message
+    lines = [
+        "<b>New Pull Request Created</b>",
+        "",
+        f"<b>PR:</b> <a href=\"{pr_url}\">{pr_url}</a>",
+    ]
+
+    if vercel_url:
+        lines.append(f"<b>Preview:</b> <a href=\"{vercel_url}\">{vercel_url}</a>")
+    else:
+        lines.append(
+            "<b>Preview:</b> Check the PR checks tab for the Vercel deployment URL"
+        )
+
+    if branch:
+        lines.append(f"<b>Branch:</b> <code>{branch}</code>")
+
+    message = "\n".join(lines)
+    send_telegram(message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a Telegram webhook integration that automatically sends notifications to Telegram when a new pull request is created via `gh pr create`. The notification includes the PR URL and optionally a Vercel preview deployment URL.

## Changes
- **New webhook script** (`.claude/hooks/telegram-pr-webhook.py`): Python script that intercepts `gh pr create` commands and sends formatted Telegram messages with:
  - PR URL extracted from command output
  - Vercel preview URL (auto-generated from branch name if `VERCEL_PROJECT_NAME` and `VERCEL_TEAM_SLUG` are set)
  - Current branch name
  
- **Hook configuration** (`.claude/settings.json`): Registers the webhook as a `PostToolUse` hook for Bash commands with a 30-second timeout

- **CLI tool component** (`cli-tool/components/hooks/automation/`): Added reusable hook component with documentation for distribution

- **Updated .gitignore**: Modified to allow the telegram-pr-webhook.py file while still ignoring other hook files

## Implementation Details
- Uses Python's standard library (`urllib`, `json`, `subprocess`, `re`) with no external dependencies
- Gracefully handles missing environment variables with informative error messages
- Vercel URL slug generation matches Vercel's branch name slugification rules (lowercase, alphanumeric + hyphens)
- Telegram messages use HTML formatting for better readability with bold text and clickable links
- Only triggers on successful PR creation (validates PR URL extraction)

## Required Configuration
Set these environment variables:
- `TELEGRAM_BOT_TOKEN` - Bot token from @BotFather
- `TELEGRAM_CHAT_ID` - Target chat ID for notifications

Optional:
- `VERCEL_PROJECT_NAME` - For automatic preview URL generation
- `VERCEL_TEAM_SLUG` - For automatic preview URL generation

https://claude.ai/code/session_013aBUK67VEy9Q2MaUGUVRJQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Telegram webhook that posts notifications after successful gh pr create. Messages include the PR URL, branch, and an optional Vercel preview link.

- **New Features**
  - Python hook sends Telegram messages with PR URL, branch, and optional Vercel preview.
  - Registered as a PostToolUse Bash hook in .claude/settings.json (30s timeout); triggers only on successful gh pr create.
  - Reusable component added under cli-tool/components/hooks/automation (script + JSON).
  - .gitignore updated to track the hook script.

- **Migration**
  - Required: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID.
  - Optional: VERCEL_PROJECT_NAME, VERCEL_TEAM_SLUG for automatic preview URL.

<sup>Written for commit ab45b66946dfcb3117049a49ee05809d3d89369d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

