### PR TITLE
feat: Add AI Maestro skill suite (6 skills for multi-agent orchestration)

### DIFF
--- a/cli-tool/components/skills/ai-maestro/agent-management/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/agent-management/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: agent-management
+description: Create, manage, and orchestrate AI agents using the AI Maestro CLI. Use when the user asks to "create agent", "list agents", "delete agent", "hibernate agent", "wake agent", "install plugin", "show agent", "restart agent", or any agent lifecycle management task.
+---
+
+# AI Maestro Agent Management
+
+Create, manage, and orchestrate multiple AI agents through a unified CLI. Handles the full agent lifecycle: create, hibernate, wake, rename, export/import, and plugin management. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## Prerequisites
+
+Requires [AI Maestro](https://github.com/23blocks-OS/ai-maestro) running locally with tmux 3.0+.
+
+```bash
+# Install the CLI
+git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
+cd ai-maestro-plugins && ./install-agent-cli.sh
+```
+
+## Core Commands
+
+### Agent Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `aimaestro-agent.sh list` | List all agents with status |
+| `aimaestro-agent.sh show <agent>` | Detailed agent information |
+| `aimaestro-agent.sh create <name> --dir <path>` | Create new agent |
+| `aimaestro-agent.sh update <agent> --task "..."` | Update task/tags |
+| `aimaestro-agent.sh delete <agent> --confirm` | Delete agent |
+| `aimaestro-agent.sh rename <old> <new>` | Rename agent |
+| `aimaestro-agent.sh hibernate <agent>` | Save state, free resources |
+| `aimaestro-agent.sh wake <agent>` | Resume hibernated agent |
+| `aimaestro-agent.sh restart <agent>` | Hibernate then wake |
+
+### Plugin Management
+
+| Command | Description |
+|---------|-------------|
+| `aimaestro-agent.sh plugin install <agent> <plugin>` | Install plugin |
+| `aimaestro-agent.sh plugin uninstall <agent> <plugin>` | Remove plugin |
+| `aimaestro-agent.sh plugin list <agent>` | List installed plugins |
+| `aimaestro-agent.sh plugin marketplace add <agent> <source>` | Add marketplace |
+
+### Export/Import
+
+| Command | Description |
+|---------|-------------|
+| `aimaestro-agent.sh export <agent>` | Export agent config |
+| `aimaestro-agent.sh import <file>` | Import agent from file |
+
+## Usage Examples
+
+```bash
+# Create a backend API agent
+aimaestro-agent.sh create backend-api \
+  --dir ~/projects/backend \
+  --task "Build REST API with TypeScript" \
+  --tags "api,typescript"
+
+# End of day -- save resources
+aimaestro-agent.sh hibernate frontend-ui
+aimaestro-agent.sh hibernate data-processor
+
+# Resume next morning
+aimaestro-agent.sh wake frontend-ui --attach
+
+# Install a plugin on an agent
+aimaestro-agent.sh plugin install backend-api my-plugin
+
+# Backup before risky changes
+aimaestro-agent.sh export backend-api -o backup.json
+```
+
+## Agent Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `online` | Running in tmux session |
+| `offline` | Registered but no active session |
+| `hibernated` | Saved state, session killed |
+
+## Full AI Maestro Experience
+
+This skill is part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform, which provides **6 skills** for AI agent orchestration: messaging, memory, docs, graph, planning, and agent management.

--- a/cli-tool/components/skills/ai-maestro/agent-messaging/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/agent-messaging/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: agent-messaging
+description: Send and receive cryptographically signed messages between AI agents using the Agent Messaging Protocol (AMP). Use when the user asks to "send a message to an agent", "check agent inbox", "message another agent", "reply to a message", "notify an agent", or any inter-agent communication task.
+---
+
+# Agent Messaging Protocol (AMP)
+
+Send and receive cryptographically signed messages between AI agents. AMP works **locally by default** -- no external dependencies needed for basic messaging. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## Prerequisites
+
+Install the AMP CLI scripts:
+```bash
+# From the AI Maestro plugin
+git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
+cd ai-maestro-plugins && ./install-messaging.sh -y
+```
+
+Scripts install to `~/.local/bin/` (ensure it's in your PATH).
+
+## Quick Start
+
+### 1. Initialize identity (first time)
+```bash
+amp-init --auto
+```
+
+### 2. Send a message
+```bash
+amp-send alice "Hello" "How are you?"
+```
+
+### 3. Check inbox
+```bash
+amp-inbox
+```
+
+### 4. Read a message
+```bash
+amp-read <message-id>
+```
+
+### 5. Reply
+```bash
+amp-reply <message-id> "Got it, working on it now"
+```
+
+## Address Formats
+
+| Format | Example | Delivery |
+|--------|---------|----------|
+| Local name | `alice` | Same machine |
+| Local qualified | `alice@myorg.aimaestro.local` | Within mesh |
+| External | `alice@acme.crabmail.ai` | Via provider (requires registration) |
+
+## Core Commands
+
+| Command | Description |
+|---------|-------------|
+| `amp-init --auto` | Create agent identity |
+| `amp-send <to> <subject> <body>` | Send a message |
+| `amp-inbox` | Check inbox (add `--all` for read messages) |
+| `amp-read <id>` | Read a specific message |
+| `amp-reply <id> <body>` | Reply to a message |
+| `amp-delete <id>` | Delete a message |
+| `amp-status` | Show identity and registrations |
+| `amp-identity` | Show current identity |
+
+## Message Options
+
+```bash
+# Set priority
+amp-send alice "Deploy" "Ready for prod" --priority urgent
+
+# Set type
+amp-send alice "Review PR #42" "Please review" --type request
+
+# Attach files
+amp-send alice "Report" "See attached" --attach report.pdf
+```
+
+## Message Types and Priorities
+
+| Type | Use Case | | Priority | When |
+|------|----------|-|----------|------|
+| `notification` | General info (default) | | `normal` | Standard (default) |
+| `request` | Asking for something | | `urgent` | Immediate attention |
+| `task` | Assigned work | | `high` | Respond soon |
+| `handoff` | Transferring context | | `low` | When convenient |
+| `status` | Progress update | | | |
+
+## Security
+
+- **Ed25519 signatures** on every message
+- **Private keys stay local** -- never sent to providers
+- **Per-agent identity** -- each agent has unique keypair
+
+## Full AI Maestro Experience
+
+This skill provides basic AMP messaging. For the complete experience including **federation with external providers**, **push notifications**, **attachment scanning**, and **5 more skills** (memory search, docs search, graph query, planning, agent management), install the full [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform.
+
+Protocol spec: [agentmessaging.org](https://agentmessaging.org)

--- a/cli-tool/components/skills/ai-maestro/docs-search/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/docs-search/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: docs-search
+description: Search auto-generated codebase documentation for function signatures, API docs, class definitions, and code comments. Use when the user asks to "search docs", "find documentation", "look up a function", "check the API", or before implementing changes to verify correct signatures and patterns.
+---
+
+# AI Maestro Documentation Search
+
+Search your codebase's auto-generated documentation for function signatures, class definitions, API docs, and code comments. Verify correct patterns before writing code. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## Prerequisites
+
+Requires [AI Maestro](https://github.com/23blocks-OS/ai-maestro) running locally with documentation indexed.
+
+```bash
+# Install doc tools
+git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
+cd ai-maestro-plugins && ./install-doc-tools.sh
+```
+
+## Core Behavior
+
+Before implementing any code changes, search docs first:
+
+```
+Receive instruction -> Search docs -> Then implement
+```
+
+## Commands
+
+### Search
+| Command | Description |
+|---------|-------------|
+| `docs-search.sh <query>` | Semantic documentation search |
+| `docs-search.sh --keyword <term>` | Exact keyword matching |
+| `docs-find-by-type.sh <type>` | Find by type (function, class, module) |
+| `docs-get.sh <doc-id>` | Get full document content |
+
+### Index
+| Command | Description |
+|---------|-------------|
+| `docs-index.sh [path]` | Full index from project |
+| `docs-index-delta.sh [path]` | Delta index (new/modified files only) |
+| `docs-list.sh` | List all indexed documents |
+| `docs-stats.sh` | Index statistics |
+
+## Document Types
+
+| Type | Sources |
+|------|---------|
+| `function` | JSDoc, RDoc, docstrings |
+| `class` | Class-level comments |
+| `module` | Module/namespace comments |
+| `interface` | TypeScript interfaces |
+| `component` | React/Vue component comments |
+| `readme` | README files |
+| `guide` | docs/ folder content |
+
+## Usage Examples
+
+```bash
+# Semantic search
+docs-search.sh "authentication flow"
+
+# Keyword search for specific identifier
+docs-search.sh --keyword "UserController"
+
+# Find all class documentation
+docs-find-by-type.sh class
+
+# Get full document details
+docs-get.sh doc-abc123
+
+# Index your codebase (first time)
+docs-index.sh /path/to/project
+
+# Update index after changes
+docs-index-delta.sh
+```
+
+## Full AI Maestro Experience
+
+This skill is part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform, which provides **6 skills** for AI agent orchestration: messaging, memory, docs, graph, planning, and agent management.

--- a/cli-tool/components/skills/ai-maestro/graph-query/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/graph-query/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: graph-query
+description: Query the code graph database to understand component relationships, dependencies, and change impact. Use when the user asks to "find callers", "check dependencies", "what uses this", "show relationships", "find serializers", or when reading code and needing to understand what depends on a component before modifications.
+---
+
+# AI Maestro Code Graph Query
+
+Query your codebase's dependency graph to understand component relationships, call chains, and the impact of changes before making modifications. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## Prerequisites
+
+Requires [AI Maestro](https://github.com/23blocks-OS/ai-maestro) running locally with codebase indexed.
+
+```bash
+# Install graph tools
+git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
+cd ai-maestro-plugins && ./install-graph-tools.sh
+```
+
+## Core Behavior
+
+After reading any code file, query the graph to understand dependencies:
+
+```
+Read file -> Query graph -> Then proceed
+```
+
+## Commands
+
+### Query
+| Command | Description |
+|---------|-------------|
+| `graph-describe.sh <name>` | Describe a component or function |
+| `graph-find-callers.sh <fn>` | Find all callers of a function |
+| `graph-find-callees.sh <fn>` | Find all functions called by this function |
+| `graph-find-related.sh <component>` | Find related components |
+| `graph-find-by-type.sh <type>` | Find all components of a type |
+| `graph-find-serializers.sh <model>` | Find serializers for a model |
+| `graph-find-associations.sh <model>` | Find model associations |
+| `graph-find-path.sh <from> <to>` | Find call path between functions |
+
+### Index
+| Command | Description |
+|---------|-------------|
+| `graph-index-delta.sh [path]` | Index or update the code graph |
+
+## Component Types
+
+Use with `graph-find-by-type.sh`: `model`, `serializer`, `controller`, `service`, `job`, `concern`, `component`, `hook`
+
+## Usage Examples
+
+```bash
+# After reading a model file
+graph-describe.sh User
+graph-find-serializers.sh User
+graph-find-associations.sh User
+
+# Before modifying a function
+graph-find-callers.sh process_payment
+graph-find-callees.sh process_payment
+
+# Find call chain between components
+graph-find-path.sh handleRequest sendResponse
+
+# Index your codebase
+graph-index-delta.sh /path/to/project
+```
+
+## Why Query Before Modifying
+
+Without checking the graph, you risk:
+- Breaking callers when changing a function signature
+- Missing serializers that need updating with a model change
+- Overlooking child classes that inherit your modifications
+
+## Full AI Maestro Experience
+
+This skill is part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform, which provides **6 skills** for AI agent orchestration: messaging, memory, docs, graph, planning, and agent management.

--- a/cli-tool/components/skills/ai-maestro/memory-search/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/memory-search/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: memory-search
+description: Search conversation history and semantic memory to recall previous discussions, decisions, and context. Use when the user asks to "search memory", "what did we discuss", "remember when", "find previous conversation", "check history", or before starting work to recall prior decisions.
+---
+
+# AI Maestro Memory Search
+
+Search your conversation history using semantic, keyword, and symbol matching. Recall past decisions, discussions, and context across sessions. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## Prerequisites
+
+Requires [AI Maestro](https://github.com/23blocks-OS/ai-maestro) running locally. Memory indexing uses CozoDB for vector search.
+
+```bash
+# Install memory tools
+git clone https://github.com/23blocks-OS/ai-maestro-plugins.git
+cd ai-maestro-plugins && ./install-memory-tools.sh
+```
+
+## Core Behavior
+
+Before starting any task, search memory for relevant context:
+
+```
+Receive instruction -> Search memory -> Then proceed
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `memory-search.sh "<query>"` | Hybrid search (recommended) |
+| `memory-search.sh "<query>" --mode semantic` | Find conceptually related |
+| `memory-search.sh "<query>" --mode term` | Exact text matching |
+| `memory-search.sh "<query>" --mode symbol` | Code symbol matching |
+| `memory-search.sh "<query>" --role user` | Only user messages |
+| `memory-search.sh "<query>" --role assistant` | Only assistant messages |
+
+## Search Modes
+
+| Mode | Best For |
+|------|----------|
+| `hybrid` (default) | General search, most cases |
+| `semantic` | Related concepts, different wording |
+| `term` | Exact function/class names |
+| `symbol` | Code identifiers across contexts |
+
+## Usage Examples
+
+```bash
+# User asks to continue previous work
+memory-search.sh "authentication"
+
+# Find a specific component discussion
+memory-search.sh "PaymentService" --mode term
+
+# Find related design discussions
+memory-search.sh "error handling patterns" --mode semantic
+
+# Find code symbol references
+memory-search.sh "processPayment" --mode symbol
+```
+
+## Combining with Other Skills
+
+For complete context, pair with docs-search and graph-query:
+```bash
+memory-search.sh "feature"       # What did we discuss?
+docs-search.sh "feature"         # What do docs say?
+graph-describe.sh ComponentName  # What is the structure?
+```
+
+## Full AI Maestro Experience
+
+This skill is part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform, which provides **6 skills** for AI agent orchestration: messaging, memory, docs, graph, planning, and agent management.

--- a/cli-tool/components/skills/ai-maestro/planning/SKILL.md
+++ b/cli-tool/components/skills/ai-maestro/planning/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: planning
+description: Create and manage persistent markdown planning files for structured task execution. Use when the user asks to "create a plan", "track progress", "start a research project", or when a task requires more than 5 tool calls and needs structured phase tracking to stay focused and avoid goal drift.
+---
+
+# AI Maestro Planning
+
+Solve the execution problem -- staying focused during complex, multi-step tasks. Uses persistent markdown files to track goals, findings, and progress so you never lose context. Part of the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) suite.
+
+## When to Use
+
+- Multi-step tasks (3+ steps)
+- Research projects
+- Building features requiring >5 tool calls
+- Any task where you might lose track of the goal
+
+## The 3-File Pattern
+
+Create in `docs_dev/` (or `$AIMAESTRO_PLANNING_DIR`):
+
+| File | Purpose | Update When |
+|------|---------|-------------|
+| `task_plan.md` | Goals, phases, decisions, errors | After each phase |
+| `findings.md` | Research, discoveries, resources | During research |
+| `progress.md` | Session log, test results | Throughout session |
+
+## Quick Start
+
+```bash
+PLAN_DIR="${AIMAESTRO_PLANNING_DIR:-docs_dev}"
+mkdir -p "$PLAN_DIR"
+```
+
+Then create `task_plan.md` with:
+```markdown
+# Task: [Goal]
+
+## Phases
+- [ ] Phase 1: Research
+- [ ] Phase 2: Design
+- [ ] Phase 3: Implement
+- [ ] Phase 4: Test
+
+## Decisions
+| Decision | Rationale | Date |
+|----------|-----------|------|
+
+## Errors Encountered
+| Error | Attempt | Resolution |
+|-------|---------|------------|
+```
+
+## The 6 Rules
+
+1. **Create plan first** -- Never start complex work without `task_plan.md`
+2. **Read before decide** -- Re-read the plan before any major decision
+3. **Update after act** -- Mark phases complete, log what changed
+4. **2-action rule** -- After every 2 search/browse operations, save findings to `findings.md`
+5. **Log all errors** -- Every error goes in the plan with attempt number and resolution
+6. **Never repeat failures** -- If an action failed, change your approach
+
+## The 3-Strike Protocol
+
+| Strike | Action |
+|--------|--------|
+| 1 | Diagnose root cause, apply targeted fix |
+| 2 | Try a different approach entirely |
+| 3 | Question assumptions, search for similar issues |
+| After 3 | Escalate to user with all attempts documented |
+
+## The 5-Question Reboot
+
+Lost? Answer these from your planning files:
+
+1. Where am I? (current phase in `task_plan.md`)
+2. Where am I going? (remaining phases)
+3. What's the goal? (goal section)
+4. What have I learned? (`findings.md`)
+5. What have I done? (`progress.md`)
+
+## Full AI Maestro Experience
+
+This skill works standalone with no dependencies. For the complete experience including **memory search**, **docs search**, **graph query**, **agent messaging**, and **agent management**, install the full [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform.


### PR DESCRIPTION
## Summary

Adds the **AI Maestro** skill suite — a new `ai-maestro/` category with 6 skills for multi-agent orchestration on macOS/Linux:

- **agent-messaging** — Send and receive cryptographically signed messages between AI agents using the [Agent Messaging Protocol (AMP)](https://agentmessaging.org)
- **memory-search** — Semantic search across conversation history to recall past decisions and context
- **docs-search** — Search auto-generated codebase documentation for function signatures, classes, and APIs
- **graph-query** — Query code dependency graphs to understand relationships and change impact
- **planning** — Structured task execution with persistent markdown files (works standalone, no dependencies)
- **agent-management** — Full agent lifecycle management: create, hibernate, wake, plugins, export/import

### Files added

| File | Lines | Content |
|------|-------|---------|
| `cli-tool/components/skills/ai-maestro/agent-messaging/SKILL.md` | 102 | AMP inter-agent communication |
| `cli-tool/components/skills/ai-maestro/memory-search/SKILL.md` | 75 | Semantic conversation memory |
| `cli-tool/components/skills/ai-maestro/docs-search/SKILL.md` | 82 | Codebase documentation search |
| `cli-tool/components/skills/ai-maestro/graph-query/SKILL.md` | 79 | Code dependency graph queries |
| `cli-tool/components/skills/ai-maestro/planning/SKILL.md` | 83 | Structured task execution |
| `cli-tool/components/skills/ai-maestro/agent-management/SKILL.md` | 85 | Agent lifecycle management |

### Design decisions

- **Own category (`ai-maestro/`)** — These 6 skills form a cohesive suite for agent orchestration, similar to how `sentry/` and `railway/` have their own categories
- **Concise SKILL.md files** — Each skill is 75-102 lines, following CCT conventions (imperative form, progressive disclosure, no README)
- **Standalone where possible** — `planning` works with zero dependencies; `agent-messaging` works for local messaging; others clearly state they require the AI Maestro server
- **Consistent CTAs** — Each skill links back to the [AI Maestro](https://github.com/23blocks-OS/ai-maestro) platform for the full experience
- **Only `name` and `description` in frontmatter** — Following the skill-creation-guide recommendation

### About AI Maestro

[AI Maestro](https://github.com/23blocks-OS/ai-maestro) is an open-source platform for orchestrating multiple Claude Code agents. It provides a web dashboard, inter-agent messaging (AMP), semantic memory, code graph analysis, and agent lifecycle management — all running locally on macOS.

## Test plan

- [x] All SKILL.md files have valid YAML frontmatter with `name` and `description`
- [x] Skill names match directory names (kebab-case)
- [x] Trigger phrases cover common user queries
- [x] Code examples are syntactically correct bash commands
- [x] Each skill is under 500 lines (total: 506 lines across 6 skills)
- [x] No README.md files included (per CCT guidelines)
- [ ] Test skill installation via `npx claude-code-templates@latest --skill agent-messaging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the AI Maestro skill suite (6 skills) for multi‑agent orchestration on macOS/Linux. Brings messaging, memory/docs/graph search, planning, and agent lifecycle management to the components library.

- Area affected: components (cli-tool/components/)
- Added new ai-maestro/ category with 6 skills: agent-messaging, memory-search, docs-search, graph-query, planning, agent-management
- New components added — regenerate docs/components.json
- No new environment variables or secrets; optional AIMAESTRO_PLANNING_DIR supported by planning
- Some skills require local AI Maestro tools/services; planning works standalone

<sup>Written for commit 9d51d2c4a7e8280de76c645da591222d689b9081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

