### PR TITLE
Add vibe-flow skill (multi-agent orchestration for vibe-kanban)

### DIFF
--- a/cli-tool/components/skills/workflow-automation/vibe-flow/SKILL.md
+++ b/cli-tool/components/skills/workflow-automation/vibe-flow/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: vibe-flow
+description: "Multi-agent orchestration for Vibe Kanban: turn a spec into merged code through wave-based parallel dispatch, two-stage code review, and autonomous fix loops. Use when the user wants to plan, ship, review, or merge issues across a vibe-kanban board with Claude Code agents."
+author: OAI-Labs
+license: MIT
+metadata:
+  version: "0.2.0"
+  homepage: "https://oai-labs.github.io/vibe-flow/"
+  repository: "https://github.com/OAI-Labs/vibe-flow"
+---
+
+# Vibe Flow
+
+You orchestrate the full spec-to-merge lifecycle on a [vibe-kanban](https://github.com/BloopAI/vibe-kanban) board: planning, parallel agent dispatch, code review, conflict resolution, and merge — with autonomous fix loops.
+
+## Prerequisites
+
+- Claude Code with the [`vibe-kanban`](https://github.com/BloopAI/vibe-kanban) MCP server configured (see install).
+- A vibe-kanban project (cloud or self-hosted).
+- `gh` CLI authenticated (`gh auth status`).
+
+## Install
+
+This skill is part of the [`vibe-flow` plugin](https://github.com/OAI-Labs/vibe-flow):
+
+```bash
+/plugin marketplace add OAI-Labs/vibe-flow
+/plugin install vibe-flow@vibe-flow
+/reload-plugins
+```
+
+Configure the vibe-kanban MCP server in `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "vibe_kanban": {
+      "command": "npx",
+      "args": ["-y", "vibe-kanban@latest", "--mcp"]
+    }
+  }
+}
+```
+
+Then in your repo:
+
+```bash
+/vibe-flow:vibe-init
+```
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `/vibe-flow:vibe-init` | First-time setup: pick project, write `.vibe-flow.yaml`, scaffold state dir |
+| `/vibe-flow:vibe-plan` | Decompose a spec into an issue tree (epic + sub-issues + deps) |
+| `/vibe-flow:vibe-ship` | Wave-based parallel dispatch with executor routing (T0 flash to T4 opus) |
+| `/vibe-flow:vibe-link` | Find / open the GitHub PR for a workspace branch, link to issue |
+| `/vibe-flow:vibe-review` | Two-stage review (spec compliance to quality), post comments to PR |
+| `/vibe-flow:vibe-merge` | Verify CI green, rebase if needed, squash merge, archive workspace |
+| `/vibe-flow:vibe-dispatch-fix` | Re-dispatch agent to fix critical review items / CI failures |
+| `/vibe-flow:vibe-rebase` | Resolve conflicts against latest main, force-with-lease push |
+| `/vibe-flow:vibe-status` | Dashboard of active workspaces + PRs + inconsistencies |
+| `/vibe-flow:vibe-standup` | Daily summary (merged / in-review / blocked / in-progress) |
+| `/vibe-flow:vibe-flow` | Meta orchestrator: full loop from spec to merged code |
+
+## Complexity routing
+
+Issues are routed to executors by tier:
+
+| Tier | Executor | When |
+|---|---|---|
+| T0 | GEMINI flash | Typo / copy / hide column |
+| T1 | CODEX mini / CLAUDE_CODE sonnet-medium | Simple CRUD, <150 LoC |
+| T2 | CLAUDE_CODE sonnet-high | Multi-file, moderate |
+| T3 | CLAUDE_CODE opus | Architecture / migration |
+| T4 | CLAUDE_CODE opus + brainstorm | Research / RFC |
+
+## Typical flow
+
+1. `/vibe-flow:vibe-init` once per repo.
+2. `/vibe-flow:vibe-plan` with a spec creates issue tree on the board.
+3. `/vibe-flow:vibe-flow` runs the full loop: plan, ship, link, review, merge.
+   - Or run individual skills (`vibe-ship`, `vibe-review`, `vibe-merge`) for finer control.
+4. `/vibe-flow:vibe-status` to monitor; `/vibe-flow:vibe-standup` for a daily digest.
+
+## State
+
+`.vibe-flow/state.json` at repo root tracks wave progress, dispatched workspaces, and cost. Auto-resume after crashes.
+
+## Links
+
+- Plugin source: https://github.com/OAI-Labs/vibe-flow
+- Documentation: https://oai-labs.github.io/vibe-flow/
+- vibe-kanban: https://github.com/BloopAI/vibe-kanban


### PR DESCRIPTION
## Summary

Adds a new skill: `vibe-flow` under `skills/workflow-automation/vibe-flow/`.

[`vibe-flow`](https://github.com/OAI-Labs/vibe-flow) is a Claude Code plugin that orchestrates the full spec-to-merge lifecycle on a [vibe-kanban](https://github.com/BloopAI/vibe-kanban) board:

- **plan** — decompose a spec into an issue tree (epic + sub-issues + deps)
- **ship** — wave-based parallel dispatch with tier-based executor routing (T0 Gemini flash through T4 Opus)
- **link** — auto-open / link the GitHub PR for each workspace branch
- **review** — two-stage code review (spec compliance, then quality), posted to PR
- **merge** — verify CI green, rebase, squash merge, archive workspace
- Plus: `dispatch-fix`, `rebase`, `status`, `standup`, and a meta `vibe-flow` orchestrator

The skill file points users to the upstream plugin (which is the source of truth) so we don't duplicate the 11 individual slash-command files in this registry.

## Test plan

- [x] `SKILL.md` placed at `cli-tool/components/skills/workflow-automation/vibe-flow/SKILL.md`
- [x] Frontmatter: `name`, `description`, `author`, `license`, `metadata.version/homepage/repository`
- [x] Description is action-oriented (\"Use when the user wants to...\")
- [x] Install instructions, prerequisites, and external links included
- [x] No bypass-permissions, no telemetry beyond the vibe-kanban MCP server and GitHub API

## Links

- Plugin: https://github.com/OAI-Labs/vibe-flow
- Docs: https://oai-labs.github.io/vibe-flow/
- vibe-kanban: https://github.com/BloopAI/vibe-kanban

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `vibe-flow` skill that orchestrates spec-to-merge workflows on a `vibe-kanban` board via the upstream Claude Code plugin. Provides install steps and command references without changing runtime code.

- Area: components (`cli-tool/components/`)
- Added `skills/workflow-automation/vibe-flow/SKILL.md` with install/prereqs and commands (`vibe-init`, `vibe-plan`, `vibe-ship`, `vibe-link`, `vibe-review`, `vibe-merge`, `vibe-dispatch-fix`, `vibe-rebase`, `vibe-status`, `vibe-standup`, `vibe-flow`)
- References the upstream `vibe-flow` plugin; no CLI/API runtime changes
- New component added — regenerate catalog (`docs/components.json`)
- No new env vars or secrets; requires `gh` auth and `vibe-kanban` MCP server configuration

<sup>Written for commit fee15fff252cf61a0f79b1701b496ae5a29a8bab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

