### PR TITLE
Add component PR welcome workflow

### DIFF
--- a/.github/workflows/component-pr-welcome.yml
+++ b/.github/workflows/component-pr-welcome.yml
@@ -28,15 +28,6 @@ jobs:
             const labelDescription = 'Component PR awaiting maintainer review';
             const marker = '<!-- component-pr-welcome:v1 -->';
 
-            const existing = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number: prNumber, per_page: 100 }
-            );
-            if (existing.some(c => c.body && c.body.includes(marker))) {
-              core.info('Welcome comment already posted — skipping.');
-              return;
-            }
-
             try {
               await github.rest.issues.getLabel({ owner, repo, name: labelName });
             } catch (err) {
@@ -59,6 +50,15 @@ jobs:
               issue_number: prNumber,
               labels: [labelName],
             });
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 }
+            );
+            if (existing.some(c => c.body && c.body.includes(marker))) {
+              core.info('Welcome comment already posted — skipping comment, label ensured.');
+              return;
+            }
 
             const body = [
               marker,

--- a/.github/workflows/component-pr-welcome.yml
+++ b/.github/workflows/component-pr-welcome.yml
@@ -2,7 +2,7 @@ name: Component PR Welcome
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     paths:
       - 'cli-tool/components/**'
 
@@ -26,6 +26,16 @@ jobs:
             const labelName = 'review-pending';
             const labelColor = 'fbca04';
             const labelDescription = 'Component PR awaiting maintainer review';
+            const marker = '<!-- component-pr-welcome:v1 -->';
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 }
+            );
+            if (existing.some(c => c.body && c.body.includes(marker))) {
+              core.info('Welcome comment already posted — skipping.');
+              return;
+            }
 
             try {
               await github.rest.issues.getLabel({ owner, repo, name: labelName });
@@ -51,6 +61,7 @@ jobs:
             });
 
             const body = [
+              marker,
               `## 👋 Thanks for contributing, @${author}!`,
               ``,
               `This PR touches \`cli-tool/components/**\` and has been marked **\`review-pending\`**.`,

--- a/.github/workflows/component-pr-welcome.yml
+++ b/.github/workflows/component-pr-welcome.yml
@@ -1,0 +1,77 @@
+name: Component PR Welcome
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - 'cli-tool/components/**'
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  welcome:
+    name: Welcome & Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add review-pending label and welcome comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.issue.number;
+            const author = context.payload.pull_request.user.login;
+
+            const labelName = 'review-pending';
+            const labelColor = 'fbca04';
+            const labelDescription = 'Component PR awaiting maintainer review';
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: labelName });
+            } catch (err) {
+              if (err.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: labelName,
+                  color: labelColor,
+                  description: labelDescription,
+                });
+              } else {
+                throw err;
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: [labelName],
+            });
+
+            const body = [
+              `## 👋 Thanks for contributing, @${author}!`,
+              ``,
+              `This PR touches \`cli-tool/components/**\` and has been marked **\`review-pending\`**.`,
+              ``,
+              `### What happens next`,
+              `1. 🤖 **Automated security audit** runs and posts results on this PR.`,
+              `2. 👀 **Maintainer review** — a human reviewer validates the component with the \`component-reviewer\` agent (format, naming, security, clarity).`,
+              `3. ✅ **Merge** — once approved, your PR is merged to \`main\`.`,
+              `4. 📦 **Catalog regeneration** — the component catalog is rebuilt automatically.`,
+              `5. 🚀 **Live on [aitmpl.com](https://www.aitmpl.com)** — your component appears on the website after deploy.`,
+              ``,
+              `### While you wait`,
+              `- Check the **Security Audit** comment below for any issues to fix.`,
+              `- Make sure your component follows the [contribution guide](https://github.com/${owner}/${repo}/blob/main/CLAUDE.md#component-system).`,
+              ``,
+              `_This is an automated message. No action is required from you right now — a maintainer will review soon._`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });


### PR DESCRIPTION
Posts a welcome comment and applies a `review-pending` label when a PR
touches `cli-tool/components/**`. The comment explains the review flow
(audit → maintainer review → merge → catalog regen → live on aitmpl.com)
so contributors know what to expect after submitting.

https://claude.ai/code/session_016JRD3XpvZag4BGgQsw84uk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-labels component PRs and posts a welcome comment to set review expectations. It now re-applies the `review-pending` label on every synchronize while keeping the comment idempotent.

- Area: components (`cli-tool/components/**`) via CI workflow
- Adds `.github/workflows/component-pr-welcome.yml` to apply `review-pending` and post a review-flow comment; creates the label if missing; uses `actions/github-script@v8`
- Triggers on `opened`, `reopened`, `synchronize`; always re-applies the label; uses a hidden HTML marker to avoid duplicate comments
- New components: none; catalog (`docs/components.json`) regen not required
- Env vars/secrets: none

<sup>Written for commit d95ea2a11caa31321d99f9fa1ee03258a4b3fb4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

