### PR TITLE
fix: resolve duplicate skill name brand-guidelines (B7, B8)

### DIFF
--- a/cli-tool/components/skills/business-marketing/brand-guidelines-anthropic/SKILL.md
+++ b/cli-tool/components/skills/business-marketing/brand-guidelines-anthropic/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brand-guidelines
+name: brand-guidelines-anthropic
 description: Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 license: Complete terms in LICENSE.txt
 ---

--- a/cli-tool/components/skills/business-marketing/brand-guidelines-community/SKILL.md
+++ b/cli-tool/components/skills/business-marketing/brand-guidelines-community/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brand-guidelines
+name: brand-guidelines-community
 description: Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
 license: Complete terms in LICENSE.txt
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two skills in `cli-tool/components/skills/business-marketing/` both declare `name: brand-guidelines` in their YAML frontmatter:

- `brand-guidelines-anthropic/SKILL.md`
- `brand-guidelines-community/SKILL.md`

In Claude Code's skill registry, the `name` field is the install key. When a user installs both skills, the second one **silently overwrites the first**, meaning one skill is permanently inaccessible regardless of which path it was installed from.

## Fix

Rename each skill's `name` field to match its directory name:

| File | Before | After |
|------|--------|-------|
| `brand-guidelines-anthropic/SKILL.md` | `name: brand-guidelines` | `name: brand-guidelines-anthropic` |
| `brand-guidelines-community/SKILL.md` | `name: brand-guidelines` | `name: brand-guidelines-community` |

The skill in `enterprise-communication/brand-guidelines/SKILL.md` already has a unique directory and is not affected.

## Why it matters

Users who install both skills from this repo get only one of them — with no error or warning. Renaming them to unique keys ensures both are independently installable and accessible by name.

The fix is minimal (two one-line frontmatter changes) and does not touch any skill content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a silent install conflict by giving two brand-guidelines skills unique `name` keys so both can be installed and used independently.

- Area: components (`cli-tool/components/`)
- Change: Renamed frontmatter `name` to `brand-guidelines-anthropic` and `brand-guidelines-community` in their `SKILL.md` files
- Why: Prevents key collision where one skill overwrote the other during install
- No new components; no `docs/components.json` regeneration needed
- No new environment variables or secrets

<sup>Written for commit 3fcf87f055b980550ceba4e250c5f6b190cdc0cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

