### PR TITLE
Add FootballBin predictions MCP and skill

### DIFF
--- a/cli-tool/components/mcps/integration/footballbin-predictions.json
+++ b/cli-tool/components/mcps/integration/footballbin-predictions.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "footballbin-predictions": {
+      "description": "AI-powered football match predictions for Premier League and Champions League. Returns half-time scores, full-time scores, next goal scorer, corner counts, and key player analysis. Public endpoint, no API key required.",
+      "url": "https://ru7m5svay1.execute-api.eu-central-1.amazonaws.com/prod/mcp"
+    }
+  }
+}

--- a/cli-tool/components/skills/sports/footballbin-predictions/SKILL.md
+++ b/cli-tool/components/skills/sports/footballbin-predictions/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: footballbin-predictions
+description: Get AI-powered match predictions for Premier League and Champions League including scores, next goal, and corners.
+homepage: https://apps.apple.com/app/footballbin/id6757111871
+metadata: {"clawdbot":{"emoji":"⚽","requires":{"bins":["curl","jq"]},"files":["scripts/*"]}}
+---
+
+# FootballBin Match Predictions
+
+Get AI-powered predictions for Premier League and Champions League matches via the FootballBin MCP API.
+
+## Quick Start
+
+Run `scripts/footballbin.sh` with the following commands:
+
+### Get current matchweek predictions
+```bash
+scripts/footballbin.sh predictions premier_league
+scripts/footballbin.sh predictions champions_league
+```
+
+### Get specific matchweek
+```bash
+scripts/footballbin.sh predictions premier_league 27
+```
+
+### Filter by team
+```bash
+scripts/footballbin.sh predictions premier_league --home arsenal
+scripts/footballbin.sh predictions premier_league --away liverpool
+scripts/footballbin.sh predictions premier_league --home chelsea --away wolves
+```
+
+### List available tools
+```bash
+scripts/footballbin.sh tools
+```
+
+## Supported Leagues
+
+| Input | League |
+|-------|--------|
+| `premier_league`, `epl`, `pl`, `prem` | Premier League |
+| `champions_league`, `ucl`, `cl` | Champions League |
+
+## Supported Team Aliases
+
+Common aliases work: `united` (Man Utd), `city` (Man City), `spurs` (Tottenham), `wolves` (Wolverhampton), `gunners` (Arsenal), `reds` (Liverpool), `blues` (Chelsea), `villa` (Aston Villa), `forest` (Nottingham Forest), `palace` (Crystal Palace), `barca` (Barcelona), `real` (Real Madrid), `bayern` (Bayern Munich), `psg` (PSG), `juve` (Juventus), `inter` (Inter Milan), `bvb` (Dortmund), `atleti` (Atletico Madrid).
+
+## Response Data
+
+Each match prediction includes:
+- **Half-time score** (e.g., "1:0")
+- **Full-time score** (e.g., "2:1")
+- **Next goal scorer** (e.g., "Home,Salah")
+- **Corner count** (e.g., "7:4")
+- **Key players** with form-based reasoning
+
+## External Endpoints
+
+| URL | Data Sent | Purpose |
+|-----|-----------|---------|
+| `https://ru7m5svay1.execute-api.eu-central-1.amazonaws.com/prod/mcp` | League, matchweek, team filters | Fetch match predictions |
+
+## Security & Privacy
+
+- No API key required (public endpoint, rate-limited)
+- No user data collected or stored
+- Read-only: only fetches prediction data
+- No secrets or environment variables needed
+
+## Links
+
+- iOS App: https://apps.apple.com/app/footballbin/id6757111871
+- Android App: https://play.google.com/store/apps/details?id=com.achan.footballbinandroid

