### PR TITLE
chore(cli-tool): bump version to 1.28.16

### DIFF
--- a/cli-tool/package-lock.json
+++ b/cli-tool/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-templates",
-  "version": "1.28.13",
+  "version": "1.28.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-templates",
-      "version": "1.28.13",
+      "version": "1.28.16",
       "license": "MIT",
       "dependencies": {
         "boxen": "^5.1.2",

--- a/cli-tool/package.json
+++ b/cli-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-templates",
-  "version": "1.28.13",
+  "version": "1.28.16",
   "description": "CLI tool to setup Claude Code configurations with framework-specific commands, automation hooks and MCP Servers for your projects",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
fixes #348 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the CLI to v1.28.16 to prepare the next patch release. Updates package.json and package-lock.json to address #348.

<sup>Written for commit 55b8c382abc412180f2c30c07644c5b2b5d01892. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

