### PR TITLE
chore: sync Anthropic skills upstream changes

### DIFF
--- a/cli-tool/components/skills/creative-design/algorithmic-art/LICENSE.txt
+++ b/cli-tool/components/skills/creative-design/algorithmic-art/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/creative-design/canvas-design/LICENSE.txt
+++ b/cli-tool/components/skills/creative-design/canvas-design/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/creative-design/slack-gif-creator/LICENSE.txt
+++ b/cli-tool/components/skills/creative-design/slack-gif-creator/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/creative-design/theme-factory/LICENSE.txt
+++ b/cli-tool/components/skills/creative-design/theme-factory/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/development/claude-api/curl/managed-agents.md
+++ b/cli-tool/components/skills/development/claude-api/curl/managed-agents.md
@@ -248,8 +248,7 @@ curl -X POST https://api.anthropic.com/v1/files \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: files-api-2025-04-14" \
-  -F "file=@path/to/file.txt" \
-  -F "purpose=agent"
+  -F "file=@path/to/file.txt"
 ```
 
 ---

--- a/cli-tool/components/skills/development/claude-api/shared/managed-agents-client-patterns.md
+++ b/cli-tool/components/skills/development/claude-api/shared/managed-agents-client-patterns.md
@@ -168,7 +168,7 @@ The `Promise.all([stream, send])` shape works too, but stream-first is simpler a
 **The mounted resource has a different `file_id` than the file you uploaded.** Session creation makes a session-scoped copy.
 
 ```ts
-const uploaded = await client.beta.files.upload({ file, purpose: 'agent_resource' })
+const uploaded = await client.beta.files.upload({ file })
 // uploaded.id         → the original file
 const session = await client.beta.sessions.create({
   /* ... */

--- a/cli-tool/components/skills/development/claude-api/shared/managed-agents-environments.md
+++ b/cli-tool/components/skills/development/claude-api/shared/managed-agents-environments.md
@@ -63,7 +63,6 @@ Upload a file first via the Files API, then reference by `file_id` + `mount_path
 // 1. Upload
 const file = await client.beta.files.upload({
   file: fs.createReadStream("data.csv"),
-  purpose: "agent",
 });
 
 // 2. Attach as a session resource

--- a/cli-tool/components/skills/development/claude-api/typescript/managed-agents/README.md
+++ b/cli-tool/components/skills/development/claude-api/typescript/managed-agents/README.md
@@ -273,7 +273,6 @@ import fs from "fs";
 
 const file = await client.beta.files.upload({
   file: fs.createReadStream("data.csv"),
-  purpose: "agent",
 });
 
 // Use in a session

--- a/cli-tool/components/skills/development/mcp-builder/LICENSE.txt
+++ b/cli-tool/components/skills/development/mcp-builder/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/development/skill-creator/LICENSE.txt
+++ b/cli-tool/components/skills/development/skill-creator/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/enterprise-communication/brand-guidelines/LICENSE.txt
+++ b/cli-tool/components/skills/enterprise-communication/brand-guidelines/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/enterprise-communication/internal-comms/LICENSE.txt
+++ b/cli-tool/components/skills/enterprise-communication/internal-comms/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/security/webapp-testing/LICENSE.txt
+++ b/cli-tool/components/skills/security/webapp-testing/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/utilities/web-artifacts-builder/LICENSE.txt
+++ b/cli-tool/components/skills/utilities/web-artifacts-builder/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Update LICENSE.txt copyright line to "Copyright 2026 Anthropic, PBC." across 10 Anthropic official skills
- Remove deprecated `purpose` parameter from managed agents file upload examples in claude-api skill (4 files)

Source: https://github.com/anthropics/skills

## Details
**LICENSE.txt updates** (10 skills): algorithmic-art, brand-guidelines, canvas-design, internal-comms, mcp-builder, skill-creator, slack-gif-creator, theme-factory, web-artifacts-builder, webapp-testing

**claude-api managed agents updates** (4 files): `purpose` parameter removed from file upload examples — the API now auto-infers the purpose.

## Test plan
- [x] Verified diffs match upstream source exactly
- [x] No SKILL.md files modified (only supporting files)
- [x] No locally customized skills overwritten

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync upstream Anthropic skills. Updates LICENSE text across skills and removes deprecated `purpose` from managed agents file upload examples.

**Changes**
- Area: components (`cli-tool/components/`)
- Update `LICENSE.txt` to "Copyright 2026 Anthropic, PBC." across 10 skills
- Remove `purpose` from Files API upload examples in `claude-api` managed agents (API now infers purpose)
- No new components; no `docs/components.json` regeneration needed
- No new environment variables or secrets

<sup>Written for commit 20f38d42fb6a60d8937ba7c01adbac7b08e093d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

