### PR TITLE
Add Claudebin to Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **📚 Documentation**: [docs.aitmpl.com](https://docs.aitmpl.com)
 - **💬 Community**: [GitHub Discussions](https://github.com/davila7/claude-code-templates/discussions)
 - **🐛 Issues**: [GitHub Issues](https://github.com/davila7/claude-code-templates/issues)
+- **📤 Session Sharing**: [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions
 
 ## Stargazers over time
 [![Stargazers over time](https://starchart.cc/davila7/claude-code-templates.svg?variant=adaptive)](https://starchart.cc/davila7/claude-code-templates)


### PR DESCRIPTION
Adding [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - a minimalistic tool for publishing and sharing Claude coding sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Claudebin to the README Links section to give users a simple way to publish and share Claude coding sessions.

- **Documentation**
  - Area: website (docs/)
  - Change: Add Claudebin link (with GitHub) under “Session Sharing”
  - New components: None; no docs/components.json regeneration
  - Env vars/secrets: None

<sup>Written for commit cfe8b9dd3d43d17bfdc3cbf4d09f9195eb6bbcc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

