### PR TITLE
refactor: support global installation for worktree-ghostty hook

### DIFF
--- a/cli-tool/components/hooks/development-tools/worktree-ghostty.json
+++ b/cli-tool/components/hooks/development-tools/worktree-ghostty.json
@@ -1,12 +1,12 @@
 {
-  "description": "Worktree Ghostty Layout. Opens a 3-panel Ghostty layout when creating worktrees: Claude Code (left) | lazygit (top-right) / yazi (bottom-right). Creates worktrees in a sibling directory (../worktrees/<repo>/<name>/) and cleans up on removal. macOS only. Requires: jq, Ghostty terminal, lazygit, yazi. Ghostty keybindings required: super+d = new_split:right, super+shift+d = new_split:down.",
+  "description": "Worktree Ghostty Layout. Opens a 3-panel Ghostty layout when creating worktrees: Claude Code (left) | lazygit (top-right) / yazi (bottom-right). Creates worktrees in a sibling directory (../worktrees/<repo>/<name>/) and cleans up on removal. Works with both project-level and global (~/.claude/settings.json) installation. macOS only. Requires: jq, Ghostty terminal, lazygit, yazi. Ghostty keybindings required: super+d = new_split:right, super+shift+d = new_split:down.",
   "hooks": {
     "WorktreeCreate": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-ghostty.sh",
+            "command": "bash -c 'HOOK=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-ghostty.sh\"; [ -f \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/worktree-ghostty.sh\"; exec bash \"$HOOK\"'",
             "timeout": 30
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-ghostty.sh",
+            "command": "bash -c 'HOOK=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-ghostty.sh\"; [ -f \"$HOOK\" ] || HOOK=\"$HOME/.claude/hooks/worktree-ghostty.sh\"; exec bash \"$HOOK\"'",
             "timeout": 15
           }
         ]

--- a/cli-tool/components/hooks/development-tools/worktree-ghostty.sh
+++ b/cli-tool/components/hooks/development-tools/worktree-ghostty.sh
@@ -14,6 +14,10 @@
 #   - lazygit (git TUI)
 #   - yazi (file manager TUI)
 #
+# Installation:
+#   Works with both project-level (<project>/.claude/) and global (~/.claude/)
+#   installation. The JSON config auto-detects the script location.
+#
 # Ghostty keybindings required:
 #   super+d       = new_split:right
 #   super+shift+d = new_split:down


### PR DESCRIPTION
` npx claude-code-templates@latest --hook=development-tools/worktree-ghostty` allows user to select the installation at user location. However this won't work out as CLAUDE_PROJECT_DIR sets the project root at code execution and fails to pick up the user level location. This PR adds the fallback so command can run at any location and add the hook at the desired location. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global fallback for the worktree-ghostty hook so it works with both project-level and user-level installs. Prevents failures when CLAUDE_PROJECT_DIR is set but the hook is installed in ~/.claude.

- **Refactors**
  - Area: components (cli-tool/components/). No new components; catalog (docs/components.json) does not need regeneration.
  - Updated JSON hook to auto-detect and exec script from <project>/.claude/hooks or ~/.claude/hooks.
  - Clarified installation in worktree-ghostty.sh comments (global and project support).
  - No new environment variables or secrets.

<sup>Written for commit d41bf47f2f69c93b819c181d92ceaca7116b0a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

