### PR TITLE
fix: dangerous-command-blocker hook points to wrong script path

### DIFF
--- a/cli-tool/components/hooks/security/dangerous-command-blocker.json
+++ b/cli-tool/components/hooks/security/dangerous-command-blocker.json
@@ -3,7 +3,7 @@
   "supportingFiles": [
     {
       "source": "dangerous-command-blocker.py",
-      "destination": ".claude/scripts/dangerous-command-blocker.py",
+      "destination": ".claude/hooks/dangerous-command-blocker.py",
       "executable": true
     }
   ],
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/scripts/dangerous-command-blocker.py 2>&1"
+            "command": "python3 .claude/hooks/dangerous-command-blocker.py"
           }
         ]
       }


### PR DESCRIPTION
## Summary

The `dangerous-command-blocker` hook config references `.claude/scripts/dangerous-command-blocker.py`, but the installer (`installIndividualHook` in `index.js`, line ~1125) places companion Python scripts in `.claude/hooks/`. This path mismatch means the hook silently fails at runtime with a "file not found" error, rendering it non-functional.

This was introduced in PR #281 which moved from inline Python to a dedicated script file. The `supportingFiles.destination` field was set to `.claude/scripts/`, but the installer doesn't read that field -- it hardcodes `.claude/hooks/` for all companion scripts.

## Changes

- Updated `supportingFiles.destination` from `.claude/scripts/` to `.claude/hooks/` to match the installer's actual behavior
- Updated `command` path from `.claude/scripts/` to `.claude/hooks/`
- Removed `2>&1` stderr redirect that was masking the underlying error (the hook runner reads stderr for diagnostics, so redirecting it to stdout hid the "file not found" message and produced a confusing "No stderr output" error instead)

## Testing

- Verified that `installIndividualHook` in `index.js` hardcodes `.claude/hooks/` as the destination for Python scripts (line ~1125)
- Verified that `supportingFiles` is not consumed by the hook installer (only used in the skill dashboard UI)
- Confirmed no other hooks in the repo have this mismatch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dangerous-command-blocker hook by pointing to the correct script path so it actually runs. Also removes a stderr redirect that hid useful error messages.

- **Area**: components (cli-tool/components/)
- Updated script path from .claude/scripts to .claude/hooks in supportingFiles and command
- Removed "2>&1" stderr redirect so hook runner surfaces real errors
- Why: wrong path caused "file not found" and silent failure; redirect masked diagnostics
- No new components. No catalog regeneration needed. No new env vars or secrets.

<sup>Written for commit 5d65f21a132dc0ac9305bd4b8e61057dd402053a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

