### PR TITLE
Add Claude Launchpad and remote task system for Mac

### DIFF
--- a/scripts/REMOTE-TASKS-GUIDE.md
+++ b/scripts/REMOTE-TASKS-GUIDE.md
@@ -1,0 +1,161 @@
+# Remote Claude Tasks - Quick Start Guide
+
+Give Claude instructions from your phone, tablet, or any browser. Tasks queue up as GitHub Issues and your Mac picks them up automatically.
+
+## How It Works
+
+```
+Phone/Browser --> GitHub Issue --> Your Mac --> Claude runs it --> Result posted back
+```
+
+1. You create a GitHub Issue with the label `claude-task`
+2. Your Mac polls for new tasks (or you trigger manually)
+3. Claude reads the issue, runs the task, posts the result as a comment
+4. The issue is closed automatically
+
+## Setup (One Time)
+
+```bash
+# 1. Run the Mac setup
+bash scripts/mac-setup.sh
+
+# 2. Set your tasks repo
+export CLAUDE_TASKS_REPO='your-username/claude-tasks'
+# Add this to your ~/.zshrc too
+
+# 3. (Optional) Enable auto-polling
+bash scripts/claude-auto-runner.sh install
+```
+
+## Creating Tasks
+
+### From Terminal
+```bash
+# Interactive
+claude-tasks create
+
+# One-liner
+claude-tasks quick "Add dark mode to my-app" "owner/my-app"
+
+# Short alias
+ct quick "Fix the login bug" "~/projects/website"
+```
+
+### From GitHub (Phone/Browser)
+1. Go to your `claude-tasks` repo on github.com
+2. Create a new Issue
+3. Add the label `claude-task`
+4. In the body, optionally add a target:
+   ```
+   Fix the broken navbar on mobile.
+
+   ---
+   **Target:** `owner/my-web-app`
+   ```
+
+### From iOS Shortcuts
+Create an iOS Shortcut with these actions:
+
+1. **Ask for Input** - "What should Claude do?"
+2. **Get Contents of URL**
+   - URL: `https://api.github.com/repos/YOUR-USER/claude-tasks/issues`
+   - Method: POST
+   - Headers:
+     - `Authorization`: `token YOUR_GITHUB_PAT`
+     - `Accept`: `application/vnd.github.v3+json`
+   - Body (JSON):
+     ```json
+     {
+       "title": "[input from step 1]",
+       "labels": ["claude-task"]
+     }
+     ```
+3. **Show Notification** - "Task sent to Claude"
+
+### From Android (Tasker/HTTP Shortcuts)
+Use the same GitHub API call as iOS above. The HTTP Shortcuts app makes this simple.
+
+## Running Tasks
+
+```bash
+# See what's pending
+claude-tasks list    # or: ct list
+
+# Run the next task in queue
+claude-tasks run-next    # or: ct run-next
+
+# Run a specific task
+claude-tasks run 42
+
+# Mark done manually
+claude-tasks done 42
+```
+
+## Auto-Runner
+
+The auto-runner polls GitHub for new tasks on a schedule:
+
+```bash
+# Install (default: check every 5 minutes, notify only)
+bash scripts/claude-auto-runner.sh install
+
+# Auto-execute tasks (hands-free mode)
+CLAUDE_AUTO_RUN=true bash scripts/claude-auto-runner.sh install
+
+# Check status
+bash scripts/claude-auto-runner.sh status
+
+# View logs
+tail -f ~/.claude-launchpad/logs/auto-runner.log
+
+# Stop
+bash scripts/claude-auto-runner.sh uninstall
+```
+
+## Task Format Tips
+
+Write issues like you'd talk to a developer:
+
+**Good tasks:**
+- "Add input validation to the signup form in src/components/Signup.tsx"
+- "Write tests for the payment module"
+- "Refactor the database queries in api/users.js to use parameterized queries"
+- "Review package.json and update outdated dependencies"
+
+**Include context when needed:**
+- Which repo/directory to work in (use `**Target:**` field)
+- What branch to work on
+- Any constraints or preferences
+
+## Launchpad
+
+The Launchpad gives you a menu-driven interface for everything:
+
+```bash
+lp    # or: launchpad
+```
+
+```
+  ╔══════════════════════════════════════════╗
+  ║         CLAUDE  LAUNCHPAD                ║
+  ╚══════════════════════════════════════════╝
+
+  Quick Actions
+  1  Start Claude in current directory
+  2  Start Claude in workspace
+  3  Resume last Claude session
+
+  Projects
+  4  Open a project (pick from workspace)
+  5  Clone a repo and start Claude
+
+  Remote Tasks
+  6  Check for remote tasks
+  7  Create a new remote task
+  8  Run next pending task
+
+  Tools
+  9  Install a component
+  10 Run Claude with prompt from clipboard
+  11 Open Claude settings
+```

