### PR TITLE
Add Mercado Pago marketplace

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -1,5 +1,31 @@
 [
   {
+    "slug": "mercadopago-claude-marketplace",
+    "name": "Mercado Pago",
+    "author": "mercadopago",
+    "description": "Official Claude Code plugin from the Mercado Pago Developer Experience team. Scaffold, review, and maintain payment integrations across 7 countries and 13 products — Checkout Pro, Bricks, Subscriptions, QR, Marketplace, and more.",
+    "github": "https://github.com/mercadopago/mercadopago-claude-marketplace",
+    "stars": 0,
+    "type": "plugin",
+    "tags": [
+      "agents",
+      "commands",
+      "skills",
+      "hooks"
+    ],
+    "contains": {
+      "agents": 1,
+      "commands": 3,
+      "skills": 13,
+      "hooks": 1
+    },
+    "highlights": [
+      "7 countries: AR, BR, MX, CL, CO, PE, UY",
+      "13 products: Checkout Pro, Bricks, QR, Subscriptions, Marketplace, and more"
+    ],
+    "website": "https://www.mercadopago.com/developers"
+  },
+  {
     "slug": "everything-claude-code",
     "name": "Everything Claude Code",
     "author": "affaan-m",


### PR DESCRIPTION
<img width="1441" height="980" alt="image" src="https://github.com/user-attachments/assets/654c176c-369b-4ab4-8a8c-e0998b5296f7" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Mercado Pago plugin to the marketplace so developers can find and use the official Claude Code integration for Mercado Pago products. This makes the plugin visible in the dashboard plugin list.

- Area: website (dashboard/)
- Change: Added a new entry in `dashboard/public/plugins.json` with slug, metadata, tags, and highlights
- No new components; no catalog (`docs/components.json`) regeneration needed
- No new environment variables or secrets

<sup>Written for commit 5c93995f20e6a5ca86c30f18893f41d3b7a9f2fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

