### PR TITLE
fix(context-timeline): detect Opus 1M context window dynamically

### DIFF
--- a/cli-tool/components/hooks/monitoring/context-timeline.py
+++ b/cli-tool/components/hooks/monitoring/context-timeline.py
@@ -27,10 +27,11 @@ from urllib.parse import parse_qs, urlparse
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
-DEFAULT_PORT     = 7878
-CONTEXT_LIMIT    = 200_000
-WATCHDOG_SECONDS = 3600
-CACHE_TTL        = 0.25
+DEFAULT_PORT             = 7878
+DEFAULT_CONTEXT_LIMIT    = 200_000
+EXTENDED_CONTEXT_LIMIT   = 1_000_000
+WATCHDOG_SECONDS         = 3600
+CACHE_TTL                = 0.25
 
 _STATE_DIR = pathlib.Path.home() / ".claude" / "state" / "context-timeline"
 
@@ -60,6 +61,40 @@ def _pid_file()      -> pathlib.Path: return _state_dir() / "server.pid"
 def _port_file()     -> pathlib.Path: return _state_dir() / "server.port"
 def _log_file()      -> pathlib.Path: return _state_dir() / "server.log"
 def _sessions_file() -> pathlib.Path: return _state_dir() / "sessions.json"
+
+# ── Context limit detection ────────────────────────────────────────────────────
+
+def _detect_context_limit(cwd: str) -> int:
+    """Resolve the model context window in tokens.
+
+    Resolution order:
+      1. CONTEXT_TIMELINE_LIMIT env var (explicit override).
+      2. "[1m]" / "[200k]" / "[1M]" suffix in the active model setting,
+         read from <cwd>/.claude/settings.json or ~/.claude/settings.json.
+      3. DEFAULT_CONTEXT_LIMIT (200_000).
+    """
+    env = os.environ.get("CONTEXT_TIMELINE_LIMIT")
+    if env:
+        try:
+            return int(env)
+        except ValueError:
+            pass
+
+    for path in (
+        pathlib.Path(cwd) / ".claude" / "settings.json",
+        pathlib.Path.home() / ".claude" / "settings.json",
+    ):
+        try:
+            cfg   = json.loads(path.read_text())
+            model = str(cfg.get("model", "")).lower()
+            if "[1m]" in model or "[1000k]" in model:
+                return EXTENDED_CONTEXT_LIMIT
+            if "[200k]" in model:
+                return DEFAULT_CONTEXT_LIMIT
+        except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError):
+            continue
+
+    return DEFAULT_CONTEXT_LIMIT
 
 # ── Pid file ───────────────────────────────────────────────────────────────────
 
@@ -214,7 +249,7 @@ def _fresh_agent(aid: str, atype="", desc="") -> dict:
         "nodes": [],
     }
 
-def _fresh_state(session_id: str) -> dict:
+def _fresh_state(session_id: str, limit: int = DEFAULT_CONTEXT_LIMIT) -> dict:
     return {
         "session_id": session_id,
         "started_at": time.time(),
@@ -223,7 +258,7 @@ def _fresh_state(session_id: str) -> dict:
         "context_window": {
             "input_tokens": 0, "output_tokens": 0,
             "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
-            "total_used": 0, "limit": CONTEXT_LIMIT,
+            "total_used": 0, "limit": limit,
             "last_update_ts": time.time(),
         },
         "edges": [],
@@ -234,7 +269,8 @@ class _Builder:
     def __init__(self, session_id: str, cwd: str):
         self._sid   = session_id
         self._cwd   = cwd
-        self._state = _fresh_state(session_id)
+        self._limit = _detect_context_limit(cwd)
+        self._state = _fresh_state(session_id, self._limit)
         self._tail  = _Tail()
 
     def update(self) -> dict:
@@ -286,7 +322,7 @@ class _Builder:
                 ctx["total_used"] = sum(ctx.values())
                 agent["context"] = ctx
                 if agent["id"] == "main":
-                    s["context_window"].update({**ctx, "last_update_ts": ts, "limit": CONTEXT_LIMIT})
+                    s["context_window"].update({**ctx, "last_update_ts": ts, "limit": self._limit})
             for block in (msg.get("content") or []):
                 if not isinstance(block, dict) or block.get("type") != "tool_use":
                     continue


### PR DESCRIPTION
## Problem

`CONTEXT_LIMIT` is hardcoded to `200_000` tokens in `context-timeline.py`. Users on **Claude Opus 4.7 with the 1M context window** (`"model": "opus[1m]"` in `~/.claude/settings.json`) see the dashboard report **80–90% usage** when actual usage is **16–18%**, producing constant false alarms and making the meter unusable on long sessions.

## Fix

Replace the constant with `_detect_context_limit(cwd)` which resolves the limit in this order:

1. **`CONTEXT_TIMELINE_LIMIT` env var** — explicit override (e.g. `export CONTEXT_TIMELINE_LIMIT=500000`).
2. **`[1m]` / `[1000k]` / `[200k]` suffix** in the `model` field of `<cwd>/.claude/settings.json` or `~/.claude/settings.json`.
3. **`200_000` fallback** — current behaviour, untouched for users without `[1m]`.

The limit is resolved once per `_Builder` instance, not per update tick — zero per-event filesystem cost.

## Backwards compatibility

- No new dependencies (still stdlib only).
- Default behaviour unchanged for users without `[1m]` in settings.
- No new hooks, no breaking API changes.

## Verification

Tested live on a real Opus 1M session of ~178K tokens:

| | Before | After |
|---|---|---|
| Header reading | 178,581 / 200,000 (**89%**) | 178,581 / 1,000,000 (**17.9%**) |
| Bar colour | Red / warning | Cyan / normal |
| Sidebar meter | Saturated | Accurate |

Resolution order also unit-tested:
- env var override → `int(env)`
- project `.claude/settings.json` with `[1m]` → `1_000_000`
- global `~/.claude/settings.json` with `[1m]` → `1_000_000`
- no settings → `200_000`

## Files changed

`cli-tool/components/hooks/monitoring/context-timeline.py` (+44, −8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect context-usage reporting by dynamically detecting the model’s context window, so Opus 1M sessions show accurate percentages instead of false alarms. Replaces the hardcoded 200k limit with a detected value.

- **Bug Fixes**
  - Area: components (`cli-tool/components/hooks/monitoring/context-timeline.py`).
  - Detects limit once per session via `_detect_context_limit(cwd)`: env var `CONTEXT_TIMELINE_LIMIT` → `[1m]/[1000k]/[200k]` in `.claude/settings.json` → `200_000` fallback.
  - No new components; no `docs/components.json` regeneration needed.
  - New optional env var: `CONTEXT_TIMELINE_LIMIT` (int). No secrets.

<sup>Written for commit 6c3750a6c3ea8e5638d0b1b1695bb53945690ae7. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/548?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

