### PR TITLE
Add trace-mcp MCP server (devtools)

### DIFF
--- a/cli-tool/components/mcps/devtools/trace-mcp.json
+++ b/cli-tool/components/mcps/devtools/trace-mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "trace-mcp": {
+      "description": "Framework-aware code intelligence — semantic navigation, impact analysis, and refactoring across 60 framework integrations and 81 languages with up to 99% token reduction.",
+      "command": "npx",
+      "args": ["-y", "trace-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds [trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) — a framework-aware code intelligence MCP server — under `cli-tool/components/mcps/devtools/`.

trace-mcp gives Claude Code semantic navigation, impact analysis, and refactoring tools (search, get_outline, get_symbol, find_usages, get_change_impact, apply_codemod, change_signature, etc.) across **60 framework integrations** and **81 languages**, with up to 99% token reduction vs. raw Read/Grep workflows.

- npm: https://www.npmjs.com/package/trace-mcp
- repo: https://github.com/nikolai-vysotskyi/trace-mcp

## File added

`cli-tool/components/mcps/devtools/trace-mcp.json`:

```json
{
  "mcpServers": {
    "trace-mcp": {
      "description": "Framework-aware code intelligence — semantic navigation, impact analysis, and refactoring across 60 framework integrations and 81 languages with up to 99% token reduction.",
      "command": "npx",
      "args": ["-y", "trace-mcp@latest"]
    }
  }
}
```

`serve` is the default CLI command, so no extra args are needed.

## Test plan

- [x] JSON validates against the schema used by other MCPs in `devtools/` (e.g. `serena.json`, `context7.json`)
- [x] `npx -y trace-mcp@latest` starts the MCP server over stdio (published on npm, no auth required)
- [x] Placed under `devtools/` alongside other code-intelligence servers (`serena`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `trace-mcp` MCP server to devtools to provide framework‑aware code intelligence. Enables semantic navigation, impact analysis, and refactors via `npx` with no extra setup.

- **Area:** components (`cli-tool/components/`)
- **New component:** `cli-tool/components/mcps/devtools/trace-mcp.json` (runs `npx -y trace-mcp@latest`)
- **Catalog:** regenerate `docs/components.json`
- **Env/Secrets:** none

<sup>Written for commit 89ef5d71545883cc03d6dc83908bd37a4b4a2f85. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