--- a/cli-tool/components/skills/sports/footballbin-predictions/scripts/footballbin.sh
+++ b/cli-tool/components/skills/sports/footballbin-predictions/scripts/footballbin.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Security Manifest:
+#   Environment variables: none
+#   External endpoints: https://ru7m5svay1.execute-api.eu-central-1.amazonaws.com/prod/mcp
+#   Local files accessed: none
+#   Data sent: league name, matchweek number, team name filters (no PII)
+
+MCP_ENDPOINT="https://ru7m5svay1.execute-api.eu-central-1.amazonaws.com/prod/mcp"
+
+usage() {
+    cat <<'EOF'
+Usage: footballbin.sh <command> [options]
+
+Commands:
+  tools                              List available MCP tools
+  predictions <league> [matchweek]   Get match predictions
+
+Options for predictions:
+  --home <team>    Filter by home team
+  --away <team>    Filter by away team
+
+Examples:
+  footballbin.sh predictions premier_league
+  footballbin.sh predictions epl 27
+  footballbin.sh predictions premier_league --home arsenal
+  footballbin.sh predictions ucl --away barcelona
+
+Leagues: premier_league, epl, pl, prem, champions_league, ucl, cl
+EOF
+    exit 1
+}
+
+# Call the MCP endpoint with a JSON-RPC payload
+mcp_call() {
+    local payload="$1"
+    curl -s -X POST "$MCP_ENDPOINT" \
+        -H "Content-Type: application/json" \
+        -d "$payload"
+}
+
+# List available tools
+cmd_tools() {
+    local payload='{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+    local response
+    response=$(mcp_call "$payload")
+
+    if command -v jq &>/dev/null; then
+        echo "$response" | jq '.result.tools[] | {name, description}'
+    else
+        echo "$response"
+    fi
+}
+
+# Get match predictions
+cmd_predictions() {
+    local league=""
+    local matchweek=""
+    local home_team=""
+    local away_team=""
+
+    # Parse arguments
+    if [[ $# -lt 1 ]]; then
+        echo "Error: league is required" >&2
+        usage
+    fi
+
+    league="$1"
+    shift
+
+    # Check if next arg is a matchweek number
+    if [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; then
+        matchweek="$1"
+        shift
+    fi
+
+    # Parse optional flags
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --home)
+                shift
+                home_team="${1:-}"
+                shift
+                ;;
+            --away)
+                shift
+                away_team="${1:-}"
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage
+                ;;
+        esac
+    done
+
+    # Build arguments JSON
+    local args
+    args="{\"league\":\"$league\""
+    if [[ -n "$matchweek" ]]; then
+        args="$args,\"matchweek\":$matchweek"
+    fi
+    if [[ -n "$home_team" ]]; then
+        args="$args,\"home_team\":\"$home_team\""
+    fi
+    if [[ -n "$away_team" ]]; then
+        args="$args,\"away_team\":\"$away_team\""
+    fi
+    args="$args}"
+
+    local payload="{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"get_match_predictions\",\"arguments\":$args}}"
+
+    local response
+    response=$(mcp_call "$payload")
+
+    if command -v jq &>/dev/null; then
+        # Check for errors
+        local is_error
+        is_error=$(echo "$response" | jq -r '.result.isError // false')
+        if [[ "$is_error" == "true" ]]; then
+            echo "Error: $(echo "$response" | jq -r '.result.content[0].text')" >&2
+            exit 1
+        fi
+
+        # Format output
+        echo "$response" | jq -r '
+            .result.structuredContent |
+            "League: \(.league) | Matchweek: \(.matchweek) | Matches: \(.count)",
+            "",
+            (.matches[] |
+                "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+                "\(.home_team) vs \(.away_team)",
+                "Kickoff: \(.kickoff_formatted) (\(.status))",
+                (.predictions[] | "  \(.type): \(.value)"),
+                (.key_players[] | "  Key: \(.player_name) - \(.reason)"),
+                ""
+            ),
+            "Download FootballBin: \(.ios_link)",
+            "Android: \(.android_link)"
+        '
+    else
+        echo "$response"
+    fi
+}
+
+# Main dispatch
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+command="$1"
+shift
+
+case "$command" in
+    tools)
+        cmd_tools
+        ;;
+    predictions)
+        cmd_predictions "$@"
+        ;;
+    *)
+        echo "Unknown command: $command" >&2
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds **FootballBin Predictions MCP** (`mcps/integration/footballbin-predictions.json`) — remote MCP endpoint for AI-powered football match predictions
- Adds **FootballBin Predictions Skill** (`skills/sports/footballbin-predictions/`) — bash wrapper with team filtering, formatted output, and league aliases
- Creates new `sports` skill category

## What it does
Returns AI predictions for Premier League and Champions League matches:
- Half-time and full-time scores
- Next goal scorer
- Corner count predictions
- Key player analysis with current season stats

## Details
- **Public endpoint** — no API key or authentication needed
- **Read-only** — only fetches prediction data, no user data collected
- Supports league aliases (`epl`, `ucl`, `pl`, `cl`, etc.) and team aliases (`gunners`, `spurs`, `reds`, etc.)
- Requires only `curl` (and optionally `jq` for formatted output)

## Test plan
- [ ] `npx claude-code-templates@latest --mcp integration/footballbin-predictions --dry-run`
- [ ] `npx claude-code-templates@latest --skill sports/footballbin-predictions --dry-run`
- [ ] Run `scripts/footballbin.sh predictions premier_league` to verify endpoint responds
- [ ] Run `scripts/footballbin.sh tools` to list available MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FootballBin Predictions MCP and a new CLI skill to fetch Premier League and Champions League match predictions with simple team filters and formatted output. This enables easy, read-only access to scores, next goal, corners, and key player insights.

- **Area**: components (cli-tool/components/)
- Added MCP config: mcps/integration/footballbin-predictions.json; new skill: skills/sports/footballbin-predictions/ (SKILL.md + scripts/footballbin.sh)
- Created new skill category: sports
- No environment variables or secrets; public endpoint; requires curl (jq optional)
- New components added — regenerate catalog (docs/components.json)

<sup>Written for commit 9f1e06499e4d0f7efc7bf20a99764ff86cac6895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

