### PR TITLE
docs: Add dashboard beta banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 ---
 
+> **🧪 NEW: Dashboard Beta** — Try our new dashboard at **[app.aitmpl.com](https://app.aitmpl.com)** to manage your collections, track installations, and explore components with a modern UI. Currently in beta — feedback welcome!
+
 # Claude Code Templates ([aitmpl.com](https://aitmpl.com))
 
 **Ready-to-use configurations for Anthropic's Claude Code.** A comprehensive collection of AI agents, custom commands, settings, hooks, external integrations (MCPs), and project templates to enhance your development workflow.


### PR DESCRIPTION
## Summary
- Adds a beta banner for the dashboard (app.aitmpl.com) in the README, placed above the main title where aitmpl.com is announced

## Test plan
- [x] Verify banner renders correctly on GitHub
- [x] Verify link to app.aitmpl.com works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dashboard beta banner to the README to promote app.aitmpl.com and collect feedback. The banner appears above the main title.

- Area: website (docs/) — README.md updated
- Change: Added beta callout linking to https://app.aitmpl.com above the project title
- No new components; docs/components.json regeneration not needed
- No new environment variables or secrets

<sup>Written for commit 9459766db46e795f69bfde5e5c8d69119a1cb855. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

