### PR TITLE
feat: add 8 language-specific coding rules for .claude/rules/

### DIFF
--- a/cli-tool/components/settings/coding-rules/README.md
+++ b/cli-tool/components/settings/coding-rules/README.md
@@ -1,0 +1,35 @@
+# Language-Specific Coding Rules
+
+Drop-in rules for `.claude/rules/` that enforce language-specific conventions.
+Each file uses YAML frontmatter with glob patterns so Claude Code automatically
+applies the rules to matching files.
+
+## Installation
+
+Copy the rules you need into `.claude/rules/` in your project:
+
+```bash
+mkdir -p .claude/rules
+cp python.md typescript.md react.md .claude/rules/
+```
+
+Claude Code will automatically apply matching rules based on the `globs` patterns in each file's frontmatter.
+
+## Available Rules
+
+| File | Globs | Key Conventions |
+|------|-------|-----------------|
+| `python.md` | `**/*.py` | PEP 8, type hints on all signatures, f-strings, pathlib, dataclasses |
+| `typescript.md` | `**/*.ts`, `**/*.tsx` | Strict mode, no `any`, unions over enums, const-first |
+| `react.md` | `**/*.tsx`, `**/*.jsx` | Functional components, custom hooks, named exports, accessibility |
+| `go.md` | `**/*.go` | Immediate error checks, context as first param, table-driven tests |
+| `rails.md` | `**/*.rb`, `**/*.erb` | Fat models/thin controllers, strong params, scopes, service objects |
+| `rust.md` | `**/*.rs` | Result over panic, `?` operator, borrows, minimize unsafe |
+| `sql.md` | `**/*.sql`, `**/migrations/**` | snake_case, BIGINT IDs, reversible migrations, index FKs |
+| `testing.md` | `**/*test*`, `**/*spec*` | Arrange-Act-Assert, one concept per test, no sleep/timeouts |
+
+## Customization
+
+Each rule file is self-contained markdown. Edit directly to match your team's conventions.
+
+Source: https://github.com/CodeWithBehnam/cc-docs

--- a/cli-tool/components/settings/coding-rules/go.md
+++ b/cli-tool/components/settings/coding-rules/go.md
@@ -1,0 +1,40 @@
+---
+description: Go idioms and conventions for .go files
+globs: ["**/*.go"]
+---
+
+# Go Rules
+
+## Error Handling
+- Check errors immediately after every call that returns one. Never defer error checks.
+- Return errors to the caller. Do not `panic` for recoverable errors.
+- Wrap errors with context: `fmt.Errorf("loading config: %w", err)`.
+- Define custom error types using `errors.New` or a struct implementing the `error` interface.
+
+## Function Signatures
+- Pass `context.Context` as the first parameter in functions that do I/O or may be cancelled.
+- Keep function signatures short. If a function needs more than four or five parameters, use an options struct.
+
+## Variables and Naming
+- Use short variable names in small scopes (`i`, `v`, `err`, `n`).
+- Use descriptive names for package-level and exported identifiers.
+- Prefer `:=` for local variable declarations. Use `var` only when zero-value initialization is intentional or the type must be explicit.
+
+## Interfaces
+- Define interfaces at the point of use (in the package that consumes them), not in the package that implements them.
+- Keep interfaces small - one to three methods is ideal.
+- Use interfaces to make code testable by allowing fake/stub implementations.
+
+## Testing
+- Use table-driven tests with `[]struct{ name, input, want }` slices.
+- Name subtests with `t.Run(tc.name, ...)` so failures are easy to identify.
+- Prefer the standard `testing` package. Add `testify/assert` only when it reduces significant boilerplate.
+
+## Project Layout
+- Follow the standard Go project layout: `cmd/`, `internal/`, `pkg/`.
+- Keep `main` packages in `cmd/<binary-name>/main.go`.
+- Put packages that must not be imported externally under `internal/`.
+
+## Concurrency
+- Use channels to communicate between goroutines. Do not share memory without a mutex.
+- Always specify goroutine lifecycle: who starts it, who waits for it, and how it exits.

