### PR TITLE
feat: add 5 CLAUDE.md starter templates for popular frameworks

### DIFF
--- a/cli-tool/components/settings/claude-md-starters/README.md
+++ b/cli-tool/components/settings/claude-md-starters/README.md
@@ -1,0 +1,44 @@
+# CLAUDE.md Starter Templates
+
+Copy-paste starting points for CLAUDE.md files, tailored to specific frameworks.
+Each starter includes the main template plus variants for popular alternatives
+within the ecosystem.
+
+## Installation
+
+Copy the starter for your stack into your project root as `CLAUDE.md`:
+
+```bash
+cp python-starter.md /path/to/your-project/CLAUDE.md
+```
+
+Then customize the placeholders (`<project-name>`, `<package_name>`, etc.).
+
+## Available Starters
+
+| File | Stack | Variants Included |
+|------|-------|-------------------|
+| `python-starter.md` | Python (uv, pytest, ruff, mypy) | pip+venv, Poetry, Django, FastAPI |
+| `typescript-starter.md` | TypeScript/Node.js (npm, Vitest) | pnpm, Bun, Express API, CLI tool |
+| `react-nextjs-starter.md` | React/Next.js (App Router, Tailwind) | Vite+React, shadcn/ui, Tailwind v3 |
+| `rails-starter.md` | Ruby on Rails (Minitest, PostgreSQL) | RSpec, API-only |
+| `monorepo-starter.md` | Monorepo (Turborepo, pnpm workspaces) | Path-specific rules, CLAUDE.md imports |
+
+## What Each Starter Includes
+
+- Project overview section (name, description, runtime, package manager)
+- Quick commands (install, run, test, lint, build)
+- Project structure diagram
+- Code style conventions specific to the framework
+- Testing patterns and commands
+- Error handling guidelines
+- Dependency management rules
+- Framework-specific patterns (e.g., Hotwire for Rails, Server Components for Next.js)
+
+## Tips
+
+- Start with the base template, then append the variant sections you need
+- The monorepo starter shows how to use `.claude/rules/` for path-specific rules
+- Add your own team conventions in the "Conventions" section at the bottom
+
+Source: https://github.com/CodeWithBehnam/cc-docs

--- a/cli-tool/components/settings/claude-md-starters/README.md
+++ b/cli-tool/components/settings/claude-md-starters/README.md
@@ -9,6 +9,7 @@ within the ecosystem.
 Copy the starter for your stack into your project root as `CLAUDE.md`:
 
 ```bash
+# From the claude-code-templates/cli-tool/components/settings/claude-md-starters/ directory:
 cp python-starter.md /path/to/your-project/CLAUDE.md
 ```
 

--- a/cli-tool/components/settings/claude-md-starters/monorepo-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/monorepo-starter.md
@@ -8,7 +8,7 @@ This template shows how to use CLAUDE.md imports and `.claude/rules/` for path-s
 
 ## Root CLAUDE.md
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -82,7 +82,7 @@ pnpm --filter ui build
 ## Conventions
 
 - <Add project-wide conventions here>
-```
+````
 
 ---
 
@@ -92,7 +92,7 @@ Create these files under `.claude/rules/` for workspace-specific instructions.
 
 ### `.claude/rules/frontend.md`
 
-```markdown
+````markdown
 ---
 paths:
   - "apps/web/**"
@@ -108,11 +108,11 @@ paths:
 - Export components from barrel `index.ts` in each directory
 - Test with Vitest + React Testing Library
 - Run `pnpm --filter web test` before committing frontend changes
-```
+````
 
 ### `.claude/rules/backend.md`
 
-```markdown
+````markdown
 ---
 paths:
   - "apps/api/**"
@@ -128,11 +128,11 @@ paths:
 - Database queries in `src/repositories/`
 - Test with Vitest, mock database calls
 - Run `pnpm --filter api test` before committing backend changes
-```
+````
 
 ### `.claude/rules/shared-packages.md`
 
-```markdown
+````markdown
 ---
 paths:
   - "packages/**"
@@ -146,11 +146,11 @@ paths:
 - Version bumps require updating all consuming workspaces
 - Test packages independently: `pnpm --filter <package> test`
 - Changes here affect multiple apps, be cautious
-```
+````
 
 ### `.claude/rules/database.md`
 
-```markdown
+````markdown
 ---
 paths:
   - "apps/api/src/db/**"
@@ -166,7 +166,7 @@ paths:
 - Add indexes for foreign keys and frequently queried columns
 - Use transactions for multi-table operations
 - Test database queries with a test database, not mocks
-```
+````
 
 ---
 
@@ -174,13 +174,13 @@ paths:
 
 Instead of path-specific rules, you can use imports in the root CLAUDE.md:
 
-```markdown
+````markdown
 # CLAUDE.md
 
 See @apps/web/README.md for frontend conventions.
 See @apps/api/README.md for backend conventions.
 See @packages/shared/README.md for shared package rules.
