### PR TITLE
Add Vouch trust management system for PR gating

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,16 +1,17 @@
-# Vouched contributors for claude-code-templates
+# Trust list for claude-code-templates
 #
-# Only vouched users can contribute to this project.
-# Denounced users are explicitly blocked.
+# This project uses permissive mode (require-vouch=false):
+# everyone can open PRs EXCEPT denounced users.
 #
-# Maintainers can vouch for new contributors by commenting "vouch" on
-# an issue by the author. Maintainers can denounce users by commenting
-# "denounce" or "denounce @username" on an issue or PR.
+# Maintainers can denounce bad actors by commenting on any issue:
+#   denounce @username <reason>
+#
+# To unblock someone:
+#   unvouch @username
 #
 # Syntax:
 #  - One handle per line (without @). Sorted alphabetically.
-#  - Optionally specify platform: `platform:username` (e.g., `github:user`).
-#  - To denounce a user, prefix with minus: `-username` or `-platform:username`.
+#  - Denounce a user with minus prefix: `-username` or `-platform:username`.
 #  - Optionally, add details after a space following the handle.
 #
 # See https://github.com/mitchellh/vouch for the full specification.

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,18 @@
+# Vouched contributors for claude-code-templates
+#
+# Only vouched users can contribute to this project.
+# Denounced users are explicitly blocked.
+#
+# Maintainers can vouch for new contributors by commenting "vouch" on
+# an issue by the author. Maintainers can denounce users by commenting
+# "denounce" or "denounce @username" on an issue or PR.
+#
+# Syntax:
+#  - One handle per line (without @). Sorted alphabetically.
+#  - Optionally specify platform: `platform:username` (e.g., `github:user`).
+#  - To denounce a user, prefix with minus: `-username` or `-platform:username`.
+#  - Optionally, add details after a space following the handle.
+#
+# See https://github.com/mitchellh/vouch for the full specification.
+
+davila7

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,27 @@
+name: Vouch - Check PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@main
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: mitchellh/vouch/action/check-pr@main
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          require-vouch: false
           auto-close: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-discussion.yml