--- a/cli-tool/components/settings/coding-rules/go.md
+++ b/cli-tool/components/settings/coding-rules/go.md
@@ -9,7 +9,7 @@ globs: ["**/*.go"]
 - Check errors immediately after every call that returns one. Never defer error checks.
 - Return errors to the caller. Do not `panic` for recoverable errors.
 - Wrap errors with context: `fmt.Errorf("loading config: %w", err)`.
-- Define custom error types using `errors.New` or a struct implementing the `error` interface.
+- Use `errors.New` for sentinel errors (e.g., `var ErrNotFound = errors.New("not found")`). For custom error types with fields, define a struct implementing the `error` interface.
 
 ## Function Signatures
 - Pass `context.Context` as the first parameter in functions that do I/O or may be cancelled.

--- a/cli-tool/components/settings/coding-rules/python.md
+++ b/cli-tool/components/settings/coding-rules/python.md
@@ -29,7 +29,7 @@ globs: ["**/*.py"]
 - Avoid nested comprehensions deeper than two levels.
 
 ## Logging and Debugging
-- Use the `logging` module. Never use `print` for program output or debugging.
+- Use the `logging` module for diagnostic output. Avoid `print` for debugging. For CLI tools that produce user-facing stdout output, `print` is acceptable.
 - Configure loggers at the module level: `logger = logging.getLogger(__name__)`.
 
 ## Error Handling

--- a/cli-tool/components/settings/coding-rules/python.md
+++ b/cli-tool/components/settings/coding-rules/python.md
@@ -1,0 +1,42 @@
+---
+description: Python conventions following PEP 8 and modern best practices
+globs: ["**/*.py"]
+---
+
+# Python Rules
+
+## Style
+- Follow PEP 8: 4-space indentation, 88-character line limit (Black-compatible).
+- Use f-strings for string interpolation. Do not use `%` formatting or `.format()`.
+- Use double quotes for strings unless the string contains a double quote.
+
+## Type Hints
+- Add type hints to all function signatures (parameters and return type).
+- Use `from __future__ import annotations` for forward references.
+- Use `Optional[X]` or `X | None` (Python 3.10+) for nullable types. Never leave them unannotated.
+- Use `TypeVar` and generics when writing reusable utilities.
+
+## Data Modeling
+- Use `dataclasses` for plain data containers. Use `pydantic` `BaseModel` when validation or serialization is needed.
+- Do not use bare `dict` or `tuple` to represent structured data.
+
+## File and Path Handling
+- Use `pathlib.Path` for all file-system operations. Never use `os.path`.
+
+## Control Flow and Collections
+- Prefer list comprehensions for simple one-to-one or filter transforms.
+- Use generator expressions when the result is consumed only once.
+- Avoid nested comprehensions deeper than two levels.
+
+## Logging and Debugging
+- Use the `logging` module. Never use `print` for program output or debugging.
+- Configure loggers at the module level: `logger = logging.getLogger(__name__)`.
+
+## Error Handling
+- Catch specific exception types. Never use a bare `except:` or `except Exception:` without re-raising or logging.
+- Raise `ValueError` for invalid input, `RuntimeError` for unexpected state.
+- Use context managers (`with`) for resource management.
+
+## Imports
+- Group imports: standard library, third-party, local. Separate each group with a blank line.
+- Do not use wildcard imports (`from module import *`).

--- a/cli-tool/components/settings/coding-rules/rails.md
+++ b/cli-tool/components/settings/coding-rules/rails.md
@@ -31,6 +31,6 @@ globs: ["**/*.rb", "**/*.erb"]
 - Keep locale files organized by feature, not by model.
 
 ## Security
-- Never trust user input. Always use parameterized queries (ActiveRecord does this by default).
+- Never trust user input. Always use parameterized queries. ActiveRecord parameterizes standard query methods (e.g., `where(name: val)`), but string interpolation in `where`, `order`, `pluck`, and `find_by_sql` is still vulnerable to SQL injection.
 - Avoid `html_safe` and `raw` in views unless the content is known to be safe.
 - Use `authenticate_user!` (Devise) or equivalent before actions that require authentication.

