### PR TITLE
fix(hooks): narrow simple-notifications to Stop and Notification events

### DIFF
--- a/cli-tool/components/hooks/automation/simple-notifications.json
+++ b/cli-tool/components/hooks/automation/simple-notifications.json
@@ -1,13 +1,22 @@
 {
-  "description": "Send simple desktop notifications when Claude Code operations complete. Works on macOS and Linux systems.",
+  "description": "Send desktop notifications when Claude Code finishes working or needs user input. Works on macOS and Linux systems.",
   "hooks": {
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Tool: $CLAUDE_TOOL_NAME completed\" with title \"Claude Code\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Claude Code' \"Tool: $CLAUDE_TOOL_NAME completed\"; fi"
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Claude has finished working\" with title \"Claude Code\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Claude Code' \"Claude has finished working\"; fi"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Claude needs your input\" with title \"Claude Code\" sound name \"Ping\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send -u critical 'Claude Code' \"Claude needs your input\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Replace the `PostToolUse` wildcard matcher with `Stop` and `Notification` events. `Stop` notifies once when Claude finishes a turn. `Notification` notifies (with sound) when Claude needs user input. This follows the same pattern already used by `discord-notifications` and `slack-notifications` hooks.

## Why

With the current state of Claude Code, where a single turn can spawn multiple subagents, each running dozens of tool calls (Read, Edit, Bash, Grep, Glob, etc.), the `PostToolUse` wildcard hook generates an overwhelming number of desktop notifications. A typical agentic workflow can easily trigger 50+ notifications in a few seconds, flooding the notification center and making the hook counterproductive.

Narrowing to `Stop` and `Notification` events gives users what they actually want: knowing when Claude is done or when it needs their attention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce notification spam by switching `simple-notifications` from `PostToolUse` wildcard to `Stop` and `Notification` events. Users now get one notice when Claude finishes and a ping when input is needed.

- Why: `PostToolUse` fired on every tool call, creating dozens of notifications per turn.
- Affected area: components (`cli-tool/components/`), file: `hooks/automation/simple-notifications.json`.
- No new components; catalog (`docs/components.json`) does not need regeneration.
- No new environment variables or secrets.

<sup>Written for commit 7d83fa8647e16e6cbd180ff8d63d5a408f29f31f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

