### PR TITLE
fix(context-timeline): cross-platform path encoding

### DIFF
--- a/cli-tool/components/hooks/monitoring/context-timeline.py
+++ b/cli-tool/components/hooks/monitoring/context-timeline.py
@@ -9,6 +9,7 @@ Modes (called by Claude Code hooks via stdin JSON):
   --run-server <PORT>   Internal: daemon entry point (do not call directly)
 """
 import argparse
+import re
 import gzip
 import io
 import json
@@ -41,7 +42,8 @@ def _state_dir() -> pathlib.Path:
     return _STATE_DIR
 
 def _encode_cwd(cwd: str) -> str:
-    return cwd.replace("/", "-")
+    # Replace any non-alphanumeric character with "-" (cross-platform)
+    return re.sub(r"[^a-zA-Z0-9]", "-", os.path.normpath(os.path.abspath(cwd)))
 
 def _transcript_path(session_id: str, cwd: str) -> pathlib.Path:
     base = pathlib.Path.home() / ".claude" / "projects" / _encode_cwd(cwd)


### PR DESCRIPTION
## Summary

Fix `_encode_cwd` function to work on Windows and any other platform.

## Problem

The original implementation only replaced `/` with `-`:
```python
return cwd.replace("/", "-")
```

This fails on Windows where paths use `\` as separator and include drive letters like `D:`.

## Solution

Use regex to replace any non-alphanumeric character:
```python
return re.sub(r"[^a-zA-Z0-9]", "-", os.path.normpath(os.path.abspath(cwd)))
```

## Before/After

| Platform | Input | Before | After |
|----------|-------|--------|-------|
| Windows | `D:\Claude\mcx` | Lookup failed | `D--Claude-mcx` |
| Unix | `/home/user/mcx` | `-home-user-mcx` | `-home-user-mcx` |

## Test plan

- [x] Tested on Windows 11 with Claude Code
- [x] Verified the encoded path matches Claude Code project directory naming

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-platform path encoding in the context timeline so transcript lookup works on Windows and Unix. _encode_cwd now normalizes the path and replaces all non-alphanumeric characters with "-" to match Claude Code project naming.

- **Bug Fixes**
  - Replaced slash-only logic with regex over normalized absolute path; Windows paths like D:\... now encode correctly; Unix behavior unchanged.
  - Area: components (cli-tool/components/); updated hooks/monitoring/context-timeline.py.
  - No new components; catalog (docs/components.json) unchanged.
  - No new environment variables or secrets.

<sup>Written for commit 4ebeb08428e27de6152cbd18af00ebfc3c9c4d48. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/550?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