--- a/cli-tool/components/settings/coding-rules/rails.md
+++ b/cli-tool/components/settings/coding-rules/rails.md
@@ -1,0 +1,36 @@
+---
+description: Rails conventions for .rb and .erb files
+globs: ["**/*.rb", "**/*.erb"]
+---
+
+# Rails Rules
+
+## MVC Structure
+- Follow "fat models, thin controllers". Business logic lives in models or service objects, not controllers.
+- Controllers are responsible only for: parsing params, calling the right service/model method, and rendering a response.
+- Views contain no business logic. Extract helpers for non-trivial view computations.
+
+## Models
+- Validate all user-supplied data at the model level using ActiveRecord validations.
+- Use scopes (not class methods) for reusable query fragments: `scope :active, -> { where(active: true) }`.
+- Extract shared model behavior into concerns under `app/models/concerns/`.
+- Use `before_action` and callbacks sparingly. Prefer explicit service calls over hidden callbacks.
+
+## Controllers
+- Use strong parameters with `require` and `permit` for every action that accepts user input.
+- Keep each action to roughly ten lines. Extract longer logic into service objects.
+- Follow RESTful routing. Create new controllers for non-CRUD actions rather than adding custom actions to existing controllers.
+
+## Service Objects
+- Place service objects in `app/services/`. One class per operation (e.g., `UserRegistrationService`).
+- Give service objects a single public method (`call` or a descriptive verb).
+- Return a result object or raise a domain exception. Never return raw ActiveRecord objects from a service that does complex logic.
+
+## Internationalization
+- Use I18n for all user-facing strings. Never hard-code English text in views or mailers.
+- Keep locale files organized by feature, not by model.
+
+## Security
+- Never trust user input. Always use parameterized queries (ActiveRecord does this by default).
+- Avoid `html_safe` and `raw` in views unless the content is known to be safe.
+- Use `authenticate_user!` (Devise) or equivalent before actions that require authentication.

--- a/cli-tool/components/settings/coding-rules/react.md
+++ b/cli-tool/components/settings/coding-rules/react.md
@@ -1,0 +1,40 @@
+---
+description: React patterns for functional components in .tsx and .jsx files
+globs: ["**/*.tsx", "**/*.jsx"]
+---
+
+# React Rules
+
+## Component Structure
+- Use functional components exclusively. Never write class components.
+- One component per file. The file name matches the component name (PascalCase).
+- Use named exports for components. Avoid default exports except at page/route level.
+
+## Hooks
+- Extract shared stateful logic into custom hooks (`use` prefix).
+- Keep hooks at the top level of a component. Never call hooks inside conditions or loops.
+- Use `useCallback` and `useMemo` only when there is a measurable performance problem. Do not add them speculatively.
+- Use `React.memo` sparingly and only after profiling.
+
+## Props and Types
+- Define prop types with a `Props` interface in the same file, above the component.
+- Do not use `React.FC` - annotate props directly: `function MyComponent({ title }: Props)`.
+- Mark props that will not change as `readonly`.
+
+## Accessibility
+- Add `aria-label` or `aria-labelledby` to interactive elements that lack visible text.
+- Use semantic HTML elements (`button`, `nav`, `main`, `section`) instead of generic `div` wrappers.
+- Ensure all images have an `alt` attribute.
+
+## Composition and Patterns
+- Prefer composition over inheritance. Use children, render props, or compound components.
+- Use error boundaries around sections that may throw (data fetching, third-party widgets).
+- Colocate styles with the component (CSS modules or styled components in the same directory).
+
+## State Management
+- Keep state as local as possible. Lift state only when two components genuinely share it.
+- Avoid putting derived data in state. Compute it during render instead.
+
+## Performance
+- Use `key` props that are stable and unique (never array indexes for reordered lists).
+- Avoid inline object and function literals in JSX props for frequently re-rendered components.

