### PR TITLE
feat: add claude-yap fun notification hook

### DIFF
--- a/cli-tool/components/hooks/automation/claude-yap.json
+++ b/cli-tool/components/hooks/automation/claude-yap.json
@@ -1,0 +1,27 @@
+{
+  "description": "Fun, customizable desktop notifications for Claude Code with random messages, auto editor detection, and message packs. Sends cheerful notifications when tasks complete or approval is needed. Supports VS Code, Cursor, Antigravity, Windsurf, Zed, iTerm2, Ghostty, Warp, and more. Works on macOS and Linux. Customize messages, sounds, and name prefix via ~/.claude-yap/config.json. By abdulrohman (github.com/zehnlyai-main/claude-yap)",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ ! -d \"$HOME/.claude-yap\" ]; then echo 'Installing claude-yap...' && git clone --depth 1 https://github.com/zehnlyai-main/claude-yap.git \"$HOME/.claude-yap\" 2>/dev/null && chmod +x \"$HOME/.claude-yap/claude-yap.sh\"; fi; \"$HOME/.claude-yap/claude-yap.sh\" stop 2>/dev/null; true"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ ! -d \"$HOME/.claude-yap\" ]; then echo 'Installing claude-yap...' && git clone --depth 1 https://github.com/zehnlyai-main/claude-yap.git \"$HOME/.claude-yap\" 2>/dev/null && chmod +x \"$HOME/.claude-yap/claude-yap.sh\"; fi; \"$HOME/.claude-yap/claude-yap.sh\" notification 2>/dev/null; true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds **claude-yap** — fun, customizable desktop notifications for Claude Code.

- Random cheerful messages from 5 message packs (default, casual, formal, anime, pirate)
- Auto-detects 11+ editors/terminals (VS Code, Cursor, Antigravity, Windsurf, Zed, iTerm2, Ghostty, Warp, etc.)
- Customizable name prefix, sounds, and messages via `~/.claude-yap/config.json`
- macOS (`terminal-notifier`) and Linux (`notify-send`) support
- Two hook events: **Stop** (task done) and **Notification** (needs approval)

### Install
```bash
npx claude-code-templates@latest --hook automation/claude-yap
```

### How it works
- On first run, auto-clones [zehnlyai-main/claude-yap](https://github.com/zehnlyai-main/claude-yap) to `~/.claude-yap/`
- Subsequent runs use the cached install
- Users customize via `~/.claude-yap/config.json` (name prefix, message pack, sounds, editor)

### Example notifications
- Stop: "Cooked Master 🍳", "Mic drop Master 🎙️", "Crushed it Master 💪"
- Notification: "Master, pretty please? 🥹", "Master, I'm stuck without you 🥺"

Repo: https://github.com/zehnlyai-main/claude-yap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `claude-yap` notification hook component to send fun desktop alerts on Stop and Notification events. Improves developer feedback with auto-install and macOS/Linux support.

- **New Features**
  - Area: components (`cli-tool/components/`); added `hooks/automation/claude-yap.json` for desktop notifications.
  - Auto-installs `zehnlyai-main/claude-yap` to `~/.claude-yap` on first run and invokes `claude-yap.sh` for Stop/Notification.
  - Supports macOS (`terminal-notifier`) and Linux (`notify-send`); auto-detects common editors/terminals; configurable via `~/.claude-yap/config.json`.
  - New component added — regenerate `docs/components.json`; no new environment variables or secrets.

<sup>Written for commit b5a227ed68b40cbc9ef0ace8f3e15053dd24e6a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

