### PR TITLE
docs: Add AI CLI YOLO/auto mode configuration guide

### DIFF
--- a/docs/guides/cli-yolo-auto-modes.md
+++ b/docs/guides/cli-yolo-auto-modes.md
@@ -1,0 +1,314 @@
+# AI CLI Auto/YOLO Mode Configuration Guide
+
+Complete reference for configuring auto-approval (YOLO) mode across all major AI coding CLIs. Each CLI has its own mechanism for bypassing permission prompts to enable autonomous operation.
+
+## Quick Reference
+
+| CLI | YOLO Flag | Config Setting | Config File |
+|---|---|---|---|
+| **Claude Code** | `--dangerously-skip-permissions` | N/A (flag only) | `~/.claude/settings.json` |
+| **Kimi** | `--yolo` / `-y` | `default_yolo = true` | `~/.kimi/config.toml` |
+| **Codex (OpenAI)** | `--dangerously-bypass-approvals-and-sandbox` | `approval_policy = "never"` + `sandbox_mode = "danger-full-access"` | `~/.codex/config.toml` |
+| **Vibe (Mistral)** | `--agent auto-approve` | `default_agent = "auto-approve"` | `~/.vibe/config.toml` |
+| **Abacus AI** | `--permission-mode yolo` | Alias in shell | `~/.zshrc` or `~/.bashrc` |
+| **OpenCode** | `--dangerously-skip-permissions` (run subcmd) | `"permission": "allow"` | `~/.config/opencode/opencode.json` |
+
+---
+
+## Claude Code
+
+```bash
+# One-shot YOLO mode
+claude --dangerously-skip-permissions "task description"
+
+# Or via settings.json allowlist
+# ~/.claude/settings.json → add tool patterns to "allow" array
+```
+
+**Notes:**
+- Flag only, no persistent config option for this flag
+- Use `allowedTools` in settings.json for persistent granular permissions
+
+---
+
+## Kimi (Kimi Code / Moonshot)
+
+### CLI Flags
+
+```bash
+# YOLO mode - auto-approve tools, AI can still ask questions
+kimi --yolo
+kimi -y
+kimi --yes
+kimi --auto-approve
+
+# AFK mode - auto-approve tools AND auto-dismiss questions
+kimi --afk
+
+# Print mode - non-interactive, auto-approve everything
+kimi --print
+
+# Combine with prompt for one-shot
+kimi --yolo --prompt "refactor all API handlers"
+kimi --afk --prompt "run tests and fix failures"
+```
+
+### Persistent Config (`~/.kimi/config.toml`)
+
+```toml
+default_yolo = true
+```
+
+### Runtime Slash Commands
+
+- `/yolo` - toggle YOLO on/off
+- `/afk` - toggle AFK on/off
+
+### Mode Hierarchy
+
+| Mode | Tool Approvals | AskUserQuestion | Interactive |
+|---|---|---|---|
+| Normal | Required | Shown | Yes |
+| YOLO (`-y`) | Auto-approved | Shown | Yes |
+| AFK | Auto-approved | Auto-dismissed | Yes |
+| Print | Auto-approved | Auto-dismissed | No |
+
+---
+
+## Codex (OpenAI)
+
+### CLI Flags
+
+```bash
+# Interactive mode - set approval + sandbox
+codex -a never -s danger-full-access "task"
+
+# Non-interactive mode (exec)
+codex exec --dangerously-bypass-approvals-and-sandbox "task"
+
+# Using a profile
+codex -p full-access-controlled "task"
+```
+
+### Persistent Config (`~/.codex/config.toml`)
+
+```toml
+# Full YOLO mode
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+# Optional: trust specific project directories
+[projects."/path/to/project"]
+trust_level = "trusted"
+```
+
+### Approval Policy Values
+
+| Value | Behavior |
+|---|---|
+| `suggest` | Ask for approval on every command |
+| `auto-edit` | Auto-approve file edits, ask for shell commands |
+| `on-request` | Model decides when to ask |
+| `never` | Never ask for approval (YOLO) |
+
+### Sandbox Mode Values
+
+| Value | Behavior |
+|---|---|
+| `read-only` | Read-only filesystem access |
+| `workspace-write` | Write only in project directory |
+| `danger-full-access` | Full filesystem access (YOLO) |
+
+### Profiles
+
+```toml
+[profiles.auto-workspace]
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[profiles.full-access-controlled]
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+```
+
+Use with: `codex -p full-access-controlled "task"`
+
+---
+
+## Vibe (Mistral)
+
+### CLI Flags
+
+```bash
+# Programmatic mode - auto-approves everything by default
+vibe -p "refactor the auth module"
+
+# Interactive with auto-approve agent
+vibe --agent auto-approve
+
+# Trust working directory (non-interactive)
+vibe --trust -p "run tests"
+```
+
+### Persistent Config (`~/.vibe/config.toml`)
+
+```toml
+# Set auto-approve as default agent
+default_agent = "auto-approve"
+
+# Or set bypass flag directly
+bypass_tool_permissions = true
+```
+
+### Per-Tool Permissions
+
+```toml
+[tools.bash]
+permission = "always"
+
+[tools.write_file]
+permission = "always"
+
+[tools.search_replace]
+permission = "always"
+
+[tools.read_file]    # already "always" by default
+[tools.grep]         # already "always" by default
+```
+
+### Built-in Agents
+
+| Agent | Safety | Behavior |
+|---|---|---|
+| `default` | NEUTRAL | Requires approval for tools |
+| `plan` | SAFE | Read-only, exploration/planning |
+| `accept-edits` | DESTRUCTIVE | Auto-approves file edits only |
+| `auto-approve` | YOLO | Auto-approves all tools |
+
+### Environment Variable
+
+```bash
+VIBE_BYPASS_TOOL_PERMISSIONS=true vibe
+```
+
+---
+
+## Abacus AI
+
+### CLI Flags
+
+```bash
+# YOLO mode
+abacusai --permission-mode yolo
+
+# Skip all permission checks (equivalent)
+abacusai --dangerously-skip-permissions
+
+# Auto-accept edits only
+abacusai --auto-accept-edits
+
+# Plan mode
+abacusai --plan-mode
+```
+
+### Shell Alias (Persistent)
+
+Add to `~/.zshrc` or `~/.bashrc`:
+
+```bash
+alias abacus='abacusai --permission-mode yolo'
+alias abacusai='abacusai --permission-mode yolo'
+```
+
+### Permission Mode Values
+
+| Mode | Behavior |
+|---|---|
+| `normal` | Ask for all approvals |
+| `accept-edits` | Auto-accept file edits |
+| `yolo` | Auto-approve everything |
+| `plan` | Read-only planning mode |
+
+### Full Options
+
+```bash
+abacusai --help
+
+Options:
+  --auto-accept-edits             Automatically accept edits
+  --dangerously-skip-permissions  Skip permission checks
+  --plan-mode                     Enable plan mode
+  --permission-mode <mode>        Permission mode: normal, accept-edits, yolo, plan
+  --allowed-tools <pattern>       Auto-allow tool patterns (repeatable)
+  --disallowed-tools <pattern>    Auto-deny tool patterns (repeatable)
+  --add-dir <path>                Additional allowed directory (repeatable)
+```
+
+---
+
+## OpenCode
+
+### CLI Flags
+
+```bash
+# Non-interactive mode - auto-approves all permissions
+opencode run --dangerously-skip-permissions "task description"
+
+# Non-interactive with specific output
+opencode -p "explain this code" -f json
+```
+
+### Persistent Config (`~/.config/opencode/opencode.json`)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": "allow"
+}
+```
+
+Or granular per-tool:
+
+```json
+{
+  "permission": {
+    "bash": "allow",
+    "edit": "allow",
+    "write": "allow",
+    "read": "allow"
+  }
+}
+```
+
+### Environment Variable
+
+```bash
+OPENCODE_PERMISSION='{"bash":"allow","edit":"allow","write":"allow"}' opencode
+```
+
+### Non-Interactive Mode
+
+```bash
+# All permissions auto-approved in non-interactive mode
+opencode -p "your task"
+
+# With JSON output
+opencode -p "your task" -f json
+
+# Quiet mode (no spinner)
+opencode -p "your task" -q
+```
+
+**Note:** OpenCode's original GitHub repo (`opencode-ai/opencode`) has been archived and continued as **Crush** by the Charm team. The installed version from `opencode.ai` (by AnomalyCo) is the actively maintained fork.
+
+---
+
+## Security Considerations
+
+All YOLO/auto modes disable safety prompts. Only use them when:
+
+1. The environment is sandboxed (Docker, VM, CI)
+2. You fully trust the project directory
+3. You understand the tool can execute arbitrary commands
+
+For production use, prefer granular permissions over full YOLO mode. Most CLIs support per-tool or per-pattern allowlists for safer autonomous operation.

--- a/scripts/configure-yolo-modes.sh
+++ b/scripts/configure-yolo-modes.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# configure-yolo-modes.sh
+# Configure auto/YOLO mode for all AI coding CLIs
+# Usage: ./configure-yolo-modes.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[CONFIGURE]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# --- Kimi ---
+configure_kimi() {
+    local config="$HOME/.kimi/config.toml"
+    if [[ ! -f "$config" ]]; then
+        warn "Kimi config not found at $config"
+        return
+    fi
+    if grep -q "^default_yolo" "$config"; then
+        log "Kimi: YOLO already configured"
+    else
+        if $DRY_RUN; then
+            log "Kimi: Would add 'default_yolo = true' to $config"
+        else
+            sed -i '' '/^default_thinking/a\
+default_yolo = true
+' "$config"
+            log "Kimi: Added default_yolo = true"
+        fi
+    fi
+}
+
+# --- Codex ---
+configure_codex() {
+    local config="$HOME/.codex/config.toml"
+    if [[ ! -f "$config" ]]; then
+        warn "Codex config not found at $config"
+        return
+    fi
+    if grep -q '^approval_policy = "never"' "$config" && grep -q '^sandbox_mode = "danger-full-access"' "$config"; then
+        log "Codex: YOLO already configured (approval_policy=never, sandbox_mode=danger-full-access)"
+    else
+        if $DRY_RUN; then
+            log "Codex: Would set approval_policy=never and sandbox_mode=danger-full-access"
+        else
+            sed -i '' 's/^approval_policy = .*/approval_policy = "never"/' "$config"
+            sed -i '' 's/^sandbox_mode = .*/sandbox_mode = "danger-full-access"/' "$config"
+            log "Codex: Configured YOLO mode"
+        fi
+    fi
+}
+
+# --- Vibe ---
+configure_vibe() {
+    local config="$HOME/.vibe/config.toml"
+    if [[ ! -f "$config" ]]; then
+        warn "Vibe config not found at $config"
+        return
+    fi
+    if grep -q '^default_agent = "auto-approve"' "$config"; then
+        log "Vibe: auto-approve already configured"
+    else
+        if $DRY_RUN; then
+            log "Vibe: Would add 'default_agent = \"auto-approve\"' to $config"
+        else
+            sed -i '' '/^active_model/a\
+default_agent = "auto-approve"
+' "$config"
+            log "Vibe: Added default_agent = auto-approve"
+        fi
+    fi
+}
+
+# --- Abacus ---
+configure_abacus() {
+    local shellrc="$HOME/.zshrc"
+    [[ ! -f "$shellrc" ]] && shellrc="$HOME/.bashrc"
+    if [[ ! -f "$shellrc" ]]; then
+        warn "No .zshrc or .bashrc found for Abacus aliases"
+        return
+    fi
+    if grep -q "abacusai --permission-mode yolo" "$shellrc"; then
+        log "Abacus: YOLO alias already configured"
+    else
+        if $DRY_RUN; then
+            log "Abacus: Would add aliases to $shellrc"
+        else
+            echo '' >> "$shellrc"
+            echo '# Abacus AI CLI - YOLO mode' >> "$shellrc"
+            echo "alias abacus='abacusai --permission-mode yolo'" >> "$shellrc"
+            echo "alias abacusai='abacusai --permission-mode yolo'" >> "$shellrc"
+            log "Abacus: Added YOLO aliases"
+        fi
+    fi
+}
+
+# --- OpenCode ---
+configure_opencode() {
+    local config="$HOME/.config/opencode/opencode.json"
+    if [[ ! -f "$config" ]]; then
+        warn "OpenCode config not found at $config"
+        return
+    fi
+    if grep -q '"permission"' "$config"; then
+        log "OpenCode: permission already configured"
+    else
+        if $DRY_RUN; then
+            log "OpenCode: Would add '\"permission\": \"allow\"' to $config"
+        else
+            sed -i '' 's/"\$schema"/"permission": "allow",\n  "\$schema"/' "$config"
+            log "OpenCode: Added permission: allow"
+        fi
+    fi
+}
+
+# --- Main ---
+echo "AI CLI YOLO Mode Configurator"
+echo "=============================="
+
+if $DRY_RUN; then
+    warn "DRY RUN - no changes will be made"
+    echo ""
+fi
+
+configure_kimi
+configure_codex
+configure_vibe
+configure_abacus
+configure_opencode
+
+echo ""
+log "Configuration complete!"
+echo ""
+echo "Verify with:"
+echo "  Kimi:     grep default_yolo ~/.kimi/config.toml"
+echo "  Codex:    grep approval_policy ~/.codex/config.toml"
+echo "  Vibe:     grep default_agent ~/.vibe/config.toml"
+echo "  Abacus:   grep abacus ~/.zshrc"
+echo "  OpenCode: grep permission ~/.config/opencode/opencode.json"


### PR DESCRIPTION
## Summary
- Added comprehensive guide for configuring auto-approval (YOLO) mode across 6 AI coding CLIs: Claude Code, Kimi, Codex (OpenAI), Vibe (Mistral), Abacus AI, and OpenCode
- Added a setup script (`scripts/configure-yolo-modes.sh`) that automatically configures YOLO mode for all installed CLIs
- Covers CLI flags, persistent config settings, permission mode values, and security considerations

## Details
Each CLI has a different mechanism for YOLO/auto mode:
- **Kimi**: `--yolo` flag or `default_yolo = true` in config
- **Codex**: `approval_policy = "never"` + `sandbox_mode = "danger-full-access"` in config
- **Vibe**: `--agent auto-approve` or `default_agent = "auto-approve"` in config
- **Abacus**: `--permission-mode yolo` flag or shell alias
- **OpenCode**: `"permission": "allow"` in config or `--dangerously-skip-permissions` for `run` subcommand

## Test plan
- [x] Verified Kimi config at `~/.kimi/config.toml` has `default_yolo = true`
- [x] Verified Codex config at `~/.codex/config.toml` has YOLO settings
- [x] Verified Vibe config at `~/.vibe/config.toml` has `default_agent = "auto-approve"`
- [x] Verified Abacus alias in `~/.zshrc` has `--permission-mode yolo`
- [x] Verified OpenCode config at `~/.config/opencode/opencode.json` has `"permission": "allow"`
- [x] Script `configure-yolo-modes.sh` tested with `--dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new guide for enabling YOLO/auto-approval across six coding CLIs and a helper script to auto-configure them. Improves setup clarity and speeds up unattended runs.

- **New Features**
  - Website (docs/): Added docs/guides/cli-yolo-auto-modes.md covering flags, config paths, modes, and safety for Claude Code, Kimi, Codex (OpenAI), Vibe (Mistral), Abacus AI, and OpenCode.
  - CLI: Added scripts/configure-yolo-modes.sh to set YOLO defaults (supports --dry-run; updates configs and shell aliases).
  - No new components; no docs/components.json regeneration needed.
  - No new project env vars or secrets required (docs note optional per-tool vars like VIBE_BYPASS_TOOL_PERMISSIONS and OPENCODE_PERMISSION).

<sup>Written for commit 14320293111eedf33cd90f5de6363289c01bb9e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