--- a/cli-tool/components/settings/coding-rules/react.md
+++ b/cli-tool/components/settings/coding-rules/react.md
@@ -17,9 +17,10 @@ globs: ["**/*.tsx", "**/*.jsx"]
 - Use `React.memo` sparingly and only after profiling.
 
 ## Props and Types
-- Define prop types with a `Props` interface in the same file, above the component.
-- Do not use `React.FC` - annotate props directly: `function MyComponent({ title }: Props)`.
-- Mark props that will not change as `readonly`.
+- In `.tsx` files, define prop types with a `Props` interface in the same file, above the component.
+- In `.tsx` files, do not use `React.FC` - annotate props directly: `function MyComponent({ title }: Props)`.
+- In `.tsx` files, mark props that will not change as `readonly`.
+- In `.jsx` files, use `PropTypes` for runtime prop validation if TypeScript is not available.
 
 ## Accessibility
 - Add `aria-label` or `aria-labelledby` to interactive elements that lack visible text.

--- a/cli-tool/components/settings/coding-rules/rust.md
+++ b/cli-tool/components/settings/coding-rules/rust.md
@@ -1,0 +1,34 @@
+---
+description: Rust patterns and idioms for .rs files
+globs: ["**/*.rs"]
+---
+
+# Rust Rules
+
+## Error Handling
+- Use `Result<T, E>` for all recoverable errors. Do not use `unwrap()` or `expect()` in library code.
+- Use the `?` operator to propagate errors rather than matching on every `Result` manually.
+- Define custom error types that implement `std::fmt::Display` and `std::error::Error`.
+- Use `thiserror` for library errors and `anyhow` for application-level error handling.
+- Reserve `panic!` for unrecoverable programmer errors (e.g., violated invariants).
+
+## Ownership and Borrowing
+- Prefer `&str` over `String` for function parameters that only need to read a string.
+- Prefer `&[T]` over `&Vec<T>` for function parameters that only need to read a slice.
+- Return owned types (`String`, `Vec<T>`) from functions that create new data.
+- Minimize clone calls. If you need to clone frequently, reconsider the ownership design.
+
+## Types and Traits
+- Use `derive` macros (`Debug`, `Clone`, `PartialEq`, `serde::Serialize`) whenever possible.
+- Implement `Display` for types that will appear in user-facing output.
+- Prefer newtype wrappers over raw primitives for domain values (e.g., `struct UserId(u64)`).
+- Use iterators and iterator adapters (`map`, `filter`, `collect`) instead of manual loops.
+
+## Unsafe Code
+- Minimize `unsafe` blocks. Encapsulate unsafe code in a small, well-documented module.
+- Every `unsafe` block must have a comment explaining the invariant that makes it sound.
+
+## Tooling
+- Follow all `clippy` recommendations. Treat clippy warnings as errors in CI.
+- Run `rustfmt` on all files. Do not manually format code that rustfmt would reformat.
+- Use `cargo test` for unit and integration tests. Place unit tests in a `#[cfg(test)]` module at the bottom of the source file.

--- a/cli-tool/components/settings/coding-rules/sql.md
+++ b/cli-tool/components/settings/coding-rules/sql.md
@@ -1,0 +1,31 @@
+---
+description: SQL guidelines for .sql files and migration files
+globs: ["**/*.sql", "**/migrations/**"]
+---
+
+# SQL Rules
+
+## Naming Conventions
+- Use `snake_case` for all table names, column names, index names, and constraint names.
+- Table names are plural nouns (`users`, `orders`, `line_items`).
+- Foreign key columns follow the pattern `<referenced_table_singular>_id` (e.g., `user_id`).
+- Index names follow the pattern `idx_<table>_<columns>` (e.g., `idx_orders_user_id`).
+
+## Schema Design
+- Use `BIGINT` (or `BIGSERIAL` in Postgres) for primary keys. Do not use `INT` for IDs on tables that may grow large.
+- Add indexes for every foreign key column.
+- Add indexes for columns that appear frequently in `WHERE`, `ORDER BY`, or `JOIN` conditions.
+- Add a `created_at` timestamp (with timezone) to every table.
+
+## Migrations
+- Every migration must include both an `up` and a `down` section. Migrations must be reversible.
+- Wrap multi-statement migrations in a transaction so a partial failure does not leave the schema in an inconsistent state.
+- When adding a column to a large table, add it as `NULL` first. Backfill data in a separate step. Then add the `NOT NULL` constraint.
+- Never drop a column or table in the same migration that removes the application code referencing it. Drop in a follow-up migration after deploying the code change.
+- Never rename a column or table directly in one step on a live database. Add the new name, migrate data, then remove the old name.
+
+## Query Style
+- Write SQL keywords in uppercase (`SELECT`, `FROM`, `WHERE`, `JOIN`).
+- Qualify ambiguous column names with the table name or alias when joining multiple tables.
+- Avoid `SELECT *` in application queries. List columns explicitly.
+- Prefer `EXISTS` over `COUNT(*)` when checking for the presence of rows.