+++ b/.github/workflows/vouch-manage-by-discussion.yml
@@ -1,0 +1,26 @@
+name: Vouch - Manage by Discussion
+
+on:
+  discussion_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-discussion@main
+        with:
+          discussion-number: ${{ github.event.discussion.number }}
+          comment-node-id: ${{ github.event.comment.node_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,27 @@
+name: Vouch - Manage by Issue
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-issue@main
+        with:
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/evaluations/vouch-integration-evaluation.md
+++ b/evaluations/vouch-integration-evaluation.md
@@ -31,18 +31,24 @@ No Nushell dependency is needed at the project level -- the GitHub Actions handl
 
 | File | Purpose |
 |------|---------|
-| `.github/VOUCHED.td` | Trust list with project owner (davila7) as initial vouched user |
-| `.github/workflows/vouch-check-pr.yml` | Auto-checks PR authors on open/reopen; closes PRs from unvouched/denounced users |
+| `.github/VOUCHED.td` | Trust list (blocklist mode: only denounced users are blocked) |
+| `.github/workflows/vouch-check-pr.yml` | Auto-checks PR authors on open/reopen; closes PRs from denounced users only (`require-vouch: false`) |
 | `.github/workflows/vouch-manage-by-issue.yml` | Lets collaborators vouch/denounce/unvouch via issue comments |
 | `.github/workflows/vouch-manage-by-discussion.yml` | Same as above but via GitHub Discussions |
 
+### Mode: Permissive (Blocklist)
+
+The integration uses `require-vouch: false`, which means **everyone can open PRs** except explicitly denounced users. This is the most permissive mode -- vouch acts as a blocklist rather than an allowlist.
+
+To switch to strict mode (only vouched users can contribute), set `require-vouch: true` in `vouch-check-pr.yml`.
+
 ### How It Works
 
-1. **PR opens** -> `vouch-check-pr` checks if the author is in `VOUCHED.td`
+1. **PR opens** -> `vouch-check-pr` checks if the author is denounced in `VOUCHED.td`
    - Bots and collaborators with write access are auto-allowed
-   - Vouched users pass
-   - Unvouched/denounced users get their PR auto-closed with a message
-   - `/recheck` comment re-triggers the check (useful after vouching someone)
+   - Denounced users get their PR auto-closed with a message
+   - Everyone else passes through (permissive mode)
+   - `/recheck` comment re-triggers the check
 
 2. **Collaborator comments `vouch` on an issue** -> `vouch-manage-by-issue` adds the issue author to `VOUCHED.td`
    - `vouch @user` vouches a specific user

--- a/evaluations/vouch-integration-evaluation.md
+++ b/evaluations/vouch-integration-evaluation.md
@@ -1,0 +1,57 @@
+# Evaluation: mitchellh/vouch for Claude Code Templates
+
+**Repository:** https://github.com/mitchellh/vouch
+**Author:** Mitchell Hashimoto (creator of Terraform, Vagrant, Ghostty)
+**License:** MIT
+**Date:** 2026-02-08
+
+## What is Vouch?
+
+A project trust management system. Maintainers explicitly **vouch** for contributors before they can interact with a project, and can **denounce** bad actors. The trust list is a flat `.td` file (Trustdown format) that can be parsed with standard tools.
+
+Key features:
+- Flat-file trust list (`VOUCHED.td`) with simple syntax
+- Web of trust across projects (shared vouch/denounce lists)
+- GitHub Actions for automated PR gating (check-pr, manage-by-issue, manage-by-discussion)
+- CLI for local management (add, check, denounce, remove)
+- Used in production by [Ghostty](https://github.com/ghostty-org/ghostty)
+
+## Compatibility Assessment
+
+### Blockers for Direct Migration
+
+| Issue | Severity | Details |
+|-------|----------|---------|
+| **Nushell dependency** | Critical | The entire CLI and library is written in Nushell (`.nu` files). Claude Code Templates components use Bash, Python, or Node.js. Nushell is not standard in most dev environments. |
+| **Not a Claude Code tool** | High | Vouch is a standalone project governance system, not designed to enhance Claude Code workflows. |
+| **GitHub Actions focus** | High | Primary integration is through GitHub Actions composite actions, which operate at CI/CD level, not developer CLI level. |
+| **Custom file format** | Medium | `.td` (Trustdown) format requires Nushell's `from td`/`to td` commands for structured parsing. |
+
+### What Could Be Adapted
+
+Despite the direct migration being impractical, we could create **inspired components** that help Claude Code users work with vouch-enabled repositories:
+
+| Component Type | Idea | Feasibility |
+|----------------|------|-------------|
+| **Agent** | Vouch-aware code reviewer that reads `VOUCHED.td` and understands the trust model | High |
+| **Command** | `/vouch-check <username>` using `gh` CLI and simple file parsing | High |
+| **Hook** | Pre-tool hook that warns when working on PRs from unvouched contributors | Medium |
+| **Setting** | Configuration for vouch-enabled repos (env vars, permissions) | Medium |
+
+## Verdict
+
+**Not recommended for direct migration.** The vouch project is well-designed but fundamentally incompatible with Claude Code Templates for these reasons:
+
+1. **Runtime mismatch** - Nushell vs Bash/Python/Node.js ecosystem
+2. **Wrong integration layer** - GitHub Actions (CI/CD) vs Claude Code (developer CLI)
+3. **Self-contained system** - Vouch works independently; wrapping it adds complexity without clear value over using the GitHub Actions directly
+
+### Alternative Recommendation
+
+If the goal is to bring trust management awareness to Claude Code, we could create **new, original components** inspired by vouch's concepts:
+
+1. A **command** (`/vouch-check`) that parses `VOUCHED.td` using bash/grep (the format is simple enough: one username per line, `-` prefix for denounced)
+2. An **agent** that understands the vouch model and helps maintainers manage their trust lists
+3. A **hook** that reads `VOUCHED.td` before PR operations and adds context about contributor trust status
+
+These would be original Claude Code Templates components that understand the vouch ecosystem, rather than a port of the Nushell tooling.


### PR DESCRIPTION
## Summary

Integrate [mitchellh/vouch](https://github.com/mitchellh/vouch) — a project trust management system — to gate contributions and manage bad actors. This adds automated PR checks and maintainer-friendly commands for vouching/denouncing contributors.

## Changes

- **`.github/VOUCHED.td`** — Trust list in Trustdown format. Uses permissive mode (`require-vouch: false`): everyone can open PRs except explicitly denounced users. Maintainers can manage the list via issue/discussion comments.

- **`.github/workflows/vouch-check-pr.yml`** — Auto-checks PR authors when PRs open/reopen. Closes PRs from denounced users; allows everyone else. Supports `/recheck` comment to re-trigger.

- **`.github/workflows/vouch-manage-by-issue.yml`** — Lets collaborators manage the trust list via issue comments:
  - `vouch @user [reason]` — add to trust list
  - `denounce @user [reason]` — block a user
  - `unvouch @user` — remove from list

- **`.github/workflows/vouch-manage-by-discussion.yml`** — Same management commands via GitHub Discussions.

- **`evaluations/vouch-integration-evaluation.md`** — Decision document explaining why vouch was chosen, how it works, and future extensibility (web of trust across projects).

## Implementation Details

- **Mode:** Permissive blocklist (not allowlist). Can be switched to strict mode by setting `require-vouch: true` in the PR check workflow.
- **No external dependencies:** GitHub Actions handle everything; no Nushell or CLI tooling required at the project level.
- **Auto-commit:** All trust list changes are committed automatically by the GitHub Actions bot.
- **Future-proof:** Vouch supports importing trust lists from other projects, enabling a web of trust across the ecosystem.

## Why Vouch?

- Simple, flat-file trust list (easy to audit and version control)
- Used in production by [Ghostty](https://github.com/ghostty-org/ghostty)
- Created by Mitchell Hashimoto (Terraform, Vagrant)
- Designed for exactly this use case: low-friction contribution with maintainer control over bad actors

https://claude.ai/code/session_01S1axwbckAwCzDuawKEogZE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Vouch-based trust management to gate PRs in permissive blocklist mode. PRs from denounced users auto-close; maintainers manage trust via simple issue/discussion comments.

- **New Features**
  - Trust list at .github/VOUCHED.td; only denounced users are blocked.
  - PR check workflow (on open/reopen and via “/recheck”) using mitchellh/vouch; auto-closes PRs from denounced users.
  - Issue/Discussion workflows to manage trust with “vouch @user [reason]”, “denounce @user [reason]”, and “unvouch @user”; changes are auto-committed.
  - Added evaluation doc explaining the approach.

- **Migration**
  - No local setup needed; GitHub Actions handle checks and list updates.
  - To switch to strict allowlist mode, set require-vouch: true in .github/workflows/vouch-check-pr.yml.

<sup>Written for commit ac292075ce01baaa7ccbecf0b73bd9ab70514a8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