-```
+````
 
 Claude will automatically load the referenced files when relevant.
 

--- a/cli-tool/components/settings/claude-md-starters/monorepo-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/monorepo-starter.md
@@ -1,0 +1,201 @@
+# CLAUDE.md Starter: Monorepo Project
+
+Copy this into your project root as `CLAUDE.md` and customize the placeholders.
+
+This template shows how to use CLAUDE.md imports and `.claude/rules/` for path-specific conventions.
+
+---
+
+## Root CLAUDE.md
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+- **Name**: <project-name>
+- **Description**: <one-line description>
+- **Monorepo tool**: <turborepo | nx | pnpm workspaces | yarn workspaces>
+- **Package manager**: pnpm
+
+## Workspace Layout
+
+```text
+<project-name>/
+├── apps/
+│   ├── web/               # Next.js frontend
+│   ├── api/               # Express/Fastify backend
+│   └── mobile/            # React Native app
+├── packages/
+│   ├── ui/                # Shared UI components
+│   ├── shared/            # Shared types and utilities
+│   └── config/            # Shared ESLint, TSConfig, etc.
+├── CLAUDE.md              # This file (root conventions)
+├── .claude/
+│   └── rules/             # Path-specific rules (see below)
+├── turbo.json
+├── pnpm-workspace.yaml
+└── package.json
+```
+
+## Quick Commands
+
+```bash
+# Install all dependencies
+pnpm install
+
+# Run all apps in dev mode
+pnpm dev
+
+# Build all packages
+pnpm build
+
+# Run all tests
+pnpm test
+
+# Lint everything
+pnpm lint
+
+# Run command in specific workspace
+pnpm --filter web dev
+pnpm --filter api test
+pnpm --filter ui build
+```
+
+## Cross-Workspace Rules
+
+- Shared types go in `packages/shared/src/types/`
+- Shared utilities go in `packages/shared/src/utils/`
+- UI components go in `packages/ui/src/`
+- Import shared packages by name: `import { Button } from "@<scope>/ui"`
+- Never use relative imports across workspace boundaries
+- Changes to `packages/shared` may affect all apps, test broadly
+- Each package has its own `tsconfig.json` extending root config
+
+## Dependency Rules
+
+- Shared dependencies go in root `package.json`
+- App-specific dependencies go in the app's `package.json`
+- Keep dependency versions consistent across workspaces
+- Use `pnpm --filter <workspace> add <package>` to add deps
+
+## Conventions
+
+- <Add project-wide conventions here>
+```
+
+---
+
+## Path-Specific Rules (`.claude/rules/`)
+
+Create these files under `.claude/rules/` for workspace-specific instructions.
+
+### `.claude/rules/frontend.md`
+
+```markdown
+---
+paths:
+  - "apps/web/**"
+  - "packages/ui/**"
+---
+
+# Frontend Rules
+
+- Use React Server Components by default, add "use client" only when needed
+- Style with Tailwind CSS, no CSS modules or styled-components
+- Use `cn()` from `packages/shared` for conditional class names
+- Component files: PascalCase (`Button.tsx`)
+- Export components from barrel `index.ts` in each directory
+- Test with Vitest + React Testing Library
+- Run `pnpm --filter web test` before committing frontend changes
+```
+
+### `.claude/rules/backend.md`
+
+```markdown
+---
+paths:
+  - "apps/api/**"
+---
+
+# Backend Rules
+
+- Use Express with TypeScript
+- Routes in `src/routes/`, grouped by domain
+- Business logic in `src/services/`, not in route handlers
+- Validate requests with zod schemas in `src/schemas/`
+- Use dependency injection for testability
+- Database queries in `src/repositories/`
+- Test with Vitest, mock database calls
+- Run `pnpm --filter api test` before committing backend changes
+```
+
+### `.claude/rules/shared-packages.md`
+
+```markdown
+---
+paths:
+  - "packages/**"
+---
+
+# Shared Package Rules
+
+- Packages must have zero app-specific dependencies
+- Export public API from `src/index.ts`
+- Include a `README.md` documenting the package's purpose
+- Version bumps require updating all consuming workspaces
+- Test packages independently: `pnpm --filter <package> test`
+- Changes here affect multiple apps, be cautious
+```
+
+### `.claude/rules/database.md`
+
+```markdown
+---
+paths:
+  - "apps/api/src/db/**"
+  - "apps/api/prisma/**"
+  - "**/migrations/**"
+---
+
+# Database Rules
+
+- Use Prisma for schema and migrations
+- Always create a migration for schema changes: `pnpm --filter api prisma migrate dev`
+- Never modify migration files after they've been applied
+- Add indexes for foreign keys and frequently queried columns
+- Use transactions for multi-table operations
+- Test database queries with a test database, not mocks
+```
+
+---
+
+## Using CLAUDE.md Imports
+
+Instead of path-specific rules, you can use imports in the root CLAUDE.md:
+
+```markdown
+# CLAUDE.md
+
+See @apps/web/README.md for frontend conventions.
+See @apps/api/README.md for backend conventions.
+See @packages/shared/README.md for shared package rules.
+```
+
+Claude will automatically load the referenced files when relevant.
+
+---
+
+## Monorepo Settings
+
+To exclude certain directories from CLAUDE.md scanning (e.g., generated code), add to `.claude/settings.json`:
+
+```json
+{
+  "claudeMdExcludes": [
+    "apps/*/node_modules/**",
+    "packages/*/dist/**",
+    "**/generated/**"
+  ]
+}
+```

