### PR TITLE
docs: fix cli README relative links

### DIFF
--- a/cli-tool/README.md
+++ b/cli-tool/README.md
@@ -149,7 +149,7 @@ Skills from [anthropics/skills](https://github.com/anthropics/skills):
 - **Open Source** (Apache 2.0): algorithmic-art, mcp-builder, skill-creator, artifacts-builder, and more
 - **Source-Available** (Reference): docx, pdf-anthropic, pptx, xlsx
 
-See [ANTHROPIC_ATTRIBUTION.md](cli-tool/components/skills/ANTHROPIC_ATTRIBUTION.md) for complete license information.
+See [ANTHROPIC_ATTRIBUTION.md](components/skills/ANTHROPIC_ATTRIBUTION.md) for complete license information.
 
 ## 📖 Documentation
 
@@ -168,7 +168,7 @@ We welcome contributions! Browse available templates and components at **[aitmpl
 
 ## 📄 License
 
-MIT License - see the [LICENSE](LICENSE) file for details.
+MIT License - see the [LICENSE](../LICENSE) file for details.
 
 ## 🔗 Links
 


### PR DESCRIPTION
## Summary
- Fix the `ANTHROPIC_ATTRIBUTION.md` link in `cli-tool/README.md` so it resolves from the `cli-tool/` directory.
- Fix the license link to point to the repository-level `LICENSE` file.

## Test plan
- Ran a focused script that checks relative Markdown links in `cli-tool/README.md`.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed broken relative links in `cli-tool/README.md` so they resolve from the `cli-tool/` directory. This restores working attribution and license links in GitHub and local views.

- Updated links to `components/skills/ANTHROPIC_ATTRIBUTION.md` and `../LICENSE`.
- Area: CLI (docs in `cli-tool/`).
- No new components; catalog (`docs/components.json`) does not need regeneration.
- No new environment variables or secrets.

<sup>Written for commit b349705bc9331b94de837cb995a7ea1df402d2d3. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/551?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

