### PR TITLE
fix(analytics): use lstat to skip broken symlinks in JSONL scan

### DIFF
--- a/cli-tool/src/analytics/core/ConversationAnalyzer.js
+++ b/cli-tool/src/analytics/core/ConversationAnalyzer.js
@@ -78,9 +78,20 @@ class ConversationAnalyzer {
 
         for (const item of items) {
           const itemPath = path.join(dir, item);
-          const stats = await fs.stat(itemPath);
+          let stats;
+          try {
+            // Use lstat so we inspect the symlink itself rather than following it.
+            // Broken symlinks (e.g. ~/.claude/debug/latest -> deleted file) would
+            // cause fs.stat() to throw ENOENT and abort the entire scan.
+            stats = await fs.lstat(itemPath);
+          } catch (e) {
+            continue; // skip unreadable / permission-denied entries
+          }
 
-          if (stats.isDirectory()) {
+          if (stats.isSymbolicLink()) {
+            // Skip symlinks entirely – conversation files are never symlinks
+            continue;
+          } else if (stats.isDirectory()) {
             // Recursively search subdirectories
             const subFiles = await findJsonlFiles(itemPath);
             files.push(...subFiles);


### PR DESCRIPTION
fs.stat() follows symlinks, so a broken symlink (e.g. ~/.claude/debug/latest pointing to a deleted file) throws ENOENT and aborts the entire conversation scan, causing the dashboard to show 0 conversations.

Switch to fs.lstat() + skip symlinks so the recursive JSONL finder is robust against broken links and any other unreadable entries in ~/.claude.

Fixes: dashboard shows "Found 0 conversations" on macOS when ~/.claude/debug/latest is a dangling symlink

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the JSONL scan resilient to broken symlinks so analytics doesn’t abort and show 0 conversations. We now inspect entries with `fs.lstat` and skip symlinks and unreadable items.

- **Bug Fixes**
  - Use `fs.lstat` and skip symlinks/unreadable entries in `ConversationAnalyzer` to prevent ENOENT aborts during scans.
  - Fixes "Found 0 conversations" when `~/.claude/debug/latest` is a dangling symlink on macOS.
  - Area: CLI (`cli-tool/src/`).
  - No new components; no catalog (`docs/components.json`) change needed.
  - No new environment variables or secrets.

<sup>Written for commit c7f984cc7679d20cb1886cc5b04425847c89baf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

