### PR TITLE
fix(cli): read version from root package.json (closes #348)

### DIFF
--- a/cli-tool/bin/create-claude-config.js
+++ b/cli-tool/bin/create-claude-config.js
@@ -5,7 +5,8 @@ const chalk = require('chalk');
 const boxen = require('boxen');
 const { createClaudeConfig } = require('../src/index');
 
-const pkg = require('../package.json');
+// Root package.json is the npm publish source; cli-tool/package.json drifts (see #348).
+const pkg = require('../../package.json');
 
 const title = 'Claude Code Templates';
 const subtitle = 'Your starting point for Claude Code projects';
@@ -44,7 +45,7 @@ function showBanner() {
 program
   .name('create-claude-config')
   .description('Setup Claude Code configurations and create global AI agents powered by Claude Code SDK')
-  .version(require('../package.json').version)
+  .version(pkg.version)
   .option('-l, --language <language>', 'specify programming language (deprecated, use --template)')
   .option('-f, --framework <framework>', 'specify framework (deprecated, use --template)')
   .option('-t, --template <template>', 'specify template (e.g., common, javascript-typescript, python, ruby)')


### PR DESCRIPTION
Issue #348 reports that `claude-code-templates` 1.28.16 on npm prints `1.28.13` from `--version`. Still reproducible on current main.

## Cause

`cli-tool/bin/create-claude-config.js` reads its version with `require('../package.json')`, which resolves to `cli-tool/package.json` — a sub-manifest that has drifted from the actual published version. The root `package.json` is the npm publish source (its `bin` field already points at `cli-tool/bin/create-claude-config.js`, and CLAUDE.md's publishing workflow bumps the root version), so the bin should read from there.

## Repro on HEAD before this PR

```
$ npm view claude-code-templates version
1.28.16
$ cd cli-tool && npm install && node bin/create-claude-config.js --version
1.28.13
```

## After this PR

```
$ node cli-tool/bin/create-claude-config.js --version
1.28.16
```

The banner (`v${pkg.version}`) and the commander `--version` flag now share a single source.

## Diff

Three lines in `cli-tool/bin/create-claude-config.js`: switch `require('../package.json')` → `require('../../package.json')`, reuse the already-imported `pkg` for `.version()` instead of requiring a second time, add a one-line comment pointing at #348 so the next refactor doesn't re-introduce the drift.

Closes #348.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI version mismatch by reading the version from the root `package.json`. Now `--version` and the banner show the published package version.

- **Bug Fixes**
  - Area: CLI (`cli-tool/bin/`)
  - Read version from root `package.json` instead of `cli-tool/package.json`; banner and `.version()` now share `pkg.version`.
  - Resolves the outdated `--version` output reported in #348.
  - No new components; no docs catalog regen needed. No new env vars or secrets.

<sup>Written for commit d16faf69b8da5033bbbc8b1886ce1bb0620b2747. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