--- a/cli-tool/components/settings/coding-rules/sql.md
+++ b/cli-tool/components/settings/coding-rules/sql.md
@@ -19,7 +19,7 @@ globs: ["**/*.sql", "**/migrations/**"]
 
 ## Migrations
 - Every migration must include both an `up` and a `down` section. Migrations must be reversible.
-- Wrap multi-statement migrations in a transaction so a partial failure does not leave the schema in an inconsistent state.
+- Wrap multi-statement migrations in a transaction where supported. Note: some DDL operations (e.g., `CREATE INDEX CONCURRENTLY` in Postgres, `ALTER TABLE` in MySQL) cannot run inside a transaction and must be handled separately.
 - When adding a column to a large table, add it as `NULL` first. Backfill data in a separate step. Then add the `NOT NULL` constraint.
 - Never drop a column or table in the same migration that removes the application code referencing it. Drop in a follow-up migration after deploying the code change.
 - Never rename a column or table directly in one step on a live database. Add the new name, migrate data, then remove the old name.

--- a/cli-tool/components/settings/coding-rules/testing.md
+++ b/cli-tool/components/settings/coding-rules/testing.md
@@ -1,0 +1,31 @@
+---
+description: Testing conventions for test and spec files across all languages
+globs: ["**/*test*", "**/*spec*", "**/test/**", "**/tests/**", "**/spec/**"]
+---
+
+# Testing Rules
+
+## Structure
+- Follow the Arrange-Act-Assert (AAA) pattern. Separate each phase with a blank line.
+- Each test covers one behavior or concept. Do not assert multiple unrelated things in one test.
+- Use descriptive test names that state the behavior under test, not the implementation: `"returns 404 when user does not exist"` not `"test_get_user_error"`.
+
+## What to Test
+- Test observable behavior (return values, state changes, emitted events), not internal implementation details.
+- Do not test private methods directly. If a private method is complex enough to test in isolation, extract it.
+- Test edge cases: empty input, null/nil, boundaries, error paths.
+
+## Test Doubles
+- Prefer real objects over mocks when the real object is fast and has no external dependencies.
+- Use mocks and stubs only for: external network calls, databases, clocks, and random number generators.
+- Keep stubs as simple as possible. A stub that replicates too much logic becomes a second implementation to maintain.
+
+## Reliability
+- Never use `sleep`, fixed timeouts, or polling loops in tests. Use deterministic triggers or dependency injection for time.
+- Tests must be independent and runnable in any order. Never rely on state left by a previous test.
+- Clean up all data and side effects created during a test (use transactions, temporary directories, or teardown hooks).
+
+## Organization
+- Place test files adjacent to the code they test, or in a mirrored directory structure.
+- Group related tests with `describe`/`context` blocks (or equivalent) to make output readable.
+- Mark slow or integration tests so they can be excluded from fast feedback loops.

