### PR TITLE
feat: add enterprise network config and permission presets

### DIFF
--- a/cli-tool/components/settings/enterprise/README.md
+++ b/cli-tool/components/settings/enterprise/README.md
@@ -1,0 +1,38 @@
+# Enterprise Configuration Templates
+
+Production-ready configuration for running Claude Code in enterprise environments.
+
+## Files
+
+| File | What It Covers |
+|------|---------------|
+| `network-configuration.md` | Proxy, custom CA, mTLS, firewall allowlist, credential refresh, troubleshooting |
+| `managed-settings-policies.md` | Server-managed settings: permissions, model restrictions, org-wide CLAUDE.md, audit hooks |
+
+## Quick Start
+
+### Network setup (proxy + custom CA)
+Add to `~/.claude/settings.json`:
+```json
+{
+  "env": {
+    "HTTPS_PROXY": "https://proxy.corp.example.com:8080",
+    "NO_PROXY": "localhost,127.0.0.1,.corp.example.com",
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/corp-ca-bundle.pem"
+  }
+}
+```
+
+### Conservative managed policy
+Deploy via Anthropic Console (Teams/Enterprise):
+```json
+{
+  "permissions": {
+    "deny": ["Bash(rm -rf *)", "Bash(git push --force *)", "Read(.env)", "Read(.env.*)"]
+  },
+  "disableBypassPermissionsMode": "disable",
+  "availableModels": ["sonnet", "haiku"]
+}
+```
+
+Source: https://github.com/CodeWithBehnam/cc-docs

--- a/cli-tool/components/settings/enterprise/managed-settings-policies.md
+++ b/cli-tool/components/settings/enterprise/managed-settings-policies.md
@@ -58,10 +58,11 @@ These settings are applied automatically to all users in your organization.
 
 ### Restrict network access
 
