### PR TITLE
Add reproducibility to scanpy import

### DIFF
--- a/cli-tool/components/skills/scientific/scanpy/SKILL.md
+++ b/cli-tool/components/skills/scientific/scanpy/SKILL.md
@@ -30,9 +30,9 @@ import pandas as pd
 import numpy as np
 
 # Configure settings
-sc.settings.verbosity = 3
-sc.settings.set_figure_params(dpi=80, facecolor='white')
+# sc.settings.verbosity = 'hint'  # enable for debugging
 sc.settings.figdir = './figures/'
+sc.print_header()  # in notebooks
 ```
 
 ### Loading Data


### PR DESCRIPTION
Hi, scanpy maintainer here: all notebooks should begin with `sc.print_header()` so reproducibility is easier.

Also no clue why you set `dpi=80, facecolor='white'`, any insight here?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `sc.print_header()` to the Scanpy SKILL to improve notebook reproducibility and simplifies default settings by removing noisy verbosity/figure params.

- **Refactors**
  - Updated `cli-tool/components/skills/scientific/scanpy/SKILL.md`: added `sc.print_header()` (for notebooks), commented out verbosity/figure params, kept `figdir`.
  - Area: components (`cli-tool/components/`).
  - No new components; no `docs/components.json` regeneration needed.
  - No new environment variables or secrets.

<sup>Written for commit 86e44315f5615dab04d296b50c628cea34d1aede. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