--- a/cli-tool/components/settings/claude-md-starters/python-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/python-starter.md
@@ -43,6 +43,7 @@ uv run mypy <package_name>
 <project-name>/
 ├── src/<package_name>/    # Main package
 │   ├── __init__.py
+│   ├── __main__.py        # Entry point for python -m
 │   ├── main.py
 │   └── ...
 ├── tests/                 # Test files mirror src/ structure

--- a/cli-tool/components/settings/claude-md-starters/python-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/python-starter.md
@@ -1,0 +1,164 @@
+# CLAUDE.md Starter: Python Project
+
+Copy this into your project root as `CLAUDE.md` and customize the placeholders.
+
+---
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+- **Name**: <project-name>
+- **Description**: <one-line description>
+- **Python version**: 3.12
+- **Package manager**: uv (use `uv run` to execute commands)
+
+## Quick Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run the application
+uv run python -m <package_name>
+
+# Run tests
+uv run pytest
+
+# Run tests with coverage
+uv run pytest --cov=<package_name> --cov-report=term-missing
+
+# Lint and format
+uv run ruff check .
+uv run ruff format .
+
+# Type checking
+uv run mypy <package_name>
+```
+
+## Project Structure
+
+```text
+<project-name>/
+├── src/<package_name>/    # Main package
+│   ├── __init__.py
+│   ├── main.py
+│   └── ...
+├── tests/                 # Test files mirror src/ structure
+│   ├── conftest.py
+│   └── test_*.py
+├── pyproject.toml         # Project config (dependencies, tools)
+└── CLAUDE.md
+```
+
+## Code Style
+
+- Use type hints on all function signatures
+- Use `from __future__ import annotations` at the top of every module
+- Prefer `pathlib.Path` over `os.path`
+- Use f-strings for string formatting
+- Maximum line length: 88 characters (ruff/black default)
+- Use snake_case for functions and variables, PascalCase for classes
+- Imports: stdlib first, then third-party, then local (ruff handles this)
+
+## Testing
+
+- Use pytest (not unittest)
+- Name test files `test_<module>.py`, test functions `test_<behavior>()`
+- Use fixtures in `conftest.py` for shared setup
+- Use `pytest.mark.parametrize` for data-driven tests
+- Mock external dependencies with `unittest.mock.patch` or `pytest-mock`
+- Always run `uv run pytest` before committing
+
+## Error Handling
+
+- Use specific exception types, never bare `except:`
+- Define custom exceptions in `<package_name>/exceptions.py`
+- Log errors with `logging` module, not `print()`
+
+## Dependencies
+
+- Add dependencies with `uv add <package>`
+- Add dev dependencies with `uv add --dev <package>`
+- Never edit `uv.lock` manually
+
+## Conventions
+
+- <Add project-specific conventions here>
+- <Add naming patterns, API design rules, etc.>
+```
+
+---
+
+## Variants
+
+### pip + venv (instead of uv)
+
+Replace the Quick Commands section:
+
+```markdown
+## Quick Commands
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Linux/macOS
+pip install -e ".[dev]"
+pytest
+ruff check . && ruff format .
+mypy <package_name>
+```
+```
+
+### Poetry
+
+Replace the Quick Commands section:
+
+```markdown
+## Quick Commands
+
+```bash
+poetry install
+poetry run pytest
+poetry run ruff check . && poetry run ruff format .
+poetry run mypy <package_name>
+```
+```
+
+### Django
+
+Add these sections:
+
+```markdown
+## Django Commands
+
+```bash
+uv run python manage.py runserver
+uv run python manage.py makemigrations
+uv run python manage.py migrate
+uv run python manage.py test
+uv run python manage.py shell
+```
+
+## Django Conventions
+
+- Apps go in `apps/` directory
+- Use class-based views for CRUD, function views for simple endpoints
+- Always create and apply migrations, never modify the database directly
+- Use `django.conf.settings` for configuration, not hardcoded values
+- Templates go in `<app>/templates/<app>/`
+```
+
+### FastAPI
+
+Add these sections:
+
+```markdown
+## API Conventions
+
+- Use Pydantic models for request/response schemas in `schemas/`
+- Use dependency injection for shared logic (auth, db sessions)
+- Group routes by domain in separate routers under `routers/`
+- Use `HTTPException` with appropriate status codes
+- All endpoints must have docstrings (used for OpenAPI docs)
+```

--- a/cli-tool/components/settings/claude-md-starters/python-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/python-starter.md
@@ -4,7 +4,7 @@ Copy this into your project root as `CLAUDE.md` and customize the placeholders.
 
 ---
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -21,7 +21,7 @@ Copy this into your project root as `CLAUDE.md` and customize the placeholders.
 uv sync
 
 # Run the application
-uv run python -m <package_name>
+uv run python -m <package_name>  # requires <package_name>/__main__.py
 
 # Run tests
 uv run pytest
@@ -87,7 +87,7 @@ uv run mypy <package_name>
 
 - <Add project-specific conventions here>
 - <Add naming patterns, API design rules, etc.>
-```
+````
 
 ---
 
