### PR TITLE
Add Rekindle MCP component for session continuity

### DIFF
--- a/cli-tool/components/mcps/devtools/rekindle.json
+++ b/cli-tool/components/mcps/devtools/rekindle.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "rekindle": {
+      "description": "Local session continuity engine for Claude Code. Provides boot reports with orientation scoring, structured end-session capture, and memory search. Run `npx rekindle init` in your project first to create the local database.",
+      "command": "npx",
+      "args": ["-y", "rekindle"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds Rekindle as an MCP component in `devtools/` category
- Rekindle is a local session continuity engine for Claude Code — boot reports with orientation scoring, structured end-session capture, and memory search
- All local SQLite, zero API keys, stdio transport
- 7 MCP tools: `boot_report`, `end_session`, `store_memory`, `search_memory`, `list_memories`, `delete_memory`, `update_memory`
- Published on npm: [rekindle](https://www.npmjs.com/package/rekindle)
- Source: [Skitchy/rekindle](https://github.com/Skitchy/rekindle)

## Component details

**File:** `cli-tool/components/mcps/devtools/rekindle.json`

**Install command:** `npx claude-code-templates@latest --mcp rekindle`

**Prerequisite:** Users run `npx rekindle init` in their project to create the local `.rekindle/` directory and SQLite database before using the MCP.

## Checklist

- [x] Valid JSON syntax
- [x] Kebab-case naming
- [x] No hardcoded secrets (no API keys required)
- [x] No absolute paths
- [x] Clear description
- [x] Correct category placement (devtools)
- [x] Tested and functional — 64 automated tests, published on npm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `rekindle` MCP component to enable local session continuity for Claude Code (boot reports, end-session capture, memory search) using local SQLite with no API keys.

- Area: components (`cli-tool/components/`), devtools category
- Component: `rekindle` MCP exposing 7 tools; runs via `npx rekindle` (stdio)
- Catalog: regenerate `docs/components.json`
- Env/secrets: none; install with `npx claude-code-templates@latest --mcp rekindle` and run `npx rekindle init` once to create the local DB

<sup>Written for commit 985a22e31cc69ee6115740fecbb803f26e80c4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