-> **Note**: In Claude Code permissions, deny rules take priority over allow rules.
-> The specific curl allows below work because they are more specific than the broad
-> deny pattern. However, verify that your version of Claude Code supports this
-> precedence model, as behavior may vary.
+> **Note**: In Claude Code, deny rules take priority over allow rules. The allow
+> entries below will be overridden by the broader `Bash(curl *)` deny. To make
+> this pattern work, use a PreToolUse hook instead that inspects the curl target
+> and blocks non-approved domains, or remove `Bash(curl *)` from deny and rely
+> on the default permission prompt for unlisted curl commands.
 
 ```json
 {

--- a/cli-tool/components/settings/enterprise/managed-settings-policies.md
+++ b/cli-tool/components/settings/enterprise/managed-settings-policies.md
@@ -58,6 +58,11 @@ These settings are applied automatically to all users in your organization.
 
 ### Restrict network access
 
+> **Note**: In Claude Code permissions, deny rules take priority over allow rules.
+> The specific curl allows below work because they are more specific than the broad
+> deny pattern. However, verify that your version of Claude Code supports this
+> precedence model, as behavior may vary.
+
 ```json
 {
   "permissions": {
@@ -180,6 +185,10 @@ For longer rules, use a managed CLAUDE.md file:
 ## Hook Policies
 
 ### Require audit logging for all users
+
+> **Note**: The log path below requires write access. Ensure the directory exists
+> and the user running Claude Code has write permissions. For non-root users,
+> consider using `~/.claude/audit.jsonl` or a path under `/tmp/` instead.
 
 ```json
 {

--- a/cli-tool/components/settings/enterprise/managed-settings-policies.md
+++ b/cli-tool/components/settings/enterprise/managed-settings-policies.md
@@ -1,0 +1,324 @@
+# Enterprise Setup: Managed Settings & Policies
+
+Configure organization-wide settings delivered via Anthropic's server-managed settings (Teams/Enterprise plans).
+
+These settings are applied automatically to all users in your organization.
+
+---
+
+## How It Works
+
+1. Admins configure settings in the Anthropic Console
+2. Settings are fetched by Claude Code at startup and polled hourly
+3. Settings apply uniformly across all org members
+4. Users cannot override managed settings (they have highest priority)
+
+---
+
+## Permission Policies
+
+### Block dangerous operations
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force *)",
+      "Bash(git reset --hard *)",
+      "Bash(curl * | bash)",
+      "Bash(wget * | bash)",
+      "Bash(chmod 777 *)"
+    ]
+  }
+}
+```
+
+### Protect sensitive files
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/credentials*)",
+      "Edit(.env)",
+      "Edit(.env.*)",
+      "Write(.env)",
+      "Write(.env.*)"
+    ]
+  }
+}
+```
+
+### Restrict network access
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(ssh *)",
+      "Bash(scp *)",
+      "WebFetch"
+    ],
+    "allow": [
+      "Bash(curl localhost*)",
+      "Bash(curl https://api.internal.corp.com/*)"
+    ]
+  }
+}
+```
+
+### Restrict MCP tool access
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "mcp__*__delete_*",
+      "mcp__*__drop_*",
+      "mcp__*__create_*"
+    ],
+    "allow": [
+      "mcp__github__*",
+      "mcp__*__read_*",
+      "mcp__*__search_*",
+      "mcp__*__list_*"
+    ]
+  }
+}
+```
+
+---
+
+## Mode Restrictions
+
+### Disable bypass permissions mode
+
+Prevent users from running `--dangerously-skip-permissions`:
+
+```json
+{
+  "disableBypassPermissionsMode": "disable"
+}
+```
+
+### Restrict available permission modes
+
+```json
+{
+  "allowedPermissionModes": ["default", "plan", "acceptEdits"]
+}
+```
+
+This prevents users from using `bypassPermissions` or `dontAsk` modes.
+
+---
+
+## Model Restrictions
+
+### Limit available models
+
+```json
+{
+  "availableModels": ["sonnet", "haiku"]
+}
+```
+
+This prevents users from selecting models not on the list (e.g., opus).
+
+### Pin model versions
+
+```json
+{
+  "env": {
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5@20251001"
+  }
+}
+```
+
+### Force a specific model
+
+```json
+{
+  "env": {
+    "ANTHROPIC_MODEL": "claude-sonnet-4-6"
+  }
+}
+```
+
+---
+
+## Organization-Wide CLAUDE.md
+
+Deploy coding standards to all users:
+
+```json
+{
+  "claudeMd": "## Organization Standards\n\n- All code must pass linting before commit\n- Use approved logging framework only\n- No direct database queries in controllers\n- All API endpoints require authentication\n- PII must not be logged\n- Follow OWASP secure coding practices"
+}
+```
+
+For longer rules, use a managed CLAUDE.md file:
+
+```json
+{
+  "claudeMdUrl": "https://internal.corp.example.com/claude-standards.md"
+}
+```
+
+---
+
+## Hook Policies
+
+### Require audit logging for all users
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c '{ts: (now|todate), user: env.USER, cmd: .tool_input.command}' >> /var/log/claude-audit.jsonl"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Block specific operations with verification
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/corp/claude-policy/validate-command.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Analytics & Monitoring
+
+### Enable usage analytics
+
+```json
+{
+  "analytics": {
+    "enabled": true,
+    "endpoint": "https://analytics.corp.example.com/claude"
+  }
+}
+```
+
+---
+
+## Complete Example: Conservative Enterprise Policy
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force *)",
+      "Bash(git reset --hard *)",
+      "Bash(curl * | bash)",
+      "Bash(wget * | bash)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Edit(.env*)",
+      "Write(.env*)"
+    ]
+  },
+  "disableBypassPermissionsMode": "disable",
+  "allowedPermissionModes": ["default", "plan", "acceptEdits"],
+  "availableModels": ["sonnet", "haiku"],
+  "env": {
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5@20251001"
+  },
+  "claudeMd": "## Corporate Policy\n- All code changes require tests\n- No PII in logs\n- Follow OWASP secure coding practices\n- Use approved dependencies only",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c '{ts: (now|todate), user: env.USER, cmd: .tool_input.command}' >> /var/log/claude-audit.jsonl"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Complete Example: Permissive Enterprise Policy
+
+For teams that need more autonomy with basic guardrails:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(curl * | bash)",
+      "Read(.env)",
+      "Read(**/secrets/**)"
+    ]
+  },
+  "disableBypassPermissionsMode": "disable",
+  "claudeMd": "## Team Guidelines\n- Run tests before committing\n- Follow existing code patterns"
+}
+```
+
+---
+
+## Settings Priority
+
+From highest to lowest:
+
+1. **Managed settings** (this template) - admins control, users cannot override
+2. **Project settings** (`.claude/settings.json`) - team-shared
+3. **User settings** (`~/.claude/settings.json`) - personal
+4. **Local settings** (`.claude/settings.local.json`) - machine-specific
+
+---
+
+## Tips
+
+- Start with a minimal policy and add restrictions as needed
+- Test policies with a small group before rolling out org-wide
+- Security-sensitive hooks (shell commands, env vars) require user approval on first use
+- Settings are cached locally so Claude Code works during brief API outages
+- Use `claude --debug` to see which managed settings are applied
+- Changes to managed settings propagate within 1 hour (polled hourly)