@@ -97,7 +97,7 @@ uv run mypy <package_name>
 
 Replace the Quick Commands section:
 
-```markdown
+````markdown
 ## Quick Commands
 
 ```bash
@@ -108,13 +108,13 @@ pytest
 ruff check . && ruff format .
 mypy <package_name>
 ```
-```
+````
 
 ### Poetry
 
 Replace the Quick Commands section:
 
-```markdown
+````markdown
 ## Quick Commands
 
 ```bash
@@ -123,13 +123,13 @@ poetry run pytest
 poetry run ruff check . && poetry run ruff format .
 poetry run mypy <package_name>
 ```
-```
+````
 
 ### Django
 
 Add these sections:
 
-```markdown
+````markdown
 ## Django Commands
 
 ```bash
@@ -147,13 +147,13 @@ uv run python manage.py shell
 - Always create and apply migrations, never modify the database directly
 - Use `django.conf.settings` for configuration, not hardcoded values
 - Templates go in `<app>/templates/<app>/`
-```
+````
 
 ### FastAPI
 
 Add these sections:
 
-```markdown
+````markdown
 ## API Conventions
 
 - Use Pydantic models for request/response schemas in `schemas/`
@@ -161,4 +161,4 @@ Add these sections:
 - Group routes by domain in separate routers under `routers/`
 - Use `HTTPException` with appropriate status codes
 - All endpoints must have docstrings (used for OpenAPI docs)
-```
+````

--- a/cli-tool/components/settings/claude-md-starters/rails-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/rails-starter.md
@@ -4,7 +4,7 @@ Copy this into your project root as `CLAUDE.md` and customize the placeholders.
 
 ---
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -115,7 +115,7 @@ bundle exec rubocop -a  # auto-fix
 ## Conventions
 
 - <Add project-specific conventions here>
-```
+````
 
 ---
 
@@ -125,7 +125,7 @@ bundle exec rubocop -a  # auto-fix
 
 Replace the testing section:
 
-```markdown
+````markdown
 ## Quick Commands (Testing)
 
 ```bash
@@ -142,13 +142,13 @@ bundle exec rspec spec/models/user_spec.rb:42  # specific line
 - Use `subject` for the object under test
 - Use `shared_examples` for common behavior
 - Use `have_enqueued_job` matcher for job testing
-```
+````
 
 ### API-only
 
 Add this section:
 
-```markdown
+````markdown
 ## API Conventions
 
 - Use `ActionController::API` base class
@@ -157,4 +157,4 @@ Add this section:
 - Use token authentication (not session)
 - Return consistent JSON: `{ data: T }` or `{ error: string, details: [] }`
 - Use HTTP status codes correctly
