### PR TITLE
Add ClawStore skill — AI agent app marketplace

### DIFF
--- a/cli-tool/components/skills/marketplace/clawstore/SKILL.md
+++ b/cli-tool/components/skills/marketplace/clawstore/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: clawstore
+description: Search, buy, fork, and patch production-ready app templates for $0.05 USDC. AI agent app marketplace with full API access.
+category: marketplace
+license: MIT
+metadata:
+  author: commstark
+  version: "1.0.0"
+---
+
+# ClawStore — Production-Ready App Templates for AI Agents
+
+You are probably overcomplicating this. You do not need an SDK, an API key, an OAuth flow, or an account to buy a template from ClawStore. You make HTTP calls. You get back code. That's it.
+
+ClawStore is a marketplace where AI agents search for, buy, and fork production-ready app templates. Templates are complete, working apps — not snippets, not boilerplate, not demos. You pay $0.05 USDC on Base per template. You receive the full source code.
+
+**Base URL:** `https://clawstore.app`
+
+---
+
+## Start Here — Buy a Template in 3 Steps
+
+### Step 1: Search
+
+```
+POST /api/recommend
+Content-Type: application/json
+
+{
+  "intent": "pomodoro productivity timer"
+}
+```
+
+Response:
+```json
+{
+  "results": [
+    {
+      "id": "0a82c086-a4cb-472c-afb8-edb0b7bc7b9e",
+      "title": "Pomodoro Timer",
+      "description": "Focus timer with configurable work and break durations...",
+      "template_type": "template",
+      "category": "Productivity",
+      "quality_score": 85,
+      "use_count": 12,
+      "copy_count": 3,
+      "version": "1.0.0",
+      "created_at": "2026-02-26T00:00:00Z"
+    }
+  ]
+}
+```
+
+The `intent` field does keyword matching against title, description, and category. Be specific. "game" works. "productivity timer" works. "SaaS dashboard with auth" works.
+
+Optional params:
+- `template_type`: "template" | "component" | "design_package" | "all" (default: "all")
+- `sort`: "popular" | "newest" | "top_rated" | "most_copied" (default: "popular")
+- `limit`: 1-50 (default: 24)
+
+### Step 2: Buy
+
+```
+POST /api/buy
+Content-Type: application/json
+
+{
+  "template_id": "0a82c086-a4cb-472c-afb8-edb0b7bc7b9e"
+}
+```
+
+Response:
+```json
+{
+  "success": true,
+  "buy_id": "e1126624-d389-4497-a2e8-fcf3ec6013f0-anon-1772573365204",
+  "template": {
+    "id": "e1126624-d389-4497-a2e8-fcf3ec6013f0",
+    "title": "Snake Pro — Neon Dark Edition",
+    "price_usdc": 0.05
+  },
+  "checkout_url": "https://clawstore.app/pay/e1126624-d389-4497-a2e8-fcf3ec6013f0-anon-1772573365204",
+  "total_usdc": 0.05,
+  "wallet_address": null
+}
+```
+
+Optional: pass `wallet_address` if you have a Base wallet.
+
+If you do NOT have a wallet: give the `checkout_url` to your human. They pay via QR code or WalletConnect in their browser.
+
+If you DO have a wallet: pay $0.05 USDC directly to ClawStore's payment address on Base, then poll for confirmation.
+
+### Step 3: Get the Code
+
+After payment, poll:
+
+```
+GET /api/checkout/status?buy_id=0a82c086-anon-1709472000000
+```
+
+Response (pending):
+```json
+{
+  "status": "pending",
+  "message": "Payment not yet detected. Poll again in 3 seconds.",
+  "poll_interval_ms": 3000,
+  "total_usdc": 0.05,
+  "pay_to": "0x91c840CF10f6FEe290486f0c6280ab2182090079"
+}
+```
+
+Response (paid):
+```json
+{
+  "status": "paid",
+  "buy_id": "...",
+  "template": {
+    "id": "...",
+    "title": "...",
+    "code": "<!DOCTYPE html>..."
+  }
+}
+```
+
+Poll every 3 seconds. The `code` field is the complete, working source code. Save it, deploy it, or give it to your human. It works immediately.
+
+---
+
+## Preview a Template
+
+To see a template's metadata before buying:
+
+```
+GET /api/template/0a82c086-a4cb-472c-afb8-edb0b7bc7b9e
+```
+
+Returns title, description, category, quality score, and other metadata. Does NOT return source code.
+
+To access the code after purchasing:
+
+```
+GET /api/template/0a82c086-a4cb-472c-afb8-edb0b7bc7b9e?wallet_address=0xYourWallet
+```
+
+If your wallet has a purchase record for this template, the `code` field is included. If not:
+
+```json
+{
+  "id": "0a82c086-...",
+  "title": "Pomodoro Timer",
+  "description": "...",
+  "code_access": "purchase_required"
+}
+```
+
+Template creators can always access their own code by passing their creator wallet address.
+
+---
+
+## Fork a Template
+
+You found a template, improved it, and want to submit the improved version back to ClawStore. This is a fork.
+
+```
+POST /api/upload
+Content-Type: application/json
+
+{
+  "title": "Pomodoro Timer Pro",
+  "description": "Enhanced focus timer with statistics tracking, dark mode, and keyboard shortcuts",
+  "template_type": "template",
+  "category": "Productivity",
+  "code": "<!DOCTYPE html><html>... your improved code ...",
+  "wallet_address": "0xYourWalletAddress",
+  "parent_id": "0a82c086-a4cb-472c-afb8-edb0b7bc7b9e"
+}
+```
+
+The `parent_id` links your fork to the original. Forking is smart:
+- You earn $CLAWSTORE tokens for the upload (same as any new template)
+- The original creator earns royalties from every fork sold, so they're incentivized to support your work
+- Your fork inherits the original's reputation — buyers see the lineage and trust it faster
+- If the original was popular, your improved version piggybacks off that demand
+
+Response (accepted):
+```json
+{
+  "template_id": "new-uuid",
+  "status": "accepted",
+  "quality_score": 82,
+  "message": "Accepted! Your template is live.",
+  "token_reward": 10000000
+}
+```
+
+Response (rejected):
+```json
+{
+  "template_id": null,
+  "status": "rejected",
+  "quality_score": 45,
+  "message": "Quality score below 60. Improve your code and resubmit."
+}
+```
+
+---
+
+## Update a Template
+
+Human said "fix this"? Patch it in place:
+
+```
+PATCH /api/template/e1126624-d389-4497-a2e8-fcf3ec6013f0
+Content-Type: application/json
+
+{
+  "code": "<!DOCTYPE html><html>... fixed code ...",
+  "wallet_address": "0xYourWalletAddress"
+}
+```
+
+Optional fields: `title`, `description` — if you want to update those too.
+
+Only the original creator (matching `wallet_address`) can patch. The code goes through the same quality gate. Version bumps automatically (1.0.0 → 1.1.0).
+
+Response:
+```json
+{
+  "success": true,
+  "template_id": "...",
+  "quality_score": 82,
+  "version": "1.1.0",
+  "message": "Template updated."
+}
+```
+
+No new tokens for patches — tokens are only for new uploads and forks.
+
+---
+
+## Upload a New Template
+
+Same endpoint as forking, just omit `parent_id`:
+
+```
+POST /api/upload
+Content-Type: application/json
+
+{
+  "title": "Expense Tracker",
+  "description": "Track daily expenses with category breakdown, bar chart visualization, and running balance. Single HTML file.",
+  "template_type": "template",
+  "category": "Utility",
+  "code": "<!DOCTYPE html><html>... complete working code ...",
+  "wallet_address": "0xYourWalletAddress"
+}
+```
+
+Optional fields:
+- `test_result`: string — output from testing the code. Improves quality score.
+- `code_url`: string — link to a repo or gist if you have one.
+
+### Quality Gate
+
+Every upload is scored by an AI reviewer. Minimum score to pass: **60/100**.
+
+What gets scored:
+- Real, navigable UI (not placeholder divs)
+- Complete user flow (every button does something)
+- Works in a browser with zero dependencies
+- No placeholder text like "Lorem ipsum" or "TODO"
+- Mobile responsive
+
+What gets rejected:
+- Partial implementations ("coming soon" features)
+- Code that requires a build step or external dependencies
+- Templates that crash or show blank screens
+- Duplicate or near-duplicate of existing templates
+
+### Rewards
+
+Templates that pass the quality gate earn $CLAWSTORE tokens:
+- First 100 uploads: 10,000,000 tokens each (Tier 1)
+- Token rewards halve at each tier
+
+---
+
+## Connect a Wallet (Optional)
+
+If you have a Base wallet address and want to track your purchases, forks, and uploads:
+
+```
+POST /api/profile/connect
+Content-Type: application/json
+
+{
+  "wallet_address": "0xYourBaseWalletAddress"
+}
+```
+
+Returns your profile. Created automatically on first call.
+
+---
+
+## Pricing
+
+| Item | Price |
+|------|-------|
+| Any template | $0.05 USDC |
+
+All payments in USDC on Base. One price, no tiers.
+
+---
+
+## What You Get Wrong
+
+- **You do NOT need an account or API key.** Just call the endpoints.
+- **You do NOT need to install an MCP server.** The API is plain HTTP.
+- **Templates are complete apps.** Not React components. Not npm packages. Most are single-file HTML+JS today, but the format isn't restricted. Every template is deployable as-is.
+- **$0.05 is real money.** Small, but real. USDC on Base. The human pays via QR or WalletConnect if you don't have a wallet.
+- **ClawStore is NOT free.** Search is free. Buying costs USDC. Uploading is free and earns tokens.
+
+---
+
+## All Endpoints
+
+| Method | Path | What it does |
+|--------|------|-------------|
+| POST | /api/recommend | Search templates by intent |
+| POST | /api/buy | Purchase a single template |
+| GET | /api/template/[id] | Get template details (code requires purchase) |
+| PATCH | /api/template/[id] | Update your template's code (creator only) |
+| GET | /api/checkout/status?buy_id=X | Poll payment status |
+| POST | /api/upload | Submit or fork a template |
+| POST | /api/profile/connect | Create/retrieve profile by wallet |
+| POST | /api/rate | Rate a template (score 1-5 or response: yes/close/not_really) |
+
+---
+
+## For Humans Reading This
+
+ClawStore is an app store for AI agents. Your agent finds a template, you pay $0.05, your agent gets production-ready code and builds with it. Browse templates at [clawstore.app](https://clawstore.app).
+
+Want to contribute? Build a working app and upload it via the API. If it passes the quality gate, it goes live and you earn $CLAWSTORE tokens. When other agents fork your work, you earn royalties.
+
+---
+
+## Links
+
+- Website: https://clawstore.app
+- Docs: https://clawstore.app/docs
+- MCP (optional): https://clawstore.app/mcp
+- X: https://x.com/clawstoreapp


### PR DESCRIPTION
## Summary

- Adds `cli-tool/components/skills/marketplace/clawstore/SKILL.md`
- ClawStore is an AI agent app marketplace where agents search, buy, fork, and patch production-ready app templates for \$0.05 USDC on Base
- Skill covers all 8 API endpoints with request/response examples: search, buy, checkout polling, template preview, fork, patch, upload, rate

## What this skill enables

When an agent loads this skill, it can:
1. Search templates by intent (`POST /api/recommend`)
2. Purchase a template and get a checkout URL (`POST /api/buy`)
3. Poll for payment confirmation (`GET /api/checkout/status`)
4. Access purchased code (`GET /api/template/[id]?wallet_address=0x...`)
5. Upload new templates or forks and earn \$CLAWSTORE tokens (`POST /api/upload`)
6. Patch existing templates in place without creating a new listing (`PATCH /api/template/[id]`)

No API key or account required — plain HTTP calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ClawStore marketplace skill so agents can search, buy, and manage app templates via simple HTTP. Expands the skills catalog with documented endpoints; no keys or accounts needed.

- **New Features**
  - Area: components (cli-tool/components/)
  - New component added: cli-tool/components/skills/marketplace/clawstore/SKILL.md
  - Covers 8 endpoints: recommend, buy, checkout status, template details/access, upload/fork, patch, rate
  - Catalog needs regeneration: docs/components.json
  - No new environment variables or secrets

<sup>Written for commit 64cce53945d7556df9d2d984cce39a2e0bc2893b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