--- a/scripts/claude-auto-runner.sh
+++ b/scripts/claude-auto-runner.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# =============================================================================
+# Claude Auto-Runner - Polls for remote tasks and runs them automatically
+#
+# Install as a LaunchAgent (macOS) to run in the background:
+#   bash scripts/claude-auto-runner.sh install
+#
+# Or run manually:
+#   bash scripts/claude-auto-runner.sh poll
+#
+# Configuration:
+#   CLAUDE_TASKS_REPO   - GitHub repo for tasks (required)
+#   CLAUDE_POLL_INTERVAL - Seconds between polls (default: 300 = 5 min)
+#   CLAUDE_AUTO_RUN     - Set to "true" to auto-execute (default: notify only)
+# =============================================================================
+
+set -euo pipefail
+
+POLL_INTERVAL="${CLAUDE_POLL_INTERVAL:-300}"
+AUTO_RUN="${CLAUDE_AUTO_RUN:-false}"
+CLAUDE_TASKS_REPO="${CLAUDE_TASKS_REPO:-}"
+PLIST_NAME="com.claude.task-runner"
+PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_NAME}.plist"
+LOG_DIR="$HOME/.claude-launchpad/logs"
+REMOTE_TASKS_SCRIPT="$HOME/.claude-launchpad/remote-tasks.sh"
+
+mkdir -p "$LOG_DIR"
+
+# ---------------------------------------------------------------------------
+# macOS LaunchAgent installation
+# ---------------------------------------------------------------------------
+
+cmd_install() {
+  if [[ -z "$CLAUDE_TASKS_REPO" ]]; then
+    echo "Error: Set CLAUDE_TASKS_REPO first."
+    echo "  export CLAUDE_TASKS_REPO='your-username/claude-tasks'"
+    exit 1
+  fi
+
+  local script_path
+  script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  mkdir -p "$(dirname "$PLIST_PATH")"
+
+  cat > "$PLIST_PATH" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${PLIST_NAME}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${script_path}</string>
+        <string>poll</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>${POLL_INTERVAL}</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CLAUDE_TASKS_REPO</key>
+        <string>${CLAUDE_TASKS_REPO}</string>
+        <key>CLAUDE_AUTO_RUN</key>
+        <string>${AUTO_RUN}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/auto-runner.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/auto-runner.err</string>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+  launchctl unload "$PLIST_PATH" 2>/dev/null || true
+  launchctl load "$PLIST_PATH"
+
+  echo "Auto-runner installed and started."
+  echo "  Polling every ${POLL_INTERVAL}s for tasks in ${CLAUDE_TASKS_REPO}"
+  echo "  Auto-run: ${AUTO_RUN}"
+  echo "  Logs: ${LOG_DIR}/auto-runner.log"
+  echo ""
+  echo "  To stop:   launchctl unload $PLIST_PATH"
+  echo "  To remove: rm $PLIST_PATH"
+}
+
+cmd_uninstall() {
+  if [[ -f "$PLIST_PATH" ]]; then
+    launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    rm "$PLIST_PATH"
+    echo "Auto-runner uninstalled."
+  else
+    echo "Auto-runner is not installed."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Poll for tasks
+# ---------------------------------------------------------------------------
+
+cmd_poll() {
+  if [[ -z "$CLAUDE_TASKS_REPO" ]]; then
+    echo "$(date): CLAUDE_TASKS_REPO not set, skipping." >> "$LOG_DIR/auto-runner.log"
+    exit 0
+  fi
+
+  local count
+  count=$(gh issue list --repo "$CLAUDE_TASKS_REPO" --label "claude-task" \
+    --state open --json number --jq 'length' 2>/dev/null || echo "0")
+
+  if [[ "$count" -gt 0 ]]; then
+    echo "$(date): Found $count pending task(s)" >> "$LOG_DIR/auto-runner.log"
+
+    if [[ "$AUTO_RUN" == "true" ]]; then
+      echo "$(date): Auto-running next task..." >> "$LOG_DIR/auto-runner.log"
+      if [[ -f "$REMOTE_TASKS_SCRIPT" ]]; then
+        bash "$REMOTE_TASKS_SCRIPT" run-next >> "$LOG_DIR/auto-runner.log" 2>&1
+      fi
+    else
+      # Send macOS notification
+      osascript -e "display notification \"$count pending task(s) in queue\" with title \"Claude Tasks\" sound name \"Glass\"" 2>/dev/null || true
+    fi
+  else
+    echo "$(date): No pending tasks" >> "$LOG_DIR/auto-runner.log"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+cmd_status() {
+  echo "Claude Auto-Runner Status"
+  echo ""
+
+  if [[ -f "$PLIST_PATH" ]]; then
+    echo "  Installed: yes"
+    if launchctl list | grep -q "$PLIST_NAME"; then
+      echo "  Running: yes"
+    else
+      echo "  Running: no (load with: launchctl load $PLIST_PATH)"
+    fi
+  else
+    echo "  Installed: no"
+  fi
+
+  echo "  Repo: ${CLAUDE_TASKS_REPO:-not set}"
+  echo "  Interval: ${POLL_INTERVAL}s"
+  echo "  Auto-run: ${AUTO_RUN}"
+  echo ""
+
+  if [[ -f "$LOG_DIR/auto-runner.log" ]]; then
+    echo "  Last 5 log entries:"
+    tail -5 "$LOG_DIR/auto-runner.log" | sed 's/^/    /'
+  fi
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+case "${1:-status}" in
+  install)   cmd_install ;;
+  uninstall) cmd_uninstall ;;
+  poll)      cmd_poll ;;
+  status)    cmd_status ;;
+  *)
+    echo "Usage: claude-auto-runner.sh [install|uninstall|poll|status]"
+    ;;
+esac