-```
+````

--- a/cli-tool/components/settings/claude-md-starters/rails-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/rails-starter.md
@@ -1,0 +1,160 @@
+# CLAUDE.md Starter: Ruby on Rails Project
+
+Copy this into your project root as `CLAUDE.md` and customize the placeholders.
+
+---
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+- **Name**: <project-name>
+- **Description**: <one-line description>
+- **Ruby version**: 3.3 (see `.ruby-version`)
+- **Rails version**: 8.0
+- **Database**: PostgreSQL
+
+## Quick Commands
+
+```bash
+# Setup
+bin/setup
+
+# Development server
+bin/dev
+
+# Run all tests
+bin/rails test
+
+# Run specific test file
+bin/rails test test/models/user_test.rb
+
+# Run system tests
+bin/rails test:system
+
+# Console
+bin/rails console
+
+# Database
+bin/rails db:migrate
+bin/rails db:seed
+bin/rails db:rollback
+
+# Generate
+bin/rails generate model <Name> <field:type>
+bin/rails generate controller <Names> <action>
+
+# Lint
+bundle exec rubocop
+bundle exec rubocop -a  # auto-fix
+```
+
+## Project Structure
+
+```text
+<project-name>/
+├── app/
+│   ├── controllers/       # Thin controllers, REST only
+│   ├── models/            # Fat models, business logic here
+│   ├── views/             # ERB templates
+│   ├── helpers/           # View helpers
+│   ├── jobs/              # Background jobs (Solid Queue)
+│   ├── mailers/           # Email senders
+│   └── components/        # ViewComponents (if used)
+├── config/
+│   ├── routes.rb          # REST routes
+│   └── database.yml
+├── db/
+│   ├── migrate/           # Database migrations
+│   └── schema.rb          # Auto-generated schema (do not edit)
+├── test/                  # Minitest files
+│   ├── models/
+│   ├── controllers/
+│   ├── system/
+│   └── fixtures/
+└── CLAUDE.md
+```
+
+## Code Style
+
+- Follow Rails conventions (convention over configuration)
+- Fat models, thin controllers
+- Use `Current` attributes for request-scoped state
+- Prefer scopes and query methods in models over raw SQL
+- Use `before_action` for shared controller logic
+- RESTful routes only, no custom actions unless absolutely necessary
+- Keep controllers to the 7 REST actions: index, show, new, create, edit, update, destroy
+- Use partials to DRY up views, name them `_<partial>.html.erb`
+
+## Database
+
+- Always create migrations, never modify `schema.rb` directly
+- Migrations must be reversible (use `change`, not `up`/`down` unless needed)
+- Add indexes for foreign keys and frequently queried columns
+- Use `null: false` and database-level constraints, not just model validations
+- Use `references` with `foreign_key: true` for associations
+
+## Testing
+
+- Use Minitest (Rails default) or RSpec
+- Fixtures for test data (in `test/fixtures/`)
+- Test models thoroughly (validations, scopes, methods)
+- Controller tests for auth and redirects
+- System tests with Capybara for critical user flows
+- Run the full suite before committing
+
+## Hotwire Patterns
+
+- Use Turbo Drive for page navigation (works by default)
+- Use Turbo Frames for partial page updates
+- Use Turbo Streams for real-time updates
+- Use Stimulus controllers for JavaScript behavior
+- Minimize custom JavaScript, prefer Stimulus + Turbo
+
+## Conventions
+
+- <Add project-specific conventions here>
+```
+
+---
+
+## Variants
+
+### RSpec (instead of Minitest)
+
+Replace the testing section:
+
+```markdown
+## Quick Commands (Testing)
+
+```bash
+bundle exec rspec
+bundle exec rspec spec/models/user_spec.rb
+bundle exec rspec spec/models/user_spec.rb:42  # specific line
+```
+
+## Testing
+
+- Use RSpec with FactoryBot for test data
+- Factories in `spec/factories/`
+- Use `let` and `let!` for lazy/eager setup
+- Use `subject` for the object under test
+- Use `shared_examples` for common behavior
+- Use `have_enqueued_job` matcher for job testing
+```
+
+### API-only
+
+Add this section:
+
+```markdown
+## API Conventions
+
+- Use `ActionController::API` base class
+- Serialize with `ActiveModel::Serializer` or jbuilder
+- Version APIs in routes: `/api/v1/`
+- Use token authentication (not session)
+- Return consistent JSON: `{ data: T }` or `{ error: string, details: [] }`
+- Use HTTP status codes correctly
+```

--- a/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
@@ -4,7 +4,7 @@ Copy this into your project root as `CLAUDE.md` and customize the placeholders.
 
 ---
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -62,7 +62,7 @@ npx tsc --noEmit
 
 - Use functional components with arrow functions
 - Use TypeScript strict mode, type all props with `interface`
-- Prefer named exports over default exports (except pages)
+- Prefer named exports over default exports (except App Router convention files: page, layout, loading, error, not-found, template)
 - Use `"use client"` directive only when the component needs interactivity
 - Keep Server Components as the default
 - Tailwind classes: use consistent ordering (layout, spacing, sizing, colors, text)
