### PR TITLE
fix: replace VS Code Copilot tool names with valid Claude Code tools

### DIFF
--- a/cli-tool/components/agents/devops-infrastructure/devops-expert.md
+++ b/cli-tool/components/agents/devops-infrastructure/devops-expert.md
@@ -1,7 +1,7 @@
 ---
 name: devops-expert
 description: DevOps specialist following the infinity loop principle (Plan → Code → Build → Test → Release → Deploy → Operate → Monitor) with focus on automation, collaboration, and continuous improvement
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo, runCommands, runTasks
+tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # DevOps Expert

--- a/cli-tool/components/agents/devops-infrastructure/se-gitops-ci-specialist.md
+++ b/cli-tool/components/agents/devops-infrastructure/se-gitops-ci-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: se-gitops-ci-specialist
 description: DevOps specialist for CI/CD pipelines, deployment debugging, and GitOps workflows focused on making deployments boring and reliable
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo
+tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # GitOps & CI Specialist

--- a/cli-tool/components/agents/devops-infrastructure/terraform-iac-reviewer.md
+++ b/cli-tool/components/agents/devops-infrastructure/terraform-iac-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-iac-reviewer
 description: Terraform-focused agent that reviews and creates safer IaC changes with emphasis on state safety, least privilege, module patterns, drift detection, and plan/apply discipline
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo
+tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # Terraform IaC Reviewer


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three agents in `cli-tool/components/agents/devops-infrastructure/` declare VS Code Copilot tool names in their `tools:` frontmatter field — names that are not valid in Claude Code:

| Agent | Invalid tools declared |
|-------|----------------------|
| `devops-expert.md` | `codebase, edit/editFiles, terminalCommand, search, githubRepo, runCommands, runTasks` |
| `se-gitops-ci-specialist.md` | `codebase, edit/editFiles, terminalCommand, search, githubRepo` |
| `terraform-iac-reviewer.md` | `codebase, edit/editFiles, terminalCommand, search, githubRepo` |

These tool names originated in GitHub Copilot's agent definition format and are not recognized by Claude Code. At runtime, Claude Code **silently ignores unknown tool names**, so these agents receive **no tools at all** — they cannot read files, run commands, or do any work.

## Fix

Replace the invalid tool names with the correct Claude Code equivalents:

```yaml
# Before
tools: codebase, edit/editFiles, terminalCommand, search, githubRepo, runCommands, runTasks

# After
tools: Read, Write, Edit, Bash, Glob, Grep
```

**Valid Claude Code tool names**: `Read`, `Write`, `Edit`, `MultiEdit`, `Bash`, `Glob`, `Grep`, `WebSearch`, `WebFetch`, `Agent`, `Task`, `TodoWrite`

The selected tools (`Read, Write, Edit, Bash, Glob, Grep`) are appropriate for DevOps/infrastructure work: reading config files, editing IaC, running shell commands, and searching codebases.

## Why it matters

Without this fix, a user who loads any of these three agents gets an agent with zero tool access — it cannot read a single file or execute any command, silently rendering it non-functional. The agent body contains extensive, high-quality DevOps guidance that deserves working tool access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced VS Code Copilot tool names with valid Claude Code tools so three DevOps agents get working tool access. This fixes agents being non-functional due to ignored tools.

- **Bug Fixes**
  - Updated tools to `Read, Write, Edit, Bash, Glob, Grep` in: `devops-expert.md`, `se-gitops-ci-specialist.md`, `terraform-iac-reviewer.md`.
  - Area: components (`cli-tool/components/agents/devops-infrastructure/`).
  - No new components; no `docs/components.json` regeneration needed.
  - No new environment variables or secrets.

<sup>Written for commit 0417c547433b6cc1cd5817da89b4f64ade3c25b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

