### PR TITLE
feat(banner): update BrainGrid ad copy and styling

### DIFF
--- a/dashboard/src/components/PartnerBanner.astro
+++ b/dashboard/src/components/PartnerBanner.astro
@@ -23,14 +23,14 @@
         <span class="text-[13px] font-semibold" style="color: #c5e063;">BrainGrid</span>
         <span class="rounded px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider" style="background: rgba(197,224,99,0.12); color: #c5e063; border: 1px solid rgba(197,224,99,0.18);">Partner</span>
       </div>
-      <p class="text-[11px] text-[var(--color-text-tertiary)] mt-0.5 truncate sm:whitespace-normal">
-        BrainGrid is the AI Product Planner that helps you shape ideas, plan features, and scope tasks that Claude Code can build right the first time.
+      <p class="text-[13px] font-light text-[var(--color-text-secondary)] mt-0.5 truncate sm:whitespace-normal" style="opacity: 0.75;">
+        The repeatable way to plan and ship quality software with AI.
       </p>
     </div>
 
     <!-- Right side -->
     <div class="relative hidden sm:flex items-center gap-3 shrink-0">
-      <span class="text-[10px] font-semibold uppercase tracking-widest text-[var(--color-text-tertiary)]">AI Product Planner</span>
+      <span class="text-[10px] font-semibold uppercase tracking-widest" style="color: #c5e063;">Plan. Build. Verify. Repeat.</span>
       <div class="flex items-center gap-1 rounded px-2 py-1" style="background: rgba(197,224,99,0.08); border: 1px solid rgba(197,224,99,0.12);">
         <svg width="10" height="10" viewBox="0 0 24 24" fill="#c5e063"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
         <span class="text-[10px] font-medium" style="color: #c5e063;">Featured</span>


### PR DESCRIPTION
## Summary

- Replace description with "The repeatable way to plan and ship quality software with AI." (lighter font, bigger size)
- Change right-side tagline from "AI Product Planner" to "Plan. Build. Verify. Repeat." in brand color (#c5e063)
- Increase description font to 13px with `font-light` weight and 75% opacity for better readability

## Changes

```
dashboard/src/components/PartnerBanner.astro | 6 +++---
```

---
Created from worktree `claude/jovial-edison-5b82ba` using `/worktree-deliver`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the BrainGrid partner banner copy and styling to improve readability and align with brand colors. The banner is clearer and more on-brand.

- Changed description to “The repeatable way to plan and ship quality software with AI.” at 13px, `font-light`, 75% opacity
- Updated right-side tagline to “Plan. Build. Verify. Repeat.” in #c5e063
- Area: components (dashboard/src/components/PartnerBanner.astro)
- No new components; no catalog regen needed
- No new environment variables or secrets

<sup>Written for commit 6f46351cbe706a3fb3334f33f11553de36ec99fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

