### PR TITLE
fix: Add thread_name for forum channel in community help bot

### DIFF
--- a/.github/workflows/daily-community-help-discord.yml
+++ b/.github/workflows/daily-community-help-discord.yml
@@ -336,7 +336,7 @@ jobs:
 
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Build payload
+          # Build payload (thread_name required for forum channels)
           PAYLOAD=$(jq -n \
             --arg emoji "$EMOJI" \
             --arg title "$TITLE" \
@@ -348,6 +348,7 @@ jobs:
             '{
               username: "Claude Code Templates",
               avatar_url: "https://aitmpl.com/img/logo.png",
+              thread_name: ($emoji + " " + $title),
               content: ($emoji + " **Community Help** — Learn something new today!"),
               embeds: [
                 {


### PR DESCRIPTION
## Summary

- Discord forum channels require `thread_name` in webhook payloads — the community help bot was failing with HTTP 400 (`Webhooks posted to forum channels must have a thread_name or thread_id`)
- Added `thread_name` using the question title so each daily post creates a new forum thread

## Test plan

- [ ] Trigger `Daily Community Help` workflow manually and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Discord Community Help workflow to work with forum channels by sending a thread_name derived from the question title. This prevents HTTP 400 errors and creates a new thread for each post.

- **Bug Fixes**
  - Updated .github/workflows/daily-community-help-discord.yml to adjust the webhook payload for forum channels.
  - Area: CI (GitHub Actions). No new components; no docs/components.json changes. No new environment variables or secrets.

<sup>Written for commit 4eb3c179b79177311fc19b2adf8888a42e91c9c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