--- a/scripts/claude-launchpad.sh
+++ b/scripts/claude-launchpad.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# =============================================================================
+# Claude Launchpad - Quick-access command center
+# Usage: launchpad  or  lp
+# =============================================================================
+
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+MAGENTA='\033[0;35m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+WORKSPACE="${CLAUDE_WORKSPACE:-$HOME/claude-workspace}"
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+show_header() {
+  clear
+  echo -e "${CYAN}${BOLD}"
+  echo "  ╔══════════════════════════════════════════╗"
+  echo "  ║         CLAUDE  LAUNCHPAD                ║"
+  echo "  ╚══════════════════════════════════════════╝"
+  echo -e "${NC}"
+  echo -e "  ${DIM}Workspace: $WORKSPACE${NC}"
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Menu
+# ---------------------------------------------------------------------------
+show_menu() {
+  echo -e "  ${BOLD}Quick Actions${NC}"
+  echo -e "  ${GREEN}1${NC}  Start Claude in current directory"
+  echo -e "  ${GREEN}2${NC}  Start Claude in workspace"
+  echo -e "  ${GREEN}3${NC}  Resume last Claude session"
+  echo ""
+  echo -e "  ${BOLD}Projects${NC}"
+  echo -e "  ${GREEN}4${NC}  Open a project (pick from workspace)"
+  echo -e "  ${GREEN}5${NC}  Clone a repo and start Claude"
+  echo ""
+  echo -e "  ${BOLD}Remote Tasks${NC}"
+  echo -e "  ${GREEN}6${NC}  Check for remote tasks (GitHub Issues)"
+  echo -e "  ${GREEN}7${NC}  Create a new remote task"
+  echo -e "  ${GREEN}8${NC}  Run next pending task"
+  echo ""
+  echo -e "  ${BOLD}Tools${NC}"
+  echo -e "  ${GREEN}9${NC}  Install a component (agent/command/hook)"
+  echo -e "  ${GREEN}10${NC} Run Claude with a prompt from clipboard"
+  echo -e "  ${GREEN}11${NC} Open Claude settings"
+  echo ""
+  echo -e "  ${DIM}q  Quit${NC}"
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+start_here() {
+  echo -e "${CYAN}Starting Claude in $(pwd)...${NC}"
+  exec claude
+}
+
+start_workspace() {
+  cd "$WORKSPACE"
+  echo -e "${CYAN}Starting Claude in $WORKSPACE...${NC}"
+  exec claude
+}
+
+resume_session() {
+  echo -e "${CYAN}Resuming last Claude session...${NC}"
+  exec claude --resume
+}
+
+pick_project() {
+  echo -e "${BOLD}Projects in $WORKSPACE:${NC}"
+  echo ""
+
+  local dirs=()
+  local i=1
+  for d in "$WORKSPACE"/*/; do
+    if [[ -d "$d" ]]; then
+      local name
+      name=$(basename "$d")
+      dirs+=("$d")
+      local marker=""
+      if [[ -d "$d/.git" ]]; then
+        local branch
+        branch=$(git -C "$d" branch --show-current 2>/dev/null || echo "?")
+        marker="${DIM}(git: $branch)${NC}"
+      fi
+      echo -e "  ${GREEN}$i${NC}  $name $marker"
+      ((i++))
+    fi
+  done
+
+  if [[ ${#dirs[@]} -eq 0 ]]; then
+    echo -e "  ${YELLOW}No projects found. Clone one first (option 5).${NC}"
+    echo ""
+    read -rp "  Press Enter to continue..." _
+    return
+  fi
+
+  echo ""
+  read -rp "  Select project number: " choice
+  if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#dirs[@]} )); then
+    local target="${dirs[$((choice-1))]}"
+    cd "$target"
+    echo -e "${CYAN}Starting Claude in $target...${NC}"
+    exec claude
+  else
+    echo -e "${YELLOW}Invalid selection.${NC}"
+    sleep 1
+  fi
+}
+
+clone_and_start() {
+  echo ""
+  read -rp "  Repo URL (or owner/repo): " repo_url
+  if [[ -z "$repo_url" ]]; then
+    return
+  fi
+
+  # Support shorthand owner/repo
+  if [[ ! "$repo_url" =~ ^https?:// ]] && [[ ! "$repo_url" =~ ^git@ ]]; then
+    repo_url="https://github.com/$repo_url.git"
+  fi
+
+  local repo_name
+  repo_name=$(basename "$repo_url" .git)
+  local target="$WORKSPACE/$repo_name"
+
+  if [[ -d "$target" ]]; then
+    echo -e "${YELLOW}$target already exists. Opening it.${NC}"
+  else
+    echo -e "${CYAN}Cloning into $target...${NC}"
+    git clone "$repo_url" "$target"
+  fi
+
+  cd "$target"
+  echo -e "${CYAN}Starting Claude in $target...${NC}"
+  exec claude
+}
+
+check_remote_tasks() {
+  local tasks_script="${HOME}/.claude-launchpad/remote-tasks.sh"
+  if [[ -f "$tasks_script" ]]; then
+    bash "$tasks_script" list
+  else
+    echo -e "${YELLOW}Remote tasks script not installed.${NC}"
+    echo -e "Run the mac-setup.sh script to install it."
+    sleep 2
+  fi
+  echo ""
+  read -rp "  Press Enter to continue..." _
+}
+
+create_remote_task() {
+  local tasks_script="${HOME}/.claude-launchpad/remote-tasks.sh"
+  if [[ -f "$tasks_script" ]]; then
+    bash "$tasks_script" create
+  else
+    echo -e "${YELLOW}Remote tasks script not installed.${NC}"
+    sleep 2
+  fi
+  echo ""
+  read -rp "  Press Enter to continue..." _
+}
+
+run_next_task() {
+  local tasks_script="${HOME}/.claude-launchpad/remote-tasks.sh"
+  if [[ -f "$tasks_script" ]]; then
+    bash "$tasks_script" run-next
+  else
+    echo -e "${YELLOW}Remote tasks script not installed.${NC}"
+    sleep 2
+  fi
+}
+
+install_component() {
+  echo ""
+  echo -e "  ${BOLD}Install a component:${NC}"
+  echo -e "  ${DIM}Examples:${NC}"
+  echo -e "    agent frontend-developer"
+  echo -e "    command setup-testing"
+  echo -e "    hook automation/simple-notifications"
+  echo ""
+  read -rp "  Type and name (e.g. 'agent security-auditor'): " type_and_name
+  if [[ -z "$type_and_name" ]]; then
+    return
+  fi
+  local comp_type comp_name
+  comp_type=$(echo "$type_and_name" | awk '{print $1}')
+  comp_name=$(echo "$type_and_name" | awk '{print $2}')
+  echo -e "${CYAN}Installing $comp_type: $comp_name...${NC}"
+  npx claude-code-templates@latest "--${comp_type}" "$comp_name"
+  echo ""
+  read -rp "  Press Enter to continue..." _
+}
+
+run_from_clipboard() {
+  local prompt
+  prompt=$(pbpaste 2>/dev/null || xclip -selection clipboard -o 2>/dev/null || echo "")
+  if [[ -z "$prompt" ]]; then
+    echo -e "${YELLOW}Clipboard is empty.${NC}"
+    sleep 1
+    return
+  fi
+  echo -e "${CYAN}Running Claude with prompt from clipboard:${NC}"
+  echo -e "${DIM}${prompt:0:200}...${NC}"
+  echo ""
+  exec claude -p "$prompt"
+}
+
+open_settings() {
+  local settings_dir="$HOME/.claude"
+  echo -e "${CYAN}Opening Claude settings directory...${NC}"
+  if command -v code &>/dev/null; then
+    code "$settings_dir"
+  elif command -v open &>/dev/null; then
+    open "$settings_dir"
+  else
+    echo "Settings at: $settings_dir"
+    ls -la "$settings_dir"
+  fi
+  echo ""
+  read -rp "  Press Enter to continue..." _
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+main() {
+  while true; do
+    show_header
+    show_menu
+    read -rp "  Choose an option: " choice
+    case "$choice" in
+      1)  start_here ;;
+      2)  start_workspace ;;
+      3)  resume_session ;;
+      4)  pick_project ;;
+      5)  clone_and_start ;;
+      6)  check_remote_tasks ;;
+      7)  create_remote_task ;;
+      8)  run_next_task ;;
+      9)  install_component ;;
+      10) run_from_clipboard ;;
+      11) open_settings ;;
+      q|Q) echo -e "${DIM}Bye.${NC}"; exit 0 ;;
+      *)  echo -e "${YELLOW}Invalid option.${NC}"; sleep 0.5 ;;
+    esac
+  done
+}
+
+main "$@"

--- a/scripts/claude-remote-tasks.sh
+++ b/scripts/claude-remote-tasks.sh
@@ -1,0 +1,346 @@
+#!/bin/bash
+# =============================================================================
+# Claude Remote Tasks - Give Claude instructions from anywhere
+#
+# Uses GitHub Issues as a task queue. Create an issue from your phone, tablet,
+# or any browser, and Claude picks it up on your Mac.
+#
+# Setup:
+#   1. Create a GitHub repo for tasks (e.g. your-username/claude-tasks)
+#   2. Set CLAUDE_TASKS_REPO below or export it
+#   3. Authenticate gh: gh auth login
+#
+# Usage:
+#   claude-tasks list          Show pending tasks
+#   claude-tasks create        Create a new task interactively
+#   claude-tasks run-next      Pick up and run the next pending task
+#   claude-tasks run <number>  Run a specific task by issue number
+#   claude-tasks done <number> Mark a task as complete
+#   claude-tasks quick "msg"   Create a task with one command
+# =============================================================================
+
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Set this to your tasks repo (owner/repo format)
+CLAUDE_TASKS_REPO="${CLAUDE_TASKS_REPO:-}"
+WORKSPACE="${CLAUDE_WORKSPACE:-$HOME/claude-workspace}"
+
+# Labels used for task states
+LABEL_PENDING="claude-task"
+LABEL_RUNNING="in-progress"
+LABEL_DONE="completed"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+check_deps() {
+  if ! command -v gh &>/dev/null; then
+    echo -e "${RED}Error: GitHub CLI (gh) is required. Install with: brew install gh${NC}"
+    exit 1
+  fi
+  if ! gh auth status &>/dev/null 2>&1; then
+    echo -e "${RED}Error: Not authenticated. Run: gh auth login${NC}"
+    exit 1
+  fi
+}
+
+check_repo() {
+  if [[ -z "$CLAUDE_TASKS_REPO" ]]; then
+    echo -e "${YELLOW}No tasks repo configured.${NC}"
+    echo ""
+    echo "  Option 1: Export the variable:"
+    echo "    export CLAUDE_TASKS_REPO='your-username/claude-tasks'"
+    echo ""
+    echo "  Option 2: Create a repo now and set it:"
+    read -rp "  Create a new tasks repo? (y/n): " yn
+    if [[ "$yn" == "y" ]]; then
+      read -rp "  Repo name (default: claude-tasks): " repo_name
+      repo_name="${repo_name:-claude-tasks}"
+      gh repo create "$repo_name" --private --description "Remote task queue for Claude" 2>/dev/null || true
+      CLAUDE_TASKS_REPO="$(gh api user --jq .login)/$repo_name"
+      echo ""
+      echo -e "${GREEN}Created $CLAUDE_TASKS_REPO${NC}"
+      echo ""
+      echo "  Add this to your shell config:"
+      echo "    export CLAUDE_TASKS_REPO='$CLAUDE_TASKS_REPO'"
+
+      # Set up labels
+      gh label create "$LABEL_PENDING" --repo "$CLAUDE_TASKS_REPO" \
+        --description "Task for Claude to pick up" --color "0E8A16" 2>/dev/null || true
+      gh label create "$LABEL_RUNNING" --repo "$CLAUDE_TASKS_REPO" \
+        --description "Claude is working on this" --color "FBCA04" 2>/dev/null || true
+      gh label create "$LABEL_DONE" --repo "$CLAUDE_TASKS_REPO" \
+        --description "Claude completed this task" --color "5319E7" 2>/dev/null || true
+    else
+      exit 1
+    fi
+  fi
+}
+
+ensure_labels() {
+  gh label create "$LABEL_PENDING" --repo "$CLAUDE_TASKS_REPO" \
+    --description "Task for Claude to pick up" --color "0E8A16" 2>/dev/null || true
+  gh label create "$LABEL_RUNNING" --repo "$CLAUDE_TASKS_REPO" \
+    --description "Claude is working on this" --color "FBCA04" 2>/dev/null || true
+  gh label create "$LABEL_DONE" --repo "$CLAUDE_TASKS_REPO" \
+    --description "Claude completed this task" --color "5319E7" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_list() {
+  echo -e "${BOLD}Pending tasks:${NC}"
+  echo ""
+  local tasks
+  tasks=$(gh issue list --repo "$CLAUDE_TASKS_REPO" --label "$LABEL_PENDING" \
+    --state open --json number,title,createdAt,labels \
+    --jq '.[] | "  #\(.number)  \(.title)  (\(.createdAt | split("T")[0]))"' 2>/dev/null || echo "")
+
+  if [[ -z "$tasks" ]]; then
+    echo -e "  ${DIM}No pending tasks.${NC}"
+  else
+    echo "$tasks"
+  fi
+
+  echo ""
+  echo -e "${BOLD}In progress:${NC}"
+  echo ""
+  local running
+  running=$(gh issue list --repo "$CLAUDE_TASKS_REPO" --label "$LABEL_RUNNING" \
+    --state open --json number,title \
+    --jq '.[] | "  #\(.number)  \(.title)"' 2>/dev/null || echo "")
+
+  if [[ -z "$running" ]]; then
+    echo -e "  ${DIM}None.${NC}"
+  else
+    echo "$running"
+  fi
+  echo ""
+}
+
+cmd_create() {
+  echo -e "${BOLD}Create a new task for Claude${NC}"
+  echo ""
+  read -rp "  Task title: " title
+  if [[ -z "$title" ]]; then
+    echo -e "${YELLOW}Cancelled.${NC}"
+    return
+  fi
+
+  echo "  Task details (press Ctrl-D when done, or leave empty):"
+  local body=""
+  body=$(cat 2>/dev/null || echo "")
+
+  echo ""
+
+  # Ask for target repo/directory
+  read -rp "  Target repo or directory (optional, e.g. owner/repo or ~/projects/myapp): " target
+
+  local full_body="$body"
+  if [[ -n "$target" ]]; then
+    full_body="${full_body}
+
+---
+**Target:** \`${target}\`"
+  fi
+
+  local issue_url
+  issue_url=$(gh issue create --repo "$CLAUDE_TASKS_REPO" \
+    --title "$title" \
+    --body "$full_body" \
+    --label "$LABEL_PENDING" 2>/dev/null)
+
+  echo -e "${GREEN}Task created: $issue_url${NC}"
+}
+
+cmd_quick() {
+  local title="$1"
+  local target="${2:-}"
+
+  local body=""
+  if [[ -n "$target" ]]; then
+    body="---
+**Target:** \`${target}\`"
+  fi
+
+  local issue_url
+  issue_url=$(gh issue create --repo "$CLAUDE_TASKS_REPO" \
+    --title "$title" \
+    --body "$body" \
+    --label "$LABEL_PENDING" 2>/dev/null)
+
+  echo -e "${GREEN}Task created: $issue_url${NC}"
+}
+
+cmd_run() {
+  local issue_number="$1"
+
+  # Get issue details
+  local issue
+  issue=$(gh issue view "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+    --json title,body,labels 2>/dev/null)
+
+  if [[ -z "$issue" ]]; then
+    echo -e "${RED}Issue #$issue_number not found.${NC}"
+    return 1
+  fi
+
+  local title body target
+  title=$(echo "$issue" | jq -r '.title')
+  body=$(echo "$issue" | jq -r '.body')
+  target=$(echo "$body" | grep -oP '(?<=\*\*Target:\*\* `)[^`]+' 2>/dev/null || echo "")
+
+  echo -e "${CYAN}Running task #$issue_number: $title${NC}"
+
+  # Mark as in-progress
+  gh issue edit "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+    --remove-label "$LABEL_PENDING" --add-label "$LABEL_RUNNING" 2>/dev/null || true
+
+  # Determine working directory
+  local workdir="$WORKSPACE"
+  if [[ -n "$target" ]]; then
+    if [[ "$target" =~ ^~/ ]] || [[ "$target" =~ ^/ ]]; then
+      workdir="${target/#\~/$HOME}"
+    elif [[ "$target" =~ / ]]; then
+      # Looks like owner/repo - clone if needed
+      local repo_name
+      repo_name=$(basename "$target")
+      workdir="$WORKSPACE/$repo_name"
+      if [[ ! -d "$workdir" ]]; then
+        echo -e "${CYAN}Cloning $target...${NC}"
+        git clone "https://github.com/$target.git" "$workdir"
+      fi
+    else
+      workdir="$WORKSPACE/$target"
+    fi
+  fi
+
+  if [[ ! -d "$workdir" ]]; then
+    mkdir -p "$workdir"
+  fi
+
+  # Build the prompt from the issue
+  local prompt="Task from remote queue (GitHub Issue #$issue_number):
+
+Title: $title
+
+$body
+
+When complete, summarize what you did."
+
+  # Run Claude
+  cd "$workdir"
+  echo -e "${CYAN}Working directory: $workdir${NC}"
+  echo -e "${CYAN}Starting Claude...${NC}"
+  echo ""
+
+  local output
+  if output=$(claude -p "$prompt" 2>&1); then
+    # Post result as comment
+    gh issue comment "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+      --body "## Claude completed this task
+
+$output" 2>/dev/null || true
+
+    # Mark as done
+    gh issue edit "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+      --remove-label "$LABEL_RUNNING" --add-label "$LABEL_DONE" 2>/dev/null || true
+    gh issue close "$issue_number" --repo "$CLAUDE_TASKS_REPO" 2>/dev/null || true
+
+    echo ""
+    echo -e "${GREEN}Task #$issue_number completed and closed.${NC}"
+  else
+    # Post error as comment
+    gh issue comment "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+      --body "## Claude encountered an error
+
+\`\`\`
+$output
+\`\`\`" 2>/dev/null || true
+
+    echo ""
+    echo -e "${RED}Task #$issue_number failed. Error posted to issue.${NC}"
+  fi
+}
+
+cmd_run_next() {
+  local next
+  next=$(gh issue list --repo "$CLAUDE_TASKS_REPO" --label "$LABEL_PENDING" \
+    --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+  if [[ -z "$next" ]] || [[ "$next" == "null" ]]; then
+    echo -e "${DIM}No pending tasks.${NC}"
+    return
+  fi
+
+  cmd_run "$next"
+}
+
+cmd_done() {
+  local issue_number="$1"
+  gh issue edit "$issue_number" --repo "$CLAUDE_TASKS_REPO" \
+    --remove-label "$LABEL_PENDING" --remove-label "$LABEL_RUNNING" \
+    --add-label "$LABEL_DONE" 2>/dev/null || true
+  gh issue close "$issue_number" --repo "$CLAUDE_TASKS_REPO" 2>/dev/null || true
+  echo -e "${GREEN}Task #$issue_number marked as complete.${NC}"
+}
+
+cmd_help() {
+  echo -e "${BOLD}Claude Remote Tasks${NC}"
+  echo ""
+  echo "  Give Claude instructions from anywhere using GitHub Issues."
+  echo "  Create tasks from your phone, tablet, or browser."
+  echo ""
+  echo -e "  ${BOLD}Usage:${NC}"
+  echo "    claude-tasks list              Show pending tasks"
+  echo "    claude-tasks create            Create task interactively"
+  echo "    claude-tasks quick \"fix bug\"   Create task with one command"
+  echo "    claude-tasks run-next          Run the next pending task"
+  echo "    claude-tasks run <number>      Run a specific task"
+  echo "    claude-tasks done <number>     Mark task as complete"
+  echo ""
+  echo -e "  ${BOLD}Quick tips:${NC}"
+  echo "    - Create tasks from GitHub mobile app (new issue + 'claude-task' label)"
+  echo "    - Use iOS/Android Shortcuts to create tasks via gh CLI"
+  echo "    - Set up a cron job to auto-run pending tasks"
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  check_deps
+  check_repo
+
+  local cmd="${1:-help}"
+  shift || true
+
+  case "$cmd" in
+    list)     cmd_list ;;
+    create)   cmd_create ;;
+    quick)    cmd_quick "$@" ;;
+    run-next) cmd_run_next ;;
+    run)      cmd_run "$@" ;;
+    done)     cmd_done "$@" ;;
+    help|*)   cmd_help ;;
+  esac
+}
+
+main "$@"

--- a/scripts/mac-setup.sh
+++ b/scripts/mac-setup.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# =============================================================================
+# Claude Mac Setup Script
+# One-command setup for a new Mac with Claude Code + Launchpad + Remote Tasks
+# Usage: curl -fsSL <raw-url> | bash
+#   or:  bash scripts/mac-setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[info]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[ok]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[warn]${NC}  $*"; }
+fail()  { echo -e "${RED}[fail]${NC}  $*"; exit 1; }
+step()  { echo -e "\n${BOLD}--- $* ---${NC}"; }
+
+# ---------------------------------------------------------------------------
+# 1. Homebrew
+# ---------------------------------------------------------------------------
+step "Checking Homebrew"
+if command -v brew &>/dev/null; then
+  ok "Homebrew already installed"
+else
+  info "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Add brew to PATH for Apple Silicon
+  if [[ -f /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
+  fi
+  ok "Homebrew installed"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Core dependencies
+# ---------------------------------------------------------------------------
+step "Installing core tools"
+
+deps=(git node jq gh)
+for dep in "${deps[@]}"; do
+  if command -v "$dep" &>/dev/null; then
+    ok "$dep already installed"
+  else
+    info "Installing $dep..."
+    case "$dep" in
+      node) brew install node ;;
+      gh)   brew install gh ;;
+      *)    brew install "$dep" ;;
+    esac
+    ok "$dep installed"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. Claude Code CLI
+# ---------------------------------------------------------------------------
+step "Installing Claude Code"
+
+if command -v claude &>/dev/null; then
+  ok "Claude Code CLI already installed ($(claude --version 2>/dev/null || echo 'unknown version'))"
+else
+  info "Installing Claude Code via npm..."
+  npm install -g @anthropic-ai/claude-code
+  ok "Claude Code CLI installed"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. GitHub CLI auth check
+# ---------------------------------------------------------------------------
+step "Checking GitHub authentication"
+
+if gh auth status &>/dev/null 2>&1; then
+  ok "GitHub CLI authenticated"
+else
+  warn "GitHub CLI not authenticated. Run: gh auth login"
+  info "This is needed for the remote task system."
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Install Launchpad
+# ---------------------------------------------------------------------------
+step "Installing Claude Launchpad"
+
+LAUNCHPAD_DIR="$HOME/.claude-launchpad"
+mkdir -p "$LAUNCHPAD_DIR"
+
+# Copy launchpad script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/claude-launchpad.sh" ]]; then
+  cp "$SCRIPT_DIR/claude-launchpad.sh" "$LAUNCHPAD_DIR/launchpad.sh"
+  chmod +x "$LAUNCHPAD_DIR/launchpad.sh"
+else
+  warn "Launchpad script not found at $SCRIPT_DIR/claude-launchpad.sh"
+  info "You can install it later from the repo."
+fi
+
+# Copy remote task runner
+if [[ -f "$SCRIPT_DIR/claude-remote-tasks.sh" ]]; then
+  cp "$SCRIPT_DIR/claude-remote-tasks.sh" "$LAUNCHPAD_DIR/remote-tasks.sh"
+  chmod +x "$LAUNCHPAD_DIR/remote-tasks.sh"
+fi
+
+# Add shell aliases
+SHELL_RC="$HOME/.zshrc"
+if [[ ! -f "$SHELL_RC" ]]; then
+  SHELL_RC="$HOME/.bashrc"
+fi
+
+if ! grep -q "claude-launchpad" "$SHELL_RC" 2>/dev/null; then
+  cat >> "$SHELL_RC" << 'ALIASES'
+
+# --- Claude Launchpad ---
+alias launchpad='~/.claude-launchpad/launchpad.sh'
+alias lp='~/.claude-launchpad/launchpad.sh'
+alias claude-tasks='~/.claude-launchpad/remote-tasks.sh'
+alias ct='~/.claude-launchpad/remote-tasks.sh'
+ALIASES
+  ok "Shell aliases added to $SHELL_RC"
+else
+  ok "Shell aliases already configured"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Create default workspace
+# ---------------------------------------------------------------------------
+step "Setting up workspace"
+
+WORKSPACE="$HOME/claude-workspace"
+mkdir -p "$WORKSPACE"
+ok "Workspace ready at $WORKSPACE"
+
+# ---------------------------------------------------------------------------
+# 7. Create global CLAUDE.md
+# ---------------------------------------------------------------------------
+step "Configuring Claude defaults"
+
+GLOBAL_CLAUDE="$HOME/.claude/CLAUDE.md"
+mkdir -p "$HOME/.claude"
+
+if [[ ! -f "$GLOBAL_CLAUDE" ]]; then
+  cat > "$GLOBAL_CLAUDE" << 'CLAUDEMD'
+# Global Claude Configuration
+
+## Preferences
+- Keep responses concise and actionable
+- Prefer simple solutions over complex ones
+- Always run tests after making changes
+- Use conventional commits (feat:, fix:, chore:, etc.)
+
+## Common Workflows
+- When fixing bugs: read the code first, write a failing test, then fix
+- When adding features: plan with todos, implement incrementally, test each step
+- When refactoring: ensure tests pass before and after
+
+## Project Locations
+- Main workspace: ~/claude-workspace
+- Launchpad: ~/.claude-launchpad
+CLAUDEMD
+  ok "Global CLAUDE.md created at $GLOBAL_CLAUDE"
+else
+  ok "Global CLAUDE.md already exists"
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${GREEN}${BOLD}Setup complete!${NC}"
+echo ""
+echo "  Quick commands:"
+echo "    lp             Open the Claude Launchpad"
+echo "    launchpad       Same as above"
+echo "    ct             Check/run remote Claude tasks"
+echo "    claude-tasks    Same as above"
+echo "    claude          Start Claude Code in current directory"
+echo ""
+echo "  To apply aliases now, run:"
+echo "    source $SHELL_RC"
+echo ""


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive task management and quick-access system for Claude Code on macOS, enabling users to queue tasks from anywhere (phone, browser, tablet) via GitHub Issues and have them automatically picked up and executed on their Mac.

## Key Changes

- **Claude Launchpad** (`claude-launchpad.sh`): Interactive menu-driven command center providing quick access to:
  - Starting Claude in various contexts (current directory, workspace, resume session)
  - Project management (browse workspace, clone repos)
  - Remote task integration
  - Component installation
  - Clipboard-based prompts and settings management

- **Remote Tasks System** (`claude-remote-tasks.sh`): GitHub Issues-based task queue with commands to:
  - List pending tasks with status tracking
  - Create tasks interactively or via one-liner
  - Run tasks with automatic directory/repo handling
  - Post results back as issue comments
  - Mark tasks complete with automatic issue closure
  - Support for task targets (local paths or GitHub repos)

- **Auto-Runner** (`claude-auto-runner.sh`): Background polling daemon that:
  - Installs as a macOS LaunchAgent for automatic startup
  - Polls GitHub for pending tasks on configurable intervals
  - Can notify or auto-execute tasks
  - Provides status monitoring and logging

- **Mac Setup Script** (`mac-setup.sh`): One-command installation that:
  - Installs Homebrew and core dependencies (git, node, jq, gh)
  - Installs Claude Code CLI via npm
  - Sets up Launchpad and remote tasks system
  - Creates shell aliases (`lp`, `ct`, `launchpad`, `claude-tasks`)
  - Initializes workspace directory and global Claude configuration

- **Documentation** (`REMOTE-TASKS-GUIDE.md`): Comprehensive guide covering:
  - Setup instructions
  - Task creation from terminal, GitHub web UI, iOS Shortcuts, and Android
  - Task execution workflows
  - Auto-runner configuration
  - Best practices for task formatting

## Implementation Details

- Uses GitHub CLI (`gh`) for all GitHub interactions
- Supports flexible task targets: local paths, GitHub repos (auto-clones), or workspace directories
- Task state managed via GitHub labels (`claude-task`, `in-progress`, `completed`)
- Results posted back to issues as comments with full Claude output
- Shell-based implementation for portability and minimal dependencies
- Includes colored output and user-friendly error messages
- Workspace defaults to `~/claude-workspace` (configurable via `CLAUDE_WORKSPACE`)

https://claude.ai/code/session_016YHJ3zNhAjhyCVKLLwGbMV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Launchpad and a GitHub Issues–based remote task system for macOS, so you can queue tasks from any device and auto-run them on your Mac. Improves workflow with a menu launcher, background runner, and a one-command Mac setup.

- Area: CLI (scripts/). Added claude-launchpad.sh, claude-remote-tasks.sh, claude-auto-runner.sh, mac-setup.sh, plus a quick-start guide.
- Remote tasks: create issues with label “claude-task”, auto-clone/open targets, run with Claude, comment results, and auto-close.
- Launchpad: menu for starting Claude, managing projects, and running/creating tasks; adds aliases lp, launchpad, ct, claude-tasks; default workspace ~/claude-workspace.
- Auto-runner: macOS LaunchAgent that polls GitHub on an interval; optional hands-free execution.
- New env vars: CLAUDE_TASKS_REPO (required), CLAUDE_POLL_INTERVAL, CLAUDE_AUTO_RUN, CLAUDE_WORKSPACE; requires gh auth. No new components; no docs/components.json regen.

<sup>Written for commit 26d858aa6d9df6a0e22ec5006cdb9f7aac9509f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

