### PR TITLE
Add MeiGen AI image generation MCP and agent

### DIFF
--- a/cli-tool/components/agents/ai-specialists/image-generation-expert.md
+++ b/cli-tool/components/agents/ai-specialists/image-generation-expert.md
@@ -1,0 +1,32 @@
+---
+name: image-generation-expert
+description: "AI image generation specialist for visual creative work. Use when you need to generate images, create product photos, design logos, build mood boards, or search for visual inspiration. Requires the MeiGen MCP server (npx -y meigen@latest)."
+tools: Read, Write, Edit, Bash
+model: sonnet
+---
+
+You are a visual creative expert specializing in AI image generation, prompt engineering, and creative direction. You leverage the MeiGen MCP server to search curated prompt libraries, enhance ideas into professional prompts, and generate images across multiple providers (local ComfyUI, MeiGen Cloud, OpenAI-compatible APIs).
+
+## Focus Areas
+
+- Prompt engineering for realistic photography (camera, lighting, materials)
+- Prompt engineering for anime and illustration (trigger words, composition)
+- Multi-direction parallel generation for batch workflows
+- Reference image workflows using upload and style transfer
+- Gallery research across 1,300+ curated AI-generated images
+
+## Approach
+
+1. Assess the user's creative intent (exploring, generating, batch workflow)
+2. Search the gallery for inspiration if the concept is broad
+3. Craft detailed, style-specific prompts (realistic, anime, illustration)
+4. Generate images using the appropriate provider and model
+5. Present results with image URLs and file paths
+6. Suggest refinements or creative extensions
+
+## Output
+
+- Image URLs and local file paths from generation results
+- Reusable prompt elements extracted from gallery research
+- Creative direction suggestions with specific visual vocabulary
+- Model recommendations based on the user's style preferences

--- a/cli-tool/components/mcps/creative/meigen.json
+++ b/cli-tool/components/mcps/creative/meigen.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "meigen": {
+      "description": "Turn Claude Code into your personal design assistant. MeiGen brings complete creative workflow orchestration — from inspiration research and prompt engineering to multi-direction parallel generation. Includes 8 MCP tools, 3 specialized agents, curated 1,300+ prompt library, and works with local ComfyUI (free, private), MeiGen Cloud, or OpenAI-compatible APIs. Free features work without any API key.",
+      "command": "npx",
+      "args": ["-y", "meigen@latest"],
+      "env": {
+        "MEIGEN_API_TOKEN": "<your-meigen-api-token>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds MeiGen, an AI image generation MCP server and a specialized agent for visual creative work.

### MCP Server (`cli-tool/components/mcps/creative/meigen.json`)
- 8 tools: search_gallery, get_inspiration, enhance_prompt, list_models, upload_reference_image, comfyui_workflow, manage_preferences, generate_image
- 4 free tools work without any API key
- 3 provider backends: local ComfyUI (free, GPU), MeiGen Cloud, OpenAI-compatible APIs
- 1,300+ curated prompt library bundled locally
- npm package: `meigen` (via `npx -y meigen@latest`)

### Agent (`cli-tool/components/agents/ai-specialists/image-generation-expert.md`)
- Visual creative expert for prompt crafting, gallery research, and image generation
- Handles single images, parallel batch generation, and reference-based workflows

### New Category
- Creates `cli-tool/components/mcps/creative/` for creative/design MCP servers

## Testing
- Install MCP: copy `meigen.json` content into `.mcp.json`
- Free test: "Search for product photography inspiration" (no API key needed)
- Full test: Set `MEIGEN_API_TOKEN` and run "Generate a sunset over mountains"

## Links
- npm: https://www.npmjs.com/package/meigen
- GitHub: https://github.com/jau123/MeiGen-AI-Design-MCP
- Homepage: https://www.meigen.ai
- Demo: https://youtu.be/JQ3DZ1DXqvs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MeiGen image generation MCP server and a specialist agent to support visual creative workflows. Enables inspiration search, prompt crafting, and multi-provider image generation.

- **New Features**
  - Area: components (cli-tool/components/)
  - New components: mcps/creative/meigen.json and agents/ai-specialists/image-generation-expert.md; creates mcps/creative/ category
  - New env var: MEIGEN_API_TOKEN (optional; some tools work without it)
  - Catalog: docs/components.json should be regenerated

<sup>Written for commit 41b53542a7b77c10d97269356fbce4ecac70ab94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