--- a/cli-tool/components/settings/enterprise/network-configuration.md
+++ b/cli-tool/components/settings/enterprise/network-configuration.md
@@ -1,0 +1,235 @@
+# Enterprise Setup: Network Configuration
+
+Complete network setup for running Claude Code in enterprise environments with proxies, firewalls, custom CAs, and mTLS.
+
+---
+
+## Corporate Proxy
+
+### Basic proxy
+
+```bash
+export HTTPS_PROXY=https://proxy.corp.example.com:8080
+export HTTP_PROXY=http://proxy.corp.example.com:8080
+```
+
+### Proxy with authentication
+
+```bash
+export HTTPS_PROXY=https://username:password@proxy.corp.example.com:8080
+```
+
+### Bypass proxy for internal services
+
+```bash
+export NO_PROXY="localhost,127.0.0.1,.corp.example.com,10.0.0.0/8,192.168.0.0/16"
+```
+
+### Persistent proxy config
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "HTTPS_PROXY": "https://proxy.corp.example.com:8080",
+    "HTTP_PROXY": "http://proxy.corp.example.com:8080",
+    "NO_PROXY": "localhost,127.0.0.1,.corp.example.com"
+  }
+}
+```
+
+---
+
+## Custom Certificate Authority (CA)
+
+For corporate CAs or self-signed certificates:
+
+### Single CA certificate
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem
+```
+
+### Multiple CA certificates (bundle)
+
+Concatenate all CA certs into one PEM file:
+
+```bash
+cat corp-root-ca.pem corp-intermediate-ca.pem > /path/to/ca-bundle.pem
+export NODE_EXTRA_CA_CERTS=/path/to/ca-bundle.pem
+```
+
+### Persistent CA config
+
+```json
+{
+  "env": {
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/corporate-ca-bundle.pem"
+  }
+}
+```
+
+---
+
+## mTLS (Mutual TLS) Client Certificates
+
+For environments requiring client certificate authentication:
+
+```bash
+export CLAUDE_CODE_CLIENT_CERT=/path/to/client-cert.pem
+export CLAUDE_CODE_CLIENT_KEY=/path/to/client-key.pem
+```
+
+With passphrase-protected key:
+
+```bash
+export CLAUDE_CODE_CLIENT_KEY_PASSPHRASE="your-passphrase"
+```
+
+### Persistent mTLS config
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_CLIENT_CERT": "/etc/ssl/certs/client-cert.pem",
+    "CLAUDE_CODE_CLIENT_KEY": "/etc/ssl/private/client-key.pem"
+  }
+}
+```
+
+---
+
+## Credential Auto-Refresh
+
+For SSO sessions that expire:
+
+### AWS SSO
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "AWS_PROFILE": "corp-sso"
+  },
+  "awsAuthRefresh": "aws sso login --profile corp-sso"
+}
+```
+
+### Generic credential refresh
+
+Create a refresh script (`~/bin/refresh-creds.sh`):
+
+```bash
+#!/bin/bash
+# Refresh corporate SSO token
+corp-cli auth refresh --silent
+# Output the new API key
+corp-cli auth token
+```
+
+```json
+{
+  "apiKeyHelper": "~/bin/refresh-creds.sh"
+}
+```
+
+Set refresh interval:
+
+```bash
+export CLAUDE_CODE_API_KEY_HELPER_TTL_MS=3600000  # 1 hour
+```
+
+---
+
+## Firewall / Domain Allowlist
+
+Claude Code needs access to these domains:
+
+### Required domains
+
+| Domain | Purpose |
+|--------|---------|
+| `api.anthropic.com` | Claude API |
+| `statsig.anthropic.com` | Feature flags and configuration |
+| `sentry.io` | Error reporting |
+
+### Additional domains (based on features used)
+
+| Domain | Purpose |
+|--------|---------|
+| `github.com` | Git operations |
+| `api.github.com` | GitHub API (MCP, Actions) |
+| `registry.npmjs.org` | npm packages (MCP servers, plugins) |
+| `pypi.org` | Python packages |
+| `mcp.slack.com` | Slack MCP integration |
+| `mcp.notion.com` | Notion MCP integration |
+
+### For cloud providers
+
+| Domain | Purpose |
+|--------|---------|
+| `bedrock-runtime.*.amazonaws.com` | AWS Bedrock |
+| `sts.amazonaws.com` | AWS STS (credential exchange) |
+| `*.aiplatform.googleapis.com` | Google Vertex AI |
+| `oauth2.googleapis.com` | Google OAuth |
+
+---
+
+## Complete Enterprise settings.json
+
+```json
+{
+  "env": {
+    "HTTPS_PROXY": "https://proxy.corp.example.com:8080",
+    "NO_PROXY": "localhost,127.0.0.1,.corp.example.com",
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/corp-ca-bundle.pem",
+    "CLAUDE_CODE_CLIENT_CERT": "/etc/ssl/certs/client.pem",
+    "CLAUDE_CODE_CLIENT_KEY": "/etc/ssl/private/client-key.pem",
+    "ANTHROPIC_BASE_URL": "https://ai-gateway.corp.example.com"
+  },
+  "apiKeyHelper": "~/bin/get-corp-api-key.sh"
+}
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Diagnostic | Fix |
+|-------|-----------|-----|
+| `UNABLE_TO_VERIFY_LEAF_SIGNATURE` | Missing CA cert | Set `NODE_EXTRA_CA_CERTS` |
+| `ECONNREFUSED` | Proxy not reachable | Check `HTTPS_PROXY` URL and port |
+| `407 Proxy Authentication Required` | Proxy needs credentials | Add user:pass to proxy URL |
+| `CERT_HAS_EXPIRED` | Expired CA or client cert | Update certificate files |
+| `ERR_TLS_CERT_ALTNAME_INVALID` | Wrong domain in cert | Verify cert covers the domain |
+| `SELF_SIGNED_CERT_IN_CHAIN` | Missing intermediate CA | Add all CAs to bundle PEM |
+| `socket hang up` | Proxy blocking WebSocket | Check proxy supports WebSocket upgrade |
+
+### Debug network issues
+
+```bash
+# Verbose mode shows network details
+claude --debug
+
+# Test proxy connection
+curl -v --proxy $HTTPS_PROXY https://api.anthropic.com
+
+# Test CA certificate
+openssl s_client -connect api.anthropic.com:443 -CAfile /path/to/ca-bundle.pem
+
+# Test client certificate
+openssl s_client -connect gateway.corp.example.com:443 \
+  -cert /path/to/client.pem -key /path/to/client-key.pem
+```
+
+---
+
+## Tips
+
+- Always test connectivity with `curl` before configuring Claude Code
+- Concatenate CA certificates in order: root CA last, intermediate CAs first
+- Use `NO_PROXY` to bypass proxy for internal tools (MCP servers, local APIs)
+- Client certificate keys should be readable only by the user (`chmod 600`)
+- For MDM-managed devices, certificates are often in `/etc/ssl/certs/` already
+- Use `claude --debug` to see detailed network error messages

--- a/cli-tool/components/settings/permission-presets/README.md
+++ b/cli-tool/components/settings/permission-presets/README.md
@@ -1,0 +1,18 @@
+# Permission Presets
+
+Copy-paste permission configurations for `.claude/settings.json` or `~/.claude/settings.json`.
+
+## Available Presets
+
+| Preset | Who It's For | Philosophy |
+|--------|-------------|------------|
+| Balanced Development | Most teams | Allow common tools, protect secrets, ask for destructive ops |
+| Python Development | Python teams | uv, pytest, ruff, mypy auto-allowed |
+| Ruby/Rails Development | Rails teams | bundle, rails, rspec, rubocop auto-allowed |
+| Go Development | Go teams | go, make auto-allowed |
+| Restrictive | New Claude Code users | Read-only by default, ask for everything else |
+| Open | Experienced users | Everything allowed except catastrophic operations |
+
+See `development-presets.md` for complete configurations.
+
+Source: https://github.com/CodeWithBehnam/cc-docs

--- a/cli-tool/components/settings/permission-presets/development-presets.md
+++ b/cli-tool/components/settings/permission-presets/development-presets.md
@@ -1,0 +1,259 @@
+# Permissions Template: Development Environment
+
+Developer-friendly permission presets that balance productivity with safety.
+
+Copy the relevant configuration into `.claude/settings.json` for project-wide settings,
+or `~/.claude/settings.json` for personal settings.
+
+---
+
+## Balanced Development (Recommended)
+
+Allow common development tools, protect sensitive files, ask for destructive operations.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash(npm run *)",
+      "Bash(npm test *)",
+      "Bash(npm install *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git branch *)",
+      "Bash(git stash *)",
+      "Bash(ls *)",
+      "Bash(cat *)",
+      "Bash(wc *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Edit",
+      "Write"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force *)",
+      "Bash(git reset --hard *)",
+      "Bash(git clean -f *)",
+      "Bash(chmod 777 *)",
+      "Bash(curl * | bash)",
+      "Bash(wget * | bash)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Edit(.env)",
+      "Edit(.env.*)",
+      "Write(.env)",
+      "Write(.env.*)"
+    ]
+  }
+}
+```
+
+---
+
+## Python Development
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write",
+      "Bash(uv *)",
+      "Bash(python *)",
+      "Bash(pytest *)",
+      "Bash(ruff *)",
+      "Bash(mypy *)",
+      "Bash(pip *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Edit(.env)",
+      "Write(.env)"
+    ]
+  }
+}
+```
+
+---
+
+## Ruby/Rails Development
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write",
+      "Bash(bundle *)",
+      "Bash(rails *)",
+      "Bash(rake *)",
+      "Bash(rspec *)",
+      "Bash(rubocop *)",
+      "Bash(bin/*)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(rails db:drop *)",
+      "Bash(rails db:reset *)",
+      "Read(.env)",
+      "Read(config/master.key)",
+      "Read(config/credentials.yml.enc)"
+    ]
+  }
+}
+```
+
+---
+
+## Go Development
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write",
+      "Bash(go *)",
+      "Bash(make *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Read(.env)",
+      "Read(.env.*)"
+    ]
+  }
+}
+```
+
+---
+
+## Restrictive (New to Claude Code)
+
+Start restrictive and relax as you get comfortable.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Bash(rm *)",
+      "Bash(git push *)",
+      "Bash(git reset *)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Read(.env*)",
+      "Read(**/*.key)",
+      "Read(**/*.pem)"
+    ]
+  }
+}
+```
+
+With this setup, Claude will ask permission for edits, writes, and most bash commands.
+
+---
+
+## Open (Experienced User)
+
+Maximum productivity, minimal interruptions. Use when you trust the codebase and review diffs before committing.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit",
+      "Write",
+      "Bash"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(git push --force *)",
+      "Bash(git reset --hard *)",
+      "Read(.env)",
+      "Read(.env.*)"
+    ]
+  }
+}
+```
+
+---
+
+## File Protection Patterns
+
+Common patterns for the `deny` list:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/credentials*)",
+      "Edit(package-lock.json)",
+      "Edit(yarn.lock)",
+      "Edit(pnpm-lock.yaml)",
+      "Edit(Gemfile.lock)",
+      "Edit(.github/workflows/**)",
+      "Write(.github/workflows/**)"
+    ]
+  }
+}
+```
+
+---
+
+## Tips
+
+- Start restrictive and relax over time using `/permissions`
+- Use project-level settings (`.claude/settings.json`) for team-shared rules
+- Use user-level settings (`~/.claude/settings.json`) for personal preferences
+- Deny rules take priority over allow rules
+- Wildcard `*` matches any arguments in Bash commands
+- Gitignore-style patterns work for file paths
+- Use `--permission-mode plan` for a safe exploration mode that allows no edits

