### PR TITLE
feat(live-task): add Open/All/Done filter pills to Component Review Loop

### DIFF
--- a/dashboard/src/components/live-task/LiveTaskPanel.tsx
+++ b/dashboard/src/components/live-task/LiveTaskPanel.tsx
@@ -5,6 +5,17 @@ import ToolTimeline from './ToolTimeline';
 
 const POLL_INTERVAL = 5000;
 
+type FilterMode = 'open' | 'all' | 'done';
+
+const FILTER_LABELS: Record<FilterMode, string> = {
+  open: 'Open',
+  all: 'All',
+  done: 'Done',
+};
+
+const OPEN_STATUSES = new Set(['active', 'completed']);
+const DONE_STATUSES = new Set(['merged', 'failed']);
+
 export default function LiveTaskPanel() {
   const [cycles, setCycles] = useState<ReviewCycle[]>([]);
   const [selectedCycleId, setSelectedCycleId] = useState<string | null>(null);
@@ -12,6 +23,7 @@ export default function LiveTaskPanel() {
   const [control, setControl] = useState<CycleControl | null>(null);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
+  const [filter, setFilter] = useState<FilterMode>('open');
 
   const fetchCycles = useCallback(async () => {
     try {
@@ -123,6 +135,18 @@ export default function LiveTaskPanel() {
   const selectedCycle = cycles.find(c => c.id === selectedCycleId) || null;
   const activeCycles = cycles.filter(c => c.status === 'active').length;
 
+  const filteredCycles = cycles.filter(c => {
+    if (filter === 'open') return OPEN_STATUSES.has(c.status);
+    if (filter === 'done') return DONE_STATUSES.has(c.status);
+    return true;
+  });
+
+  const filterCounts: Record<FilterMode, number> = {
+    open: cycles.filter(c => OPEN_STATUSES.has(c.status)).length,
+    all: cycles.length,
+    done: cycles.filter(c => DONE_STATUSES.has(c.status)).length,
+  };
+
   return (
     <div style={{
       maxWidth: 1200,
@@ -149,6 +173,9 @@ export default function LiveTaskPanel() {
           </h1>
           <p style={{ color: '#6b7280', fontSize: 13, margin: '4px 0 0' }}>
             {loading ? 'Loading...' : `${cycles.length} cycles total | ${activeCycles} active`}
+          </p>
+          <p style={{ color: '#4b5563', fontSize: 11, margin: '2px 0 0', fontFamily: 'monospace' }}>
+            {loading ? '' : `showing ${filteredCycles.length} of ${cycles.length}`}
           </p>
         </div>
 
@@ -200,18 +227,56 @@ export default function LiveTaskPanel() {
         overflow: 'hidden',
       }}>
         <div style={{
-          padding: '10px 16px',
+          padding: '8px 16px',
           borderBottom: '1px solid #1a1a1a',
-          fontSize: 12,
-          color: '#6b7280',
-          fontFamily: "'Geist Mono', monospace",
-          textTransform: 'uppercase',
-          letterSpacing: '0.05em',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
         }}>
-          Review Cycles
+          <span style={{
+            fontSize: 12,
+            color: '#6b7280',
+            fontFamily: "'Geist Mono', monospace",
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}>
+            Review Cycles
+          </span>
+          <div style={{ display: 'flex', gap: 4 }}>
+            {(['open', 'all', 'done'] as FilterMode[]).map(f => (
+              <button
+                key={f}
+                onClick={() => setFilter(f)}
+                style={{
+                  padding: '3px 10px',
+                  borderRadius: 4,
+                  border: '1px solid',
+                  borderColor: filter === f ? '#3b82f6' : '#2a2a2a',
+                  background: filter === f ? '#1e3a5f' : 'transparent',
+                  color: filter === f ? '#60a5fa' : '#6b7280',
+                  fontSize: 11,
+                  fontFamily: "'Geist Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'all 0.15s',
+                }}
+              >
+                {FILTER_LABELS[f]}
+                <span style={{
+                  marginLeft: 5,
+                  padding: '0 4px',
+                  borderRadius: 3,
+                  background: filter === f ? '#2563eb33' : '#ffffff0d',
+                  color: filter === f ? '#93c5fd' : '#4b5563',
+                  fontSize: 10,
+                }}>
+                  {filterCounts[f]}
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
         <CycleTable
-          cycles={cycles}
+          cycles={filteredCycles}
           selectedId={selectedCycleId}
           onSelect={setSelectedCycleId}
         />


### PR DESCRIPTION
## Summary

- Adds three filter pills (**Open** / **All** / **Done**) to the Review Cycles table header
- Default view is **Open** — shows only `active` and `completed` cycles, hiding merged/failed noise
- **Done** tab shows `merged` + `failed` cycles for history
- **All** shows everything (previous behavior)
- Each pill displays a live badge count that updates with polling
- Adds a "showing N of M" subtitle below the main header

## Changes

- `dashboard/src/components/live-task/LiveTaskPanel.tsx`: +73 lines — filter state, computed counts, filter pills UI in table header

---
Created from worktree `claude/sad-faraday-d4eec0` using `/worktree-deliver`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Open/All/Done filter pills to the Review Cycles header so users can focus on relevant work. Default is Open to reduce merged/failed noise, with live counts and a “showing N of M” line.

- **New Features**
  - Review Cycles now support filters: Open (active + completed), Done (merged + failed), All (everything); defaults to Open.
  - Live badge counts per filter and a “showing N of M” subtitle, updated via existing polling.
  - Area: components (dashboard/src/components/live-task/LiveTaskPanel.tsx).
  - No new components; no catalog regen needed. No new env vars or secrets.

<sup>Written for commit 40471727bb854471466fc4969ba704d487e5759b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