@@ -118,7 +118,7 @@ export function MyComponent({ title, children }: MyComponentProps) {
 ## Conventions
 
 - <Add project-specific conventions here>
-```
+````
 
 ---
 
@@ -128,7 +128,7 @@ export function MyComponent({ title, children }: MyComponentProps) {
 
 Replace framework-specific sections:
 
-```markdown
+````markdown
 - **Framework**: React 19 + Vite
 
 ## Project Structure
@@ -151,13 +151,13 @@ Replace framework-specific sections:
 - Use React Router v7 for client-side routing
 - Route definitions in `src/routes.tsx`
 - Lazy-load page components with `React.lazy()`
-```
+````
 
 ### shadcn/ui
 
 Add this section:
 
-```markdown
+````markdown
 ## UI Components (shadcn/ui)
 
 - Install components with `npx shadcn@latest add <component>`
@@ -165,12 +165,12 @@ Add this section:
 - Use `cn()` helper from `lib/utils` for conditional class merging
 - Follow shadcn patterns for form handling (react-hook-form + zod)
 - Don't modify component internals unless necessary, compose instead
-```
+````
 
 ### Tailwind CSS v3 (instead of v4)
 
-```markdown
+````markdown
 - **Styling**: Tailwind CSS v3
 - Config in `tailwind.config.ts`
 - Use `@apply` sparingly, prefer component extraction
-```
+````

--- a/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
@@ -126,7 +126,7 @@ export function MyComponent({ title, children }: MyComponentProps) {
 
 ### Vite + React (no Next.js)
 
-Replace framework-specific sections:
+Replace the Project Overview, Project Structure, and Data Fetching sections. Remove the "use client"/"use server" and Server Components guidance from Code Style:
 
 ````markdown
 - **Framework**: React 19 + Vite

--- a/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/react-nextjs-starter.md
@@ -1,0 +1,176 @@
+# CLAUDE.md Starter: React / Next.js Project
+
+Copy this into your project root as `CLAUDE.md` and customize the placeholders.
+
+---
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+- **Name**: <project-name>
+- **Description**: <one-line description>
+- **Framework**: Next.js 15 (App Router)
+- **Styling**: Tailwind CSS v4
+- **Package manager**: npm
+
+## Quick Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Development server
+npm run dev
+
+# Production build
+npm run build
+
+# Run tests
+npm test
+
+# Lint
+npm run lint
+
+# Type check
+npx tsc --noEmit
+```
+
+## Project Structure
+
+```text
+<project-name>/
+├── app/                   # Next.js App Router
+│   ├── layout.tsx         # Root layout
+│   ├── page.tsx           # Home page
+│   ├── globals.css        # Global styles
+│   └── <route>/
+│       ├── page.tsx       # Route page
+│       └── loading.tsx    # Loading UI
+├── components/
+│   ├── ui/                # Reusable UI primitives (Button, Input, etc.)
+│   └── <feature>/         # Feature-specific components
+├── lib/                   # Utilities, API clients, helpers
+├── hooks/                 # Custom React hooks
+├── types/                 # Shared TypeScript types
+├── public/                # Static assets
+└── CLAUDE.md
+```
+
+## Code Style
+
+- Use functional components with arrow functions
+- Use TypeScript strict mode, type all props with `interface`
+- Prefer named exports over default exports (except pages)
+- Use `"use client"` directive only when the component needs interactivity
+- Keep Server Components as the default
+- Tailwind classes: use consistent ordering (layout, spacing, sizing, colors, text)
+- Extract repeated Tailwind patterns into components, not @apply
+
+## Component Patterns
+
+```tsx
+// Standard component pattern
+interface MyComponentProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function MyComponent({ title, children }: MyComponentProps) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  );
+}
+```
+
+- Props interface named `<Component>Props`
+- Destructure props in function signature
+- One component per file, file named same as component
+
+## Data Fetching
+
+- Use Server Components for data fetching when possible
+- Use React Server Actions for mutations (`"use server"`)
+- Use `fetch()` with Next.js caching in Server Components
+- Use React Query / SWR for client-side data fetching
+- API routes go in `app/api/<route>/route.ts`
+
+## State Management
+
+- Use `useState` for local component state
+- Use `useReducer` for complex local state
+- Use React Context for shared state within a feature
+- Use Zustand or Jotai for global client state (if needed)
+- Avoid prop drilling deeper than 2-3 levels
+
+## Testing
+
+- Use Vitest + React Testing Library for component tests
+- Test behavior, not implementation details
+- Use `screen.getByRole()` and `screen.getByText()` over test IDs
+- Mock API calls with MSW (Mock Service Worker)
+- Name test files `<Component>.test.tsx`
+
+## Conventions
+
+- <Add project-specific conventions here>
+```
+
+---
+
+## Variants
+
+### Vite + React (no Next.js)
+
+Replace framework-specific sections:
+
+```markdown
+- **Framework**: React 19 + Vite
+
+## Project Structure
+
+```text
+├── src/
+│   ├── main.tsx           # Entry point
+│   ├── App.tsx            # Root component
+│   ├── components/        # Reusable components
+│   ├── pages/             # Page-level components
+│   ├── hooks/             # Custom hooks
+│   ├── lib/               # Utilities
+│   └── types/             # TypeScript types
+├── public/
+└── index.html
+```
+
+## Routing
+
+- Use React Router v7 for client-side routing
+- Route definitions in `src/routes.tsx`
+- Lazy-load page components with `React.lazy()`
+```
+
+### shadcn/ui
+
+Add this section:
+
+```markdown
+## UI Components (shadcn/ui)
+
+- Install components with `npx shadcn@latest add <component>`
+- Components live in `components/ui/` and are fully editable
+- Use `cn()` helper from `lib/utils` for conditional class merging
+- Follow shadcn patterns for form handling (react-hook-form + zod)
+- Don't modify component internals unless necessary, compose instead
+```
+
+### Tailwind CSS v3 (instead of v4)
+
+```markdown
+- **Styling**: Tailwind CSS v3
+- Config in `tailwind.config.ts`
+- Use `@apply` sparingly, prefer component extraction
+```

--- a/cli-tool/components/settings/claude-md-starters/typescript-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/typescript-starter.md
@@ -4,7 +4,7 @@ Copy this into your project root as `CLAUDE.md` and customize the placeholders.
 
 ---
 
-```markdown
+````markdown
 # CLAUDE.md
 
 ## Project Overview
@@ -92,7 +92,7 @@ npx tsc --noEmit
 ## Conventions
 
 - <Add project-specific conventions here>
-```
+````
 
 ---
 
@@ -102,7 +102,7 @@ npx tsc --noEmit
 
 Replace package manager references:
 
-```markdown
+````markdown
 - **Package manager**: pnpm
 
 ```bash
@@ -110,13 +110,13 @@ pnpm install
 pnpm run dev
 pnpm test
 ```
-```
+````
 
 ### Bun
 
 Replace package manager references:
 
-```markdown
+````markdown
 - **Package manager**: Bun
 
 ```bash
@@ -124,13 +124,13 @@ bun install
 bun run dev
 bun test
 ```
-```
+````
 
 ### Express API
 
 Add these sections:
 
-```markdown
+````markdown
 ## API Conventions
 
 - Routes go in `src/routes/` grouped by domain
@@ -139,18 +139,18 @@ Add these sections:
 - Validate request bodies with zod schemas
 - Return consistent JSON: `{ data: T }` on success, `{ error: string }` on failure
 - Use HTTP status codes correctly (201 for creation, 204 for deletion, etc.)
-```
+````
 
 ### CLI Tool
 
 Add these sections:
 
-```markdown
+````markdown
 ## CLI Conventions
 
 - Use `commander` or `yargs` for argument parsing
 - Entry point in `src/cli.ts` with `#!/usr/bin/env node` shebang
 - Subcommands in `src/commands/<name>.ts`
-- Use `process.exit(1)` for errors, `process.exit(0)` for success
+- Use `process.exit(1)` for errors; for success, let the event loop drain naturally (or use `process.exitCode = 0`)
 - Write to stderr for errors/warnings, stdout for output
-```
+````

--- a/cli-tool/components/settings/claude-md-starters/typescript-starter.md
+++ b/cli-tool/components/settings/claude-md-starters/typescript-starter.md
@@ -1,0 +1,156 @@
+# CLAUDE.md Starter: TypeScript / Node.js Project
+
+Copy this into your project root as `CLAUDE.md` and customize the placeholders.
+
+---
+
+```markdown
+# CLAUDE.md
+
+## Project Overview
+
+- **Name**: <project-name>
+- **Description**: <one-line description>
+- **Runtime**: Node.js 20+
+- **Package manager**: npm (use `npm run` for scripts)
+
+## Quick Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Run in development
+npm run dev
+
+# Build for production
+npm run build
+
+# Run tests
+npm test
+
+# Lint
+npm run lint
+
+# Format
+npm run format
+
+# Type check
+npx tsc --noEmit
+```
+
+## Project Structure
+
+```text
+<project-name>/
+├── src/
+│   ├── index.ts           # Entry point
+│   ├── config/            # Configuration and env loading
+│   ├── services/          # Business logic
+│   ├── utils/             # Pure utility functions
+│   └── types/             # Shared TypeScript types
+├── tests/
+│   └── *.test.ts          # Test files (co-located or mirrored)
+├── tsconfig.json
+├── package.json
+└── CLAUDE.md
+```
+
+## Code Style
+
+- Use strict TypeScript (`"strict": true` in tsconfig)
+- Prefer `interface` over `type` for object shapes (unless unions needed)
+- Use `const` by default, `let` only when reassignment is needed, never `var`
+- Use named exports, not default exports
+- Use async/await, never raw `.then()` chains
+- Use template literals for string interpolation
+- Prefer early returns over nested if/else
+- Maximum line length: 100 characters (Prettier)
+
+## Testing
+
+- Use Vitest (or Jest) for unit and integration tests
+- Name test files `<module>.test.ts` next to the source file
+- Use `describe()` for grouping, `it()` or `test()` for individual cases
+- Use `vi.mock()` (or `jest.mock()`) for mocking modules
+- Always run `npm test` before committing
+
+## Error Handling
+
+- Use typed error classes extending `Error`
+- Never swallow errors with empty `catch` blocks
+- Use `Result<T, E>` pattern or explicit error types for expected failures
+- Log with a structured logger (e.g., pino), not `console.log`
+
+## Dependencies
+
+- Add with `npm install <package>`
+- Add dev deps with `npm install --save-dev <package>`
+- Keep `package-lock.json` in git
+- Never edit `package-lock.json` manually
+
+## Conventions
+
+- <Add project-specific conventions here>
+```
+
+---
+
+## Variants
+
+### pnpm
+
+Replace package manager references:
+
+```markdown
+- **Package manager**: pnpm
+
+```bash
+pnpm install
+pnpm run dev
+pnpm test
+```
+```
+
+### Bun
+
+Replace package manager references:
+
+```markdown
+- **Package manager**: Bun
+
+```bash
+bun install
+bun run dev
+bun test
+```
+```
+
+### Express API
+
+Add these sections:
+
+```markdown
+## API Conventions
+
+- Routes go in `src/routes/` grouped by domain
+- Middleware in `src/middleware/`
+- Use `express-async-errors` or wrap handlers to catch async errors
+- Validate request bodies with zod schemas
+- Return consistent JSON: `{ data: T }` on success, `{ error: string }` on failure
+- Use HTTP status codes correctly (201 for creation, 204 for deletion, etc.)
+```
+
+### CLI Tool
+
+Add these sections:
+
+```markdown
+## CLI Conventions
+
+- Use `commander` or `yargs` for argument parsing
+- Entry point in `src/cli.ts` with `#!/usr/bin/env node` shebang
+- Subcommands in `src/commands/<name>.ts`
+- Use `process.exit(1)` for errors, `process.exit(0)` for success
+- Write to stderr for errors/warnings, stdout for output
+```


### PR DESCRIPTION
## Summary

- Adds 5 copy-paste CLAUDE.md starter templates tailored to specific frameworks
- Each starter includes the main template plus **variants** for popular alternatives within the ecosystem
- Covers project overview, commands, structure, code style, testing, error handling, and framework-specific patterns

### Starters
| Starter | Base Stack | Variants |
|---------|-----------|----------|
| `python-starter.md` | Python, uv, pytest, ruff, mypy | pip+venv, Poetry, Django, FastAPI |
| `typescript-starter.md` | TypeScript, Node.js, npm, Vitest | pnpm, Bun, Express API, CLI tool |
| `react-nextjs-starter.md` | Next.js 15 App Router, Tailwind | Vite+React, shadcn/ui, Tailwind v3 |
| `rails-starter.md` | Rails 8, Minitest, PostgreSQL, Hotwire | RSpec, API-only |
| `monorepo-starter.md` | Turborepo, pnpm workspaces | Path-specific `.claude/rules/`, CLAUDE.md imports |

### What each starter includes
- Project overview (name, description, runtime, package manager)
- Quick commands (install, run, test, lint, build)
- Project structure diagram
- Code style conventions specific to the framework
- Testing patterns and commands
- Error handling guidelines
- Framework-specific patterns (Hotwire, Server Components, etc.)

## Test plan

- [ ] Copy a starter to a project root as CLAUDE.md and verify Claude understands the conventions
- [ ] Verify variant sections can be appended without conflicts
- [ ] Verify monorepo path-specific rules work with `.claude/rules/` directory

Source: [cc-docs](https://github.com/CodeWithBehnam/cc-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five CLAUDE.md starter templates (Python, TypeScript/Node, React/Next.js, Rails, Monorepo) to speed up setup and onboarding. Also improves clarity and rendering across templates.

- New Features
  - Added starters under `cli-tool/components/settings/claude-md-starters/` with quick commands, structure, style, testing, and error-handling guidance.
  - Monorepo starter shows `.claude/rules/` path rules and CLAUDE.md imports. Area: components (`cli-tool/components/`). No new UI components; catalog `docs/components.json` not regenerated. No new env vars or secrets.

- Bug Fixes
  - Fixed nested code fence rendering with quadruple backticks; clarified README copy path and Vite variant scope.
  - Python: noted `__main__.py` requirement and added it to the structure tree; TypeScript: use `process.exitCode`; Next.js: listed all App Router files that require default exports.

<sup>Written for commit 90117de904fbd86a56f57e78ec768438c00a522f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

