### PR TITLE
Add shell-wrapper-guard: detect destructive commands in interpreter one-liners

### DIFF
--- a/cli-tool/components/hooks/security/shell-wrapper-guard.json
+++ b/cli-tool/components/hooks/security/shell-wrapper-guard.json
@@ -1,0 +1,23 @@
+{
+  "description": "Detects destructive commands hidden inside shell wrappers (sh -c, bash -c, python3 -c, node -e, perl -e, ruby -e). Complements dangerous-command-blocker by catching bypass vectors like 'sh -c \"rm -rf /\"' that evade direct command checks. Covers 8 bypass patterns: interpreter one-liners, nested wrappers, pipe-to-shell, here-strings, and env-based wrappers.",
+  "supportingFiles": [
+    {
+      "source": "shell-wrapper-guard.sh",
+      "destination": ".claude/hooks/shell-wrapper-guard.sh",
+      "executable": true
+    }
+  ],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/shell-wrapper-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli-tool/components/hooks/security/shell-wrapper-guard.sh
+++ b/cli-tool/components/hooks/security/shell-wrapper-guard.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# shell-wrapper-guard.sh — Detect destructive commands hidden in shell wrappers
+#
+# Solves: Bypass vectors that evade destructive-guard by wrapping commands:
+#   sh -c "rm -rf /"
+#   bash -c "git reset --hard"
+#   python3 -c "import os; os.system('rm -rf ~')"
+#   perl -e "system('rm -rf /')"
+#   ruby -e "system('rm -rf /')"
+#   node -e "require('child_process').execSync('rm -rf /')"
+#
+# Complements destructive-guard.sh which checks direct commands.
+# This hook unwraps interpreter one-liners and checks the inner command.
+#
+# Usage: PreToolUse hook on "Bash"
+#
+# TRIGGER: PreToolUse  MATCHER: "Bash"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Destructive patterns to detect inside wrappers
+DESTRUCT_PATTERN='rm\s+-[rf]*\s+[/~]|rm\s+-[rf]*\s+\.\.|git\s+reset\s+--hard|git\s+clean\s+-[fd]+|git\s+checkout\s+\.|mkfs\.|dd\s+if=|>\s*/dev/sd|chmod\s+777\s+/'
+
+# === Check 1: sh/bash -c wrappers ===
+if echo "$COMMAND" | grep -qE '(sh|bash|zsh|dash)\s+-c\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*(sh|bash|zsh|dash)\s+-c\s+['\"]?//" | sed "s/['\"]?\s*$//")
+    if echo "$INNER" | grep -qE "$DESTRUCT_PATTERN"; then
+        echo "BLOCKED: Destructive command hidden in shell wrapper" >&2
+        echo "  Detected: $INNER" >&2
+        exit 2
+    fi
+fi
+
+# === Check 2: Python one-liners ===
+if echo "$COMMAND" | grep -qE 'python[23]?\s+-c\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*python[23]?\s+-c\s+['\"]?//" | sed "s/['\"]?\s*$//")
+    if echo "$INNER" | grep -qiE "os\.system\(.*($DESTRUCT_PATTERN)|subprocess\.(run|call|Popen)\(.*($DESTRUCT_PATTERN)|shutil\.rmtree\s*\(\s*['\"/~]"; then
+        echo "BLOCKED: Destructive command in Python one-liner" >&2
+        exit 2
+    fi
+fi
+
+# === Check 3: Perl/Ruby one-liners ===
+if echo "$COMMAND" | grep -qE '(perl|ruby)\s+-e\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*(perl|ruby)\s+-e\s+['\"]?//" | sed "s/['\"]?\s*$//")
+    if echo "$INNER" | grep -qE "system\(.*($DESTRUCT_PATTERN)|exec\(.*($DESTRUCT_PATTERN)"; then
+        echo "BLOCKED: Destructive command in interpreter one-liner" >&2
+        exit 2
+    fi
+fi
+
+# === Check 4: Node.js one-liners ===
+if echo "$COMMAND" | grep -qE 'node\s+-e\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*node\s+-e\s+['\"]?//" | sed "s/['\"]?\s*$//")
+    if echo "$INNER" | grep -qE "execSync\(.*($DESTRUCT_PATTERN)|exec\(.*($DESTRUCT_PATTERN)"; then
+        echo "BLOCKED: Destructive command in Node.js one-liner" >&2
+        exit 2
+    fi
+fi
+
+# === Check 5: Nested wrappers (sh -c "bash -c 'rm -rf /'") ===
+if echo "$COMMAND" | grep -qE '(sh|bash)\s+-c\s+.*(sh|bash)\s+-c'; then
+    if echo "$COMMAND" | grep -qE "$DESTRUCT_PATTERN"; then
+        echo "BLOCKED: Nested shell wrapper with destructive command" >&2
+        exit 2
+    fi
+fi
+
+# === Check 6: Pipe to shell (echo "rm -rf /" | sh) ===
+if echo "$COMMAND" | grep -qE '\|\s*(sh|bash|zsh)\s*$'; then
+    # Extract the piped content
+    PIPED=$(echo "$COMMAND" | sed -E 's/\s*\|\s*(sh|bash|zsh)\s*$//')
+    if echo "$PIPED" | grep -qE "$DESTRUCT_PATTERN"; then
+        echo "BLOCKED: Destructive command piped to shell" >&2
+        exit 2
+    fi
+fi
+
+# === Check 7: Here-string to shell (bash <<< "rm -rf /") ===
+if echo "$COMMAND" | grep -qE '(sh|bash|zsh)\s+<<<\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*(sh|bash|zsh)\s+<<<\s+['\"]?//" | sed "s/['\"]?\s*$//")
+    if echo "$INNER" | grep -qE "$DESTRUCT_PATTERN"; then
+        echo "BLOCKED: Destructive command via here-string" >&2
+        exit 2
+    fi
+fi
+
+# === Check 8: env-based bypass (env VAR=val sh -c "$VAR") ===
+if echo "$COMMAND" | grep -qE '^\s*env\s+.*\s+(sh|bash)\s+-c'; then
+    if echo "$COMMAND" | grep -qE "$DESTRUCT_PATTERN"; then
+        echo "BLOCKED: Destructive command via env wrapper" >&2
+        exit 2
+    fi
+fi
+
+exit 0

