### PR TITLE
Remove Z.AI partnership from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![npm downloads](https://img.shields.io/npm/dt/claude-code-templates.svg)](https://www.npmjs.com/package/claude-code-templates)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Sponsored by Z.AI](https://img.shields.io/badge/Sponsored%20by-Z.AI-2563eb?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMiAyMkgyMkwxMiAyWiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+)](https://z.ai/subscribe?ic=8JVLJQFSKB&utm_source=github&utm_medium=badge&utm_campaign=readme)
 [![Neon Open Source Program](https://img.shields.io/badge/Neon-Open%20Source%20Program-00E599?style=flat)](https://get.neon.com/4eCjZDz)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?style=flat&logo=buy-me-a-coffee)](https://buymeacoffee.com/daniavila)
 [![GitHub stars](https://img.shields.io/github/stars/davila7/claude-code-templates.svg?style=social&label=Star)](https://github.com/davila7/claude-code-templates)


### PR DESCRIPTION
Remove the Z.AI sponsored badge and the entire Partnership section
including the GLM Coding Plan promotion.

https://claude.ai/code/session_015Z97CJXk1nhT9QDp9CBAGL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Z.AI Partnership section from the README, including the GLM Coding Plan promotion, to keep documentation vendor-neutral and free of ads.

<sup>Written for commit 301ab64585120c4faedd140b2c61eeb207ce49e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

