### PR TITLE
feat: upgrade MiniMax provider default to M3

### DIFF
--- a/cli-tool/components/settings/partnerships/minimax-provider.json
+++ b/cli-tool/components/settings/partnerships/minimax-provider.json
@@ -1,0 +1,10 @@
+{
+  "description": "MiniMax AI Provider - Configure Claude Code to use MiniMax's Anthropic-compatible API. MiniMax-M2.7 delivers peak performance at exceptional value for complex reasoning tasks, while MiniMax-M2.7-highspeed offers the same performance with faster, more agile responses. Requires a MiniMax API key from https://platform.minimax.io",
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "YOUR-MINIMAX-API-KEY",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7-highspeed",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7"
+  }
+}

--- a/cli-tool/components/settings/partnerships/minimax-provider.json
+++ b/cli-tool/components/settings/partnerships/minimax-provider.json
@@ -1,10 +1,10 @@
 {
-  "description": "MiniMax AI Provider - Configure Claude Code to use MiniMax's Anthropic-compatible API. MiniMax-M2.7 delivers peak performance at exceptional value for complex reasoning tasks, while MiniMax-M2.7-highspeed offers the same performance with faster, more agile responses. Requires a MiniMax API key from https://platform.minimax.io",
+  "description": "MiniMax AI Provider - Configure Claude Code to use MiniMax's Anthropic-compatible API. MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K output, and image input support; MiniMax-M2.7 and MiniMax-M2.7-highspeed remain available as alternatives. Requires a MiniMax API key from https://platform.minimax.io",
   "env": {
     "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
     "ANTHROPIC_AUTH_TOKEN": "YOUR-MINIMAX-API-KEY",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7-highspeed",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7"
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M3",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M3"
   }
 }

--- a/cli-tool/tests/unit/minimax-provider.test.js
+++ b/cli-tool/tests/unit/minimax-provider.test.js
@@ -1,0 +1,85 @@
+/**
+ * Unit Tests for MiniMax Provider Settings
+ * Validates structure and content of the MiniMax partnership configuration
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const MINIMAX_SETTINGS_PATH = path.join(
+  __dirname,
+  '../../components/settings/partnerships/minimax-provider.json'
+);
+
+describe('MiniMax Provider Settings', () => {
+  let settings;
+
+  beforeAll(() => {
+    const raw = fs.readFileSync(MINIMAX_SETTINGS_PATH, 'utf8');
+    settings = JSON.parse(raw);
+  });
+
+  describe('File structure', () => {
+    it('should be valid JSON', () => {
+      expect(settings).toBeDefined();
+      expect(typeof settings).toBe('object');
+    });
+
+    it('should have a description field', () => {
+      expect(settings.description).toBeDefined();
+      expect(typeof settings.description).toBe('string');
+      expect(settings.description.length).toBeGreaterThan(10);
+    });
+
+    it('should have an env field', () => {
+      expect(settings.env).toBeDefined();
+      expect(typeof settings.env).toBe('object');
+    });
+  });
+
+  describe('Environment variables', () => {
+    it('should set ANTHROPIC_BASE_URL to MiniMax Anthropic-compatible endpoint', () => {
+      expect(settings.env.ANTHROPIC_BASE_URL).toBeDefined();
+      expect(settings.env.ANTHROPIC_BASE_URL).toBe('https://api.minimax.io/anthropic');
+    });
+
+    it('should include ANTHROPIC_AUTH_TOKEN placeholder', () => {
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBeDefined();
+      expect(typeof settings.env.ANTHROPIC_AUTH_TOKEN).toBe('string');
+    });
+
+    it('should not contain a real API key', () => {
+      const authToken = settings.env.ANTHROPIC_AUTH_TOKEN;
+      // Placeholder should not look like a real token (real keys are long hex/base64 strings)
+      expect(authToken).toMatch(/YOUR[-_]/i);
+    });
+
+    it('should configure MiniMax-M2.7 as the sonnet (default) model', () => {
+      expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('MiniMax-M2.7');
+    });
+
+    it('should configure MiniMax-M2.7 as the opus (most capable) model', () => {
+      expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('MiniMax-M2.7');
+    });
+
+    it('should configure MiniMax-M2.7-highspeed as the haiku (fast) model', () => {
+      expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('MiniMax-M2.7-highspeed');
+    });
+
+    it('should use the international MiniMax endpoint (not domestic)', () => {
+      expect(settings.env.ANTHROPIC_BASE_URL).toContain('api.minimax.io');
+      expect(settings.env.ANTHROPIC_BASE_URL).not.toContain('api.minimax.chat');
+      expect(settings.env.ANTHROPIC_BASE_URL).not.toContain('api.minimaxi.com');
+    });
+  });
+
+  describe('Description content', () => {
+    it('should mention MiniMax in the description', () => {
+      expect(settings.description.toLowerCase()).toContain('minimax');
+    });
+
+    it('should mention API key requirement', () => {
+      expect(settings.description.toLowerCase()).toMatch(/api.key|minimax.api/);
+    });
+  });
+});

--- a/cli-tool/tests/unit/minimax-provider.test.js
+++ b/cli-tool/tests/unit/minimax-provider.test.js
@@ -54,12 +54,12 @@ describe('MiniMax Provider Settings', () => {
       expect(authToken).toMatch(/YOUR[-_]/i);
     });
 
-    it('should configure MiniMax-M2.7 as the sonnet (default) model', () => {
-      expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('MiniMax-M2.7');
+    it('should configure MiniMax-M3 as the sonnet (default) model', () => {
+      expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('MiniMax-M3');
     });
 
-    it('should configure MiniMax-M2.7 as the opus (most capable) model', () => {
-      expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('MiniMax-M2.7');
+    it('should configure MiniMax-M3 as the opus (most capable) model', () => {
+      expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('MiniMax-M3');
     });
 
     it('should configure MiniMax-M2.7-highspeed as the haiku (fast) model', () => {


### PR DESCRIPTION
## Summary

Upgrade the MiniMax partnership setting so Claude Code defaults to the latest `MiniMax-M3` model. `MiniMax-M2.7-highspeed` is kept as the haiku (fast) tier for low-latency use cases.

### What changed

- **`cli-tool/components/settings/partnerships/minimax-provider.json`** — Maps Claude model tiers to MiniMax models:
  - `MiniMax-M3` → default (Sonnet) and most capable (Opus) — latest flagship model with 512K context window, up to 128K output, and image input support
  - `MiniMax-M2.7-highspeed` → fast (Haiku) — kept as the low-latency tier
- **`cli-tool/tests/unit/minimax-provider.test.js`** — Tests updated to assert the new M3 defaults

### Usage

```bash
npx claude-code-templates@latest --setting partnerships/minimax-provider
```

Then set your key:
```bash
export ANTHROPIC_AUTH_TOKEN=<your-minimax-api-key>
```

Get your API key at: https://platform.minimax.io

## Why

`MiniMax-M3` is the current latest MiniMax model. It has a 512K context window, up to 128K output, supports image input on both OpenAI- and Anthropic-compatible endpoints, and is the right default for Claude Code workflows.

## References

- MiniMax Chat API (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo
- Models: `MiniMax-M3`, `MiniMax-M2.7-highspeed`