### PR TITLE
bug: Replace deprecated code snippets to working code snippets for rag-qdrant skill

### DIFF
--- a/cli-tool/components/skills/ai-research/rag-qdrant/SKILL.md
+++ b/cli-tool/components/skills/ai-research/rag-qdrant/SKILL.md
@@ -279,7 +279,8 @@ prompt = f"Context: {context}\n\nQuestion: What is Python?"
 ### With LangChain
 
 ```python
-from langchain_qdrant import QdrantVectorStore from langchain_community.embeddings import FastEmbedEmbeddings
+from langchain_qdrant import QdrantVectorStore
+from langchain_community.embeddings import FastEmbedEmbeddings
 
 embeddings = FastEmbedEmbeddings(model_name="BAAI/bge-small-en-v1.5")
 vectorstore = QdrantVectorStore(


### PR DESCRIPTION
Overview:

- The Qdrant client no longer supports the search endpoint after data ingestion. The search endpoint has been replaced by query points. Source: [https://api.qdrant.tech/api-reference/search/query-points](https://api.qdrant.tech/api-reference/search/query-points)
- The LangChain example is outdated. You can now directly define a Qdrant vector store using langchain_qdrant and ingest data with add_documents, which is the recommended approach.
- The hybrid search logic has also been updated. The correct way is to use VectorParams for dense vectors and SparseVectorParams for sparse vectors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Qdrant and LangChain examples in the rag-qdrant skill to replace deprecated calls and align with current APIs. This fixes broken snippets and keeps the docs current.

- **Bug Fixes**
  - Components (cli-tool/components/): Replace client.search with client.query_points; use .points in results; align imports with the latest Qdrant client API.
  - Update batch and filtered search: query_batch_points, QueryRequest, using="dense".
  - Refresh LangChain example: langchain_qdrant.QdrantVectorStore + FastEmbedEmbeddings; use add_documents for ingestion.
  - Correct hybrid search setup: VectorParams for dense; SparseVectorParams with SparseIndexParams and IDF modifier.
  - No new components; no docs/components.json regeneration; no new env vars or secrets.

<sup>Written for commit 68f27faca1466f7a08d38f4837b8ea2c1e10196d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

