### PR TITLE
feat: add desktop notification hook on Stop event

### DIFF
--- a/cli-tool/components/hooks/monitoring/desktop-notification-on-stop.json
+++ b/cli-tool/components/hooks/monitoring/desktop-notification-on-stop.json
@@ -1,0 +1,16 @@
+{
+  "description": "Sends a native desktop notification when Claude Code finishes responding. Uses the Stop hook event so you get a single notification per response instead of one per tool call (which is very noisy with PostToolUse). Supports macOS (osascript) and Linux (notify-send). Useful when you switch to another window while Claude works — you'll get a notification when it's ready for your input.",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Response complete\" with title \"Claude Code\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Claude Code' 'Response complete'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new **monitoring hook** that sends a native desktop notification when Claude Code finishes responding
- Uses the `Stop` hook event instead of `PostToolUse` — this sends a **single notification per response** instead of one per tool call, which is significantly less noisy
- Supports **macOS** (`osascript`) and **Linux** (`notify-send`)

## Why Stop instead of PostToolUse?

Using `PostToolUse` with a `*` matcher fires a notification on every single tool use (Read, Edit, Bash, Grep, etc.). A typical response can trigger 5-20+ tool calls, flooding the user with notifications. The `Stop` event fires exactly once when Claude finishes its full response, which is the moment the user actually needs to know.

## File added

- `cli-tool/components/hooks/monitoring/desktop-notification-on-stop.json`

## Test plan

- [ ] On macOS: verify `osascript` notification appears when Claude finishes responding
- [ ] On Linux: verify `notify-send` notification appears when Claude finishes responding
- [ ] Confirm only one notification per response (not per tool call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a monitoring hook that sends a desktop notification when Claude Code finishes responding. Uses the Stop event so you get one notification per response instead of many per tool call.

- **New Features**
  - Area: components (cli-tool/components/)
  - New component: hooks/monitoring/desktop-notification-on-stop.json — regenerate docs/components.json
  - Supports macOS (osascript) and Linux (notify-send)
  - No new environment variables or secrets

<sup>Written for commit 96112aa44708805ee9fcf2fb4e8cbaf9b502243a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