--- a/cli-tool/components/settings/permission-presets/development-presets.md
+++ b/cli-tool/components/settings/permission-presets/development-presets.md
@@ -11,6 +11,10 @@ or `~/.claude/settings.json` for personal settings.
 
 Allow common development tools, protect sensitive files, ask for destructive operations.
 
+> **Note**: `Bash(cat *)` and similar file-reading commands in the allow list can
+> read files that are denied via `Read(...)` rules. If you need strict file access
+> control, also deny the Bash equivalents: `Bash(cat .env*)`, `Bash(cat **/*.pem)`, etc.
+
 ```json
 {
   "permissions": {
@@ -29,7 +33,6 @@ Allow common development tools, protect sensitive files, ask for destructive ope
       "Bash(git branch *)",
       "Bash(git stash *)",
       "Bash(ls *)",
-      "Bash(cat *)",
       "Bash(wc *)",
       "Bash(head *)",
       "Bash(tail *)",
@@ -46,6 +49,10 @@ Allow common development tools, protect sensitive files, ask for destructive ope
       "Bash(chmod 777 *)",
       "Bash(curl * | bash)",
       "Bash(wget * | bash)",
+      "Bash(cat .env*)",
+      "Bash(cat **/secrets/*)",
+      "Bash(cat **/*.pem)",
+      "Bash(cat **/*.key)",
       "Read(.env)",
       "Read(.env.*)",
       "Read(**/secrets/**)",


### PR DESCRIPTION
## Summary

- Adds **enterprise network configuration** templates for proxy, custom CA, mTLS, and firewall setup
- Adds **managed settings policies** for org-wide control (permissions, models, audit hooks)
- Adds **6 development permission presets** from restrictive to open

### Enterprise Configuration
| File | What It Covers |
|------|---------------|
| `network-configuration.md` | Corporate proxy (basic + auth + NO_PROXY), custom CA certs (single + bundle), mTLS client certs, credential auto-refresh (AWS SSO), firewall domain allowlist, troubleshooting table with diagnostics |
| `managed-settings-policies.md` | Server-managed permissions (block dangerous ops, protect files, restrict network), mode restrictions, model restrictions/pinning, org-wide CLAUDE.md, audit hooks, complete conservative + permissive policy examples |

### Permission Presets
| Preset | Philosophy |
|--------|------------|
| Balanced Development | Allow common tools, protect secrets, ask for destructive ops |
| Python Development | uv, pytest, ruff, mypy auto-allowed |
| Ruby/Rails Development | bundle, rails, rspec, rubocop auto-allowed |
| Go Development | go, make auto-allowed |
| Restrictive | Read-only by default, ask for everything else |
| Open | Everything allowed except catastrophic operations |

### Why this is valuable
These fill a gap for enterprise teams. The network config includes real troubleshooting commands (`openssl s_client`, `curl -v --proxy`) and a diagnostic table for common SSL/TLS errors. The permission presets are copy-paste ready.

## Test plan

- [ ] Verify network config env vars are correctly formatted for settings.json
- [ ] Verify permission presets use valid permission patterns (e.g., `Bash(npm run *)`)
- [ ] Verify managed settings examples are valid JSON

Source: [cc-docs](https://github.com/CodeWithBehnam/cc-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enterprise network configuration and managed policy templates, plus six permission presets, with hardened defaults and clarified deny-over-allow behavior for network rules. Affects components (`cli-tool/components/`).

- Enterprise templates: network (proxy, CA, mTLS, firewall allowlist, credential refresh) and server-managed settings (permissions, model restrictions/pinning, org-wide CLAUDE.md, audit hooks, mode limits); clarified that deny rules override allow rules for curl and that selective access should use a PreToolUse hook or remove the broad deny; noted audit-log path write permissions.
- Permission presets: Balanced, Python, Rails, Go, Restrictive, Open; tightened by removing `Bash(cat *)` and adding `Bash(cat .env*)` deny.
- New components: `settings/enterprise` and `settings/permission-presets`; regenerate `docs/components.json`.
- No new required env vars; optional support for proxy/CA/mTLS and Bedrock (e.g., `HTTPS_PROXY`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS`, `CLAUDE_CODE_CLIENT_CERT/KEY`, `AWS_PROFILE`, `CLAUDE_CODE_USE_BEDROCK`).

<sup>Written for commit c743aae33745e3709cb1c9576535ff1068ec95dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

