### PR TITLE
Add diagrammer skill

### DIFF
--- a/cli-tool/components/skills/creative-design/diagrammer/SKILL.md
+++ b/cli-tool/components/skills/creative-design/diagrammer/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: diagrammer
+description: Render clean blueprint-style SVG diagrams from JSON specs. Use when users ask to draw, sketch, or diagram a request flow, neural net, transformer block, system architecture, state machine, data pipeline, or any node-and-edge technical visual they want as an SVG for docs, READMEs, posts, or slides.
+---
+
+# diagrammer
+
+Use `diagrammer` to turn a small JSON spec into a clean SVG diagram. It is useful when the user wants a precise technical diagram without opening a design tool.
+
+## Install
+
+The renderer must be installed locally:
+
+```bash
+pipx install diagrammer
+```
+
+## Workflow
+
+1. Convert the user's plain-English diagram request into a JSON spec.
+2. Save the spec to a temporary or project file.
+3. Render it:
+
+```bash
+diagrammer path/to/spec.json > path/to/diagram.svg
+```
+
+4. Return the SVG path to the user.
+
+## Spec Essentials
+
+```json
+{
+  "nodes": [
+    {"id": "client", "type": "box", "label": "client"},
+    {"id": "api", "type": "box", "label": "api"},
+    {"id": "db", "type": "database", "label": "postgres"}
+  ],
+  "edges": [
+    {"from": "client", "to": "api", "label": "request"},
+    {"from": "api", "to": "db", "label": "query"}
+  ]
+}
+```
+
+Built-in node types: `box`, `circle`, `text`, `database`, `stack`, `group`, `note`, and `custom`.
+
+Useful optional fields:
+
+- `direction`: `"LR"` or `"TB"`
+- `router`: `"straight"` or `"ortho"`
+- `label` on edges
+- `style`: `"solid"` or `"dashed"`
+- `weight`: `"thin"` or `"thick"`
+
+For the full reference, run:
+
+```bash
+diagrammer prompt
+```
+
+## When To Choose This
+
+Use `diagrammer` when the output should be a checked-in SVG artifact, especially for:
+
+- README diagrams
+- architecture sketches
+- request flows
+- state machines
+- neural-net or transformer diagrams
+- simple data pipelines
+
+Prefer Mermaid when the user specifically asks for Mermaid syntax or wants diagrams rendered by a Markdown platform. Prefer Excalidraw when the user wants editable hand-drawn canvas files.


### PR DESCRIPTION
## Summary
- adds a diagrammer skill under creative-design
- documents the pipx install flow and CLI rendering workflow
- positions diagrammer for README diagrams, architecture sketches, request flows, state machines, and neural-net diagrams

## Source
- https://github.com/Anish-Reddy-K/diagrammer

## Testing
- docs/skill-only addition; no runtime tests run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `diagrammer` skill that renders clean SVG diagrams from JSON with the `diagrammer` CLI. Documents install with `pipx` and a simple render workflow for README and architecture diagrams.

- **New Features**
  - Area: components (`cli-tool/components/`); adds `creative-design/diagrammer/SKILL.md`.
  - Documents `pipx` install and CLI usage (`diagrammer spec.json > diagram.svg`) with guidance on when to choose it.
  - New component added; regenerate `docs/components.json`.
  - No runtime code changes; no new environment variables or secrets.

<sup>Written for commit 2deb92f6bd4f585eb49ef90a314e982a4a35101b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