--- a/cli-tool/components/hooks/security/shell-wrapper-guard.sh
+++ b/cli-tool/components/hooks/security/shell-wrapper-guard.sh
@@ -34,8 +34,8 @@ if echo "$COMMAND" | grep -qE '(sh|bash|zsh|dash)\s+-c\s+'; then
 fi
 
 # === Check 2: Python one-liners ===
-if echo "$COMMAND" | grep -qE 'python[23]?\s+-c\s+'; then
-    INNER=$(echo "$COMMAND" | sed -E "s/.*python[23]?\s+-c\s+['\"]?//" | sed "s/['\"]?\s*$//")
+if echo "$COMMAND" | grep -qE 'python[23]?(\.[0-9]+)?\s+-c\s+'; then
+    INNER=$(echo "$COMMAND" | sed -E "s/.*python[23]?(\.[0-9]+)?\s+-c\s+['\"]?//" | sed "s/['\"]?\s*$//")
     if echo "$INNER" | grep -qiE "os\.system\(.*($DESTRUCT_PATTERN)|subprocess\.(run|call|Popen)\(.*($DESTRUCT_PATTERN)|shutil\.rmtree\s*\(\s*['\"/~]"; then
         echo "BLOCKED: Destructive command in Python one-liner" >&2
         exit 2
@@ -69,9 +69,9 @@ if echo "$COMMAND" | grep -qE '(sh|bash)\s+-c\s+.*(sh|bash)\s+-c'; then
 fi
 
 # === Check 6: Pipe to shell (echo "rm -rf /" | sh) ===
-if echo "$COMMAND" | grep -qE '\|\s*(sh|bash|zsh)\s*$'; then
-    # Extract the piped content
-    PIPED=$(echo "$COMMAND" | sed -E 's/\s*\|\s*(sh|bash|zsh)\s*$//')
+if echo "$COMMAND" | grep -qE '\|\s*(sh|bash|zsh)(\s|$)'; then
+    # Extract the piped content (handles "| sh", "| sh -s", "| bash -c ...")
+    PIPED=$(echo "$COMMAND" | sed -E 's/\s*\|\s*(sh|bash|zsh)(\s.*)?$//')
     if echo "$PIPED" | grep -qE "$DESTRUCT_PATTERN"; then
         echo "BLOCKED: Destructive command piped to shell" >&2
         exit 2


### PR DESCRIPTION
Adds a new security hook that detects destructive commands hidden inside shell wrappers — a common bypass vector for existing command blockers.
**Problem:** `dangerous-command-blocker` catches direct destructive commands but misses the same commands wrapped in interpreter one-liners like `sh -c`, `python3 -c`, etc.
**Solution:** `shell-wrapper-guard` unwraps 8 bypass patterns including shell wrappers, Python/Perl/Ruby/Node one-liners, nested wrappers, pipe-to-shell, here-strings, and env-based wrappers.
From [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) — 667 hooks, 9,200+ tests, built from 800 hours of autonomous Claude Code operation.
- [x] Verified hook blocks wrapper-hidden destructive commands
- [x] Verified hook passes safe commands through
- [x] JSON format matches existing security hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new security hook `shell-wrapper-guard` to block destructive commands hidden in interpreter/shell one‑liners and wrappers. Improves coverage for versioned Python binaries and pipe‑to‑shell with arguments.

- **New Features**
  - Area: components (`cli-tool/components/`); adds `hooks/security/shell-wrapper-guard.json` and `shell-wrapper-guard.sh` — new component; regenerate `docs/components.json`; no new environment variables or secrets.
  - Blocks 8 bypass patterns (shell `-c`, Python `-c`, Perl/Ruby/Node `-e`, nested wrappers, pipe-to-shell, here-strings, env wrappers); registered as `PreToolUse` for `Bash` to run `.claude/hooks/shell-wrapper-guard.sh`.

- **Bug Fixes**
  - Python one-liners: detects version-suffixed executables (e.g., `python3.11`) via `python[23]?(\.[0-9]+)?`.
  - Pipe-to-shell: detects shells with arguments (e.g., `| sh -s`, `| bash -c`) to close bypass gaps.

<sup>Written for commit aa977104c9ce7a53acd915f169c8afdbff63f376. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