--- a/cli-tool/components/settings/coding-rules/typescript.md
+++ b/cli-tool/components/settings/coding-rules/typescript.md
@@ -1,0 +1,33 @@
+---
+description: Strict TypeScript conventions for .ts and .tsx files
+globs: ["**/*.ts", "**/*.tsx"]
+---
+
+# TypeScript Rules
+
+## Type Safety
+- Enable strict mode in tsconfig (`"strict": true`). Never disable it per-file.
+- Never use `any`. Use `unknown` when the type is truly unknown, then narrow it.
+- Avoid type assertions (`as Foo`) unless you have no alternative. Prefer type guards.
+- Use proper generics instead of widening to `object` or `{}`.
+
+## Variables and Declarations
+- Prefer `const` over `let`. Use `let` only when reassignment is necessary.
+- Never use `var`.
+- Destructure imports: `import { useState, useEffect } from 'react'`.
+- Use template literals instead of string concatenation.
+
+## Functions and Signatures
+- Annotate all function return types explicitly (exceptions: trivial one-liners).
+- Use optional chaining (`?.`) and nullish coalescing (`??`) instead of manual null checks.
+- Prefer arrow functions for callbacks and short utilities.
+
+## Types and Interfaces
+- Prefer `interface` for object shapes that may be extended; use `type` for unions, intersections, and aliases.
+- Use union types instead of enums: `type Direction = 'left' | 'right'` rather than `enum Direction`.
+- Use `readonly` on properties that should not be mutated.
+- Define error types explicitly. Never `catch (e: any)`.
+
+## Imports and Modules
+- Use named exports by default. Use a default export only when the module represents a single concept (e.g., a React component file).
+- Keep import order: external packages first, then internal modules, then relative paths.


### PR DESCRIPTION
## Summary

- Adds 8 drop-in rule files for `.claude/rules/` with glob pattern matching
- Each file uses YAML frontmatter so Claude Code auto-applies rules to matching files
- Concise, actionable conventions (not exhaustive style guides)

### Rules
| File | Globs | Key Conventions |
|------|-------|-----------------|
| `python.md` | `**/*.py` | PEP 8, type hints on all signatures, f-strings, pathlib, dataclasses |
| `typescript.md` | `**/*.ts`, `**/*.tsx` | Strict mode, no `any`, unions over enums, const-first |
| `react.md` | `**/*.tsx`, `**/*.jsx` | Functional components, custom hooks, named exports, accessibility |
| `go.md` | `**/*.go` | Immediate error checks, context as first param, table-driven tests |
| `rails.md` | `**/*.rb`, `**/*.erb` | Fat models/thin controllers, strong params, scopes, service objects |
| `rust.md` | `**/*.rs` | Result over panic, `?` operator, borrows, minimize unsafe |
| `sql.md` | `**/*.sql`, `**/migrations/**` | snake_case, BIGINT IDs, reversible migrations, index FKs |
| `testing.md` | `**/*test*`, `**/*spec*` | Arrange-Act-Assert, one concept per test, no sleep/timeouts |

## Test plan

- [ ] Verify each file has valid YAML frontmatter with `description` and `globs` fields
- [ ] Copy to `.claude/rules/` in a project and verify Claude applies them to matching files
- [ ] Verify README installation instructions are accurate

Source: [cc-docs](https://github.com/CodeWithBehnam/cc-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 8 language-specific coding rule templates for `.claude/rules/` with YAML frontmatter and glob patterns so Claude Code auto-applies them. Incorporates review feedback clarifying SQL DDL transaction caveats, Go error types, Rails SQL injection risks, Python CLI printing, and React `.tsx` vs `.jsx` prop guidance.

- **New Features**
  - Added `python.md`, `typescript.md`, `react.md`, `go.md`, `rails.md`, `rust.md`, `sql.md`, `testing.md` under `cli-tool/components/settings/coding-rules/`.
  - Clarified rules per feedback: SQL DDL outside transactions; Go `errors.New` vs custom types; Rails string interpolation warning; Python allow `print` for CLI stdout; React prop typing differs for `.tsx` and `.jsx`.
  - Each file defines `globs` and concise conventions; `README.md` includes copy/paste install steps.
  - Area: components (`cli-tool/components/`). No new UI components; `docs/components.json` does not need regeneration.
  - No new environment variables or secrets.

<sup>Written for commit 005940e1664a0952e1b4d022fd0e1630ecd55d82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

