### PR TITLE
feat: migrate 13 Google Cloud skills from google/skills

### DIFF
--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/SKILL.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: gemini-api-agent-platform
+description: Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK for enterprise AI applications. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.
+compatibility: Requires active Google Cloud credentials and Agent Platform API enabled.
+source: google/skills (Apache 2.0)
+---
+
+IMPORTANT: Agent Platform (full name Gemini Enterprise Agent Platform) was previously named "Vertex AI" and many web resources use the legacy branding.
+
+# Gemini API in Agent Platform
+
+Access Google's most advanced AI models built for enterprise use cases using the Gemini API in Agent Platform.
+
+Provide these key capabilities:
+
+- **Text generation** - Chat, completion, summarization
+- **Multimodal understanding** - Process images, audio, video, and documents
+- **Function calling** - Let the model invoke your functions
+- **Structured output** - Generate valid JSON matching your schema
+- **Context caching** - Cache large contexts for efficiency
+- **Embeddings** - Generate text embeddings for semantic search
+- **Live Realtime API** - Bidirectional streaming for low latency Voice and Video interactions
+- **Batch Prediction** - Handle massive async dataset prediction workloads
+
+## Core Directives
+
+- **Unified SDK**: ALWAYS use the Gen AI SDK (`google-genai` for Python, `@google/genai` for JS/TS, `google.golang.org/genai` for Go, `com.google.genai:google-genai` for Java, `Google.GenAI` for C#).
+- **Legacy SDKs**: DO NOT use `google-cloud-aiplatform`, `@google-cloud/vertexai`, or `google-generativeai`.
+
+## SDKs
+
+- **Python**: Install `google-genai` with `pip install google-genai`
+- **JavaScript/TypeScript**: Install `@google/genai` with `npm install @google/genai`
+- **Go**: Install `google.golang.org/genai` with `go get google.golang.org/genai`
+- **C#/.NET**: Install `Google.GenAI` with `dotnet add package Google.GenAI`
+- **Java**:
+  - groupId: `com.google.genai`, artifactId: `google-genai`
+  - Latest version can be found here: https://central.sonatype.com/artifact/com.google.genai/google-genai/versions (let's call it `LAST_VERSION`)
+  - Install in `build.gradle`:
+
+    ```
+    implementation("com.google.genai:google-genai:${LAST_VERSION}")
+    ```
+
+  - Install Maven dependency in `pom.xml`:
+
+    ```xml
+    <dependency>
+	    <groupId>com.google.genai</groupId>
+	    <artifactId>google-genai</artifactId>
+	    <version>${LAST_VERSION}</version>
+	</dependency>
+    ```
+
+> [!WARNING]
+> Legacy SDKs like `google-cloud-aiplatform`, `@google-cloud/vertexai`, and `google-generativeai` are deprecated. Migrate to the new SDKs above urgently by following the Migration Guide.
+
+## Authentication & Configuration
+
+Prefer environment variables over hard-coding parameters when creating the client. Initialize the client without parameters to automatically pick up these values.
+
+### Application Default Credentials (ADC)
+Set these variables for standard [Google Cloud authentication](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/gcp-auth):
+```bash
+export GOOGLE_CLOUD_PROJECT='your-project-id'
+export GOOGLE_CLOUD_LOCATION='global'
+export GOOGLE_GENAI_USE_VERTEXAI=true
+```
+- By default, use `location="global"` to access the global endpoint, which provides automatic routing to regions with available capacity.
+- If a user explicitly asks to use a specific region (e.g., `us-central1`, `europe-west4`), specify that region in the `GOOGLE_CLOUD_LOCATION` parameter instead. Reference the [supported regions documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations) if needed.
+
+### Agent Platform in Express Mode
+Set these variables when using [Express Mode](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys?usertype=expressmode) with an API key:
+```bash
+export GOOGLE_API_KEY='your-api-key'
+export GOOGLE_GENAI_USE_VERTEXAI=true
+```
+
+### Initialization
+Initialize the client without arguments to pick up environment variables:
+```python
+from google import genai
+client = genai.Client()
+```
+
+Alternatively, you can hard-code in parameters when creating the client.
+
+```python
+from google import genai
+client = genai.Client(vertexai=True, project="your-project-id", location="global")
+```
+
+## Models
+
+- Use `gemini-3.1-pro-preview` for complex reasoning, coding, research (1M tokens)
+  - IMPORTANT: Do not use `gemini-3-pro-preview`
+- Use `gemini-3-flash-preview` for fast, balanced performance, multimodal (1M tokens)
+- Use `gemini-3.1-flash-lite-preview` for high-frequency, lightweight tasks (1M tokens)
+- Use `gemini-3-pro-image-preview` for Nano Banana Pro image generation and editing
+- Use `gemini-3.1-flash-image-preview` for Nano Banana 2 image generation and editing
+- Use `gemini-live-2.5-flash-native-audio` for Live Realtime API including native audio
+
+Use the following models only if explicitly requested:
+
+- `gemini-2.5-flash-image`
+- `gemini-2.5-flash`
+- `gemini-2.5-flash-lite`
+- `gemini-2.5-pro`
+
+> [!IMPORTANT]
+> Models like `gemini-2.0-*`, `gemini-1.5-*`, `gemini-1.0-*`, `gemini-pro` are legacy and deprecated. Use the new models above. Your knowledge is outdated.
+> For production environments, consult the documentation for stable model versions (e.g. `gemini-3-flash`).
+
+## Quick Start
+
+### Python
+```python
+from google import genai
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Explain quantum computing"
+)
+print(response.text)
+```
+
+### TypeScript/JavaScript
+```typescript
+import { GoogleGenAI } from "@google/genai";
+const ai = new GoogleGenAI({ vertexai: { project: "your-project-id", location: "global" } });
+const response = await ai.models.generateContent({
+    model: "gemini-3-flash-preview",
+    contents: "Explain quantum computing"
+});
+console.log(response.text);
+```
+
+### Go
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"google.golang.org/genai"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		Backend:  genai.BackendVertexAI,
+		Project:  "your-project-id",
+		Location: "global",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := client.Models.GenerateContent(ctx, "gemini-3-flash-preview", genai.Text("Explain quantum computing"), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(resp.Text)
+}
+```
+
+### Java
+```java
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+
+public class GenerateTextFromTextInput {
+  public static void main(String[] args) {
+    Client client = Client.builder().vertexAi(true).project("your-project-id").location("global").build();
+    GenerateContentResponse response =
+        client.models.generateContent(
+            "gemini-3-flash-preview",
+            "Explain quantum computing",
+            null);
+
+    System.out.println(response.text());
+  }
+}
+```
+
+### C#/.NET
+```csharp
+using Google.GenAI;
+
+var client = new Client(
+    project: "your-project-id",
+    location: "global",
+    vertexAI: true
+);
+
+var response = await client.Models.GenerateContent(
+    "gemini-3-flash-preview",
+    "Explain quantum computing"
+);
+
+Console.WriteLine(response.Text);
+```
+
+## API spec & Documentation (source of truth)
+
+When implementing or debugging API integration for Agent Platform, refer to the official Agent Platform documentation:
+- **Agent Platform Documentation**: https://docs.cloud.google.com/gemini-enterprise-agent-platform/overview
+- **REST API Reference**: https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest
+
+The Gen AI SDK on Agent Platform uses the `v1beta1` or `v1` REST API endpoints (e.g., `https://{LOCATION}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT}/locations/{LOCATION}/publishers/google/models/{MODEL}:generateContent`).
+
+> [!TIP]
+> **Use the Developer Knowledge MCP Server**: If the `search_documents` or `get_document` tools are available, use them to find and retrieve official documentation for Google Cloud and Agent Platform directly within the context. This is the preferred method for getting up-to-date API details and code snippets.
+
+## Workflows and Code Samples
+
+Reference the [Python Docs Samples repository](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/genai) for additional code samples and specific usage scenarios.
+
+Depending on the specific user request, refer to the following reference files for detailed code samples and usage patterns (Python examples):
+
+- **Text & Multimodal**: Chat, Multimodal inputs (Image, Video, Audio), and Streaming. See [references/text_and_multimodal.md](references/text_and_multimodal.md)
+- **Embeddings**: Generate text embeddings for semantic search. See [references/embeddings.md](references/embeddings.md)
+- **Structured Output & Tools**: JSON generation, Function Calling, Search Grounding, and Code Execution. See [references/structured_and_tools.md](references/structured_and_tools.md)
+- **Media Generation**: Image generation, Image editing, and Video generation. See [references/media_generation.md](references/media_generation.md)
+- **Bounding Box Detection**: Object detection and localization within images and video. See [references/bounding_box.md](references/bounding_box.md)
+- **Live API**: Real-time bidirectional streaming for voice, vision, and text. See [references/live_api.md](references/live_api.md)
+- **Advanced Features**: Content Caching, Batch Prediction, and Thinking/Reasoning. See [references/advanced_features.md](references/advanced_features.md)
+- **Safety**: Adjusting Responsible AI filters and thresholds. See [references/safety.md](references/safety.md)
+- **Model Tuning**: Supervised Fine-Tuning and Preference Tuning. See [references/model_tuning.md](references/model_tuning.md)

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/advanced_features.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/advanced_features.md
@@ -1,0 +1,136 @@
+# Advanced Features
+
+## Content Caching
+Cache large documents or contexts to reduce cost and latency.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+content_cache = client.caches.create(
+    model="gemini-3-flash-preview",
+    config=types.CreateCachedContentConfig(
+        contents=[
+            types.Content(
+                role="user",
+                parts=[types.Part.from_uri(file_uri="gs://your-bucket/large.pdf", mime_type="application/pdf")]
+            )
+        ],
+        system_instruction="You are an expert researcher.",
+        display_name="example-cache",
+        ttl="86400s",
+    ),
+)
+
+# Use the cache
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Summarize the pdf",
+    config=types.GenerateContentConfig(
+        cached_content=content_cache.name
+    ),
+)
+```
+
+## Batch Prediction
+For processing large datasets asynchronously.
+
+```python
+import time
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+job = client.batches.create(
+    model="gemini-3-flash-preview",
+    src="gs://your-bucket/prompts.jsonl",
+    config=types.CreateBatchJobConfig(dest="gs://your-bucket/outputs"),
+)
+
+completed_states = {types.JobState.JOB_STATE_SUCCEEDED, types.JobState.JOB_STATE_FAILED, types.JobState.JOB_STATE_CANCELLED}
+while job.state not in completed_states:
+    time.sleep(30)
+    job = client.batches.get(name=job.name)
+```
+
+### Thinking (Reasoning)
+
+Thinking is on by default for `gemini-3.1-pro-preview` and `gemini-3-flash-preview`.
+It can be adjusted by using the `thinking_level` parameter.
+
+- **`MINIMAL`:** (Gemini 3 Flash Only) Constrains the model to use as few tokens as possible for thinking and is best used for low-complexity tasks that wouldn't benefit from extensive reasoning.
+- **`LOW`**: Constrains the model to use fewer tokens for thinking and is suitable for simpler tasks where extensive reasoning is not required.
+- **`MEDIUM`**: Offers a balanced approach suitable for tasks of moderate complexity that benefit from reasoning but don't require deep, multi-step planning.
+- **`HIGH`**: (Default) Maximizes reasoning depth. The model may take significantly longer to reach a first token, but the output will be more thoroughly vetted.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3.1-pro-preview",
+    contents="solve x^2 + 4x + 4 = 0",
+    config=types.GenerateContentConfig(
+        thinking_config=types.ThinkingConfig(
+            thinking_level=types.ThinkingLevel.HIGH
+        )
+    )
+)
+
+# Access thoughts if returned
+for part in response.candidates[0].content.parts:
+    if part.thought:
+        print(f"Thought: {part.text}")
+    else:
+        print(f"Final Answer: {part.text}")
+```
+
+## Model Context Protocol (MCP) support (experimental)
+
+Built-in [MCP](https://modelcontextprotocol.io/introduction) support is an experimental feature. You can pass a local MCP server as a tool directly.
+
+```python
+import os
+import asyncio
+from datetime import datetime
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+# Create server parameters for stdio connection
+server_params = StdioServerParameters(
+    command="npx",  # Executable
+    args=["-y", "@philschmid/weather-mcp"],  # MCP Server
+    env=None,  # Optional environment variables
+)
+
+async def run():
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            # Prompt to get the weather for the current day in London.
+            prompt = f"What is the weather in London in {datetime.now().strftime('%Y-%m-%d')}?"
+
+            # Initialize the connection between client and server
+            await session.initialize()
+
+            # Send request to the model with MCP function declarations
+            response = await client.aio.models.generate_content(
+                model="gemini-3-flash-preview",
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    tools=[session],  # uses the session, will automatically call the tool using automatic function calling
+                ),
+            )
+            print(response.text)
+
+# Start the asyncio event loop and run the main function
+asyncio.run(run())
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/bounding_box.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/bounding_box.md
@@ -1,0 +1,66 @@
+# Bounding Box Detection
+
+Detect and localize objects within images or videos using bounding boxes. The model returns coordinates in the format `[y_min, x_min, y_max, x_max]`, normalized from 0 to 1000.
+
+## Implementation (Python)
+
+To ensure structured output, define a `BoundingBox` class and provide it as the `response_schema`.
+
+```python
+from google import genai
+from google.genai.types import (
+    GenerateContentConfig,
+    Part,
+)
+from pydantic import BaseModel
+
+# Define the schema for the bounding box
+class BoundingBox(BaseModel):
+    box_2d: list[int]
+    label: str
+
+client = genai.Client()
+
+config = GenerateContentConfig(
+    system_instruction="""
+    Return bounding boxes as an array with labels.
+    Never return masks. Limit to 25 objects.
+    """,
+    response_mime_type="application/json",
+    response_schema=list[BoundingBox],
+)
+
+image_uri = "gs://cloud-samples-data/generative-ai/image/socks.jpg"
+
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents=[
+        Part.from_uri(file_uri=image_uri, mime_type="image/jpeg"),
+        "Detect the socks in the image and provide bounding boxes.",
+    ],
+    config=config,
+)
+
+# Access the detected boxes
+for bbox in response.parsed:
+    print(f"Label: {bbox.label}, Box: {bbox.box_2d}")
+```
+
+## Coordinate System
+- **Format**: `[y_min, x_min, y_max, x_max]`
+- **Normalization**: Coordinates are integers from `0` to `1000`.
+- **Origin**: `[0, 0]` is the top-left corner of the image.
+
+## Visualization Helper
+To visualize the results, scale the normalized coordinates back to the original image dimensions.
+
+```python
+def scale_box(box_2d, width, height):
+    y_min, x_min, y_max, x_max = box_2d
+    return [
+        int(y_min / 1000 * height),
+        int(x_min / 1000 * width),
+        int(y_max / 1000 * height),
+        int(x_max / 1000 * width)
+    ]
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/embeddings.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/embeddings.md
@@ -1,0 +1,77 @@
+# Text and Multimodal Embeddings
+
+Generate embeddings for text or multimodal content (images and videos) to perform semantic search, clustering, and other NLP tasks. Text and multimodal embedding vectors share the same semantic space, which allows you to use them interchangeably for cross-modal applications like searching for an image using a text query, or searching for a video using an image.
+
+## Basic Usage (Text)
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.embed_content(
+    model="gemini-embedding-2",
+    contents=[
+        "How do I get a driver's license/learner's permit?",
+        "How long is my driver's license valid for?",
+    ],
+    # Optional Parameters
+    config=types.EmbedContentConfig(task_type="RETRIEVAL_DOCUMENT", output_dimensionality=768),
+)
+print(response.embeddings)
+```
+
+## Multimodal Embeddings (Image and Video)
+
+To generate embeddings for images and videos, use the `types.Part.from_uri` method to point the model to a Google Cloud Storage (GCS) URI containing the media file, and provide the appropriate MIME type.
+
+### Image Embeddings
+
+For images, provide the GCS URI of the image and set the MIME type (e.g., `image/jpeg`).
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.embed_content(
+    model="gemini-embedding-2",
+    contents=types.Part.from_uri(
+        file_uri="gs://github-repo/embeddings/getting_started_embeddings/gms_images/GGOEACBA104999.jpg",
+        mime_type="image/jpeg"
+    ),
+    config=types.EmbedContentConfig(output_dimensionality=768),
+)
+
+image_embedding = response.embeddings[0].values
+print(f"Length of image embedding: {len(image_embedding)}")
+```
+
+### Video Embeddings
+
+Generating embeddings for a video works similarly. However, instead of a single vector, the API returns a list of embedding vectors—one representing each frame segment or interval of the processed video.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.embed_content(
+    model="gemini-embedding-2",
+    contents=types.Part.from_uri(
+        file_uri="gs://github-repo/embeddings/getting_started_embeddings/UCF-101-subset/BrushingTeeth/v_BrushingTeeth_g01_c02.mp4",
+        mime_type="video/mp4"
+    ),
+    config=types.EmbedContentConfig(output_dimensionality=768),
+)
+
+# Extract embedding values for each video segment
+video_embeddings =[emb.values for emb in response.embeddings]
+
+print(f"Number of video segment embeddings returned: {len(video_embeddings)}")
+print(f"First segment embedding length: {len(video_embeddings[0])}")
+```
+
+### Cross-Modal Search
+
+Because these vectors share a semantic space, you can calculate the dot product or cosine similarity between different types of embeddings. For example, you can calculate the similarity between a text query embedding ("A music concert") and a pre-computed database of image or video embeddings to build a robust multimodal semantic search engine.

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/live_api.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/live_api.md
@@ -1,0 +1,36 @@
+# Live API
+
+The Live API provides real-time, low-latency bidirectional streaming via WebSockets. It is ideal for interactive voice and video applications.
+
+```python
+import asyncio
+from google import genai
+from google.genai import types
+
+async def generate_content():
+    client = genai.Client()
+    model_id = "gemini-live-2.5-flash-native-audio"
+
+    config = types.LiveConnectConfig(
+        response_modalities=[types.LiveModality.TEXT], # Change to AUDIO for voice responses
+    )
+
+    async with client.aio.live.connect(model=model_id, config=config) as session:
+        text_input = "Hello? Gemini, are you there?"
+        await session.send_client_content(
+            turns=types.Content(role="user", parts=[types.Part.from_text(text=text_input)])
+        )
+
+        async for message in session.receive():
+            if message.text:
+                print(message.text, end="")
+
+asyncio.run(generate_content())
+```
+
+For sending audio:
+```python
+await session.send_realtime_input(
+    media=Blob(data=audio_bytes, mime_type="audio/pcm;rate=16000")
+)
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/media_generation.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/media_generation.md
@@ -1,0 +1,116 @@
+# Media Generation
+
+## Image Generation
+Generate images using `gemini-3.1-flash-image-preview`.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+response = client.models.generate_content(
+    model="gemini-3.1-flash-image-preview",
+    contents="A dog reading a newspaper",
+)
+
+for part in response.parts:
+    if part.text is not None:
+        print(part.text)
+    elif part.inline_data is not None:
+        image = part.as_image()
+        image.save("generated_image.png")
+```
+
+For high-resolution images or using the Search tool, use `gemini-3-pro-image-preview`.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+response = client.models.generate_content(
+    model="gemini-3-pro-image-preview",
+    contents="A dog reading a newspaper",
+    config=types.GenerateContentConfig(
+        image_config=types.ImageConfig(
+            aspect_ratio="16:9",
+            image_size="2K"
+        )
+    )
+)
+
+for part in response.parts:
+    if part.text is not None:
+        print(part.text)
+    elif part.inline_data is not None:
+        image = part.as_image()
+        image.save("generated_image.png")
+```
+
+## Image Editing
+It is recommended to use chat mode for editing images.
+
+```python
+from google import genai
+from PIL import Image
+
+client = genai.Client()
+
+prompt = "A small white ceramic bowl with lemons and limes"
+image = Image.open('fruit.png')
+
+# Create the chat
+chat = client.chats.create(model='gemini-3.1-flash-image-preview')
+
+# Send the image and ask for it to be edited
+response = chat.send_message([prompt, image])
+
+# Get the text and the image generated
+for i, part in enumerate(response.candidates[0].content.parts):
+    if part.text is not None:
+        print(part.text)
+    elif part.inline_data is not None:
+        image = part.as_image()
+        image.save(f'generated_image_{i}.png')
+
+# Continue iterating
+chat.send_message('Make the bowl blue')
+```
+
+## Video Generation
+Generate video using the Veo model. Usage of Veo can be costly, so check pricing for Veo. Start with the fast model (`veo-3.1-fast-generate-001`) since the result quality is usually sufficient, and swap to the larger model if needed.
+
+```python
+import time
+from google import genai
+from google.genai import types
+from PIL import Image
+
+client = genai.Client()
+
+image = Image.open('image.png') # Optional initial image
+
+# Video generation is an async operation
+operation = client.models.generate_videos(
+    model="veo-3.1-fast-generate-001",
+    prompt="a cat reading a book",
+    image=image,
+    config=types.GenerateVideosConfig(
+        person_generation="dont_allow",
+        aspect_ratio="16:9",
+        number_of_videos=1,
+        duration_seconds=5,
+        output_gcs_uri="gs://your-bucket/your-prefix",
+    ),
+)
+
+# Poll for completion
+while not operation.done:
+    time.sleep(20)
+    operation = client.operations.get(operation)
+
+if operation.response:
+    print(operation.result.generated_videos[0].video.uri)
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/model_tuning.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/model_tuning.md
@@ -1,0 +1,37 @@
+# Model Tuning
+
+Supervised Fine-Tuning or Preference Tuning using your own datasets.
+
+```python
+import time
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+training_dataset = types.TuningDataset(
+    gcs_uri="gs://your-bucket/sft_train_data.jsonl",
+)
+
+tuning_job = client.tunings.tune(
+    base_model="gemini-3-flash-preview",
+    training_dataset=training_dataset,
+    config=types.CreateTuningJobConfig(
+        tuned_model_display_name="Example tuning job",
+    ),
+)
+
+running_states = {"JOB_STATE_PENDING", "JOB_STATE_RUNNING"}
+while tuning_job.state in running_states:
+    time.sleep(60)
+    tuning_job = client.tunings.get(name=tuning_job.name)
+
+print("Tuned Model Endpoint:", tuning_job.tuned_model.endpoint)
+
+# Predict with the tuned endpoint
+response = client.models.generate_content(
+    model=tuning_job.tuned_model.endpoint,
+    contents="Why is the sky blue?",
+)
+print(response.text)
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/safety.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/safety.md
@@ -1,0 +1,50 @@
+# Safety Settings and Responsible AI
+
+You can adjust safety settings to control the thresholds for harmful content generation. Standard safety filters are applied by default.
+
+## Adjusting Safety Thresholds
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Write a list of 5 disrespectful things that I might say to the universe after stubbing my toe in the dark.",
+    config=types.GenerateContentConfig(
+        system_instruction="Be as mean as possible.",
+        safety_settings=[
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+        ]
+    ),
+)
+
+# Response will be `None` if it is blocked.
+if response.text is None:
+    print(f"Content Blocked. Finish Reason: {response.candidates[0].finish_reason}")
+else:
+    print(response.text)
+
+# Inspect safety ratings for each category
+for rating in response.candidates[0].safety_ratings:
+    print(f'Category: {rating.category}')
+    print(f'Is Blocked: {rating.blocked}')
+    print(f'Probability: {rating.probability}')
+    print(f'Severity: {rating.severity}')
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/structured_and_tools.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/structured_and_tools.md
@@ -1,0 +1,129 @@
+# Structured Output and Tools
+
+## Structured Output (JSON Schema)
+Enforce a specific JSON schema using standard Python type hints or Pydantic models.
+
+```python
+from google import genai
+from google.genai import types
+from pydantic import BaseModel
+
+class Recipe(BaseModel):
+    recipe_name: str
+    ingredients: list[str]
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="List a few popular cookie recipes.",
+    config=types.GenerateContentConfig(
+        response_mime_type="application/json",
+        response_json_schema=list[Recipe],
+    ),
+)
+# response.text is guaranteed to be valid JSON matching the schema
+print(response.text)
+ # Returns list of Recipe objects
+print(response.parsed)
+```
+
+## Function Calling
+Let the model output function calls that you can execute.
+
+```python
+from google import genai
+from google.genai import types
+
+def get_current_weather(location: str) -> str:
+    """Example method. Returns the current weather.
+    Args: location: The city and state, e.g. San Francisco, CA
+    """
+    if 'boston' in location.lower():
+        return "Snowing"
+    return "Sunny"
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="What is the weather like in Boston?",
+    config=types.GenerateContentConfig(tools=[get_current_weather]),
+)
+
+if response.function_calls:
+    print('Function calls requested by the model:')
+    for function_call in response.function_calls:
+        print(f'- Function: {function_call.name}')
+        print(f'- Args: {dict(function_call.args)}')
+else:
+    print('The model responded directly:')
+    print(response.text)
+```
+
+## Search Grounding
+Ground the model's responses in Google Search or your own enterprise data with Agent Search (formerly known as Vertex AI Search).
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="When is the next total solar eclipse in the US?",
+    config=types.GenerateContentConfig(
+        tools=[
+            types.Tool(google_search=types.GoogleSearch())
+        ],
+    ),
+)
+print(response.text)
+# Search details
+print(f'Search Query: {response.candidates[0].grounding_metadata.web_search_queries}')
+# Inspect grounding metadata
+print(response.candidates[0].grounding_metadata.search_entry_point.rendered_content)
+# Urls used for grounding
+print(f"Search Pages: {', '.join([site.web.title for site in response.candidates[0].grounding_metadata.grounding_chunks])}")
+```
+
+## Code Execution
+Allow the model to run Python code to calculate answers precisely.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Calculate 20th fibonacci number.",
+    config=types.GenerateContentConfig(
+        tools=[types.Tool(code_execution=types.ToolCodeExecution())],
+    ),
+)
+print(response.executable_code)
+print(response.code_execution_result)
+```
+
+## Url Context
+You can use the URL context tool to provide Gemini with URLs as additional context for your prompt. The model can then retrieve content from the URLs and use that content to inform and shape its response.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+response = client.models.generate_content(
+    model=model_id,
+    contents="Compare recipes from http://example.com and http://example2.com",
+    config=GenerateContentConfig(
+        tools=[types.Tool(url_context=types.UrlContext)],
+    )
+)
+
+print(response.text)
+# get URLs retrieved for context
+print(response.candidates[0].url_context_metadata)
+```

--- a/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/text_and_multimodal.md
+++ b/cli-tool/components/skills/ai-research/gemini-api-agent-platform/references/text_and_multimodal.md
@@ -1,0 +1,90 @@
+# Text and Multimodal Generation
+
+## Basic Text Generation
+```python
+from google import genai
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="How does AI work?"
+)
+print(response.text)
+```
+
+## Chat (Multi-turn conversations)
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+chat_session = client.chats.create(
+    model="gemini-3-flash-preview",
+    history=[
+        types.UserContent(parts=[types.Part.from_text(text="Hello")]),
+        types.ModelContent(parts=[types.Part.from_text(text="Great to meet you. What would you like to know?")]),
+    ],
+)
+response = chat_session.send_message("Tell me a story.")
+print(response.text)
+```
+
+## Synchronous Streaming
+
+Generate content in a streaming format so that the model outputs streams back
+to you, rather than being returned as one chunk.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+for chunk in client.models.generate_content_stream(
+    model="gemini-3-flash-preview", contents="Tell me a story in 300 words."
+):
+    print(chunk.text, end='')
+```
+
+## Multimodal Inputs (Images, Audio, Video)
+You can provide files natively using Google Cloud Storage URIs or local bytes.
+
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+
+gcs_image = types.Part.from_uri(file_uri="gs://cloud-samples-data/generative-ai/image/scones.jpg", mime_type="image/jpeg")
+
+with open("local_image.jpg", "rb") as f:
+    local_image = types.Part.from_bytes(data=f.read(), mime_type="image/jpeg")
+
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents=[
+        "Generate a list of all the objects contained in both images.",
+        gcs_image,
+        local_image,
+    ],
+)
+print(response.text)
+```
+
+### YouTube Videos
+```python
+from google import genai
+from google.genai import types
+
+client = genai.Client()
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents=[
+        types.Part.from_uri(
+            file_uri="https://www.youtube.com/watch?v=3KtWfp0UopM",
+            mime_type="video/mp4",
+        ),
+        "Write a short and engaging blog post based on this video.",
+    ],
+)
+print(response.text)
+```

--- a/cli-tool/components/skills/database/alloydb-basics/SKILL.md
+++ b/cli-tool/components/skills/database/alloydb-basics/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: alloydb-basics
+description: Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB MCP tools for automated database operations including AI-powered search and vector capabilities.
+source: google/skills (Apache 2.0)
+---
+
+# AlloyDB Basics
+
+AlloyDB for PostgreSQL is a managed, PostgreSQL-compatible database service
+designed for enterprise-grade performance and availability. It utilizes a
+disaggregated compute and storage architecture to scale resources independently.
+It also provides AlloyDB AI, a collection of features that includes AI-powered
+search (vector, hybrid search, and AI functions), natural language capabilities,
+conversational analytics, and inference features like forecasting and model
+endpoint management to help developers build AI apps faster.
+
+## Quick Start
+
+1.  **Enable the AlloyDB API:**
+
+    ```bash
+    gcloud services enable alloydb.googleapis.com --quiet
+    ```
+
+2.  **Create a Cluster:**
+
+    ```bash
+    gcloud alloydb clusters create my-cluster --region=us-central1 \
+        --password=my-password --network=my-vpc \
+        --quiet
+    ```
+
+    *Note: For production, we recommend using IAM database authentication
+    instead of passwords. If passwords must be used, use secure secret
+    management (e.g., Secret Manager) instead of passing passwords in
+    cleartext.*
+
+3.  **Create a Primary Instance:**
+
+    ```bash
+    gcloud alloydb instances create my-primary --cluster=my-cluster \
+        --region=us-central1 --instance-type=PRIMARY --cpu-count=2 \
+        --quiet
+    ```
+
+## Reference Directory
+
+-   [Core Concepts](references/core-concepts.md): Architecture, disaggregated
+    storage, and performance features.
+
+-   [CLI Usage](references/cli-usage.md): Essential `gcloud alloydb` commands
+    for cluster and instance management.
+
+-   [Client Libraries & Connectors](references/client-library-usage.md):
+    Connecting to AlloyDB using Python, Java, Node.js, and Go.
+
+-   [MCP Usage](references/mcp-usage.md): Using the AlloyDB remote MCP server
+    and Gemini CLI extension.
+
+-   [Infrastructure as Code](references/iac-usage.md): Terraform
+    configuration and deployment examples.
+
+-   [IAM & Security](references/iam-security.md): Predefined roles, service
+    agents, and database authentication.
+
+*If you need product information not found in these references, use the
+    Developer Knowledge MCP server `search_documents` tool.*

--- a/cli-tool/components/skills/database/alloydb-basics/references/cli-usage.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/cli-usage.md
@@ -1,0 +1,37 @@
+# AlloyDB CLI Usage
+
+AlloyDB resources are managed using the `gcloud alloydb` command group.
+
+## Clusters
+
+1. Create a cluster: `gcloud alloydb clusters create CLUSTER_ID --region=REGION
+   --password=PASSWORD`
+
+2. List clusters: `gcloud alloydb clusters list --region=REGION`
+
+3. Get cluster info: `gcloud alloydb clusters describe CLUSTER_ID
+   --region=REGION`
+
+4. Delete a cluster: `gcloud alloydb clusters delete CLUSTER_ID --region=REGION`
+
+## Instances
+
+1. Create a primary instance: `gcloud alloydb instances create INSTANCE_ID
+   --cluster=CLUSTER_ID --region=REGION --instance-type=PRIMARY --cpu-count=8`
+
+2. Create a read pool instance: `gcloud alloydb instances create INSTANCE_ID
+   --cluster=CLUSTER_ID --region=REGION --instance-type=READ_POOL
+   --read-pool-node-count=2 --cpu-count=2`
+
+3. List instances: `gcloud alloydb instances list --cluster=CLUSTER_ID
+   --region=REGION`
+
+4. Restart an instance: `gcloud alloydb instances restart INSTANCE_ID
+   --cluster=CLUSTER_ID --region=REGION`
+
+## Backups
+
+1. Create a backup: `gcloud alloydb backups create BACKUP_ID
+   --cluster=CLUSTER_ID --region=REGION`
+
+2. List backups: `gcloud alloydb backups list --region=REGION`

--- a/cli-tool/components/skills/database/alloydb-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/client-library-usage.md
@@ -1,0 +1,187 @@
+# AlloyDB Client Libraries & Connectors
+
+Google Cloud provides various ways to connect to AlloyDB idiomatically from
+different programming languages. We optionally provide Client Libraries and
+Connectors to facilitate secure authentication and connection from your clients
+to your AlloyDB instances. These tools handle the management of SSL
+certificates, firewall rules, and IAM Auth token automation.
+
+## AlloyDB Language Connectors
+
+Language connectors are libraries for Python, Java, and Go designed for
+developers who prefer an integrated, driver-level experience over the
+operational overhead of managing the Auth Proxy as a separate binary.
+
+### Python
+
+-   **Installation:**
+
+  ```bash
+  pip install "google-cloud-alloydb-connector[pg8000]" sqlalchemy
+  ```
+
+-   **Usage Example:**
+
+  ```python
+  import sqlalchemy
+  from google.cloud.alloydbconnector import Connector
+
+  INSTANCE_URI = "projects/MY_PROJECT/locations/MY_REGION/clusters/MY_CLUSTER/instances/MY_INSTANCE"
+
+  with Connector() as connector:
+      pool = sqlalchemy.create_engine(
+          "postgresql+pg8000://",
+          creator=lambda: connector.connect(
+              INSTANCE_URI,
+              "pg8000",
+              user="my-user",
+              password="my-password",
+              db="my-db",
+          ),
+      )
+
+      with pool.connect() as conn:
+          result = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+          print(result)
+  ```
+
+### Java
+
+-   **Maven Dependency:**
+
+  ```xml
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>alloydb-jdbc-connector</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>org.postgresql</groupId>
+    <artifactId>postgresql</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>com.zaxxer</groupId>
+    <artifactId>HikariCP</artifactId>
+  </dependency>
+  ```
+
+-   **Configuring a Connection Pool:**
+
+    We recommend using HikariCP for connection pooling. To use HikariCP with the
+    Java Connector, you will need to set the usual properties (e.g., JDBC URL,
+    username, password, etc) and you will need to set two Connector specific
+    properties:
+
+    *   `socketFactory` should be set to
+        `com.google.cloud.alloydb.SocketFactory`
+    *   `alloydbInstanceName` should be set to the AlloyDB instance you want to
+    connect to, e.g.:
+        `projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>`
+
+    Basic configuration of a data source looks like this:
+
+  ```java
+  import com.zaxxer.hikari.HikariConfig;
+  import com.zaxxer.hikari.HikariDataSource;
+
+  public class ExampleApplication {
+
+    private HikariDataSource dataSource;
+
+    public HikariDataSource getDataSource() {
+      HikariConfig config = new HikariConfig();
+
+      // There is no need to set a host on the JDBC URL
+      // since the Connector will resolve the correct IP address.
+      config.setJdbcUrl(String.format("jdbc:postgresql:///%s", System.getenv("ALLOYDB_DB")));
+      config.setUsername(System.getenv("ALLOYDB_USER"));
+      config.setPassword(System.getenv("ALLOYDB_PASS"));
+
+      // Tell the driver to use the AlloyDB Java Connector's SocketFactory
+      // when connecting to an instance/
+      config.addDataSourceProperty("socketFactory",
+          "com.google.cloud.alloydb.SocketFactory");
+      // Tell the Java Connector which instance to connect to.
+      config.addDataSourceProperty("alloydbInstanceName",
+          System.getenv("ALLOYDB_INSTANCE_NAME"));
+
+      dataSource = new HikariDataSource(config);
+      return dataSource;
+    }
+
+    // Use DataSource as usual ...
+
+  }
+  ```
+
+    See [end to end
+        test](https://github.com/GoogleCloudPlatform/alloydb-java-connector/blob/main/jdbc/postgres/src/test/java/com/google/cloud/alloydb/postgres/PgJdbcIntegrationTests.java)
+    for a full example.
+
+    See [About Pool
+        Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing)
+    for useful guidance on getting the best performance from a connection pool.
+
+### Go
+
+-   **Installation:**
+
+  ```bash
+  go get cloud.google.com/go/alloydbconn
+  ```
+
+-   **Usage Example:**
+
+  ```go
+  package main
+
+  import (
+      "database/sql"
+      "fmt"
+      "log"
+
+      "cloud.google.com/go/alloydbconn/driver/pgxv5"
+  )
+
+  func main() {
+      // Register the AlloyDB driver with the name "alloydb"
+      // Uses Private IP by default. See Network Options below for details.
+      cleanup, err := pgxv5.RegisterDriver("alloydb")
+      if err != nil {
+          log.Fatal(err)
+      }
+      defer cleanup()
+
+      // Instance URI format:
+      //   projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE
+      db, err := sql.Open("alloydb", fmt.Sprintf(
+          "host=%s user=%s password=%s dbname=%s sslmode=disable",
+          "projects/my-project/locations/us-central1/clusters/my-cluster/instances/my-instance",
+          "my-user",
+          "my-password",
+          "my-db",
+      ))
+      if err != nil {
+          log.Fatal(err)
+      }
+      defer db.Close()
+
+      var greeting string
+      if err := db.QueryRow("SELECT 'Hello, AlloyDB!'").Scan(&greeting); err != nil {
+          log.Fatal(err)
+      }
+      fmt.Println(greeting)
+  }
+  ```
+
+## Standard PostgreSQL Drivers
+
+Since AlloyDB is PostgreSQL-compatible, you can also use standard drivers:
+
+-   **Python:** `psycopg2`, `asyncpg`, `pg8000`
+
+-   **Java:** `PostgreSQL JDBC Driver`
+
+-   **Go:** `lib/pq`, `jackc/pgx`
+
+For more details, see: [AlloyDB
+Connectors](https://cloud.google.com/alloydb/docs/connect-external).

--- a/cli-tool/components/skills/database/alloydb-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/core-concepts.md
@@ -1,0 +1,50 @@
+# AlloyDB Core Concepts
+
+AlloyDB for PostgreSQL is a fully managed, PostgreSQL-compatible database
+service designed for high performance, scale, and availability. It is built on
+top of a cloud-native storage engine that separates compute from storage,
+allowing for efficient scaling and high availability.
+
+AlloyDB is ideal for enterprise-grade transactional workloads, such as ERP or
+CRM systems, as well as for analytical workloads that benefit from its columnar
+engine, and vector workloads using its [vector search
+capabilities](https://docs.cloud.google.com/alloydb/docs/ai/perform-vector-search).
+
+## Regional Availability
+
+AlloyDB is a regional service. A cluster consists of a primary instance and
+optional read pool instances, all of which are located in the same region. The
+storage is replicated across multiple zones within the region to ensure high
+availability.
+
+## AlloyDB Auth Proxy
+
+The [AlloyDB Auth
+Proxy](https://cloud.google.com/alloydb/docs/auth-proxy/connect) is a standalone
+tool that can be deployed in any environment, and works by opening a local
+socket and proxying connections to your AlloyDB instance.
+
+## Connectivity Options
+
+### Private vs Public IP
+
+When connecting to AlloyDB, you can use either a Private IP or a Public IP:
+
+-   **Private IP:** Your client must be deployed either in the same VPC network
+    as your AlloyDB cluster (when using PSA), or have a PSC endpoint in your VPC
+    (when using PSC) to connect directly using Private IP. For indirect methods
+    of connecting outside your VPC, see [Enable private services
+    access](https://cloud.google.com/alloydb/docs/configure-connectivity).
+-   **Public IP:** If enabled on your instance, you can connect from outside the
+    VPC network.
+
+## Connection Pooling
+
+For production workloads, use connection poolers like **PgBouncer** (integrated
+in AlloyDB) to manage high numbers of concurrent connections efficiently.
+
+## Pricing
+
+For up-to-date pricing information, visit the official [AlloyDB
+Pricing](https://cloud.google.com/alloydb/pricing) page. Pricing is based on the
+number of vCPUs and memory for each instance, as well as the storage used.

--- a/cli-tool/components/skills/database/alloydb-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/iac-usage.md
@@ -1,0 +1,135 @@
+# AlloyDB Infrastructure as Code Usage
+
+AlloyDB resources can be managed using Terraform via the Google Cloud Provider,
+or via Kubernetes Config Connector (KCC).
+
+## Terraform
+
+### Resources
+
+1.  `google_alloydb_cluster`: Manages an AlloyDB cluster.
+2.  `google_alloydb_instance`: Manages an AlloyDB instance within a cluster.
+
+### Example
+
+```terraform
+data "google_project" "project" {}
+
+resource "google_compute_network" "default" {
+  name = "alloydb-network"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          =  "alloydb-cluster"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 16
+  network       = google_compute_network.default.id
+}
+
+resource "google_service_networking_connection" "vpc_connection" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "alloydb-cluster"
+  location   = "us-central1"
+  network_config {
+    network = google_compute_network.default.id
+  }
+
+  initial_user {
+    password = "alloydb-cluster"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "alloydb-instance"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+
+  depends_on = [google_service_networking_connection.vpc_connection]
+}
+```
+
+For more information, see the [Google Provider
+Reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/alloydb_cluster).
+
+## Kubernetes Config Connector (KCC)
+
+### Resources
+
+1.  `AlloyDBCluster`: Manages an AlloyDB cluster.
+2.  `AlloyDBInstance`: Manages an AlloyDB instance within a cluster.
+
+### Example
+
+```yaml
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: alloydb-network-kcc
+spec:
+  routingMode: REGIONAL
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeAddress
+metadata:
+  name: alloydb-kcc-addr
+spec:
+  location: global
+  addressType: INTERNAL
+  purpose: VPC_PEERING
+  prefixLength: 16
+  networkRef:
+    name: alloydb-network-kcc
+---
+apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+kind: ServiceNetworkingConnection
+metadata:
+  name: alloydb-vpc-connection-kcc
+spec:
+  networkRef:
+    name: alloydb-network-kcc
+  service: servicenetworking.googleapis.com
+  reservedPeeringRanges:
+    - name: alloydb-kcc-addr
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBCluster
+metadata:
+  name: alloydb-cluster-kcc
+spec:
+  location: us-central1
+  networkConfig:
+    networkRef:
+      name: alloydb-network-kcc
+  initialUser:
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: alloydb-secret
+          key: password
+---
+apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+kind: AlloyDBInstance
+metadata:
+  name: alloydb-instance-kcc
+spec:
+  clusterRef:
+    name: alloydb-cluster-kcc
+  instanceType: PRIMARY
+  machineConfig:
+    cpuCount: 2
+```
+
+For more information, see the [Config Connector resources](https://docs.cloud.google.com/config-connector/docs/reference/overview).

--- a/cli-tool/components/skills/database/alloydb-basics/references/iam-security.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/iam-security.md
@@ -1,0 +1,93 @@
+# AlloyDB IAM & Security
+
+AlloyDB utilizes Google Cloud Identity and Access Management (IAM) to provide
+granular access control and robust security features.
+
+## Predefined IAM Roles
+
+The following table describes the predefined roles available for AlloyDB:
+
+| Role Name | Usage |
+| :--- | :--- |
+| `roles/alloydb.admin` | Full control of all AlloyDB resources. |
+| `roles/alloydb.client` | Connectivity access to AlloyDB instances. |
+| `roles/alloydb.databaseUser` | Authenticated database-user access to instances. |
+| `roles/alloydb.viewer` | Read-only access to all AlloyDB resources. |
+
+## Secure Connectivity
+
+1.  **Network Security:**
+    -   **Private IP:** Keeps traffic internal to Google Cloud.
+        -   **Private Service Connect (PSC):** Recommended for new
+            configurations. Offers enhanced security, better IP management, and
+            flexible multi-VPC topologies without peering.
+        -   **Private Services Access (PSA):** Uses VPC peering.
+    -   **Public IP:** Allows connections from outside GCP.
+        -   **ALWAYS** use with **Authorized Networks** to restrict access to
+            specific IP ranges.
+        -   **NEVER** use `0.0.0.0/0` in Authorized Networks.
+    -   **VPC Service Controls (VPC-SC):** Define security perimeters around
+        your AlloyDB instances to prevent data exfiltration.
+
+1.  **Encryption:**
+    -   **In Transit:** TLS encryption is enforced by default for all
+        connections.
+    -   **At Rest:** Data is always encrypted, using Google-managed keys by
+        default. Customer-Managed Encryption Keys (CMEK) are supported for
+        greater control.
+
+1.  **Authentication & Authorization:**
+    -   **IAM Authentication:** **Recommended.** Uses Google Cloud Identity and
+        Access Management (IAM) principals (users/service accounts) and
+        short-lived OAuth tokens. Centralizes access control and avoids database
+        passwords.
+    -   **Built-in Database Authentication:** Standard PostgreSQL
+        username/password. Use strong password policies if this method is
+        chosen.
+    -   **Database Authorization:** Standard PostgreSQL GRANT / REVOKE
+        statements manage permissions within the database, regardless of the
+        authentication method.
+
+1.  **Connection Methods:**
+    -   **Direct Connection:** Standard PostgreSQL connection.
+    -   **AlloyDB Connectors (Auth Proxy & Language Libraries):** **Highly
+        Recommended for security.**
+        -   Provide connection-level **IAM Authorization**.
+        -   Automatically use **mTLS** (Mutual TLS) for encrypted and
+            authenticated connections.
+        -   Simplify using IAM Database Authentication (tokens are handled
+            automatically).
+        -   Essential for secure Public IP access without wide open Authorized
+            Networks.
+        -   Best practice: Run Auth Proxy as a sidecar to the application.
+
+**Key Recommendations for Agents:**
+
+-   **Prioritize Private IP:** Guide users to use Private IP (especially PSC)
+    over Public IP whenever their application is within GCP.
+-   **Push AlloyDB Connectors:** Strongly recommend AlloyDB Connectors (Auth
+    Proxy or language libraries) because they enhance security through IAM
+    connection authorization and mTLS, especially crucial for Public IP.
+-   **IAM Authentication is Preferred:** Encourages centralized management and
+    token-based auth.
+-   **Secure Public IP:** If Public IP is necessary, stress the absolute need
+    for tightly restricted Authorized Networks.
+-   **Leverage Cloud Security Tools:** Remind users to use VPC-SC and Security
+    Command Center for monitoring and policy enforcement.
+
+## Data Security
+
+- **Encryption at Rest:** All data is encrypted by default. Use Customer-Managed
+  Encryption Keys (CMEK) for greater control.
+
+- **IAM Database Authentication:** Authenticate to the database using IAM
+  identities (users or service accounts) instead of static passwords.
+
+## Service Agents
+
+AlloyDB uses a managed service agent
+(`service-PROJECT_NUMBER@gcp-sa-alloydb.iam.gserviceaccount.com`) to manage
+resources like storage and backups. Ensure this agent has the necessary
+permissions in your project.
+
+For more information, see: [Security, privacy, risk, and compliance for AlloyDB for PostgreSQL](https://docs.cloud.google.com/alloydb/docs/security-privacy-compliance).

--- a/cli-tool/components/skills/database/alloydb-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/database/alloydb-basics/references/mcp-usage.md
@@ -1,0 +1,29 @@
+# AlloyDB MCP Usage
+
+AlloyDB supports a remote Model Context Protocol (MCP) server, allowing AI
+applications to interact with AlloyDB resources.
+
+## Endpoint
+
+The AlloyDB MCP server endpoint is regional:
+`https://alloydb.REGION.rep.googleapis.com/mcp`
+
+Replace `REGION` with the regional location of the endpoint (e.g.,
+`us-central1`).
+
+## Setup and Authentication
+
+1. Enable the AlloyDB API in your project.
+2. Grant the `roles/mcp.toolUser` role to the principal making the tool calls.
+3. Configure your MCP host to point to the regional endpoint.
+
+For more details, see the [Use the AlloyDB remote MCP
+server](https://cloud.google.com/alloydb/docs/ai/use-alloydb-mcp) guide.
+
+## Resources
+
+- [AlloyDB MCP Reference](https://cloud.google.com/alloydb/docs/reference/mcp)
+- [MCP Toolbox](https://mcp-toolbox.dev/): An open-source alternative to the remote MCP server that runs on a local machine or IDE.
+    - [MCP Toolbox AlloyDB Integration](https://mcp-toolbox.dev/integrations/alloydb/source/)
+    - [Configure your MCP client](https://docs.cloud.google.com/alloydb/docs/connect-ide-using-mcp-toolbox#configure-your-mcp-client)
+- For additional specialized skills including health auditing, performance monitoring, and lifecycle management, install the [AlloyDB for PostgreSQL](https://github.com/gemini-cli-extensions/alloydb) Gemini CLI extension or Claude Plugin.

--- a/cli-tool/components/skills/database/bigquery-basics/SKILL.md
+++ b/cli-tool/components/skills/database/bigquery-basics/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: bigquery-basics
+description: Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use for SQL queries, resource management, data ingestion, or AI applications on BigQuery.
+source: google/skills (Apache 2.0)
+---
+
+# BigQuery Basics
+
+BigQuery is a serverless, AI-ready data platform that enables high-speed
+analysis of large datasets using SQL and Python. Its disaggregated architecture
+separates compute and storage, allowing them to scale independently while
+providing built-in machine learning, geospatial analysis, and business
+intelligence capabilities.
+
+## Setup and Basic Usage
+
+1.  **Enable the BigQuery API:**
+    ```bash
+    gcloud services enable bigquery.googleapis.com --quiet
+    ```
+
+2.  **Create a Dataset:**
+    ```bash
+    bq mk --dataset --location=US my_dataset
+    ```
+
+3.  **Create a Table:**
+
+    Create a file named `schema.json` with your table schema:
+
+    ```json
+    [
+      {
+        "name": "name",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "post_abbr",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      }
+    ]
+    ```
+
+    Then create the table with the `bq` tool:
+
+    ```bash
+    bq mk --table my_dataset.mytable schema.json
+    ```
+
+4.  **Run a Query:**
+    ```bash
+    bq query --use_legacy_sql=false \
+    'SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+    WHERE state = "TX" LIMIT 10'
+    ```
+
+## Reference Directory
+
+- [Core Concepts](references/core-concepts.md): Storage types, analytics
+  workflows, and BigQuery Studio features.
+
+- [CLI Usage](references/cli-usage.md): Essential `bq` command-line tool
+  operations for managing data and jobs.
+
+- [Client Libraries](references/client-library-usage.md): Using Google Cloud
+  client libraries for Python, Java, Node.js, and Go.
+
+- [MCP Usage](references/mcp-usage.md): Using the BigQuery remote MCP server and
+  Gemini CLI extension.
+
+- [Infrastructure as Code](references/iac-usage.md): Terraform examples for
+  datasets, tables, and reservations.
+
+- [IAM & Security](references/iam-security.md): Roles, permissions, and data
+  governance best practices.
+
+*If you need product information not found in these references, use the
+Developer Knowledge MCP server `search_documents` tool.*
+
+## Related Skills
+
+- [BigQuery AI & ML Skill](https://github.com/google/adk-python/tree/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml):
+  SKILL.md file for BigQuery AI and ML capabilities.
+- [BigQuery AI & ML References](https://github.com/google/adk-python/tree/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references):
+  Reference files published for the BigQuery AI and ML skill.
+  - [bigquery_ai_classify.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_classify.md)
+  - [bigquery_ai_detect_anomalies.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_detect_anomalies.md)
+  - [bigquery_ai_forecast.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_forecast.md)
+  - [bigquery_ai_generate.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_generate.md)
+  - [bigquery_ai_generate_bool.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_generate_bool.md)
+  - [bigquery_ai_generate_double.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_generate_double.md)
+  - [bigquery_ai_generate_int.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_generate_int.md)
+  - [bigquery_ai_if.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_if.md)
+  - [bigquery_ai_score.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_score.md)
+  - [bigquery_ai_search.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_search.md)
+  - [bigquery_ai_similarity.md](https://github.com/google/adk-python/blob/main/src/google/adk/tools/bigquery/skills/bigquery-ai-ml/references/bigquery_ai_similarity.md)

--- a/cli-tool/components/skills/database/bigquery-basics/references/cli-usage.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/cli-usage.md
@@ -1,0 +1,111 @@
+# BigQuery CLI Usage
+
+The `bq` command-line tool is used to interact with BigQuery for managing
+resources and running jobs.
+
+## Basic Syntax
+
+```bash
+bq COMMAND [FLAGS] [ARGUMENTS]
+```
+
+## Essential Commands
+
+### Dataset Management
+
+- **Create a dataset:**
+
+  ```bash
+  bq mk --dataset --location=us my_dataset
+  ```
+
+- **List datasets:**
+
+  ```bash
+  bq ls --project_id my_project
+  ```
+
+### Table Management
+
+- **Create a table from a schema file:**
+
+  ```bash
+  bq mk --table my_dataset.my_table schema.json
+  ```
+
+- **Copy a table within or across datasets:**
+
+  ```bash
+  bq cp my_dataset.my_table my_other_dataset.my_table_copy
+  ```
+
+- **Create a table snapshot (read-only copy):**
+
+  ```bash
+  bq cp --snapshot --no_clobber my_dataset.my_table my_other_dataset.my_table_snapshot
+  ```
+
+- **Load data from Cloud Storage (CSV):**
+
+  ```bash
+  bq load --source_format=CSV my_dataset.my_table gs://my-bucket/data.csv
+  ```
+
+- **Stream data into a table from a newline-delimited JSON file:**
+
+  ```bash
+  bq insert my_dataset.my_table data.json
+  ```
+
+- **Delete a table:**
+
+  ```bash
+  bq rm -f my_dataset.my_table
+  ```
+
+### Querying Data
+
+- **Run a standard SQL query:**
+
+  ```bash
+  bq query --use_legacy_sql=false \
+  'SELECT count(*) FROM `my_project.my_dataset.my_table`'
+  ```
+
+- **Run a dry run to estimate bytes processed:**
+
+  ```bash
+  bq query --use_legacy_sql=false --dry_run \
+  'SELECT * FROM `my_project.my_dataset.my_table`'
+  ```
+
+### Job Management
+
+- **List recent jobs:**
+
+  ```bash
+  bq ls -j
+  ```
+
+- **Show job details:**
+
+  ```bash
+  bq show -j job_id
+  ```
+
+- **Cancel a job:**
+
+  ```bash
+  bq cancel job_id
+  ```
+
+## Global Flags
+
+- `--location`: Specifies the geographic location for the job or resource.
+
+- `--project_id`: Overrides the default project for the command.
+
+- `--format`: Changes output format (e.g., `prettyjson`, `sparse`, `csv`).
+
+For the complete BigQuery CLI reference guide, visit:
+[bq command-line tool reference](https://docs.cloud.google.com/bigquery/docs/reference/bq-cli-reference).

--- a/cli-tool/components/skills/database/bigquery-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/client-library-usage.md
@@ -1,0 +1,99 @@
+# BigQuery Client Libraries
+
+Google Cloud client libraries provide an idiomatic way to interact with BigQuery
+from your preferred programming language.
+
+## Getting Started
+
+To use the client libraries, ensure you have the Google Cloud SDK installed and
+authenticated.
+[Install Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+
+### Python
+
+- **Installation:**
+
+  ```bash
+  pip install --upgrade google-cloud-bigquery
+  ```
+
+- **Usage Example:**
+
+  ```python
+  from google.cloud import bigquery
+  client = bigquery.Client()
+  query_job = client.query("SELECT * FROM `project.dataset.table` LIMIT 10")
+  results = query_job.result()
+  ```
+
+- [Python Reference](https://docs.cloud.google.com/python/docs/reference/bigquery/latest)
+
+### Java
+
+- **Maven Dependency:**
+
+  ```xml
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigquery</artifactId>
+  </dependency>
+  ```
+
+- **Usage Example:**
+
+  ```java
+  BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+  QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(
+      "SELECT * FROM dataset.table").build();
+  TableResult results = bigquery.query(queryConfig);
+  ```
+
+- [Java Reference](https://docs.cloud.google.com/java/docs/reference/google-cloud-bigquery/latest/overview)
+
+### Node.js (TypeScript)
+
+- **Installation:**
+
+  ```bash
+  npm install @google-cloud/bigquery
+  ```
+
+- **Usage Example:**
+
+  ```typescript
+  import {BigQuery} from '@google-cloud/bigquery';
+  const bigquery = new BigQuery();
+  const [rows] = await bigquery.query('SELECT * FROM dataset.table');
+  ```
+
+- [Node.js Reference](https://googleapis.dev/nodejs/bigquery/latest/index.html)
+
+### Go
+
+- **Installation:**
+
+  ```bash
+  go get cloud.google.com/go/bigquery
+  ```
+
+- **Usage Example:**
+
+  ```go
+  ctx := context.Background()
+  client, _ := bigquery.NewClient(ctx, "project-id")
+  q := client.Query("SELECT * FROM dataset.table")
+  it, _ := q.Read(ctx)
+  ```
+
+- [Go Reference](https://docs.cloud.google.com/go/docs/reference/cloud.google.com/go/bigquery/latest)
+
+## BigQuery DataFrames (BigFrames)
+
+For Python users, `bigframes` provides a pandas-like API that executes directly
+in BigQuery.
+
+```bash
+pip install --upgrade bigframes
+```
+
+- [BigFrames Guide](https://dataframes.bigquery.dev/)

--- a/cli-tool/components/skills/database/bigquery-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/core-concepts.md
@@ -1,0 +1,83 @@
+# BigQuery Core Concepts
+
+BigQuery is a fully managed, AI-ready data platform that helps you manage and
+analyze your data with built-in features like machine learning, search,
+geospatial analysis, and business intelligence. BigQuery's serverless
+architecture lets you use languages like SQL and Python to answer your
+organization's biggest questions with zero infrastructure management.
+
+BigQuery provides a uniform way to work with both structured and unstructured
+data and supports open table formats like Apache Iceberg. BigQuery streaming
+supports continuous data ingestion and analysis while BigQuery's scalable,
+distributed analysis engine lets you query terabytes in seconds and petabytes in
+minutes.
+
+## Architecture
+
+BigQuery's architecture separates compute and storage, connected by a
+petabit-scale network.
+
+-   **BigQuery Storage:** A columnar storage format optimized for analytical
+    queries. It can be replicated across multiple locations for high
+    availability.
+
+-   **BigQuery Analytics:** A scalable, distributed analysis engine that can
+    process data in BigQuery and in external sources.
+
+## Resource Hierarchy
+
+BigQuery organizes resources in a structured hierarchy:
+
+1.  **Organization/Folder/Project:** Standard Google Cloud resource containers.
+2.  **Dataset:** The top-level container for tables and views.
+3.  **Table/View:** The basic unit of data storage and logical representation.
+
+## Analytics Workflows
+
+-   **Ad Hoc Analysis:** Using GoogleSQL for interactive queries.
+
+-   **Geospatial Analysis:** Analyzing and visualizing spatial data using
+    geography types.
+
+-   **Machine Learning (BigQuery ML):** Creating and executing ML models
+    directly in BigQuery using SQL.
+
+-   **Gemini in BigQuery:** AI-powered assistance for data preparation, SQL
+    generation, and visualization. Refer to the [Gemini
+    Models](https://ai.google.dev/gemini-api/docs/models) for more information.
+
+-   **Stream Processing (BigQuery continuous queries):** Long running SQL
+    statements that analyze and transform incoming data in near real time as it
+    arrives in BigQuery. This feature enables unbounded streaming pipelines for
+    real-time AI inference (using Vertex AI) and Reverse ETL to downstream
+    systems. Results can be exported to Pub/Sub, Bigtable, Spanner, or other
+    BigQuery tables. Note that running continuous queries requires a BigQuery
+    reservation with a `CONTINUOUS` assignment type.
+
+## BigQuery Studio
+
+A unified workspace for data engineering, analysis, and predictive modeling.
+
+-   **SQL Editor:** With code completion and generation.
+
+-   **Python Notebooks:** Built-in support for Colab Enterprise and BigQuery
+    DataFrames (BigFrames).
+
+-   **Data Discovery:** Integrated with Dataplex for search and profiling.
+
+## Pricing
+
+BigQuery pricing consists of two main components: compute (analysis) costs and
+storage costs.
+
+-   **Storage:** Storage costs are based on the amount of data stored in
+    BigQuery tables. Storage is classified as either active storage (any table
+    or partition modified in the last 90 days) and long-term storage (data that
+    hasn't been modified for 90 consecutive days, resulting in a price drop of
+    approximately 50%).
+
+-   **Analysis:** Billed based on bytes processed (On-demand) or dedicated slots
+    (Capacity/Reservations).
+
+For the latest pricing details, visit: [BigQuery
+Pricing](https://cloud.google.com/bigquery/pricing).

--- a/cli-tool/components/skills/database/bigquery-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/iac-usage.md
@@ -1,0 +1,70 @@
+# BigQuery Infrastructure as Code
+
+Managing BigQuery resources using Infrastructure as Code (IaC) ensures
+consistency and repeatability across environments.
+
+## Terraform
+
+The Google Cloud Terraform provider supports BigQuery datasets, tables, jobs,
+and reservations.
+
+### Dataset and Table Example
+
+```terraform
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id                  = "example_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+  default_table_expiration_ms = 3600000
+
+  labels = {
+    env = "default"
+  }
+}
+
+resource "google_bigquery_table" "default" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  table_id   = "example_table"
+
+  time_partitioning {
+    type = "DAY"
+  }
+
+  labels = {
+    env = "default"
+  }
+
+  schema = <<EOF
+[
+  {
+    "name": "name",
+    "type": "STRING",
+    "mode": "REQUIRED",
+    "description": "The user's name"
+  },
+  {
+    "name": "age",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "The user's age"
+  }
+]
+EOF
+}
+```
+
+### Reference Documentation
+
+- [Terraform Google Provider - BigQuery Dataset](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset)
+
+- [Terraform Google Provider - BigQuery Table](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table)
+
+- [Terraform Google Provider - BigQuery Job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_job)
+
+## YAML Samples
+
+BigQuery resources can also be managed via Deployment Manager or other tools
+using YAML configurations.
+
+- [BigQuery YAML Samples](https://docs.cloud.google.com/docs/samples?language=yaml&text=bigquery)

--- a/cli-tool/components/skills/database/bigquery-basics/references/iam-security.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/iam-security.md
@@ -1,0 +1,49 @@
+# BigQuery IAM & Security
+
+BigQuery uses Identity and Access Management (IAM) to provide granular access
+control to its resources. As a security best practice, follow the
+**principle of least privilege**: grant only the permissions required to
+perform a specific action. This includes using the least permissive IAM role at
+the most granular level—such as the table or view level—that is necessary.
+
+## Predefined IAM Roles
+
+For a complete list of predefined roles and detailed usage information, see [BigQuery IAM roles](https://docs.cloud.google.com/bigquery/docs/access-control#bigquery-roles).
+
+## Service Accounts and Agents
+
+- **Default Service Account:** BigQuery uses a managed service account
+  (`bq-PROJECT_NUMBER@bigquery-encryption.iam.gserviceaccount.com` or the more
+  general BigQuery Service Agent
+  `service-PROJECT_NUMBER@gcp-sa-bigquery.iam.gserviceaccount.com`) for
+  internal operations.
+
+- **Service Account Impersonation:** Use
+  `gcloud config set auth/impersonate_service_account` for secure, temporary
+  credential access.
+
+## Data Security
+
+- **Encryption at Rest:** All data is encrypted by default using Google-managed
+  keys. Use Customer-Managed Encryption Keys (CMEK) for greater control.
+
+- **VPC Service Controls:** Define a service perimeter to prevent data
+  exfiltration.
+
+- **Column-Level Security:** Use policy tags to restrict access to sensitive
+  columns.
+
+- **Row-Level Security:** Use row access policies to filter data based on user
+  identity.
+
+- **Data Masking:** Obscure sensitive data in a table while still permitting
+  authorized users to access surrounding data.
+
+- **Audit Logs:** Record user activity and system events to enforce data
+  governance policies and identify potential security risks.
+
+- **Authorized Views:** Allow users to query a view without granting them access
+  to the underlying tables.
+
+For more detailed information, see:
+[BigQuery Security Overview](https://cloud.google.com/bigquery/docs/data-governance).

--- a/cli-tool/components/skills/database/bigquery-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/database/bigquery-basics/references/mcp-usage.md
@@ -1,0 +1,45 @@
+# BigQuery MCP Usage
+
+BigQuery is supported by a remote Model Context Protocol (MCP) server that
+provides a set of tools for automated data management and analysis.
+
+## MCP Tools for BigQuery
+
+- **list_dataset_ids:** List BigQuery dataset IDs in a Google Cloud project.
+- **get_dataset_info:** Get metadata information about a BigQuery dataset.
+- **list_table_ids:** List table ids in a BigQuery dataset.
+- **get_table_info:** Get metadata information about a BigQuery table.
+- **execute_sql:** Run a SQL query in the project and return the result. This
+tool is restricted to only `SELECT` statements. `INSERT`, `UPDATE`, and
+`DELETE` statements and stored procedures aren't allowed. If the query
+doesn't include a `SELECT` statement, an error is returned. For information
+on creating queries, see the GoogleSQL documentation. The `execute_sql` tool
+can also have side effects if the query invokes remote functions or Python
+UDFs. All queries that are run using the `execute_sql` tool have a label that
+identifies the tool as the source. You can use this label to filter the
+queries using the label and value pair `goog-mcp-server: true`. Queries are
+charged to the project specified in the `project_id` field.
+
+## Setup Instructions
+
+To connect to the BigQuery MCP server, see [Configure a client connection](https://docs.cloud.google.com/bigquery/docs/use-bigquery-mcp#configure-client).
+
+## Supported Operations
+
+Agents using the BigQuery MCP remote server can perform tasks such as:
+
+- Answering questions about data by generating and running SQL.
+- Getting dataset metadata.
+- Getting table metadata.
+
+For more information about the BigQuery MCP server, visit:
+[Use the BigQuery MCP server](https://docs.cloud.google.com/bigquery/docs/use-bigquery-mcp).
+Alternatively, you can use
+[MCP Toolbox](https://mcp-toolbox.dev/integrations/bigquery/source/), an
+open-source CLI tool that runs a local MCP server for BigQuery connections. For
+more on connecting BigQuery to your tools, see
+[Connect LLMs to BigQuery with MCP](https://docs.cloud.google.com/bigquery/docs/pre-built-tools-with-mcp-toolbox)
+for details. For additional specialized skills and advanced analytics workflows,
+install the
+[BigQuery Data Analytics extension](https://github.com/gemini-cli-extensions/bigquery-data-analytics)
+for the Gemini CLI or plugin for Claude Code and Codex.

--- a/cli-tool/components/skills/database/cloud-sql-basics/SKILL.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: cloud-sql-basics
+description: Creates and manages Cloud SQL instances for MySQL, PostgreSQL, and SQL Server. Handles backups, high availability, and secure connectivity for relational database workloads on Google Cloud.
+source: google/skills (Apache 2.0)
+---
+
+# Cloud SQL Basics
+
+Cloud SQL is a fully managed relational database service for MySQL, PostgreSQL,
+and SQL Server. It automates time-consuming tasks like patches, updates,
+backups, and replicas, while providing high performance and availability for
+your applications.
+
+## Prerequisites
+
+Ensure you have the necessary IAM permissions to create and manage Cloud SQL
+instances. The **Cloud SQL Admin** (`roles/cloudsql.admin`) role provides full
+access to Cloud SQL resources.
+
+## Quick Start (PostgreSQL)
+
+1.  **Enable the API:**
+    ```bash
+    gcloud services enable sqladmin.googleapis.com --quiet
+    ```
+
+2.  **Create an Instance:**
+    ```bash
+    gcloud sql instances create INSTANCE_NAME \
+      --database-version=POSTGRES_18 \
+      --cpu=2 \
+      --memory=7680MiB \
+      --region=REGION \
+      --quiet
+    ```
+
+3.  **Set a password for the default user:**
+
+    Because this is a Cloud SQL for PostgreSQL instance, the default admin user
+    is `postgres`:
+    ```bash
+    gcloud sql users set-password postgres \
+      --instance=INSTANCE_NAME --password=PASSWORD \
+      --quiet
+    ```
+
+4.  **Create a database:**
+    ```bash
+    gcloud sql databases create DATABASE_NAME \
+      --instance=INSTANCE_NAME \
+      --quiet
+    ```
+
+5.  **Get the instance connection name:**
+
+    You need the instance connection name (which is formatted as
+    `PROJECT_ID:REGION:INSTANCE_NAME`) to connect using the Cloud SQL Auth
+    Proxy. Retrieve it with the following command:
+    ```bash
+    gcloud sql instances describe INSTANCE_NAME \
+      --format="value(connectionName)" \
+      --quiet
+    ```
+
+6.  **Connect to the instance:**
+
+    The Cloud SQL Auth Proxy must be running to be able to connect to the
+    instance. In a separate terminal, start the proxy using the connection name:
+    ```bash
+    ./cloud-sql-proxy INSTANCE_CONNECTION_NAME
+    ```
+
+    With the proxy running, connect using `psql` in another terminal:
+    ```bash
+    psql "host=127.0.0.1 port=5432 user=postgres dbname=DATABASE_NAME password=PASSWORD sslmode=disable"
+    ```
+
+## Reference Directory
+
+-   [Core Concepts](references/core-concepts.md): Instance architecture, high
+    availability (HA), and supported database engines.
+
+-   [CLI Usage](references/cli-usage.md): Essential `gcloud sql` commands for
+    instance, database, and user management.
+
+-   [Client Libraries & Connectors](references/client-library-usage.md):
+    Connecting to Cloud SQL using Python, Java, Node.js, and Go.
+
+-   [MCP Usage](references/mcp-usage.md): Using the Cloud SQL remote MCP
+    server and Gemini CLI extension.
+
+-   [Infrastructure as Code](references/iac-usage.md): Terraform
+    configuration for instances, databases, and users.
+
+-   [IAM & Security](references/iam-security.md): Predefined roles, SSL/TLS
+    certificates, and Auth Proxy configuration.
+
+*If you need product information not found in these references, use the
+    Developer Knowledge MCP server `search_documents` tool.*

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/cli-usage.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/cli-usage.md
@@ -1,0 +1,84 @@
+# Cloud SQL CLI Usage
+
+The `gcloud sql` command group is used to manage Cloud SQL instances and
+related resources.
+
+## Basic Syntax
+
+```bash
+gcloud sql [GROUP] [COMMAND] [FLAGS]
+```
+
+## Essential Commands
+
+### Instance Management
+
+- **Create an instance:**
+
+  ```bash
+  gcloud sql instances create my-instance --database-version=MYSQL_8_0 \
+      --tier=db-f1-micro --region=us-central1 \
+      --quiet
+  ```
+
+- **List instances:**
+
+  ```bash
+  gcloud sql instances list --quiet
+  ```
+
+- **Describe an instance:**
+
+  ```bash
+  gcloud sql instances describe my-instance --quiet
+  ```
+
+- **Restart an instance:**
+
+  ```bash
+  gcloud sql instances restart my-instance --quiet
+  ```
+
+### Database and User Management
+
+- **Create a database:**
+
+  ```bash
+  gcloud sql databases create my-db --instance=my-instance --quiet
+  ```
+
+- **Create a user:**
+
+  ```bash
+  gcloud sql users create my-user --instance=my-instance \
+      --password=my-password \
+      --quiet
+  ```
+
+### Operations and Backups
+
+- **List operations:**
+
+  ```bash
+  gcloud sql operations list --instance=my-instance --quiet
+  ```
+
+- **Create a backup:**
+
+  ```bash
+  gcloud sql backups create --instance=my-instance --quiet
+  ```
+
+- **Restore from a backup:**
+
+  ```bash
+  gcloud sql backups restore backup_id --restore-instance=my-instance --quiet
+  ```
+
+## Common Flags
+
+- `--project`: Specifies the project ID.
+
+- `--region`: The region where the instance is located.
+
+- `--format`: Changes output format (e.g., `json`, `yaml`).

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/client-library-usage.md
@@ -1,0 +1,116 @@
+# Cloud SQL Client Libraries
+
+Google Cloud provides client libraries and connectors to simplify connecting to
+Cloud SQL from various programming languages.
+
+## Getting Started
+
+Ensure you have the latest version of the Google Cloud SDK installed and
+authenticated.
+[Install Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+
+### Language Connectors
+
+The Cloud SQL Language Connectors (Python, Java, Go, Node.js) provide a secure
+way to connect to the Cloud SQL instance without managing IP allowlists or SSL
+certificates.
+
+#### Python
+
+-   **Installation for a Cloud SQL for PostgreSQL instance:**
+
+    ```bash
+    pip install "cloud-sql-python-connector[pg8000]"
+    ```
+
+-   **Usage Example:**
+
+    ```python
+    from google.cloud.sql.connector import Connector
+    connector = Connector()
+    def getconn():
+      conn = connector.connect(
+          "project:region:instance",
+          "pg8000",
+          user="my-user",
+          password="my-password",
+          db="my-db"
+      )
+      return conn
+    ```
+
+#### Java
+
+-   **Maven Dependencies:**
+
+    The recommended method is to use the Cloud SQL JDBC Socket Factory. Add the
+    BOM to your `<dependencyManagement>` section:
+
+    ```xml
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud.sql</groupId>
+          <artifactId>jdbc-socket-factory-bom</artifactId>
+          <version>1.18.0</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+    ```
+
+    Then add dependencies for your database:
+
+    *   **PostgreSQL:**
+        ```xml  
+        <dependencies>
+          <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.3</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>postgres-socket-factory</artifactId>
+          </dependency>
+        </dependencies>
+        ```
+
+    *   **MySQL:**
+        ```xml 
+        <dependencies>
+          <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>mysql-socket-factory-connector-j-8</artifactId>
+          </dependency>
+        </dependencies>
+        ```
+
+#### Node.js (TypeScript)
+
+-   **Installation:**
+
+    ```bash
+    npm install @google-cloud/cloud-sql-connector
+    ```
+
+#### Go
+
+-   **Installation:**
+
+    ```bash
+    go get cloud.google.com/go/cloudsqlconn
+    ```
+
+## Cloud SQL Admin API
+
+To manage Cloud SQL resources (e.g., list instances) programmatically, use the
+`sqladmin` libraries.
+
+-   [Cloud SQL Admin API Overview](https://docs.cloud.google.com/sql/docs/mysql/admin-api)

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/core-concepts.md
@@ -1,0 +1,62 @@
+# Cloud SQL Core Concepts
+
+Cloud SQL provides managed relational databases, abstracting the underlying
+infrastructure while offering standard database engines.
+
+## Supported Engines
+
+Cloud SQL supports the following database engines (see [supported
+versions](https://docs.cloud.google.com/sql/docs/db-versions)):
+
+-   **MySQL:** Versions 5.6, 5.7, 8.0, and 8.4.
+
+-   **PostgreSQL:** Versions 9.6, 10, 11, 12, 13, 14, 15, 16, 17, and 18
+    (default).
+
+-   **SQL Server:** 2017 (Express, Web, Standard, Enterprise), 2019, 2022, and
+    2025 (Express, Enterprise, Standard).
+
+## Instance Architecture
+
+Each Cloud SQL instance is powered by a virtual machine (VM) running the
+database program.
+
+-   **Primary Instance:** The main read/write connection point.
+
+-   **High Availability (HA):** Provides a standby VM in a different zone with
+    automatic failover.
+
+-   **Read Replicas:** Used to scale read traffic and provide local access in
+    different regions.
+
+## Storage and Networking
+
+-   **Persistent Disk:** Scalable and durable network storage attached to the
+    VM.
+
+-   **Connectivity:** Supports Private IP (using VPC peering for MySQL and
+    PostgreSQL only; or using private services access or Private Service Connect
+    for all Cloud SQL engines) and Public IP (with authorized networks or Auth
+    Proxy).
+
+## Pricing
+
+Cloud SQL pricing is based on:
+
+-   **Instance Type:** vCPUs and RAM.
+
+-   **Storage:** Amount of data stored and IOPS.
+
+-   **Networking:** Network egress and IP address usage.
+
+-   **DNS pricing:** Charge is per zone per month (regardless of whether you use
+    your zone). You also pay for queries against your zones.
+
+-   **Licensing:** Applies to SQL Server only. In addition to instance and
+    resource pricing, SQL Server also has a licensing component. High
+    availability, or regional instances, will only incur the cost for a single
+    license for the active resource. As a managed service, Cloud SQL does not
+    support BYOL (Bring your own license).
+
+For the latest pricing, visit: [Cloud SQL
+Pricing](https://cloud.google.com/sql/pricing).

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/iac-usage.md
@@ -1,0 +1,46 @@
+# Cloud SQL Infrastructure as Code
+
+Cloud SQL resources can be provisioned and managed using Terraform and other IaC
+tools.
+
+## Terraform
+
+The Google Cloud Terraform provider supports Cloud SQL instances, databases, and
+users.
+
+### Cloud SQL Instance Example
+
+```terraform
+resource "google_sql_database_instance" "default" {
+  name             = "master-instance"
+  region           = "us-central1"
+  database_version = "POSTGRES_15"
+
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled = true
+    }
+  }
+}
+
+resource "google_sql_database" "database" {
+  name     = "my-database"
+  instance = google_sql_database_instance.default.name
+}
+
+resource "google_sql_user" "users" {
+  name     = "me"
+  instance = google_sql_database_instance.default.name
+  password = "changeme"
+}
+```
+
+### Reference Documentation
+
+- [Terraform Google Provider - SQL Database Instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance)
+
+- [Terraform Google Provider - SQL Database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database)
+
+- [Terraform Google Provider - SQL User](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user)
+

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/iam-security.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/iam-security.md
@@ -1,0 +1,67 @@
+# Cloud SQL IAM & Security
+
+Cloud SQL uses Identity and Access Management (IAM) to control access to
+instances and databases.
+
+## Predefined IAM Roles
+
+| Predefined Role | Usage |
+| :--- | :--- |
+| `roles/cloudsql.admin` | Full control over all Cloud SQL resources. |
+| `roles/cloudsql.editor` | Manage Cloud SQL resources. Cannot see or modify
+
+ permissions, nor modify users or ssl Certs. Cannot import data or restore from
+a backup, nor clone, delete, or promote instances. Cannot start or stop
+  replicas. Cannot delete databases, replicas, or backups. |
+| `roles/cloudsql.viewer` | Read-only access to Cloud SQL resources. |
+| `roles/cloudsql.client` | Connectivity access to Cloud SQL instances from App
+ Engine and the Cloud SQL Auth Proxy. Not required for accessing an instance
+  using IP addresses. |
+| `roles/cloudsql.instanceUser` | Permission to log in to a Cloud SQL
+  instance. |
+| `roles/cloudsql.schemaViewer` | Role allowing access to a Cloud SQL instance
+  schema in Knowledge Catalog. |
+| `roles/cloudsql.studioUser` | Role allowing access to Cloud SQL Studio. |
+
+## Secure Connectivity
+
+-   **Cloud SQL Auth Proxy:** The recommended way to connect securely. It
+    provides IAM-based authentication and end-to-end encryption without
+    requiring SSL/TLS certificates or authorized networks.
+
+-   **Private IP:** Use VPC, private services access, or Private Service Connect
+    (PSC) to keep database traffic within the Google Cloud network.
+
+-   **Authorized Networks:** If using Public IP, restrict access to specific
+    CIDR ranges.
+
+## Data Security
+
+-   **Encryption at Rest:** All data is encrypted by default. Use
+    Customer-Managed Encryption Keys (CMEK) for additional control.
+
+-   **IAM Database Authentication:** Authenticate to the database using IAM
+    users or service accounts instead of static passwords (available for MySQL
+    and PostgreSQL).
+
+## Organization Policies
+
+-   **Cloud SQL organization policies:** Organization policies let organization
+    administrators set restrictions on how users can configure instances under
+    that organization.
+
+## Service Accounts
+
+-   **Service Identity:** Cloud SQL uses an instance service account
+    (`p[PROJECT_NUMBER]-[UNIQUE_ID]@gcp-sa-cloud-sql.iam.gserviceaccount.com`)
+    for tasks like exporting a SQL dump file to Cloud Storage. Service agent
+    accounts (`service-PROJECT_NUMBER@gcp-sa-cloud-sql.iam.gserviceaccount.com`)
+    are used only for internal management tasks.
+
+-   **App Connectivity:** Grant the service account running your app (e.g., on
+    Cloud Run or GKE) the `roles/cloudsql.client` role.
+
+For more information, see: 
+- [About Access Control - Cloud SQL for MySQL](https://docs.cloud.google.com/sql/docs/mysql/instance-access-control)
+- [About Access Control - Cloud SQL for PostgreSQL](https://docs.cloud.google.com/sql/docs/postgres/instance-access-control)
+- [About Access Control - Cloud SQL for SQL Server](https://docs.cloud.google.com/sql/docs/sqlserver/instance-access-control)

--- a/cli-tool/components/skills/database/cloud-sql-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/database/cloud-sql-basics/references/mcp-usage.md
@@ -1,0 +1,51 @@
+# Cloud SQL MCP Usage
+
+Cloud SQL can be managed via the Model Context Protocol (MCP), which allows
+agents to manage database instances and execute SQL queries. MCP is available
+via remote servers and through local execution with the MCP Toolbox:
+
+*   [Cloud SQL for PostgreSQL](https://mcp-toolbox.dev/integrations/cloud-sql-pg/source/)
+*   [Cloud SQL for MySQL](https://mcp-toolbox.dev/integrations/cloud-sql-mysql/source/)
+*   [Cloud SQL for SQL Server](https://mcp-toolbox.dev/integrations/cloud-sql-mssql/source/)
+
+## MCP Tools for Cloud SQL
+
+The Cloud SQL MCP server typically includes the following tools:
+
+-   `clone_instance`: creates a Cloud SQL instance as a clone of source
+    instance.
+-   `create_instance`: initiates the creation of a Cloud SQL instance.
+-   `create_user`: creates a database user for a Cloud SQL instance.
+-   `execute_sql`: executes any valid SQL statements (DDL, DCL, DQL, DML) on a
+    Cloud SQL instance.
+-   `get_instance`: gets the details of a Cloud SQL instance.
+-   `get_operation`: gets the status of a long-running operation in Cloud SQL.
+-   `list_instances`: lists all Cloud SQL instances in a project.
+-   `list_users`: lists all database users for a Cloud SQL instance.
+-   `import_data`: imports data into a Cloud SQL instance from Cloud Storage.
+-   `update_instance`: updates supported settings of a Cloud SQL instance.
+-   `update_user`: updates a database user for a Cloud SQL instance.
+
+For additional specialized skills including health auditing, performance
+monitoring, and lifecycle management, install the Gemini CLI extension or Claude
+Plugin:
+
+*   [Cloud SQL for PostgreSQL](https://github.com/gemini-cli-extensions/cloud-sql-postgresql)
+*   [Cloud SQL for MySQL](https://github.com/gemini-cli-extensions/cloud-sql-mysql)
+*   [Cloud SQL for SQL Server](https://github.com/gemini-cli-extensions/cloud-sql-sqlserver)
+
+## Setup Instructions
+
+Setup varies by database engine and whether you are connecting to a remote
+server or using the MCP Toolbox. For remote server setup, see Setting up
+Cloud SQL MCP for [PostgreSQL](https://docs.cloud.google.com/sql/docs/postgres/use-cloudsql-mcp),
+[MySQL](https://docs.cloud.google.com/sql/docs/mysql/use-cloudsql-mcp), or
+[SQL Server](https://docs.cloud.google.com/sql/docs/sqlserver/use-cloudsql-mcp).
+
+## Supported Operations
+
+Agents using the Cloud SQL MCP can:
+
+-   Automate database schema migrations.
+-   Perform health checks and monitor operation logs.
+-   Assist in debugging SQL performance issues.

--- a/cli-tool/components/skills/development/cloud-run-basics/SKILL.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: cloud-run-basics
+description: Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs), or handle always-on pull-based background processing (worker pools).
+source: google/skills (Apache 2.0)
+---
+
+# Cloud Run Basics
+
+Cloud Run is a fully managed application platform for running your code,
+function, or container on top of Google's highly scalable infrastructure. It
+abstracts away infrastructure management, providing three primary resource
+types:
+
+1.  **Services:** Responds to HTTP requests sent to a unique and stable
+    endpoint, using stateless instances that autoscale based on a variety of key
+    metrics, also responds to events and functions.
+2.  **Jobs:** Executes parallelizable tasks that are executed manually, or on a
+    schedule, and run to completion.
+3.  **Worker pools:** Handles always-on background workloads such as pull-based
+    workloads, for example, Kafka consumers, Pub/Sub pull queues, or RabbitMQ
+    consumers.
+
+## Prerequisites
+
+1.  Enable the Cloud Run Admin API and Cloud Build APIs:
+
+    ```bash
+    gcloud services enable run.googleapis.com cloudbuild.googleapis.com --quiet
+    ```
+
+1.  If you are under a domain restriction organization policy [restricting](https://docs.cloud.google.com/organization-policy/restrict-domains)
+   unauthenticated invocations for your project, you will need to access your
+    deployed service as described under [Testing private
+    services](https://docs.cloud.google.com/run/docs/triggering/https-request#testing-private).
+
+### Required roles
+
+You need the following roles to deploy your Cloud Run resource:
+
+*   Cloud Run Admin (`roles/run.admin`) on the project
+*   Cloud Run Source Developer (`roles/run.sourceDeveloper`) on the project
+*   Service Account User (`roles/iam.serviceAccountUser`) on the service
+    identity
+*   Logs Viewer (`roles/logging.viewer`) on the project
+
+Cloud Build automatically uses the Compute Engine default service account as the
+default Cloud Build service account to build your source code and Cloud Run
+resource, unless you override this behavior.
+
+For Cloud Build to build your sources, grant the Cloud Build service account the
+Cloud Run Builder (`roles/run.builder`) role on your project:
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member=serviceAccount:SERVICE_ACCOUNT_EMAIL_ADDRESS \
+    --role=roles/run.builder \
+    --quiet
+```
+
+Replace `PROJECT_ID` with your Google Cloud project ID and
+`SERVICE_ACCOUNT_EMAIL_ADDRESS` with the email address of the Cloud Build
+service account.
+
+## Deploy a Cloud Run service
+
+You can deploy your service to Cloud Run by using a container image or deploy
+directly from source code using a single Google Cloud CLI command.
+
+> **CRITICAL RULE:** Any deployed code MUST listen on 0.0.0.0 (not 127.0.0.1)
+> and use the injected $PORT environment variable (defaults to 8080), or it will
+> crash on boot.
+
+### Deploy a container image to Cloud Run
+
+Cloud Run imports your container image during deployment. Cloud Run keeps this
+copy of the container image as long as it is used by a serving revision.
+Container images are not pulled from their container repository when a new Cloud
+Run instance is started.
+
+### Supported container images
+
+You can directly use container images stored in the [Artifact
+Registry](https://docs.cloud.google.com/artifact-registry/docs/overview), or
+[Docker Hub](https://hub.docker.com/). Google recommends the use of Artifact
+Registry since Docker Hub images are
+[cached](https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images)
+for up to one hour.
+
+You can use container images from other public or private registries (like JFrog
+Artifactory, Nexus, or GitHub Container Registry), by setting up an [Artifact
+Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+You should only consider [Docker Hub](https://hub.docker.com/) for deploying
+popular container images such as [Docker Official
+Images](https://docs.docker.com/docker-hub/official_images/) or [Docker
+Sponsored OSS images](https://docs.docker.com/docker-hub/dsos-program/). For
+higher availability, Google recommends deploying these Docker Hub images using
+an [Artifact Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+To deploy a container image, run the following command:
+
+```bash
+    gcloud run deploy SERVICE_NAME \
+        --image IMAGE_URL \
+        --region us-central1 \
+        --allow-unauthenticated \
+        --quiet
+```
+
+Replace the following:
+
+*   SERVICE_NAME: the name of the service you want to deploy to. Service names
+    must be 49 characters or less and must be unique per region and project. If
+    the service does not exist yet, this command creates the service during the
+    deployment. You can omit this parameter entirely, but you will be prompted
+    for the service name if you omit it.
+*   IMAGE_URL: a reference to the container image, for example,
+    `us-docker.pkg.dev/cloudrun/container/hello:latest`. If you use Artifact
+    Registry, the repository REPO_NAME must already be created. The URL follows
+    the format of `LOCATION-docker.pkg.dev/PROJECT_ID/REPO_NAME/PATH:TAG`. Note
+    that if you don't supply the `--image` flag, the deploy command will attempt
+    to deploy from source code.
+
+### Deploy from source code
+
+There are two different ways to deploy your service from source:
+
+*   Deploy from source with build (default): This option uses Google Cloud's
+    buildpacks and Cloud Build to automatically build container images from your
+    source code without having to install Docker on your machine or set up
+    buildpacks or Cloud Build. By default, Cloud Run uses the default machine
+    type provided by Cloud Build.
+
+    *   To deploy from source with automatic base image updates enabled, run the
+        following command:
+
+         ```bash
+         gcloud run deploy SERVICE_NAME --source . \
+         --base-image BASE_IMAGE \
+         --automatic-updates \
+         --quiet
+         ```
+
+        Cloud Run only supports automatic base images that use [Google Cloud's
+        buildpacks base
+        images](https://docs.cloud.google.com/docs/buildpacks/base-images).
+
+        *   To deploy from source using a Dockerfile, run the following command:
+
+         ```bash
+          gcloud run deploy SERVICE_NAME --source . --quiet
+         ```
+            When you provide a Dockerfile, Cloud Build runs it in the cloud, and
+            deploys the service.
+
+*   Deploy from source without build (Preview): This option deploys artifacts
+    directly to Cloud Run, bypassing the Cloud Build step. This allows for rapid
+    deployment times. To deploy from source without build, run the following
+    command:
+
+    ```bash
+    gcloud beta run deploy SERVICE_NAME \
+     --source APPLICATION_PATH \
+     --no-build \
+     --base-image=BASE_IMAGE \
+     --command=COMMAND \
+     --args=ARG \
+     --quiet
+    ```
+
+    Replace the following:
+
+    *   SERVICE_NAME: the name of your Cloud Run service.
+    *   APPLICATION_PATH: the location of your application on the local file
+        system.
+    *   BASE_IMAGE: the [runtime base image](https://docs.cloud.google.com/run/docs/configuring/services/runtime-base-images#how_to_obtain_base_images)
+    you want to use for your application. For example,
+        `us-central1-docker.pkg.dev/serverless-runtimes/google-24-full/runtimes/nodejs24`.
+        You can also deploy a pre-compiled binary without configuring additional
+        language-specific runtime components using the OS only base image, such
+    as `osonly24`.
+    *   COMMAND: the command that the container starts up with.
+    *   ARG: an argument you send to the container command. If you use multiple
+    arguments, specify each on its own line.
+
+    For examples on deploying from source without build, see [Examples of
+        deploying from source without
+        build](https://docs.cloud.google.com/run/docs/deploying-source-code#examples-without-build).
+
+## Create and execute a Cloud Run job
+
+To create a new job, run the following command:
+
+```bash
+gcloud run jobs create JOB_NAME --image IMAGE_URL OPTIONS --quiet
+```
+
+Alternatively, use the deploy command:
+
+```bash
+gcloud run jobs deploy JOB_NAME --image IMAGE_URL OPTIONS --quiet
+```
+
+Replace the following:
+
+*   JOB_NAME: the name of the job you want to create. If you omit this
+    parameter, you will be prompted for the job name when you run the command.
+*   IMAGE_URL: a reference to the container image—for example,
+    `us-docker.pkg.dev/cloudrun/container/job:latest`.
+
+*   Optionally, replace OPTIONS with any of the following flags:
+
+    *   `--tasks`: Accepts integers greater or equal to 1. Defaults to 1;
+        maximum is 10,000. Each task is provided the environment variables
+        `CLOUD_RUN_TASK_INDEX` with a value between 0 and the number of tasks
+        minus 1, along with `CLOUD_RUN_TASK_COUNT`, which is the number of
+        tasks.
+    *   `--max-retries`: The number of times a failed task is retried. Once any
+        task fails beyond this limit, the entire job is marked as failed. For
+        example, if set to 1, a failed task will be retried once, for a total of
+        two attempts. The default is 3. Accepts integers from 0 to 10.
+    *   `--task-timeout`: Accepts a duration like "2s". Defaults to 10 minutes;
+        maximum is 168 hours (7 days). For tasks using GPUs, the maximum
+        available timeout is 1 hour.
+    *   `--parallelism`: The maximum number of tasks that can execute in
+        parallel. By default, tasks will be started as quickly as possible in
+        parallel.
+    *   --execute-now: If set, immediately after the job is created, a job
+        execution is started. Equivalent to calling `gcloud run jobs create`
+        followed by `gcloud run jobs execute`.
+
+    In addition to these preceding options, you also specify more configuration
+    such as environment variables or memory limits.
+
+For a full list of available options when creating a job, refer to the [`gcloud
+run jobs
+create`](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/create)
+command line documentation.
+
+Wait for the job creation to finish. You'll see a success message upon a
+successful completion.
+
+To execute an existing job, run the following command:
+
+```bash
+gcloud run jobs execute JOB_NAME --quiet
+```
+
+If you want the command to wait until the execution completes, run the following
+command:
+
+```bash
+gcloud run jobs execute JOB_NAME --wait --region=REGION --quiet
+```
+
+Replace the following:
+
+*   JOB_NAME: the name of the job.
+*   REGION: the region in which the resource can be found. For example,
+    `europe-west1`. Alternatively, set the `run/region` property.
+
+## Deploy a worker pool
+
+You can deploy a Cloud Run worker pool using container images or deploy directly
+from the source.
+
+### Deploy a container image
+
+You can specify a container image with a tag (for example,
+`us-docker.pkg.dev/my-project/container/my-image:latest`) or with an exact
+digest (for example,
+`us-docker.pkg.dev/my-project/container/my-image@sha256:41f34ab970ee...`).
+
+### Supported container images
+
+You can directly use container images stored in the [Artifact
+Registry](https://docs.cloud.google.com/artifact-registry/docs/overview), or
+[Docker Hub](https://hub.docker.com/). Google recommends the use of Artifact
+Registry since Docker Hub images are
+[cached](https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images)
+for up to one hour.
+
+You can use container images from other public or private registries (like JFrog
+Artifactory, Nexus, or GitHub Container Registry), by setting up an [Artifact
+Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+You should only consider [Docker Hub](https://hub.docker.com/) for deploying
+popular container images such as [Docker Official
+Images](https://docs.docker.com/docker-hub/official_images/) or [Docker
+Sponsored OSS images](https://docs.docker.com/docker-hub/dsos-program/). For
+higher availability, Google recommends deploying these Docker Hub images using
+an [Artifact Registry remote
+repository](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-repo).
+
+To deploy a container image, run the following command:
+
+```bash
+gcloud run worker-pools deploy WORKER_POOL_NAME --image IMAGE_URL --quiet
+```
+
+Replace the following:
+
+*   WORKER_POOL_NAME: the name of the worker pool you want to deploy to. If the
+  worker pool does not exist yet, this command creates the worker pool during
+    the deployment. You can omit this parameter entirely, but you will be
+    prompted for the worker pool name if you omit it.
+
+*   IMAGE_URL: a reference to the container image that contains the worker pool,
+    such as `us-docker.pkg.dev/cloudrun/container/worker-pool:latest`. Note that
+    if you don't supply the `--image` flag, the deploy command attempts to
+    deploy from source code.
+
+Wait for the deployment to finish. Upon successful completion, Cloud Run
+displays a success message along with the revision information about the
+deployed worker pool.
+
+### Deploy a worker pool from source
+
+You can deploy a new worker pool or worker pool revision to Cloud Run directly
+from source code using a single gcloud CLI command, `gcloud run worker-pools`
+deploy with the `--source` flag.
+
+The deploy command defaults to source deployment if you don't supply the
+`--image` or `--source` flags.
+
+Behind the scenes, this command uses [Google Cloud's
+buildpacks](https://docs.cloud.google.com/docs/buildpacks/overview) and Cloud
+Build to automatically build container images from your source code without
+having to install Docker on your machine or set up buildpacks or Cloud Build. By
+default, Cloud Run uses the default machine type provided by Cloud Build.
+
+To deploy a worker pool from source, run the following command:
+
+```bash
+gcloud run worker-pools deploy WORKER_POOL_NAME --source . --quiet
+```
+
+Replace `WORKER_POOL_NAME` with the name you want for your worker pool.
+
+### What to do if a deployment fails:
+
+1.  **IAM/Permission Error:** Read
+    [iam-security.md](references/iam-security.md).
+2.  **Crash on Boot / Healthcheck failed:** Fetch the logs immediately using
+    `gcloud logging read "resource.labels.service_name=SERVICE_NAME" --limit=20`
+    to find the exact runtime error.
+3.  **Native Dependency Error (Node/Python):** If using `--no-build`, switch to
+    `--source .` (Buildpacks) to compile native extensions properly for Linux.
+
+## Reference Directory
+
+-   [Core Concepts](references/core-concepts.md): Services vs. Jobs vs.
+    Worker pools, resource model, and auto-scaling behavior for services.
+
+-   [CLI Usage](references/cli-usage.md): Essential `gcloud run` commands for
+    deployment and management.
+
+-   [Client Libraries](references/client-library-usage.md): Using Google
+    Cloud client libraries to interact with Cloud Run.
+
+-   [MCP Usage](references/mcp-usage.md): Using the Cloud Run remote MCP
+    server.
+
+-   [Infrastructure as Code](references/iac-usage.md): Terraform examples for
+    services, jobs, worker pools, and IAM bindings.
+
+-   [IAM & Security](references/iam-security.md): Roles, service identities,
+    and ingress/egress controls.
+
+*If you need product information not found in these references, use the
+    Developer Knowledge MCP server `search_documents` tool.*

--- a/cli-tool/components/skills/development/cloud-run-basics/references/cli-usage.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/cli-usage.md
@@ -1,0 +1,119 @@
+# Cloud Run CLI
+
+Use the `gcloud run` command to manage your Cloud Run applications.
+
+## Basic Syntax
+
+```bash
+gcloud run [GROUP] [COMMAND] [FLAGS]
+```
+
+## Essential Commands
+
+### Cloud Run service
+
+-   **Deploy a service from an image:**
+
+    ```bash
+    gcloud run deploy my-service \
+        --image us-docker.pkg.dev/cloudrun/container/hello:latest \
+        --quiet
+    ```
+
+-   **Deploy from source code:**
+
+    ```bash
+    gcloud run deploy my-service --source . --quiet
+    ```
+
+-   **Deploy a Cloud Run function:** 
+
+    ```bash
+    gcloud run deploy my-service
+    --source . --function example-hello --base-image go126 --region us-central1 --quiet
+    ```
+
+-   **List services:**
+
+    ```bash
+    gcloud run services list --quiet
+    ```
+
+-   **Update traffic split:**
+
+    ```bash
+    gcloud run services update-traffic my-service --to-revisions=REV1=50,REV2=50 --quiet
+    ```
+
+### Cloud Run job
+
+-   **Create a job:**
+
+    ```bash
+    gcloud run jobs create my-job \
+      --image us-docker.pkg.dev/cloudrun/container/job:latest \
+      --quiet
+    ```
+
+-   **Execute a job:**
+
+    ```bash
+    gcloud run jobs execute my-job --quiet
+    ```
+
+-   **List jobs:** `gcloud run jobs list`
+
+-   **List job executions:**
+
+    ```bash
+    gcloud run executions list --job my-job
+    ```
+
+### Cloud Run worker pools
+
+-   **Deploy a worker pool from an image:**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool \
+      --image us-docker.pkg.dev/cloudrun/container/worker-pool:latest \
+      --quiet
+    ```
+
+-   **Deploy from source code:**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool --source . --quiet
+    ```
+
+-   **List worker pools:**
+
+    ```bash
+    gcloud run worker-pools list --region us-central1 --quiet
+    ```
+
+-   **Configure scaling (manual):**
+
+    ```bash
+    gcloud run worker-pools deploy my-workerpool --instances=5 \
+      --image us-docker.pkg.dev/cloudrun/container/worker-pool:latest \
+      --quiet
+    ```
+
+### Configuration and logs
+
+-   **View more details about a service:** `gcloud run services describe my-service`
+
+-   **View logs:**
+
+    ```bash
+    gcloud logging read "resource.type=cloud_run_revision AND \
+      resource.labels.service_name=my-service" \
+      --quiet
+    ```
+
+## Common Flags
+
+-   `--region`: The region where the service or job is located.
+-   `--allow-unauthenticated`: Makes the service publicly accessible.
+
+-   `--no-allow-unauthenticated`: Restricts access to authenticated users only.

--- a/cli-tool/components/skills/development/cloud-run-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/client-library-usage.md
@@ -1,0 +1,146 @@
+# Cloud Run Client Libraries
+
+Google Cloud client libraries provide an idiomatic way to manage Cloud Run
+resources programmatically.
+
+## Getting Started
+
+Ensure you have the Google Cloud SDK installed and authenticated.
+[Install Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+
+### Python
+
+- **Installation:**
+
+  ```bash
+  pip install --upgrade google-cloud-run
+  ```
+
+- **Usage Example:**
+
+  ```python
+  from google.cloud import run_v2
+  client = run_v2.ServicesClient()
+  request = run_v2.ListServicesRequest(
+    parent="projects/my-project/locations/us-central1"
+  )
+  page_result = client.list_services(request=request)
+  ```
+
+- [Python Reference](https://docs.cloud.google.com/python/docs/reference/run/latest)
+
+### Java
+
+- **Maven Dependency:**
+
+  ```xml
+  <dependencyManagement>
+  <dependencies>
+   <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>26.79.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+   </dependency>
+  </dependencies>
+  </dependencyManagement>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-run</artifactId>
+  </dependency>
+  ```
+
+- **Usage Example:**
+
+  ```java
+  try (ServicesClient servicesClient = ServicesClient.create()) {
+    ListServicesRequest request = ListServicesRequest.newBuilder()
+        .setParent(LocationName.of("my-project", "us-central1").toString())
+        .build();
+    for (Service element : servicesClient.listServices(request).iterateAll()) {
+      System.out.println(element.getName());
+    }
+  }
+  ```
+
+- [Java Reference](https://docs.cloud.google.com/java/docs/reference/google-cloud-run/latest/overview)
+
+### Node.js (TypeScript)
+
+- **Installation:**
+
+  ```bash
+  npm install @google-cloud/run
+  ```
+
+- **Usage Example:**
+
+  ```typescript
+  import {ServicesClient} from '@google-cloud/run';
+  const client = new ServicesClient();
+  const [services] = await client.listServices({
+    parent: 'projects/my-project/locations/us-central1',
+  });
+  ```
+
+- [Node.js Reference](https://googleapis.dev/nodejs/run/latest/index.html)
+
+### Go
+
+- **Installation:**
+
+  ```bash
+  go get cloud.google.com/go/run/apiv2
+  ```
+
+- **Usage Example:**
+
+  ```go
+  package main
+
+  import (
+  	"context"
+  	"fmt"
+  	"log" // Import the log package
+
+  	run "cloud.google.com/go/run/apiv2"
+  	runpb "cloud.google.com/go/run/apiv2/runpb"
+  	"google.golang.org/api/iterator"
+  )
+
+  func main() {
+  	ctx := context.Background()
+  	client, err := run.NewServicesClient(ctx)
+  	if err != nil {
+  		// Log the error and exit if the client can't be created
+  		log.Fatalf("Failed to create Cloud Run Services client: %v", err)
+  	}
+  	defer client.Close()
+
+  	req := &runpb.ListServicesRequest{
+  		Parent: "projects/my-project/locations/us-central1", // Remember to replace my-project
+  	}
+  	it := client.ListServices(ctx, req)
+
+  	fmt.Println("Cloud Run Services:")
+  	for {
+  		resp, err := it.Next()
+  		if err == iterator.Done {
+  			break // Finished iterating successfully
+  		}
+  		if err != nil {
+  			// Log the error and exit if iteration fails
+  			log.Fatalf("Error iterating services: %v", err)
+  		}
+  		fmt.Println(resp.GetName())
+  	}
+  }
+  ```
+
+- [Go Reference](https://docs.cloud.google.com/go/docs/reference/cloud.google.com/go/run/latest)
+
+## Source Code Samples
+
+For more examples across languages, visit the
+[Cloud Run Code Samples](https://cloud.google.com/run/docs/samples).

--- a/cli-tool/components/skills/development/cloud-run-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/core-concepts.md
@@ -1,0 +1,134 @@
+# Cloud Run core concepts
+
+Cloud Run is a fully managed application platform for running your code,
+function, or container on top of Google's highly scalable infrastructure. On
+Cloud Run, your code can run as a service, job, or worker pool. All of these
+resource types are running sandboxed container instances in the same execution
+environment and can integrate with Google Cloud services.
+
+## Services vs. Jobs vs. Worker pools
+
+-   **Cloud Run services:** Used for code that handles requests or events (e.g.,
+    web apps, APIs). They provide an HTTPS endpoint and automatically scale
+    based on traffic.
+
+-   **Cloud Run jobs:** Used for code that performs a specific task and then
+    exits (e.g., data processing, database migrations). They can run a single
+    task or an array of parallel tasks.
+
+-   **Cloud Run worker pools:** Designed for continuous, non-HTTP, pull-based
+    background processing (e.g., Kafka consumers).
+
+## Resource model
+
+Cloud Run organizes resources as follows:
+
+1.  **Service** The top-level resource. You can deploy a service from a
+    container, repository, or source code.
+                    1.  **Revision:** An immutable snapshot of a service's
+                        configuration and container image. Each service
+                        deployment creates a new revision.
+                    1.  **Service instances:** The running container that
+                        processes requests. Each service revision receiving
+                        requests is automatically scaled to the number of
+                        instances needed to handle all these requests.
+                    1.  **Cloud Run functions**: Deploy functions as Cloud Run
+                        services. You can deploy single-purpose functions that
+                        respond to events emitted from your cloud infrastructure
+                        and services
+
+1.  **Job**: Executes one or more containers to completion. A job consists of
+    one or multiple independent tasks that are executed in parallel in a given
+    job execution.
+
+1.  **Worker pools**: If your code processes workloads from an external source
+    but not from an HTTP request, such as pulling work from a message queue, you
+    can deploy it to a Cloud Run worker pool .
+
+## Autoscaling for Cloud Run services
+
+Cloud Run services scale automatically based on:
+
+-   **Request concurrency:** The number of concurrent requests per instance.
+-   **CPU utilization:**: The average CPU utilization of existing instances over
+    a one minute window.
+-   **Scale to zero:** Cloud Run autoscales from one to zero instances only
+    after verifying that an instance is no longer processing requests. If you
+    use instance-based billing, Cloud Run instances are charged for the entire
+    lifecycle of instances, even when there are no incoming requests.
+
+## Container contract 
+
+Your container image can run code written in the programming language
+of your choice and use any base image, provided that it respects the
+constraints listed in the [Container runtime contract](https://docs.cloud.google.com/run/docs/container-contract).
+
+Executables in the container image must be compiled for
+Linux 64-bit. Cloud Run specifically supports the Linux x86_64 ABI format.
+
+Cloud Run accepts container images in the Docker Imag
+ Manifest V2, Schema 1, Schema 2, and OCI image formats. Cloud Run
+also accepts Zstd compressed container images.
+
+If deploying a multi-architecture image, the manifest list must include
+linux/amd64.
+
+For functions deployed with Cloud Run, you can use one of the
+Cloud Run runtime base images that are published by Google
+Cloud's buildpacks to receive automatic security and maintenance updates.
+For more information about the supported runtimes, see the [Runtime support schedule](https://docs.cloud.google.com/run/docs/runtime-support).
+
+### Container requirements
+
+When deploying containers to Cloud Run, the following requirements must be met:
+
+* Container deployed to services must listen for requests on the correct port
+* A Cloud Run service starts Cloud Run instances to handle incoming
+  requests. A Cloud Run instance always has one single ingress
+  container that listens for requests, and optionally one or more
+  sidecar containers. The following port configuration details
+  apply only to the ingress container, not to sidecars.
+* The ingress container within an instance must listen for
+  requests on `0.0.0.0` on the port to which requests are sent. Notably,
+  the ingress container should not listen on `127.0.0.1`. By default, request
+  are sent to 8080, but you can configure Cloud Run to send requests to the port of your choice.
+  Cloud Run injects the PORT environment variable into the ingress container.
+
+## VPC network connectivity
+
+Cloud Run services and jobs support Direct VPC egress. This means
+that they can send traffic to private resources within your
+configured VPC network, such as databases or internal services. Cloud Run
+services and jobs don't support Direct VPC ingress.
+Cloud Run worker pools support both Direct VPC egress and Direct VPC
+ingress. When you configure Direct VPC for your Cloud Run worker pool
+deployment, each worker instance receives a private IP address on the
+configured network and subnet. Only resources from your VPC network can
+connect to the worker pool private IP address endpoint. For more information
+about obtaining the private IP addresses of your worker pool instance, see
+[Retrieve the private IP addresses using the metadata server (MDS)](https://docs.cloud.google.com/run/docs/configuring/vpc-direct-vpc#mds-support).
+
+For Cloud Run worker pools with Direct VPC ingress, such as database
+connections or any other custom TCP-based protocol, the container must
+listen for TCP connections on the port exposed in your container image
+through the Dockerfile or specified by the PORT environment variable.
+
+## AI and GPU support
+
+Cloud Run supports hosting AI inference models. You can configure services with
+GPUs (e.g., NVIDIA RTX PRO 6000 Blackwell GPU, NVIDIA L4) to accelerate
+workloads like LLM inference using Gemma 3. For more information, see GPU
+support for
+[services](https://docs.cloud.google.com/run/docs/configuring/services/gpu),
+[jobs](https://docs.cloud.google.com/run/docs/configuring/jobs/gpu), and [worker
+pools](https://docs.cloud.google.com/run/docs/configuring/workerpools/gpu).
+
+## Pricing
+
+Cloud Run uses a pay-as-you-go model:
+
+-   **Request-based:** Charged for resources used during request processing.
+-   **Instance-based:** Charged for the entire lifetime of an instance.
+
+For the latest pricing, visit: [Cloud Run
+pricing](https://cloud.google.com/run/pricing).

--- a/cli-tool/components/skills/development/cloud-run-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/iac-usage.md
@@ -1,0 +1,76 @@
+# Cloud Run Infrastructure as Code
+
+Cloud Run resources can be provisioned and managed using Terraform and other IaC
+tools.
+
+## Terraform
+
+The Google Cloud Terraform provider supports Cloud Run services, jobs, and worker pools.
+
+### Cloud Run service example
+
+```terraform
+resource "google_cloud_run_v2_service" "default" {
+  name     = "cloudrun-service"
+  location = "us-central1"
+  deletion_protection = false
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "noauth" {
+  location = google_cloud_run_v2_service.default.location
+  name     = google_cloud_run_v2_service.default.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+```
+
+### Cloud Run job example
+
+```terraform
+resource "google_cloud_run_v2_job" "default" {
+  name     = "cloudrun-job"
+  location = "us-central1"
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+    }
+  }
+}
+```
+
+### Cloud Run worker pool example
+
+```terraform
+resource "google_cloud_run_v2_worker_pool" "default" {
+  name     = "cloudrun-workerpool"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/worker-pool:latest"
+    }
+  }
+}
+```
+
+### Reference dpcumentation
+
+- [Terraform Google Provider - Cloud Run v2 Service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service)
+
+- [Terraform Google Provider - Cloud Run v2 Job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job)
+- [Terraform Google Provider - Cloud Run v2 Worker pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_worker_pool)
+
+## YAML
+
+Cloud Run resources can also be defined using YAML. For more information, see
+[Cloud Run YAML reference](https://docs.cloud.google.com/run/docs/reference/yaml/v1).

--- a/cli-tool/components/skills/development/cloud-run-basics/references/iam-security.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/iam-security.md
@@ -1,0 +1,102 @@
+# Cloud Run IAM & security
+
+Cloud Run uses Identity and Access Management (IAM) to secure your resources and control who can deploy or invoke them.
+
+## Predefined IAM Roles
+
+| Predefined Role | Usage |
+| :--- | :--- |
+| `roles/run.admin` | Full control over all Cloud Run resources. |
+| `roles/run.invoker` | Invoke Cloud Run services and execute Cloud Run jobs. |
+| `roles/run.developer` | Read and write access to services, jobs and worker pools; cannot
+  set IAM policies. |
+| `roles/run.viewer` | Read-only access to Cloud Run resources. |
+
+## Types of service accounts for service identity
+
+Cloud Run resources run as a specific service account (the service
+identity).
+
+- **User-managed service account (recommended)**: You manually create this
+  service account and determine the most minimal set of permissions that
+  the service account needs to access specific Google Cloud resources. The
+  user-managed service account follows the format of `SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com`.
+
+- **Compute Engine default service account:** Cloud Run automatically
+  provides the Compute Engine default service account as the default
+  service identity. The Compute Engine default service account
+  follows the format of `PROJECT_NUMBER-compute@developer.gserviceaccount.com`.
+
+## Best practices
+
+By default, the Compute Engine default service account is automatically
+created. If you don't specify a service account when the
+Cloud Run service or job is created, Cloud Run uses this service account.
+Depending on your organization policy configuration, the default
+service account might automatically be granted the Editor role on your
+project. We strongly recommend that you disable the automatic role
+grant by enforcing the `iam.automaticIamGrantsForDefaultServiceAccounts`
+organization policy constraint. If you created your organization after
+May 3, 2024, this constraint is enforced by default.
+
+Create a user-managed service account with minimal
+permissions for each Cloud Run resource.
+
+To allow a service to access another GCP resource (e.g.,
+Cloud SQL), grant the service's identity the appropriate IAM role on that
+resource.
+
+## Security controls
+
+- **Ingress Settings:** Control whether your service is reachable from the
+  internet (`all`), only from within the VPC (`internal`), or via a load
+  balancer (`internal-and-cloud-load-balancing`).
+
+- **VPC Egress:** Use a VPC connector or Direct VPC egress to allow Cloud Run to
+  access resources in your VPC.
+
+- **Binary Authorization:** Ensure only trusted container images are deployed.
+
+- **Secrets Management:** Use Secret Manager to securely pass sensitive
+  information (e.g., API keys, database passwords) to your containers as
+  environment variables or volumes.
+
+## Public access
+
+There are two ways to create a public Cloud Run service, you can either:
+
+* Disable the Cloud Run Invoker IAM check (recommended).
+* Assign the Cloud Run Invoker IAM role to the `allUsers` member type.
+
+For more information, see:
+[Cloud Run security overview](https://docs.cloud.google.com/run/docs/securing/managing-access#make-service-public).
+
+## Configure IAP to secure access
+
+By enabling IAP on Cloud Run directly, you can secure traffic with a single
+click from all ingress paths, including default `run.app` URLs and load
+balancers.
+
+When you integrate IAP with Cloud Run, you can manage user or group access in
+the following ways:
+
+* Inside the organization - configure access to users who are within the same
+  organization as your Cloud Run service
+
+* Outside the organization - configure access to users who are from
+  organizations different than your Cloud Run service
+
+* No organization - configure access in projects that are not part of any
+  Google organization
+
+Enabling IAP on a Cloud Run service can be as easy as deploying a new service with
+the following flags:
+
+```bash
+gcloud run deploy SERVICE_NAME \
+  --region=REGION \
+  --image=IMAGE_URL \
+  --no-allow-unauthenticated \
+  --iap \
+  --quiet
+```

--- a/cli-tool/components/skills/development/cloud-run-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/development/cloud-run-basics/references/mcp-usage.md
@@ -1,0 +1,43 @@
+# Cloud Run MCP Usage
+
+Cloud Run is supported by a remote Model Context Protocol (MCP) server that
+enables agents to deploy, manage, and monitor serverless applications.
+
+## MCP Tools for Cloud Run
+
+The Cloud Run MCP server typically includes tools for:
+
+- `get_service`: Get info about a Cloud Run service, such as its URI and
+  whether the deploy succeeded.
+- `list_services`: List Cloud Run services in a given Google Cloud project and
+  region.
+- `deploy_service_from_image`: Deploy a container image from Artifact Registry
+  or Docker Hub as a Cloud Run service.
+- `deploy_service_from_archive`: Deploy a Cloud Run service directly from a
+  self-contained source code archive (.tar.gz), skipping the container image
+  build step for faster deployment. The archive must include all dependencies.
+- `deploy_service_from_file_contents`: Deploys a Cloud Run service directly from
+  local source files. This method is suitable for scripting languages like Python
+  and Node.js, of which the source code can be embedded in the request. This is
+  ideal for quick tests and development feedback loops. You must include all
+  necessary dependencies within the source files because it skips the build step
+  for faster deployment.
+
+## Setup Instructions
+
+To connect to the Cloud Run MCP server:
+
+1.  Enable the Cloud Run API in your Google Cloud project.
+2.  Configure the agent's MCP connection using the Gemini CLI extension.
+3.  Follow the setup guide:
+    [Setting up Cloud Run MCP](https://docs.cloud.google.com/run/docs/reference/mcp).
+
+## Supported Operations
+
+Agents using the Cloud Run MCP can:
+
+- Automate the rollout of new revisions.
+- Troubleshoot failing deployments by inspecting logs and status.
+- Manage scheduled jobs and verify their execution history.
+
+Alternatively, use the [open source Cloud Run MCP server](https://github.com/GoogleCloudPlatform/cloud-run-mcp) which runs locally.

--- a/cli-tool/components/skills/development/firebase-basics/SKILL.md
+++ b/cli-tool/components/skills/development/firebase-basics/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: firebase-basics
+description: Sets up and develops projects using Firebase products and services, especially for mobile or web apps. Covers Firebase CLI setup, project configuration, and integration with Firebase platform services.
+source: google/skills (Apache 2.0)
+---
+
+# Firebase Basics
+
+### **CRITICAL** Mandatory prerequisites
+
+Before attempting to fulfill any user request regarding Firebase, you **MUST**
+follow these steps in order. Do not proceed to implementation until these are
+completed. Failure to follow these instructions may result in using outdated
+patterns and lack of access to essential reference materials.
+
+1.  **Leverage the planning phase**
+
+    If you use a planning mode (e.g., maintaining a `task.md` file), you
+    **MUST** include a task to check and install `firebase/agent-skills` as your
+    very first item.
+
+2.  **Ensure NPM is installed.**
+
+    ```bash
+    ## Check if NPM is installed
+    npm --version
+    ```
+
+    If NPM is not installed, guide the user to download and install the
+    LTS version from https://nodejs.org/en/download.
+
+    Then, request the user to manually install Node.js and to reply with a
+    confirmation that the installation is finished. **Stop and wait** for the
+    user's confirmation.
+
+3.  **Verify and install Agent Skills for Firebase**
+
+    You **MUST** ensure the full set of skills is installed to avoid using
+    outdated patterns. Run this command:
+
+    ```bash
+    npx -y skills add firebase/agent-skills -y
+    ```
+
+    *If the skills are already installed, this command will ensure they are up
+    to date. Do not skip this step.*
+
+
+## Quick start
+
+After completing the mandatory prerequisites above, proceed with these steps to
+set up your environment:
+
+1.  **Log in to the Firebase CLI.**
+
+    Run this command:
+
+    ```bash
+    npx -y firebase-tools@latest login
+    ```
+
+    Then, ask the user to complete the login flow in the browser.
+
+2.  **Set an active project for the CLI.**
+
+    Most Firebase tasks require an active project context. Check the current
+    project for the Firebase CLI by running this command:
+
+    ```bash
+    npx -y firebase-tools@latest use
+    ```
+
+    - If the command outputs `Active Project: <PROJECT_ID>`, you can proceed
+      with your task.
+
+    - If the command does *not* output an active project, ask the user if they
+      have an existing Firebase project ID.
+
+      - If yes: Set the ID as the active project and add a default alias by
+        running:
+
+        ```bash
+        npx -y firebase-tools@latest use --add <PROJECT_ID>
+        ```
+
+      - If no: Create a new Firebase project by running:
+
+        ```bash
+        npx -y firebase-tools@latest projects:create <PROJECT_ID> --display-name <DISPLAY_NAME>
+        ```
+
+## Reference directory
+
+- [Firebase core concepts](references/core-concepts.md)
+- [Firebase CLI usage](references/cli-usage.md)
+- [Firebase client library usage](references/client-library-usage.md)
+- [Firebase CLI and MCP server](references/mcp-usage.md)
+- [Firebase IaC usage](references/iac-usage.md)
+- [Firebase security-related features](references/iam-security.md)
+- [Additional Published Skills](references/additional-skills.md)
+
+If you need product information that's not found in these references, check the
+other skills for Firebase that you have installed, or use the `search_documents`
+tool of the Developer Knowledge MCP server.

--- a/cli-tool/components/skills/development/firebase-basics/references/additional-skills.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/additional-skills.md
@@ -1,0 +1,122 @@
+## Additional Published Skills
+
+The following skills and reference files are published in the
+[Firebase Agent Skills repository](https://github.com/firebase/agent-skills/tree/main/skills):
+
+### `developing-genkit-dart`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/SKILL.md)
+-   [`references/genkit.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit.md)
+-   [`references/genkit_anthropic.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_anthropic.md)
+-   [`references/genkit_chrome.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_chrome.md)
+-   [`references/genkit_firebase_ai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_firebase_ai.md)
+-   [`references/genkit_google_genai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_google_genai.md)
+-   [`references/genkit_mcp.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_mcp.md)
+-   [`references/genkit_middleware.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_middleware.md)
+-   [`references/genkit_openai.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_openai.md)
+-   [`references/genkit_shelf.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/genkit_shelf.md)
+-   [`references/schemantic.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-dart/references/schemantic.md)
+
+### `developing-genkit-go`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/SKILL.md)
+-   [`references/flows-and-http.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/flows-and-http.md)
+-   [`references/generation.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/generation.md)
+-   [`references/getting-started.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/getting-started.md)
+-   [`references/prompts.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/prompts.md)
+-   [`references/providers.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/providers.md)
+-   [`references/tools.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-go/references/tools.md)
+
+### `developing-genkit-js`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/SKILL.md)
+-   [`references/best-practices.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/best-practices.md)
+-   [`references/common-errors.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/common-errors.md)
+-   [`references/docs-and-cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/docs-and-cli.md)
+-   [`references/examples.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/examples.md)
+-   [`references/setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/developing-genkit-js/references/setup.md)
+
+### `firebase-ai-logic-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-ai-logic-basics/SKILL.md)
+-   [`references/usage_patterns_web.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-ai-logic-basics/references/usage_patterns_web.md)
+
+### `firebase-app-hosting-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/SKILL.md)
+-   [`references/cli_commands.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/cli_commands.md)
+-   [`references/configuration.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/configuration.md)
+-   [`references/emulation.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-app-hosting-basics/references/emulation.md)
+
+### `firebase-auth-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/SKILL.md)
+-   [`references/client_sdk_web.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/references/client_sdk_web.md)
+-   [`references/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-auth-basics/references/security_rules.md)
+
+### `firebase-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/SKILL.md)
+-   [`references/firebase-cli-guide.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/firebase-cli-guide.md)
+-   [`references/firebase-service-init.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/firebase-service-init.md)
+-   [`references/local-env-setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/local-env-setup.md)
+-   [`references/web_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/web_setup.md)
+-   [`references/refresh/antigravity.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/antigravity.md)
+-   [`references/refresh/claude.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/claude.md)
+-   [`references/refresh/gemini-cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/gemini-cli.md)
+-   [`references/refresh/other-agents.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/refresh/other-agents.md)
+-   [`references/setup/antigravity.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/antigravity.md)
+-   [`references/setup/claude_code.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/claude_code.md)
+-   [`references/setup/cursor.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/cursor.md)
+-   [`references/setup/gemini_cli.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/gemini_cli.md)
+-   [`references/setup/github_copilot.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/github_copilot.md)
+-   [`references/setup/other_agents.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-basics/references/setup/other_agents.md)
+
+### `firebase-data-connect-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/SKILL.md)
+-   [`examples.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/examples.md)
+-   [`templates.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/templates.md)
+-   [`reference/advanced.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/advanced.md)
+-   [`reference/config.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/config.md)
+-   [`reference/native_sql.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/native_sql.md)
+-   [`reference/operations.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/operations.md)
+-   [`reference/schema.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/schema.md)
+-   [`reference/sdks.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/sdks.md)
+-   [`reference/security.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-data-connect-basics/reference/security.md)
+
+### `firebase-firestore`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/SKILL.md)
+
+#### Enterprise Edition
+
+-   [`references/enterprise/android_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/android_sdk_usage.md)
+-   [`references/enterprise/data_model.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/data_model.md)
+-   [`references/enterprise/flutter_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/flutter_setup.md)
+-   [`references/enterprise/indexes.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/indexes.md)
+-   [`references/enterprise/ios_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/ios_setup.md)
+-   [`references/enterprise/provisioning.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/provisioning.md)
+-   [`references/enterprise/python_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/python_sdk_usage.md)
+-   [`references/enterprise/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/security_rules.md)
+-   [`references/enterprise/web_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/enterprise/web_sdk_usage.md)
+
+#### Standard Edition
+
+-   [`references/standard/android_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/android_sdk_usage.md)
+-   [`references/standard/flutter_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/flutter_setup.md)
+-   [`references/standard/indexes.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/indexes.md)
+-   [`references/standard/ios_setup.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/ios_setup.md)
+-   [`references/standard/provisioning.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/provisioning.md)
+-   [`references/standard/security_rules.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/security_rules.md)
+-   [`references/standard/web_sdk_usage.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-firestore/references/standard/web_sdk_usage.md)
+
+### `firebase-hosting-basics`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/SKILL.md)
+-   [`references/configuration.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/references/configuration.md)
+-   [`references/deploying.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-hosting-basics/references/deploying.md)
+
+### `firebase-security-rules-auditor`
+
+-   [`SKILL.md`](https://github.com/firebase/agent-skills/blob/main/skills/firebase-security-rules-auditor/SKILL.md)

--- a/cli-tool/components/skills/development/firebase-basics/references/cli-usage.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/cli-usage.md
@@ -1,0 +1,31 @@
+# Firebase CLI usage
+
+The Firebase CLI (`firebase-tools`) is the primary tool for managing Firebase
+projects and resources from the command line.
+
+**Use npx for Firebase CLI commands**: To ensure you always use the latest
+version of the Firebase CLI, always run commands with
+`npx -y firebase-tools@latest` instead of just `firebase`. (e.g., use
+`npx -y firebase-tools@latest --version` instead of `firebase --version`).
+
+## Exploring commands
+
+The Firebase CLI documents itself. Use help commands to discover functionality.
+
+- **Global help**: List all available commands and categories:
+
+  ```bash
+  npx -y firebase-tools@latest --help
+  ```
+
+- **Command help**: Get detailed usage for a specific command:
+
+  ```bash
+  npx -y firebase-tools@latest [command] --help
+  ```
+
+  ```bash
+  # Example:
+  npx -y firebase-tools@latest deploy --help
+  npx -y firebase-tools@latest firestore:indexes --help
+  ```

--- a/cli-tool/components/skills/development/firebase-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/client-library-usage.md
@@ -1,0 +1,45 @@
+# Firebase client library usage
+
+Firebase provides SDKs for both client-side application development and
+server-side administrative tasks.
+
+For a full list of Firebase client libraries and links to their documentation
+and GitHub repositories, see https://firebase.google.com/docs/libraries
+
+## Mobile and web client-side SDKs
+
+The Firebase client-side SDKs allow direct interaction with Firebase services
+from a mobile or web app. These SDKs are available for iOS (Swift and
+Objective-C), Android (Kotlin and Java), Web (JavaScript), Flutter (Dart),
+Unity, and C++.
+
+-   For **web apps**, Agent Skills for Firebase provide guides to get started
+    with the JavaScript client SDK. Install these skills by running:
+
+    ```bash
+    npx -y skills add firebase/agent-skills -y
+    ```
+
+-   For **native iOS or Android mobile apps**, see the documentation to get
+    started:
+
+    -   **iOS**: https://firebase.google.com/docs/ios/setup.md.txt
+    -   **Android**: https://firebase.google.com/docs/android/setup.md.txt
+
+-   For **Flutter apps**, see the documentation to get started:
+
+    -   **Flutter**: https://firebase.google.com/docs/flutter/setup.md.txt
+
+-   For **Unity and C++ mobile apps**, see the documentation to get started:
+
+    -   **Unity**: https://firebase.google.com/docs/unity/setup.md.txt
+    -   **C++**: https://firebase.google.com/docs/cpp/setup.md.txt
+
+## Server-side Admin SDKs
+
+The Firebase Admin SDKs provide privileged access to Firebase services from a
+server environment. These SDKs are available for Node.js, Java, Python, and Go.
+
+For details about Firebase Admin SDKs and getting started, see
+https://firebase.google.com/docs/reference/admin.md.txt and
+https://firebase.google.com/docs/admin/setup.md.txt

--- a/cli-tool/components/skills/development/firebase-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/core-concepts.md
@@ -1,0 +1,61 @@
+# Firebase core concepts
+
+Firebase is a platform of services for mobile and web applications. It offers
+products for managed backend infrastructure (BaaS), building AI-powered
+experiences in apps, DevOps, and end-user engagement. Most services are
+integrated into apps using mobile and web client SDKs.
+
+## Key services
+
+Here are some popular Firebase products:
+
+- **Firebase Authentication**: Simplify end-user authentication and sign-in on a
+  secure, all-in-one identity platform.
+- **Firestore**: Store and sync data using a secure, scalable NoSQL cloud
+  database with rich data models and queryability.
+- **Firebase Data Connect**: Build and scale your apps using a fully-managed
+  PostgreSQL relational database service.
+- **Cloud Storage for Firebase**: Store and serve unstructured content like
+  images, audio, video with a secure cloud-hosted solution.
+- **Firebase App Hosting**: Deploy modern, full-stack web apps that require
+  server-side rendering and automated secret management, CI/CD, and CDN caching.
+- **Firebase Hosting**: Deploy static and single-page web apps to a global CDN
+  with a single command.
+- **Cloud Functions for Firebase**: Run backend code in response to events and
+  HTTPS requests without provisioning or managing a server.
+- **Firebase AI Logic**: Build secure AI-powered experiences in mobile and web
+  apps using the Gemini API and without provisioning or managing a server.
+- **Firebase Crashlytics**: Track, prioritize, and fix stability issues in
+  mobile apps.
+- **Firebase Cloud Messaging (FCM)**: Send push notifications and messages to
+  end users.
+
+## Regional availability
+
+Firebase services are available globally, with several products supporting
+specific regional configurations.
+
+- **Firestore**: Each instance can be provisioned in a different location;
+  supports multi-region (e.g., `nam5`) and regional (e.g., `us-east1`)
+  locations.
+- **Cloud Storage for Firebase**: Each bucket can be provisioned in a different
+  location.
+- **Firebase App Hosting**: Can be deployed to specific regions to minimize
+  latency for operations and end users.
+- **Firebase Hosting**: Content is delivered via a global CDN.
+- **Cloud Functions for Firebase**: Can be deployed to specific regions to
+  minimize latency for operations and end users.
+
+## Pricing
+
+Firebase offers two pricing plans:
+
+- **Spark (no-cost) pricing plan**: Projects don't need a billing account to
+  use only the no-cost Firebase services and to get started with generous
+  no-cost usage quota.
+- **Blaze (pay-as-you-go) pricing plan**: Link a billing account to the project
+  to access more products and services and to get usage levels beyond the
+  no-cost usage quota.
+
+For up-to-date detailed pricing information, see the Firebase pricing
+page: https://firebase.google.com/pricing

--- a/cli-tool/components/skills/development/firebase-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/iac-usage.md
@@ -1,0 +1,40 @@
+# Firebase IaC usage
+
+Firebase resources can be provisioned using Infrastructure as Code (IaC) tools,
+like Terraform.
+
+## Terraform configuration
+
+Use the `google` or `google-beta` providers to manage Firebase resources.
+
+### Example: Firebase project setup
+
+```hcl
+resource "google_firebase_project" "default" {
+ provider = google-beta
+ project  = "user-defined-project-id"
+}
+
+resource "google_firebase_web_app" "default" {
+ provider     = google-beta
+ project      = google_firebase_project.default.project
+ display_name = "user-defined-display-name"
+}
+```
+
+### Supported Terraform resources
+
+Here are some common Terraform resources for Firebase:
+
+- `google_firebase_project`: Enable Firebase services on an existing
+  Google Cloud project.
+- `google_identity_platform_config`: Set up Firebase Authentication.
+- `google_firestore_database`: Provision a Firestore database.
+  Always set `type = "FIRESTORE_NATIVE"`.
+- `google_firebaserules_ruleset`: Define Firebase Security Rules to protect
+  Firestore data or Cloud Storage for Firebase data.
+- `google_firebaserules_release`: Deploy Firebase Security Rules rulesets for
+  Firestore or for Cloud Storage for Firebase.
+
+For a complete list of Terraform resources, and details about Terraform and
+Firebase, see: https://firebase.google.com/docs/projects/terraform/get-started

--- a/cli-tool/components/skills/development/firebase-basics/references/iam-security.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/iam-security.md
@@ -1,0 +1,74 @@
+# Firebase security-related features
+
+Firebase offers several security-related features and services, including:
+
+- **Identity and Access Management (IAM)**: Restrict a project member's
+  administrative access for projects, resources, and data.
+- **Firebase Security Rules**: Restrict client-side access for Firestore data
+  and Cloud Storage for Firebase data to only authorized users.
+- **Firebase App Check**: Restrict client-side access for APIs and backend
+  resources to only an authentic client and an authentic, untampered device.
+
+## Identity and Access Management (IAM)
+
+Here are some common IAM roles:
+
+| Role | Description |
+|---|---|
+| `roles/viewer` | Permissions for read-only actions, such as viewing (but not modifying) existing resources or data. |
+| `roles/editor` | All the `roles/viewer` permissions, plus permissions for actions that modify state, such as changing existing resources. |
+| `roles/owner` | All the `roles/editor` permissions, plus permissions for the following actions: manage IAM for a project, manage all resources within the project, set up and manage billing for a project, and delete or restore a project. |
+| `roles/firebase.viewer` | Read-only access to Firebase resources and data. |
+| `roles/firebase.admin` | Full access to all Firebase products and project management. |
+
+For details about IAM and Firebase, see
+https://firebase.google.com/docs/projects/iam/overview.md.txt
+
+## Firebase Security Rules
+
+Firebase Security Rules are CRITICAL to protecting Firestore data and
+Cloud Storage for Firebase data from unauthorized mobile and web client-side
+access. They are defined in the project directory (e.g., `firestore.rules`)
+and deployed using the Firebase CLI.
+
+Here is a basic example of Security Rules for Firestore that restricts access
+to authenticated end-users only:
+
+```
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /some_collection/{document} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}
+```
+
+**CRITICAL**: Agent Skills for Firebase provide tools to draft and test Firebase
+Security Rules. Install these skills by running:
+
+```bash
+npx -y skills add firebase/agent-skills -y
+```
+
+## Firebase App Check
+
+Firebase App Check is CRITICAL to protecting a project's enabled APIs and
+backend resources from unauthorized clients and devices. For example, it can
+help protect Firebase AI Logic, Firestore, Cloud Storage for Firebase,
+Cloud Functions for Firebase, and Firebase Data Connect.
+
+For details about Firebase App Check, see
+https://firebase.google.com/docs/app-check.md.txt
+
+## Security best practices
+
+- **Principle of least privilege:** Assign specific product-level roles instead
+  of `roles/owner` whenever possible.
+- **Firebase App Check:** Use this service to protect a project's enabled APIs
+  and backend resources from abuse by allowing only authentic clients and
+  devices to access them.
+- **Environment management:** Use separate Firebase projects for development,
+  staging, and production.
+- **Sensitive operations:** Always have a human user approve sensitive
+  operations like granting permissive IAM roles or deleting a database.

--- a/cli-tool/components/skills/development/firebase-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/development/firebase-basics/references/mcp-usage.md
@@ -1,0 +1,63 @@
+# Firebase CLI and MCP server
+
+The Firebase CLI includes a built-in local MCP server that can help with common
+tasks.
+
+1.  **Locate MCP configuration**
+
+    Find the configuration file for your agent
+    (e.g., `~/.codeium/windsurf/mcp_config.json`, `cline_mcp_settings.json`, or
+    `claude_desktop_config.json`).
+
+    *Note: If the document or its containing directory does not exist, create
+    them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+
+2.  **Check existing configuration**
+
+    Open the configuration file and check the `mcpServers` section for a
+    `firebase` entry.
+
+    - Firebase is already configured if the `command` is `"firebase"` OR if the
+      `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+
+    - **Important**: If a valid `firebase` entry is found, the MCP server is
+      already configured. **Skip step 3** and proceed directly to step 4.
+
+    **Example valid configurations**:
+    ```json
+    "firebase": {
+      "command": "npx",
+      "args": ["-y", "firebase-tools@latest", "mcp"]
+    }
+    ```
+    OR
+    ```json
+    "firebase": {
+      "command": "firebase",
+      "args": ["mcp"]
+    }
+    ```
+
+3.  **Add or update configuration**
+
+    If the `firebase` entry is missing or incorrect, add it to the `mcpServers`
+    object:
+
+    ```json
+    "firebase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "firebase-tools@latest",
+        "mcp"
+      ]
+    }
+    ```
+
+    *CRITICAL: Merge this configuration into the existing file. You MUST
+    preserve any other existing servers inside the `mcpServers` object.*
+
+4.  **Verify configuration**
+
+    Save the file and confirm the `firebase` block is present and is properly
+    formatted JSON.

--- a/cli-tool/components/skills/development/gke-basics/SKILL.md
+++ b/cli-tool/components/skills/development/gke-basics/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: gke-basics
+description: Plans, creates, and configures production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers networking, security, observability, scaling, cost optimization, and AI/ML inference on GKE.
+source: google/skills (Apache 2.0)
+---
+
+# Google Kubernetes Engine (GKE) Basics
+
+GKE is a managed Kubernetes platform on Google Cloud for deploying, scaling, and operating containerized applications. This skill defaults to the **golden path Autopilot configuration** — see [gke-golden-path.md](./references/gke-golden-path.md) for defaults, rules, and guardrails.
+
+## Quick Start
+
+```bash
+gcloud services enable container.googleapis.com --quiet
+gcloud container clusters create-auto my-cluster --region=us-central1 --quiet
+gcloud container clusters get-credentials my-cluster --region=us-central1 --quiet
+kubectl create deployment hello-server \
+  --image=us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0
+```
+
+## Reference Directory
+
+Load the relevant reference based on trigger keywords. Prefer the most specific match; if ambiguous, ask the user to clarify.
+
+| Scenario | Trigger Keywords | Reference |
+|----------|-----------------|-----------|
+| Core Concepts | Autopilot vs Standard, architecture, pricing, what is GKE | [core-concepts.md](./references/core-concepts.md) |
+| Golden Path & Defaults | golden path, Day-0 checklist, production defaults, cluster defaults | [gke-golden-path.md](./references/gke-golden-path.md) |
+| Cluster Creation | create cluster, new cluster, provision GKE | [gke-cluster-creation.md](./references/gke-cluster-creation.md) |
+| Networking | private cluster, VPC, subnet, Gateway API, DNS, ingress, egress, datapath | [gke-networking.md](./references/gke-networking.md) |
+| Security & IAM | Workload Identity, Secret Manager, RBAC, Binary Auth, hardening, audit, gVisor, IAM roles | [gke-security.md](./references/gke-security.md) |
+| Scaling | HPA, VPA, autoscaler, autoscaling, NAP, scale pods, scale nodes | [gke-scaling.md](./references/gke-scaling.md) |
+| Compute Classes | ComputeClass, machine family, Spot fallback, GPU node pool, node selection | [gke-compute-classes.md](./references/gke-compute-classes.md) |
+| Cost | cost, savings, Spot VMs, rightsizing, CUD, optimize spend, budget | [gke-cost.md](./references/gke-cost.md) |
+| AI/ML Inference | inference, model serving, LLM, GPU, TPU, GIQ, vLLM | [gke-inference.md](./references/gke-inference.md) |
+| Upgrades | upgrade, maintenance window, release channel, patching, version | [gke-upgrades.md](./references/gke-upgrades.md) |
+| Observability | monitoring, logging, Prometheus, Grafana, metrics, alerts, dashboards | [gke-observability.md](./references/gke-observability.md) |
+| Multi-tenancy | multi-tenant, namespace isolation, team access, enterprise, RBAC planning | [gke-multitenancy.md](./references/gke-multitenancy.md) |
+| Batch & HPC | batch, HPC, job queue, high performance, MPI, parallel | [gke-batch-hpc.md](./references/gke-batch-hpc.md) |
+| App Onboarding | containerize, deploy app, Dockerfile, onboard, migrate to GKE | [gke-app-onboarding.md](./references/gke-app-onboarding.md) |
+| Backup & DR | backup, restore, disaster recovery, CMEK | [gke-backup-dr.md](./references/gke-backup-dr.md) |
+| Storage | storage, PVC, persistent volume, StorageClass, Filestore, GCS FUSE | [gke-storage.md](./references/gke-storage.md) |
+| Reliability | PDB, health probe, liveness, readiness, topology spread, graceful shutdown | [gke-reliability.md](./references/gke-reliability.md) |
+| Client Libraries | client library, client-go, kubernetes python, kubernetes java, kubernetes SDK | [client-library-usage.md](./references/client-library-usage.md) |
+| Infrastructure as Code | Terraform, IaC, HCL, infrastructure as code | [iac-usage.md](./references/iac-usage.md) |
+| MCP Server | MCP tools, MCP server, MCP setup | [mcp-usage.md](./references/mcp-usage.md) |
+| CLI / Tools | gcloud, kubectl, commands, how to | [cli-reference.md](./references/cli-reference.md) |
+| Production Audit | production readiness, compliance, golden path check | [gke-cluster-creation.md](./references/gke-cluster-creation.md) |
+
+*If you need product information not found in these references, use the Developer Knowledge MCP server `search_documents` tool.*

--- a/cli-tool/components/skills/development/gke-basics/assets/default-deny-netpol.yaml
+++ b/cli-tool/components/skills/development/gke-basics/assets/default-deny-netpol.yaml
@@ -1,0 +1,10 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/cli-tool/components/skills/development/gke-basics/assets/golden-path-autopilot.yaml
+++ b/cli-tool/components/skills/development/gke-basics/assets/golden-path-autopilot.yaml
@@ -1,0 +1,147 @@
+# Golden Path Autopilot Configuration (cluster-level policy settings only)
+# Condensed from `gcloud container clusters describe` export.
+# Full export: resources/recommended-ap.yaml
+#
+# Autopilot manages all node pools, node config, and provisioning defaults
+# automatically. Only cluster-level policy decisions are shown here.
+
+# --- Addons ---
+addonsConfig:
+  dnsCacheConfig:
+    enabled: true
+  gcePersistentDiskCsiDriverConfig:
+    enabled: true
+  gcpFilestoreCsiDriverConfig:
+    enabled: true
+  gcsFuseCsiDriverConfig:
+    enabled: true
+  gkeBackupAgentConfig: {}
+  httpLoadBalancing: {}
+  kubernetesDashboard:
+    disabled: true
+  networkPolicyConfig:
+    disabled: true
+  parallelstoreCsiDriverConfig:
+    enabled: true
+  rayOperatorConfig: {}
+  statefulHaConfig:
+    enabled: true
+
+# --- Cluster Mode ---
+autopilot:
+  enabled: true
+
+# --- Autoscaling ---
+autoscaling:
+  autoscalingProfile: OPTIMIZE_UTILIZATION
+  enableNodeAutoprovisioning: true
+  resourceLimits:
+  - maximum: '1000000000'
+    resourceType: cpu
+  - maximum: '1000000000'
+    resourceType: memory
+  - maximum: '1000000000'
+    resourceType: nvidia-tesla-t4
+  - maximum: '1000000000'
+    resourceType: nvidia-tesla-a100
+
+# --- Security ---
+binaryAuthorization:
+  evaluationMode: DISABLED
+controlPlaneEndpointsConfig:
+  dnsEndpointConfig:
+    allowExternalTraffic: true          # Customer-configurable
+  ipEndpointsConfig:
+    authorizedNetworksConfig:
+      privateEndpointEnforcementEnabled: true
+masterAuthorizedNetworksConfig:
+  privateEndpointEnforcementEnabled: true
+privateClusterConfig:
+  enablePrivateNodes: true
+rbacBindingConfig:
+  enableInsecureBindingSystemAuthenticated: false
+  enableInsecureBindingSystemUnauthenticated: false
+secretManagerConfig:
+  enabled: true
+  rotationConfig:
+    enabled: true
+    rotationInterval: 120s
+shieldedNodes:
+  enabled: true
+workloadIdentityConfig:
+  workloadPool: <PROJECT_ID>.svc.id.goog
+
+# --- Networking ---
+networkConfig:
+  datapathProvider: ADVANCED_DATAPATH
+  defaultEnablePrivateNodes: true
+  dnsConfig:
+    clusterDns: CLOUD_DNS
+    clusterDnsDomain: cluster.local
+    clusterDnsScope: CLUSTER_SCOPE
+  enableIntraNodeVisibility: true
+  gatewayApiConfig:
+    channel: CHANNEL_STANDARD
+
+# --- IP Allocation ---
+ipAllocationPolicy:
+  autoIpamConfig:
+    enabled: true                       # Customer-configurable
+  createSubnetwork: true                # Customer-configurable
+  stackType: IPV4
+  useIpAliases: true
+defaultMaxPodsConstraint:
+  maxPodsPerNode: '48'                  # Customer-configurable (48 or 110)
+
+# --- Logging ---
+loggingConfig:
+  componentConfig:
+    enableComponents:
+    - SYSTEM_COMPONENTS
+    - WORKLOADS
+
+# --- Monitoring ---
+monitoringConfig:
+  advancedDatapathObservabilityConfig:
+    enableMetrics: true
+  componentConfig:
+    enableComponents:
+    - SYSTEM_COMPONENTS
+    - STORAGE
+    - POD
+    - DEPLOYMENT
+    - STATEFULSET
+    - DAEMONSET
+    - HPA
+    - JOBSET
+    - CADVISOR
+    - KUBELET
+    - DCGM
+    - APISERVER
+    - SCHEDULER
+    - CONTROLLER_MANAGER
+  managedPrometheusConfig:
+    enabled: true
+
+# --- Maintenance ---
+maintenancePolicy:
+  window:
+    maintenanceExclusions:
+      blackout-1:
+        maintenanceExclusionOptions:
+          scope: NO_MINOR_UPGRADES
+        # 1-year exclusion window (customer-configurable dates)
+
+# --- Upgrades ---
+releaseChannel:
+  channel: REGULAR
+
+# --- Scaling ---
+verticalPodAutoscaling:
+  enabled: true
+
+# --- Node Config & Pools ---
+# Autopilot manages all node pools, node config (disk, machine type, shielded
+# instances, gvnic, gcfs, workload metadata mode), and upgrade strategy
+# automatically. These are not user-configurable in Autopilot mode.
+# See resources/recommended-ap.yaml for the full describe output.

--- a/cli-tool/components/skills/development/gke-basics/assets/hpa-example.yaml
+++ b/cli-tool/components/skills/development/gke-basics/assets/hpa-example.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-hpa
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: example-deployment
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 70

--- a/cli-tool/components/skills/development/gke-basics/assets/vpa-example.yaml
+++ b/cli-tool/components/skills/development/gke-basics/assets/vpa-example.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: example-vpa
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: example-deployment
+  updatePolicy:
+    updateMode: "Off"  # Recommendation only - safest starting point
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "*"
+      minAllowed:
+        cpu: 100m
+        memory: 50Mi
+      maxAllowed:
+        cpu: 1
+        memory: 1Gi

--- a/cli-tool/components/skills/development/gke-basics/assets/workload-identity-pod.yaml
+++ b/cli-tool/components/skills/development/gke-basics/assets/workload-identity-pod.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: workload-identity-test
+  namespace: workload-identity-test-ns
+spec:
+  serviceAccountName: <ksa-name>  # Replace with your KSA name
+  automountServiceAccountToken: false
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    name: workload-identity-test
+    command: ["sleep", "infinity"]
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      readOnlyRootFilesystem: true
+  nodeSelector:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault

--- a/cli-tool/components/skills/development/gke-basics/references/cli-reference.md
+++ b/cli-tool/components/skills/development/gke-basics/references/cli-reference.md
@@ -1,0 +1,239 @@
+# CLI & Tool Reference for GKE
+
+## Tool Preference
+
+Default preference order:
+
+```
+1. GKE MCP Tools  (preferred — structured, auditable, no shell required)
+2. gcloud CLI     (fallback — when MCP doesn't expose the operation)
+3. kubectl        (fallback — purely in-cluster ops not covered by MCP)
+```
+
+### When to use each
+
+| Interface | When to Use | Examples |
+|-----------|-------------|---------|
+| **GKE MCP Tools** | Default for all cluster and K8s operations when MCP server is available. Structured I/O, supports dry-run, no shell/kubeconfig needed. | `create_cluster`, `get_cluster`, `get_k8s_resource`, `apply_k8s_manifest`, `get_k8s_logs` |
+| **`gcloud` CLI** | No MCP equivalent, or user explicitly requested CLI. Required for: GIQ model discovery, available K8s versions, maintenance windows, monitoring components, IAM/SA setup, Cloud Logging queries. | `gcloud container ai profiles`, `gcloud container get-server-config`, `gcloud iam service-accounts` |
+| **`kubectl`** | Neither MCP nor `gcloud` covers the operation, or user explicitly prefers kubectl. Required for: `kubectl top`, `kubectl scale`, `kubectl exec`, `kubectl port-forward`, Helm, custom CRDs not in MCP. | `kubectl top pods`, `kubectl scale deployment`, `helm install` |
+
+### User preference override
+
+If the user states a preference, respect it for the session:
+
+- **"Use gcloud" / "Use CLI"** → `gcloud` for cluster ops, `kubectl` for K8s resource ops. Skip MCP.
+- **"Use kubectl"** → `kubectl` for all K8s resource ops, `gcloud` for cluster-level ops. Skip MCP.
+- **"Use MCP"** / no preference → Default. Use MCP for everything it supports.
+
+Even with an override, fall back through the chain for unsupported operations (e.g., cluster creation always requires `gcloud` or MCP).
+
+---
+
+> All MCP tools use hierarchical resource paths — see [`parent` format](#parent--name-format-quick-reference) at the bottom.
+
+## Cluster Operations
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| List clusters | `list_clusters` | `gcloud container clusters list` | READ |
+| Get cluster details | `get_cluster` | `gcloud container clusters describe` | READ |
+| Create cluster | `create_cluster` | `gcloud container clusters create-auto` | MUTATE |
+| Update cluster | `update_cluster` | `gcloud container clusters update` | DESTRUCTIVE |
+| Get K8s versions | — | `gcloud container get-server-config` | READ |
+| Get credentials | — | `gcloud container clusters get-credentials` | READ |
+| Delete cluster | — | `gcloud container clusters delete` | DESTRUCTIVE |
+
+```
+# List clusters in a project (all regions)
+list_clusters(parent="projects/<PROJECT_ID>/locations/-")
+
+# Get cluster details (all fields)
+get_cluster(name="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>", readMask="*")
+
+# Create golden path Autopilot cluster
+create_cluster(
+  parent="projects/<PROJECT_ID>/locations/<REGION>",
+  cluster='{"name":"<CLUSTER_NAME>","autopilot":{"enabled":true},"privateClusterConfig":{"enablePrivateNodes":true},...}'
+)
+```
+
+```bash
+# Get available Kubernetes versions (CLI-only)
+gcloud container get-server-config --region <REGION> --format="yaml(channels)" --quiet
+
+# Create golden path Autopilot cluster (see gke-cluster-creation.md for full templates)
+gcloud container clusters create-auto <CLUSTER_NAME> \
+  --region <REGION> --project <PROJECT_ID> \
+  --enable-private-nodes --enable-master-authorized-networks \
+  --enable-dns-access --release-channel regular \
+  --enable-secret-manager --scoped-rbs-bindings \
+  --quiet
+
+# Get credentials (CLI-only)
+gcloud container clusters get-credentials <CLUSTER_NAME> --region <REGION> --project <PROJECT_ID> --quiet
+```
+
+## Node Pool Operations
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| List node pools | `list_node_pools` | `gcloud container node-pools list` | READ |
+| Get node pool | `get_node_pool` | `gcloud container node-pools describe` | READ |
+| Create node pool | `create_node_pool` | `gcloud container node-pools create` | MUTATE |
+| Update node pool | `update_node_pool` | `gcloud container node-pools update` | DESTRUCTIVE |
+
+```
+list_node_pools(parent="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>")
+
+create_node_pool(
+  parent="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>",
+  nodePool='{"name":"<POOL_NAME>","config":{"machineType":"e2-standard-4"},"initialNodeCount":3,...}'
+)
+```
+
+## Cluster Updates
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| Update cluster settings | `update_cluster` | `gcloud container clusters update` | DESTRUCTIVE |
+| Update monitoring | — | `gcloud container clusters update --monitoring=...` | DESTRUCTIVE |
+| Set maintenance window | — | `gcloud container clusters update --maintenance-window-*` | DESTRUCTIVE |
+
+```
+# Enable VPA via MCP
+update_cluster(
+  name="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>",
+  update='{"desiredVerticalPodAutoscaling":{"enabled":true}}'
+)
+```
+
+```bash
+# Update monitoring components (CLI-only)
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --monitoring=SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER,STORAGE,POD,DEPLOYMENT,STATEFULSET,DAEMONSET,HPA \
+  --quiet
+```
+
+## Kubernetes Resource Operations
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| Get/list resources | `get_k8s_resource` | `kubectl get` | READ |
+| Describe resource | `describe_k8s_resource` | `kubectl describe` | READ |
+| Apply manifest | `apply_k8s_manifest` | `kubectl apply` | DESTRUCTIVE |
+| Patch resource | `patch_k8s_resource` | `kubectl patch` | DESTRUCTIVE |
+| Delete resource | `delete_k8s_resource` | `kubectl delete` | DESTRUCTIVE |
+| List API resources | `list_k8s_api_resources` | `kubectl api-resources` | READ |
+| Check auth | `check_k8s_auth` | `kubectl auth can-i` | READ |
+
+```
+# List all deployments in a namespace
+get_k8s_resource(
+  parent="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>",
+  resourceType="deployment", namespace="<NAMESPACE>"
+)
+
+# Apply a manifest (with dry-run)
+apply_k8s_manifest(parent="...", yamlManifest="...", dryRun=true)
+
+# Patch deployment resources for rightsizing
+patch_k8s_resource(
+  parent="projects/<PROJECT_ID>/locations/<REGION>/clusters/<CLUSTER_NAME>",
+  resourceType="deployment", name="<DEPLOYMENT>", namespace="<NAMESPACE>",
+  patch='{"spec":{"template":{"spec":{"containers":[{"name":"app","resources":{"requests":{"cpu":"200m","memory":"256Mi"}}}]}}}}'
+)
+
+# Check RBAC permissions
+check_k8s_auth(parent="...", verb="create", resourceType="deployments", namespace="<NAMESPACE>")
+```
+
+## Diagnostics & Observability
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| List events | `list_k8s_events` | `kubectl events` | READ |
+| Get container logs | `get_k8s_logs` | `kubectl logs` | READ |
+| Cluster info | `get_k8s_cluster_info` | `kubectl cluster-info` | READ |
+| K8s version | `get_k8s_version` | `kubectl version` | READ |
+| Rollout status | `get_k8s_rollout_status` | `kubectl rollout status` | READ |
+| Query Cloud Logging | — | `gcloud logging read` | READ |
+
+```
+# Get recent events across all namespaces
+list_k8s_events(parent="...", allNamespaces=true, limit="50")
+
+# Get logs (last 100 lines, or previous crash)
+get_k8s_logs(parent="...", name="<POD>", namespace="<NS>", tail="100")
+get_k8s_logs(parent="...", name="<POD>", namespace="<NS>", previous=true)
+
+# Check rollout status
+get_k8s_rollout_status(parent="...", resourceType="deployment", name="<DEPLOY>", namespace="<NS>")
+```
+
+## Operations Tracking
+
+| Operation | MCP Tool | CLI Fallback | Mode |
+|-----------|----------|-------------|------|
+| List operations | `list_operations` | `gcloud container operations list` | READ |
+| Get operation | `get_operation` | `gcloud container operations describe` | READ |
+| Cancel operation | `cancel_operation` | `gcloud container operations cancel` | DESTRUCTIVE |
+
+```
+list_operations(parent="projects/<PROJECT_ID>/locations/<REGION>")
+get_operation(name="projects/<PROJECT_ID>/locations/<REGION>/operations/<OP_ID>")
+```
+
+## AI/ML Inference (GIQ) — CLI-Only
+
+```bash
+gcloud container ai profiles models list --quiet
+gcloud container ai profiles list --model=<MODEL_NAME> --quiet
+gcloud container ai profiles manifests create \
+  --model=<MODEL_NAME> --model-server=<SERVER> \
+  --accelerator-type=<ACCELERATOR> \
+  --target-ntpot-milliseconds=<NTPOT> --quiet > inference.yaml
+
+# Deploy generated manifest via MCP
+apply_k8s_manifest(parent="...", yamlManifest="<contents of inference.yaml>")
+```
+
+## kubectl-Only Operations
+
+No MCP or `gcloud` equivalent:
+
+```bash
+kubectl top pods --all-namespaces --sort-by=cpu
+kubectl top nodes
+kubectl scale deployment <DEPLOYMENT> --replicas=<N> -n <NAMESPACE>
+kubectl exec -it <POD_NAME> -n <NAMESPACE> -- /bin/sh
+kubectl port-forward svc/<SERVICE> <LOCAL_PORT>:<REMOTE_PORT> -n <NAMESPACE>
+kubectl cp <NAMESPACE>/<POD>:<PATH> <LOCAL_PATH>
+kubectl run debug --rm -it --image=busybox -- /bin/sh
+kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
+helm install <RELEASE> <CHART> -n <NAMESPACE>
+helm upgrade <RELEASE> <CHART> -n <NAMESPACE>
+```
+
+## `parent` / `name` Format Quick Reference
+
+```
+Project+Region:  projects/{PROJECT}/locations/{REGION}
+Cluster:         projects/{PROJECT}/locations/{REGION}/clusters/{CLUSTER}
+Node Pool:       projects/{PROJECT}/locations/{REGION}/clusters/{CLUSTER}/nodePools/{POOL}
+Operation:       projects/{PROJECT}/locations/{REGION}/operations/{OP_ID}
+```
+
+Use `locations/-` to match all regions/zones when listing.
+
+## Error Handling
+
+| Error / Symptom | Likely Cause | Remediation |
+|-----------------|--------------|-------------|
+| `PERMISSION_DENIED` on cluster create | Missing `container.clusters.create` IAM role | Grant `roles/container.admin` or `roles/container.clusterAdmin` |
+| Quota exceeded | Regional vCPU, GPU, or IP address limits | Request quota increase or select a different region |
+| IP exhaustion / CIDR conflict | Pod subnet too small or overlapping ranges | Re-plan IP ranges; may require cluster recreation (Day-0) |
+| Workload Identity not working | Missing OIDC issuer or federated credential | Verify `workloadIdentityConfig.workloadPool`; configure federated identity binding |
+| Private cluster unreachable | No authorized networks or DNS endpoint | Enable `dnsEndpointConfig.allowExternalTraffic` or add authorized networks |
+| Secret Manager rotation failing | SA missing `secretmanager.versions.access` | Grant Secret Manager accessor role to workload's GSA |
+| Control-plane metrics missing | Monitoring components not configured | Enable APISERVER, SCHEDULER, CONTROLLER_MANAGER in `monitoringConfig` |

--- a/cli-tool/components/skills/development/gke-basics/references/client-library-usage.md
+++ b/cli-tool/components/skills/development/gke-basics/references/client-library-usage.md
@@ -1,0 +1,91 @@
+# GKE Client Libraries
+
+To interact with the GKE (Kubernetes) API programmatically, use the official
+Kubernetes client libraries.
+
+**Prerequisite:** These libraries interact with the Kubernetes API. You
+must already have a running GKE cluster and valid credentials
+(for example, by running `gcloud container clusters get-credentials`)
+before running this code.
+
+## Getting Started
+
+Kubernetes client libraries allow you to manage clusters and workloads from
+within your application code.
+
+### Python
+
+- **Installation:**
+
+  ```bash
+  pip install kubernetes
+  ```
+
+- **Usage Example:**
+
+  ```python
+  from kubernetes import client, config
+  config.load_kube_config() # Loads from ~/.kube/config
+  v1 = client.CoreV1Api()
+  print("Listing pods with their IPs:")
+  ret = v1.list_pod_for_all_namespaces(watch=False)
+  for i in ret.items:
+      print("%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name))
+  ```
+
+### Go
+
+- **Installation:**
+
+  ```bash
+  go get k8s.io/client-go@latest
+  ```
+
+- **Usage Example:**
+
+  ```go
+  import (
+      "k8s.io/client-go/kubernetes"
+      "k8s.io/client-go/tools/clientcmd"
+  )
+  config, _ := clientcmd.BuildConfigFromFlags("", kubeconfig)
+  clientset, _ := kubernetes.NewForConfig(config)
+  pods, _ := clientset.CoreV1().Pods("").List(
+      context.TODO, metav1.ListOptions{})
+  ```
+
+### Node.js (TypeScript)
+
+- **Installation:**
+
+  ```bash
+  npm install @kubernetes/client-node
+  ```
+
+- **Usage Example:**
+
+  ```javascript
+  const k8s = require('@kubernetes/client-node');
+
+  const kc = new k8s.KubeConfig();
+  kc.loadFromDefault(); // Automatically detects local vs. in-cluster configuration
+
+  const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+  // In most recent library versions, parameters must be passed inside an object
+  k8sApi.listNamespacedPod({ namespace: 'default' }).then((res) => {
+      const pods = res.items || res.body.items;
+      console.log(`Found ${pods.length} pods in 'default' namespace.`);
+  });
+  ```
+
+### Java
+
+- [Java Reference](https://github.com/kubernetes-client/java)
+
+## GKE-specific API (Container Service)
+
+To manage the GKE *service* itself (e.g., create/delete clusters)
+programmatically, use the Google Cloud Container client libraries.
+
+- [Google Cloud Container Client Libraries](https://cloud.google.com/kubernetes-engine/docs/reference/libraries)

--- a/cli-tool/components/skills/development/gke-basics/references/core-concepts.md
+++ b/cli-tool/components/skills/development/gke-basics/references/core-concepts.md
@@ -1,0 +1,54 @@
+# GKE Core Concepts
+
+Google Kubernetes Engine (GKE) is a managed Kubernetes platform for deploying, managing, and scaling containerized applications on Google Cloud infrastructure. It handles cluster provisioning, upgrades, and node management, letting teams focus on workloads rather than infrastructure.
+
+> **MCP Tools:** `list_clusters`, `get_cluster`
+
+## Cluster Modes
+
+| Mode | Who Manages Nodes | Best For |
+|------|-------------------|----------|
+| **Autopilot** (recommended) | Google — fully managed nodes, scaling, and security | Most workloads. No node-level ops. Pay per pod resource request. |
+| **Standard** | You — full control over node pools, OS, machine types | Workloads requiring kernel customization, specific node OS, or DaemonSets not supported by Autopilot |
+
+**Default: Autopilot.** Use Standard only when Autopilot has a documented limitation for your workload.
+
+## Cluster Architecture
+
+- **Regional clusters** (recommended): Control plane replicated across 3 zones. Higher availability, no single-zone failure risk.
+- **Zonal clusters**: Single control plane zone. Lower cost, acceptable for dev/test.
+- **Private clusters** (golden path default): Nodes have no public IPs. Control plane accessible via private endpoint or DNS endpoint.
+
+## Networking Model
+
+GKE uses **VPC-native** clusters with alias IP ranges:
+- Each pod gets a routable IP from the pod CIDR
+- Dataplane V2 (eBPF-based) is the golden path default — provides built-in Network Policy enforcement
+- Cloud DNS for in-cluster DNS resolution
+- Gateway API for ingress/load balancing
+
+## Scaling Model
+
+- **Horizontal Pod Autoscaler (HPA)**: Scales pod replicas based on CPU, memory, or custom metrics
+- **Vertical Pod Autoscaler (VPA)**: Recommends or auto-adjusts pod resource requests
+- **Cluster Autoscaler / NAP**: Scales nodes to match pod demand (Autopilot handles this automatically)
+- **ComputeClasses**: Declarative node selection — machine family, Spot VMs, GPU targeting
+
+## Identity & Security Model
+
+- **Workload Identity Federation**: Pods assume Google Cloud IAM identities without static keys
+- **Secret Manager integration**: Secrets synced to Kubernetes with automatic rotation
+- **Pod Security Standards**: `restricted` profile enforced on production namespaces
+- **Shielded Nodes**: Secure Boot and integrity monitoring (Autopilot-enforced)
+
+## Regional Availability
+
+GKE is available in all Google Cloud regions. Autopilot clusters are regional by default. See https://cloud.google.com/about/locations for the full region list.
+
+## Pricing
+
+GKE pricing depends on the cluster mode:
+- **Autopilot**: Pay for pod resource requests (vCPU, memory, ephemeral storage). No cluster management fee.
+- **Standard**: Pay for underlying Compute Engine VMs plus a per-cluster management fee.
+
+For current pricing, see https://cloud.google.com/kubernetes-engine/pricing.

--- a/cli-tool/components/skills/development/gke-basics/references/gke-app-onboarding.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-app-onboarding.md
@@ -1,0 +1,160 @@
+# GKE App Onboarding
+
+This reference provides workflows for containerizing and deploying applications to GKE for the first time.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `get_k8s_rollout_status`, `get_k8s_logs`, `describe_k8s_resource`
+
+## Workflow
+
+### 1. App Assessment
+
+Before containerizing, assess the application:
+
+- **Language & Framework**: Identify the tech stack
+- **Dependencies**: List required libraries and external services
+- **Configuration**: How is the app configured? (env vars, config files, secrets)
+- **Statefulness**: Does it need persistent storage? (databases, file storage)
+- **Networking**: Port mapping and protocol (HTTP, gRPC, TCP)
+- **Health endpoints**: Does the app expose health check endpoints?
+
+### 2. Containerization
+
+Create a container image:
+
+**Dockerfile (recommended for most apps):**
+
+```dockerfile
+# Multi-stage build for smaller, more secure images
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o server .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /app/server /server
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/server"]
+```
+
+**Best practices:**
+- Use multi-stage builds to keep production images small
+- Use distroless or minimal base images to reduce attack surface
+- Run as non-root user
+- Log to `stdout` and `stderr` for Cloud Logging collection
+
+**Alternatives:**
+- **Cloud Native Buildpacks** — auto-detect language and build without a Dockerfile: `pack build <image> --builder gcr.io/buildpacks/builder:latest`
+- **Skaffold** — development workflow tool for iterating on containerized apps: `skaffold dev`
+
+### 3. Image Management
+
+Build and store the container image:
+
+```bash
+# Configure Docker for Artifact Registry
+gcloud auth configure-docker <REGION>-docker.pkg.dev --quiet
+
+# Build and push
+docker build -t <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG> .
+docker push <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG>
+```
+
+**Vulnerability scanning**: Enable automatic scanning in Artifact Registry to detect issues in base images and dependencies.
+
+```bash
+# Check scan results
+gcloud artifacts docker images describe \
+  <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG> \
+  --show-package-vulnerability \
+  --quiet
+```
+
+### 4. Manifest Generation
+
+Generate Kubernetes manifests for the application:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+      - name: my-app
+        image: <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/<IMAGE>:<TAG>
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+spec:
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP
+```
+
+**Checklist for manifests:**
+- Resource requests and limits set
+- Liveness and readiness probes configured
+- At least 2 replicas for production
+- Service type appropriate (ClusterIP for internal, use Gateway API for external)
+
+### 5. Deploy
+
+```
+# MCP (preferred)
+apply_k8s_manifest(parent="projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>", yamlManifest="<manifest>")
+
+# Verify
+get_k8s_rollout_status(parent="...", resourceType="deployment", name="my-app")
+get_k8s_resource(parent="...", resourceType="pod", labelSelector="app=my-app")
+```
+
+**kubectl fallback:**
+
+```bash
+kubectl apply -f manifests/
+kubectl rollout status deployment/my-app
+kubectl get pods -l app=my-app
+```
+
+## Next Steps
+
+Once the application is running on GKE:
+- Configure autoscaling — see [gke-scaling.md](./gke-scaling.md)
+- Set up observability — see [gke-observability.md](./gke-observability.md)
+- Harden security — see [gke-security.md](./gke-security.md)
+- Configure reliability (PDBs, topology spread) — see [gke-reliability.md](./gke-reliability.md)

--- a/cli-tool/components/skills/development/gke-basics/references/gke-backup-dr.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-backup-dr.md
@@ -1,0 +1,86 @@
+# GKE Backup & Disaster Recovery
+
+This reference provides workflows for protecting stateful workloads on GKE using Backup for GKE.
+
+> **MCP Tools:** `get_cluster`, `update_cluster`. **CLI-only:** `gcloud container backup-restore *`
+
+## Workflows
+
+### 1. Enable Backup for GKE
+
+Backup for GKE must be enabled at the cluster level.
+
+```bash
+# Check if enabled
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="value(addonsConfig.gkeBackupAgentConfig.enabled)" \
+  --quiet
+
+# Enable (Day-1 change)
+gcloud container clusters update <CLUSTER_NAME> \
+  --enable-gke-backup \
+  --region <REGION> \
+  --quiet
+```
+
+### 2. Create a Backup Plan
+
+A Backup Plan defines what to back up, when, and for how long.
+
+```bash
+gcloud container backup-restore backup-plans create <PLAN_NAME> \
+  --cluster=<CLUSTER_NAME> \
+  --location=<REGION> \
+  --retention-days=<DAYS> \
+  --cron-schedule="<CRON>" \
+  --all-namespaces \
+  --quiet
+```
+
+**Options:**
+- `--all-namespaces` — back up everything
+- `--included-namespaces=<ns1>,<ns2>` — back up specific namespaces
+- `--backup-encryption-key=<KEY>` — encrypt with Customer-Managed Encryption Key (CMEK)
+
+### 3. Create a Manual Backup
+
+Trigger a backup immediately outside the schedule:
+
+```bash
+gcloud container backup-restore backups create <BACKUP_NAME> \
+  --backup-plan=<PLAN_NAME> \
+  --location=<REGION> \
+  --quiet
+```
+
+### 4. Restore from Backup
+
+**Create a restore plan:**
+
+```bash
+gcloud container backup-restore restore-plans create <RESTORE_PLAN_NAME> \
+  --cluster=<TARGET_CLUSTER_NAME> \
+  --location=<REGION> \
+  --backup-plan=<SOURCE_BACKUP_PLAN_NAME> \
+  --cluster-resource-conflict-policy=USE_EXISTING_VERSION \
+  --namespaced-resource-restore-mode=FAIL_ON_CONFLICT \
+  --quiet
+```
+
+**Execute the restore:**
+
+```bash
+gcloud container backup-restore restores create <RESTORE_NAME> \
+  --restore-plan=<RESTORE_PLAN_NAME> \
+  --backup=<BACKUP_NAME> \
+  --location=<REGION> \
+  --quiet
+```
+
+## Best Practices
+
+1. **Automate backups**: Always use a cron schedule for production workloads
+2. **Test restores regularly**: Restore to a separate namespace or cluster to verify data integrity
+3. **Cross-region DR**: Store backups in a different region or configure cross-region restore plans
+4. **Encrypt backups**: Use CMEK for compliance and security requirements
+5. **Scope backups**: Back up specific namespaces rather than the entire cluster when possible to reduce restore complexity

--- a/cli-tool/components/skills/development/gke-basics/references/gke-batch-hpc.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-batch-hpc.md
@@ -1,0 +1,168 @@
+# GKE Batch & HPC Workloads
+
+This reference covers running batch processing and high-performance computing (HPC) workloads on GKE.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `describe_k8s_resource`, `get_k8s_logs`, `delete_k8s_resource`, `list_k8s_events`
+
+## When to Use
+
+- Running batch data processing pipelines
+- HPC simulations (CFD, molecular dynamics, financial modeling)
+- Large-scale parallel computation (MPI, MapReduce)
+- ML training jobs
+- CI/CD build farms
+
+## Batch Processing on GKE
+
+### Kubernetes Jobs
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: batch-job
+spec:
+  parallelism: 10
+  completions: 100
+  backoffLimit: 3
+  template:
+    spec:
+      containers:
+      - name: worker
+        image: <IMAGE>
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+      restartPolicy: Never
+```
+
+### JobSet (for Complex Multi-Job Workflows)
+
+The golden path enables JobSet monitoring (`JOBSET` in monitoringConfig).
+
+```yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: training-job
+spec:
+  replicatedJobs:
+  - name: workers
+    replicas: 4
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        template:
+          spec:
+            containers:
+            - name: worker
+              image: <IMAGE>
+              resources:
+                requests:
+                  cpu: "4"
+                  memory: "8Gi"
+```
+
+### Kueue (Job Queuing)
+
+Kueue manages job scheduling and resource allocation for batch workloads:
+
+```bash
+# Install Kueue
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/latest/download/manifests.yaml
+```
+
+```yaml
+# Define a ClusterQueue
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: batch-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: default
+      resources:
+      - name: "cpu"
+        nominalQuota: 100
+      - name: "memory"
+        nominalQuota: "200Gi"
+---
+# Allow a namespace to use the queue
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: batch-local
+  namespace: batch-jobs
+spec:
+  clusterQueue: batch-queue
+```
+
+## HPC on GKE
+
+### Compact Placement (Low-Latency Networking)
+
+For tightly-coupled HPC workloads that need low-latency inter-node communication:
+
+```bash
+# Standard clusters: create node pool with compact placement
+gcloud container node-pools create hpc-pool \
+  --cluster <CLUSTER_NAME> --region <REGION> \
+  --machine-type c3-standard-44 \
+  --placement-type COMPACT \
+  --num-nodes 8 \
+  --enable-autoscaling --min-nodes 0 --max-nodes 16 \
+  --quiet
+```
+
+### MPI Workloads
+
+Use the MPI Operator for MPI-based HPC applications:
+
+```bash
+# Install MPI Operator
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/mpi-operator/master/deploy/v2beta1/mpi-operator.yaml
+```
+
+```yaml
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: hpc-simulation
+spec:
+  slotsPerWorker: 4
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: launcher
+            image: <MPI_IMAGE>
+            command: ["mpirun", "-np", "32", "./simulation"]
+    Worker:
+      replicas: 8  # Set resource requests per worker
+```
+
+## Cost Optimization for Batch/HPC
+
+### Spot VMs for Batch
+
+Batch workloads are ideal Spot VM candidates (interruptible, can checkpoint). Use a ComputeClass with Spot-first priority and `activeMigration` to return to Spot when available. See [gke-compute-classes.md](./gke-compute-classes.md) for the Spot-with-fallback pattern.
+
+### Scale-to-Zero
+
+For batch clusters, allow node pools to scale to zero when no jobs are running:
+
+- Autopilot (golden path): Automatic, nodes scale to zero when no pods are scheduled
+- Standard: Set `--min-nodes 0` on batch node pools
+
+## Best Practices
+
+- **Kueue** for multi-tenant job scheduling; **JobSet** for multi-component workflows
+- **Set `backoffLimit`** on Jobs; **checkpoint long jobs** for preemption resilience
+- **Spot VMs** for fault-tolerant batch; **compact placement** for tightly-coupled HPC

--- a/cli-tool/components/skills/development/gke-basics/references/gke-cluster-creation.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-cluster-creation.md
@@ -1,0 +1,142 @@
+# GKE Cluster Creation
+
+This reference guides creating GKE clusters. The **golden path Autopilot** configuration is the default for all new clusters.
+
+> **MCP Tools:** `list_clusters`, `create_cluster`, `get_cluster`, `list_operations`, `get_operation`
+
+## Workflow
+
+1. **Discover context**: Use `list_clusters` to see existing clusters. Use `gcloud config get-value project` if project unknown.
+2. **Gather inputs**: project_id, region, cluster_name, environment type
+3. **Select mode**: Autopilot (default) vs Standard
+4. **Configure networking**: auto-create subnet (default) or bring-your-own
+5. **Review golden path settings**: present the config and confirm with user
+6. **Create**: Use MCP `create_cluster` tool. Fall back to `gcloud` CLI only if MCP is unavailable.
+7. **Track**: Use `get_operation` to monitor creation progress
+8. **Verify**: Use `get_cluster` with `readMask="*"` to confirm golden path settings applied
+
+## Mode Selection
+
+| Criteria | Autopilot (Golden Path) | Standard |
+|----------|------------------------|----------|
+| Node management | Google-managed | Self-managed |
+| Pricing | Pay per pod resource request | Pay per node (VM) |
+| Node customization | Via ComputeClasses | Full control |
+| DaemonSets | Allowed (with restrictions) | Full control |
+| GPU/TPU | Supported via ComputeClasses | Supported via node pools |
+| Best for | Most production workloads | Kernel tuning, custom OS, privileged workloads |
+
+> **Rule**: Default to Autopilot unless the customer has a specific requirement that Autopilot cannot satisfy.
+
+## Templates
+
+### 1. Golden Path Autopilot (Production)
+
+This is the default. All settings match `assets/golden-path-autopilot.yaml`.
+
+**Via gcloud:**
+
+```bash
+gcloud container clusters create-auto <CLUSTER_NAME> \
+  --region <REGION> \
+  --project <PROJECT_ID> \
+  --release-channel regular \
+  --enable-private-nodes \
+  --enable-master-authorized-networks \
+  --enable-dns-access \
+  --enable-secret-manager \
+  --secret-manager-rotation-interval=120s \
+  --scoped-rbs-bindings \
+  --monitoring=SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER,STORAGE,POD,DEPLOYMENT,STATEFULSET,DAEMONSET,HPA,CADVISOR,KUBELET,DCGM \
+  --quiet
+```
+
+**Via MCP (`create_cluster`):**
+
+```json
+{
+  "parent": "projects/<PROJECT_ID>/locations/<REGION>",
+  "cluster": {
+    "name": "<CLUSTER_NAME>",
+    "autopilot": { "enabled": true },
+    "privateClusterConfig": { "enablePrivateNodes": true },
+    "masterAuthorizedNetworksConfig": {
+      "privateEndpointEnforcementEnabled": true
+    },
+    "releaseChannel": { "channel": "REGULAR" },
+    "secretManagerConfig": {
+      "enabled": true,
+      "rotationConfig": { "enabled": true, "rotationInterval": "120s" }
+    },
+    "rbacBindingConfig": {
+      "enableInsecureBindingSystemAuthenticated": false,
+      "enableInsecureBindingSystemUnauthenticated": false
+    }
+  }
+}
+```
+
+### 2. Autopilot Dev/Test
+
+Relaxes some golden path defaults for cost savings and easier access in non-production.
+
+```bash
+gcloud container clusters create-auto <CLUSTER_NAME> \
+  --region <REGION> \
+  --project <PROJECT_ID> \
+  --release-channel rapid \
+  --quiet
+```
+
+> **Warning**: This does not apply golden path security hardening. Suitable for dev/test only.
+
+### 3. Standard Regional (When Autopilot is Not an Option)
+
+```bash
+gcloud container clusters create <CLUSTER_NAME> \
+  --region <REGION> \
+  --project <PROJECT_ID> \
+  --num-nodes 3 \
+  --machine-type e2-standard-4 \
+  --disk-type pd-balanced \
+  --enable-autoscaling --min-nodes 1 --max-nodes 10 \
+  --enable-shielded-nodes --enable-secure-boot \
+  --workload-pool=<PROJECT_ID>.svc.id.goog \
+  --enable-private-nodes \
+  --enable-master-authorized-networks \
+  --enable-vertical-pod-autoscaling \
+  --enable-dataplane-v2 \
+  --release-channel regular \
+  --quiet
+```
+
+### 4. GPU/AI Workloads (Autopilot with ComputeClass)
+
+Create a golden path Autopilot cluster, then apply a ComputeClass for GPU workloads:
+
+```bash
+# 1. Create golden path cluster (same as template 1)
+gcloud container clusters create-auto <CLUSTER_NAME> \
+  --region <REGION> --project <PROJECT_ID> \
+  --enable-private-nodes --enable-master-authorized-networks \
+  --enable-dns-access --enable-secret-manager --scoped-rbs-bindings \
+  --quiet
+
+# 2. Apply GPU ComputeClass (see gke-compute-classes.md)
+kubectl apply -f gpu-compute-class.yaml
+
+# 3. Or use GIQ for inference (see gke-inference.md)
+gcloud container ai profiles manifests create \
+  --model=gemma-2-9b-it --model-server=vllm --accelerator-type=nvidia-l4 --quiet > inference.yaml
+kubectl apply -f inference.yaml
+```
+
+## Instructions
+
+- **ALWAYS** ask for `project_id` if not in context
+- **ALWAYS** ask for `region`
+- **ALWAYS** ask for a unique `cluster_name`
+- **DEFAULT** to golden path Autopilot unless customer specifies otherwise
+- **WARN** about Day-0 decisions (networking, private nodes) that are hard to change later
+- **WARN** about cost for GPU or multi-region clusters
+- When using MCP `create_cluster`, the `cluster.name` should be the **short name** (e.g., `my-cluster`), not the full resource path

--- a/cli-tool/components/skills/development/gke-basics/references/gke-compute-classes.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-compute-classes.md
@@ -1,0 +1,172 @@
+# GKE ComputeClasses
+
+ComputeClasses allow declarative node configuration and autoscaling priorities in GKE Autopilot (and Standard with NAP). Use them to specify machine families, Spot VM fallback, GPU requirements, and zone targeting.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `describe_k8s_resource`, `delete_k8s_resource`
+
+## When to Use
+
+- Cost optimization: Spot VMs with on-demand fallback
+- GPU/TPU workloads: target specific accelerators
+- Performance: select specific machine families (c3, c4, n4)
+- Zone targeting: colocate workloads with zonal resources
+
+## CRD Structure
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: <string>
+spec:
+  # Required. Ordered list of rules. GKE tries them in order.
+  priorities:
+    - <PriorityRule>
+
+  # Optional. Default: "DoNotScaleUp"
+  whenUnsatisfiable: <"DoNotScaleUp" | "ScaleUpAnyway">
+
+  # Optional. Auto-create node pools. Default: true
+  nodePoolAutoCreation:
+    enabled: <boolean>
+
+  # Optional. Move workloads back to higher-priority when available
+  activeMigration:
+    optimizeRulePriority: <boolean>
+
+  # Optional. Scale-down delay
+  autoscalingPolicy:
+    consolidationDelay: <duration>
+
+  # Optional. Defaults for fields omitted in priorities
+  priorityDefaults: <PriorityRule>
+```
+
+## PriorityRule Fields
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `machineFamily` | string | Compute Engine machine family | `n4`, `c3`, `t2a` |
+| `machineType` | string | Specific machine type | `n4-standard-32` |
+| `spot` | boolean | Use Spot VMs | `true` |
+| `minCores` | int | Minimum vCPUs | `4` |
+| `minMemoryGb` | int | Minimum memory in GB | `16` |
+| `gpu` | object | GPU config: `type`, `count`, `driverVersion` | See below |
+| `tpu` | object | TPU config: `type`, `count`, `topology` | See below |
+| `storage` | object | Boot disk: `type`, `sizeGb`, `kmsKey`; Local SSD: `count`, `interface` | See below |
+| `location` | object | Zone targeting: `zones: [...]` or `type: "Any"` | See below |
+| `reservations` | object | Reservation consumption: `NO_RESERVATION`, `ANY_RESERVATION`, `SPECIFIC_RESERVATION` | See below |
+
+### GPU Configuration
+
+```yaml
+gpu:
+  type: "nvidia-l4"        # nvidia-l4, nvidia-h100-80gb, etc.
+  count: 1                 # GPUs per node
+  driverVersion: "latest"  # Optional
+```
+
+### TPU Configuration
+
+```yaml
+tpu:
+  type: "v5p-slice"
+  count: 8
+  topology: "2x2x1"
+```
+
+### Storage Configuration
+
+```yaml
+storage:
+  bootDisk:
+    type: "pd-balanced"     # pd-balanced (golden path), pd-ssd, hyperdisk-balanced
+    sizeGb: 100
+    kmsKey: "projects/.../cryptoKeys/..."  # Optional CMEK
+  localSsd:
+    count: 1
+    interface: "NVME"
+```
+
+### Location Configuration
+
+```yaml
+location:
+  zones:
+    - "us-central1-a"
+    - "us-central1-b"
+  # OR
+  type: "Any"              # Let GKE pick from cluster zones
+```
+
+## Common Patterns
+
+### Spot VMs with On-Demand Fallback
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: spot-with-fallback
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+  - machineFamily: n4
+    spot: true
+  - machineFamily: n4
+    spot: false
+```
+
+### GPU Workload (L4)
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: l4-gpu-class
+spec:
+  priorities:
+  - machineFamily: g2
+    gpu:
+      type: nvidia-l4
+      count: 1
+    minCores: 4
+    minMemoryGb: 16
+    storage:
+      bootDisk:
+        type: pd-balanced
+        sizeGb: 100
+```
+
+### Spot with Active Migration (Return to Spot When Available)
+
+Add `activeMigration` to the Spot-with-fallback pattern above to auto-migrate workloads back to Spot when capacity returns:
+
+```yaml
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  priorities:
+  - machineFamily: n4
+    spot: true
+  - machineFamily: n4
+    spot: false
+```
+
+> **Other patterns** — HPC (`machineFamily: c3`, `minCores: 8`) and zone targeting (`location.zones: [...]`) follow the same CRD structure. See the PriorityRule fields table and sub-config examples above.
+
+## Workload Usage
+
+Pods must specify the ComputeClass via node selector:
+
+```yaml
+nodeSelector:
+  cloud.google.com/compute-class: "<compute-class-name>"
+```
+
+## Warnings
+
+- Do not mix ComputeClass selection with other hard node selectors (like `cloud.google.com/gke-spot`) — this causes scheduling conflicts.
+- When using `activeMigration`, workloads will be evicted and rescheduled — ensure PDBs are in place.
+- Spot VMs can be evicted with 30-second notice. Set `terminationGracePeriodSeconds < 30` for Spot workloads.

--- a/cli-tool/components/skills/development/gke-basics/references/gke-cost.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-cost.md
@@ -1,0 +1,158 @@
+# GKE Cost Optimization
+
+This reference covers strategies for reducing GKE costs while maintaining the golden path security and reliability posture.
+
+> **MCP Tools:** `get_k8s_resource`, `describe_k8s_resource`, `apply_k8s_manifest`, `patch_k8s_resource`, `get_cluster`
+
+## Golden Path Cost Features
+
+The golden path already includes cost-optimizing settings:
+
+| Setting | Value | Impact |
+|---------|-------|--------|
+| `autoscalingProfile` | `OPTIMIZE_UTILIZATION` | Aggressive node scale-down reduces idle compute |
+| `verticalPodAutoscaling` | `enabled` | VPA recommendations prevent over-provisioning |
+| Autopilot pricing | Pay per pod request | No charge for unused node capacity |
+| Node Auto Provisioning | enabled | Right-sized node pools created automatically |
+
+## Cost Optimization Strategies
+
+### 1. Spot VMs via ComputeClasses
+
+Use Spot VMs for fault-tolerant workloads (60-90% cost reduction).
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: spot-with-fallback
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  priorities:
+  - machineFamily: n4
+    spot: true
+  - machineFamily: n4
+    spot: false
+```
+
+**Spot-suitable workloads:**
+
+| Workload | Spot-Suitable? |
+|----------|----------------|
+| Batch / data processing | Yes |
+| Dev / test environments | Yes |
+| Stateless web/API (replicas >= 2) | Yes (with PDBs) |
+| Jobs with checkpointing | Yes |
+| Stateful workloads (databases) | No |
+| Single-replica critical services | No |
+
+**Handling eviction:**
+
+```yaml
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 25  # Must be < 30s for Spot
+      containers:
+      - name: app
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
+```
+
+### 2. Pod Rightsizing
+
+Use VPA recommendations to reduce over-provisioned requests.
+
+```bash
+# 1. Deploy VPA in recommendation mode
+kubectl apply -f - <<EOF
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: <DEPLOYMENT>-vpa
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <DEPLOYMENT>
+  updatePolicy:
+    updateMode: "Off"
+EOF
+
+# 2. Wait 24+ hours for data collection
+
+# 3. Read recommendations
+kubectl get vpa <DEPLOYMENT>-vpa -o jsonpath='{.status.recommendation}'
+```
+
+**Optimization rules:**
+
+| Condition | Action | Savings |
+|-----------|--------|---------|
+| CPU request >5x P95 actual | Reduce to `P95 * 1.2` | High |
+| Memory request >3x P95 actual | Reduce to `P95 * 1.2` | High |
+| CPU request >2x P95 actual | Reduce to `P95 * 1.2` | Medium |
+| No resource requests set | Add requests (enables bin-packing) | Medium |
+
+### 3. Machine Type Selection
+
+| Family | Use Case | Relative Cost |
+|--------|----------|---------------|
+| e2 | General purpose, burstable | Lowest |
+| t2a / t2d | Scale-out (Arm/AMD), price-performance optimized | Low |
+| n4a | Axion Arm-based, general-purpose price-performance | Low |
+| n4 / n4d | General purpose (Intel/AMD), flexible shapes | Low-Medium |
+| c4a | Compute-optimized (Arm), high efficiency | Medium-High |
+| c3 / c4 | Compute-optimized (Intel) | Medium-High |
+| c3d / c4d | Compute-optimized (AMD), high-performance throughput | Medium-High |
+| ek-standard | Autopilot enhanced (golden path) | Medium |
+| m3 / x4 | Memory-optimized, SAP HANA, large databases | High |
+| g2 (L4 GPU) | AI inference | High |
+| a3 (H100 GPU) | AI training | Highest |
+| a4 / a4x | Ultra-scale AI (Blackwell GPUs) | Highest |
+
+> In Autopilot, machine type is managed. Use ComputeClasses to influence selection.
+
+### 4. Committed Use Discounts (CUDs)
+
+For steady-state workloads, purchase 1-year or 3-year CUDs:
+
+- 1-year: ~20-30% discount
+- 3-year: ~50-55% discount
+- Applied automatically to matching usage in the region
+- Purchase via Google Cloud Console > Billing > Committed use discounts
+
+### 5. Cluster Management
+
+- **Stop/start dev clusters**: Idle dev clusters cost money even with no workloads (control plane fee).
+- **Right-size node pools** (Standard): Use Cluster Autoscaler with appropriate min/max.
+- **Multi-tenant clusters**: Share a single cluster across teams instead of per-team clusters (see [gke-multitenancy.md](./gke-multitenancy.md)).
+
+## Cost Monitoring
+
+```bash
+# View cluster cost breakdown (requires Cost Management API)
+gcloud billing budgets list --billing-account=<BILLING_ACCOUNT> --quiet
+
+# View node utilization
+kubectl top nodes
+
+# View pod resource usage vs requests
+kubectl top pods --all-namespaces --containers
+```
+
+## Dev/Test Cost Savings
+
+For non-production environments, these golden path deviations are acceptable:
+
+| Setting | Production (Golden Path) | Dev/Test |
+|---------|-------------------------|----------|
+| Cluster mode | Autopilot | Autopilot (cheaper with fewer pods) |
+| Release channel | Regular | Rapid (get fixes faster) |
+| Private nodes | Required | Optional (simpler access) |
+| Monitoring components | Full suite | SYSTEM_COMPONENTS only |
+| Secret Manager rotation | 120s | Disabled |
+| Maintenance windows | Configured | Not needed |

--- a/cli-tool/components/skills/development/gke-basics/references/gke-golden-path.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-golden-path.md
@@ -1,0 +1,76 @@
+# GKE Golden Path Configuration
+
+The golden path is the recommended Autopilot configuration for production clusters. It defines sensible defaults — when the user requests different settings, apply them and note relevant trade-offs.
+
+> **MCP Tools:** `get_cluster`, `create_cluster`, `update_cluster`
+
+## Rules
+
+1. **Default to the golden path.** Use golden path values unless the user requests otherwise. When deviating, note trade-offs but respect the user's choice.
+2. **Day-0 vs Day-1.** Flag Day-0 decisions (networking, private nodes, subnets, IP allocation) prominently — they are hard/impossible to change after creation.
+3. **Tool preference: MCP > gcloud > kubectl.** See [cli-reference.md](./cli-reference.md) for full coverage matrix and override options. If the user says "use gcloud" or "use kubectl", respect that for the session.
+4. **Document decisions and rationale**, especially for Day-0 choices and golden path deviations.
+
+## Required Inputs
+
+If the user is unsure, use golden path defaults.
+
+- **Project ID** (required)
+- **Region** (required, e.g., `us-central1`)
+- **Cluster name** (required)
+- **Environment type**: dev/test or production (defaults to production)
+- **Networking**: bring-your-own VPC/subnet or auto-create (default: auto-create)
+- **Scale expectations**: expected node/pod count, workload types
+- **Cost constraints**: Spot VM tolerance, budget considerations
+
+## Always-Apply Defaults
+
+Recommended best practices applied by default. If the user requests a different setting, apply it and briefly note the security or operational trade-off.
+
+| Setting | Golden Path Value |
+|---------|-------------------|
+| `autopilot.enabled` | `true` |
+| `privateClusterConfig.enablePrivateNodes` | `true` |
+| `masterAuthorizedNetworksConfig.privateEndpointEnforcementEnabled` | `true` |
+| `secretManagerConfig.enabled` + `rotationInterval: 120s` | `true` |
+| `rbacBindingConfig.enableInsecureBinding*` | `false` (both) |
+| `workloadIdentityConfig.workloadPool` | enabled |
+| `networkConfig.datapathProvider` | `ADVANCED_DATAPATH` |
+| `networkConfig.dnsConfig.clusterDns` | `CLOUD_DNS` |
+| `autoscaling.autoscalingProfile` | `OPTIMIZE_UTILIZATION` |
+| `verticalPodAutoscaling.enabled` | `true` |
+| `monitoringConfig` components | SYSTEM_COMPONENTS, STORAGE, POD, DEPLOYMENT, STATEFULSET, DAEMONSET, HPA, JOBSET, CADVISOR, KUBELET, DCGM, APISERVER, SCHEDULER, CONTROLLER_MANAGER |
+| `advancedDatapathObservabilityConfig.enableMetrics` | `true` |
+| `nodeConfig.shieldedInstanceConfig.enableSecureBoot` | `true` |
+| `nodeConfig.workloadMetadataConfig.mode` | `GKE_METADATA` |
+| `nodeConfig.gcfsConfig.enabled` / `gvnic.enabled` | `true` / `true` |
+| `addonsConfig.statefulHaConfig.enabled` | `true` |
+| Storage CSI drivers (Filestore, GCS FUSE, Parallelstore) | enabled |
+| Pod Security Standards | `restricted` on production namespaces |
+
+## Customer-Configurable Settings
+
+These have golden path defaults but customers may deviate with valid justification. **Ask before changing.**
+
+| Setting | Default | Why Deviate |
+|---------|---------|-------------|
+| `dnsEndpointConfig.allowExternalTraffic` | `true` | Restrict if cluster only accessed from within VPC |
+| `autoIpamConfig` / `createSubnetwork` | `true` / `true` | Customer has pre-existing VPC/subnets |
+| `maxPodsPerNode` | `48` | `110` for high pod-density (costs more CIDR space) |
+| `subnetwork` | auto-created | Customer brings existing subnets |
+| Maintenance exclusion windows | configured (NO_MINOR_UPGRADES, 1yr) | Customer-specific scheduling |
+| `nodeConfig.bootDisk.diskType` | `pd-balanced` | `pd-ssd` for I/O-intensive, `pd-standard` for cost |
+| `nodeConfig.machineType` | `ek-standard-8` (Autopilot) | Varies by workload; use ComputeClasses |
+
+## Guardrails
+
+- Do not request or output secrets (tokens, keys, service account JSON).
+- Discover project/cluster context via MCP tools or `gcloud config get-value project` — don't ask users to paste project IDs.
+- For Day-0 decisions, always ask clarifying questions before proceeding.
+- For Day-1 features, propose golden path defaults with trade-offs and let the customer confirm.
+- Do not promise zero downtime; advise PDBs, health probes, replicas, and staged upgrades.
+- When auditing existing clusters, compare against golden path and report deviations with severity and remediation.
+
+## Golden Path Config
+
+See [golden-path-autopilot.yaml](../assets/golden-path-autopilot.yaml) for the full cluster-level policy settings.

--- a/cli-tool/components/skills/development/gke-basics/references/gke-inference.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-inference.md
@@ -1,0 +1,161 @@
+# GKE AI/ML Inference
+
+This reference covers deploying AI/ML inference workloads on GKE using Google's Inference Quickstart (GIQ) and best practices for LLM serving.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `get_k8s_logs`, `get_k8s_rollout_status`, `describe_k8s_resource`, `list_k8s_events`. **CLI-only:** `gcloud container ai profiles *`
+
+## When to Use
+
+- Deploy an AI model (Llama, Gemma, Mistral, etc.) to GKE
+- Generate optimized Kubernetes manifests for inference
+- Select GPU/TPU accelerators for model serving
+- Configure autoscaling for LLM inference
+
+## Prerequisites
+
+- A golden path GKE Autopilot cluster (GPU workloads are supported via ComputeClasses and NAP)
+- `gcloud` CLI authenticated
+- Sufficient GPU/TPU quota in the target region
+
+## Workflow
+
+### 1. Discovery: Find Models and Hardware
+
+```bash
+# List all supported models
+gcloud container ai profiles models list --quiet
+
+# Find valid accelerator/server combinations for a model
+gcloud container ai profiles list --model=<MODEL_NAME> --quiet
+
+# Example: what can run Gemma 2 9B?
+gcloud container ai profiles list --model=gemma-2-9b-it --quiet
+```
+
+### 2. Generate Manifest
+
+```bash
+gcloud container ai profiles manifests create \
+  --model=<MODEL_NAME> \
+  --model-server=<SERVER> \
+  --accelerator-type=<ACCELERATOR> \
+  --target-ntpot-milliseconds=<NTPOT> --quiet > inference.yaml
+```
+
+**Parameters:**
+- `--model`: Model ID (e.g., `gemma-2-9b-it`, `llama-3-8b`)
+- `--model-server`: Inference server (`vllm`, `tgi`, `triton`, `tensorrt-llm`)
+- `--accelerator-type`: GPU/TPU type (`nvidia-l4`, `nvidia-tesla-a100`, `nvidia-h100-80gb`)
+- `--target-ntpot-milliseconds`: Target Normalized Time Per Output Token (optional, for latency optimization)
+
+**Example:**
+
+```bash
+gcloud container ai profiles manifests create \
+  --model=gemma-2-9b-it \
+  --model-server=vllm \
+  --accelerator-type=nvidia-l4 \
+  --target-ntpot-milliseconds=50 --quiet > inference.yaml
+```
+
+### 3. Review and Deploy
+
+```bash
+# Review for placeholders (HF tokens, PVCs)
+cat inference.yaml
+
+# Deploy
+kubectl apply -f inference.yaml
+
+# Monitor
+kubectl get pods -w
+kubectl logs -f <POD_NAME>
+```
+
+> Some models require Hugging Face tokens. Create a Kubernetes Secret and reference it in the manifest.
+
+## GPU ComputeClass for Inference
+
+For Autopilot clusters, create a ComputeClass to target GPU nodes:
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: l4-inference
+spec:
+  priorities:
+  - machineFamily: g2
+    gpu:
+      type: nvidia-l4
+      count: 1
+    minCores: 4
+    minMemoryGb: 16
+```
+
+## Accelerator Selection Guide
+
+| Accelerator | Best For | Memory | Relative Cost |
+|-------------|----------|--------|---------------|
+| NVIDIA T4 | Budget inference, lightweight legacy models | 16 GB | Lowest |
+| NVIDIA L4 (G2) | Small-medium model inference, video, graphics | 24 GB | Low |
+| NVIDIA RTX PRO 6000 (G4) | Multimodal AI, high-fidelity 3D, fine-tuning | 96 GB | Medium |
+| Cloud TPU v5e | Cost-effective transformer inference | Varies | Medium |
+| Cloud TPU v5p | High-performance training | Varies | High |
+| Cloud TPU v6e (Trillium) | High-efficiency next-gen training & serving | 32 GB/chip | Medium-High |
+| Cloud TPU v7x (Ironwood) | Ultra-scale inference & agentic workflows | 192 GB/chip | High |
+| NVIDIA A100 | Large model inference, enterprise ML | 40/80 GB | High |
+| NVIDIA H100 / H200 | Frontier model training, high throughput | 80/141 GB | Highest |
+| NVIDIA B200 (A4) | Blackwell-scale training, FP4 precision | 192 GB | Highest |
+| NVIDIA GB200 (A4X) | Rack-scale AI (Grace Blackwell Superchip) | Massive | Highest |
+
+## Autoscaling LLM Inference
+
+### GPU-based autoscaling
+
+Use custom metrics for GPU utilization:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: llm-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: llm-server
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: gpu_duty_cycle
+      target:
+        type: AverageValue
+        averageValue: "80"
+```
+
+### Best practices for inference autoscaling
+
+1. **Use DCGM metrics**: Golden path enables DCGM monitoring for GPU utilization metrics
+2. **Set appropriate minReplicas**: At least 1 for always-on serving; 0 for batch/on-demand
+3. **Tune scale-down delay**: LLM model loading is slow; use longer stabilization windows
+4. **Consider queue depth**: Scale on pending requests rather than pure GPU utilization for latency-sensitive workloads
+
+## Optimization Tips
+
+- **Quantization**: Use quantized models (GPTQ, AWQ) to reduce GPU memory and increase throughput
+- **Batching**: Configure model server batch size for throughput vs latency trade-off
+- **Tensor parallelism**: Split large models across multiple GPUs within a node
+- **KV cache optimization**: Tune `--gpu-memory-utilization` in vLLM for KV cache allocation
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Invalid model/accelerator combination | Unsupported tuple | Re-run `gcloud container ai profiles list --model=<MODEL>` |
+| GPU quota exceeded | Regional quota limit | Request quota increase or try a different region |
+| OOM on GPU | Model too large for accelerator | Use larger GPU, enable quantization, or use tensor parallelism |
+| Slow cold start | Large model loading from registry | Use local SSD for model caching; pre-pull images |

--- a/cli-tool/components/skills/development/gke-basics/references/gke-multitenancy.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-multitenancy.md
@@ -1,0 +1,163 @@
+# GKE Multi-Tenancy
+
+This reference covers enterprise multi-tenancy patterns on GKE, including namespace isolation, RBAC planning, resource quotas, and network segmentation.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `check_k8s_auth`, `describe_k8s_resource`, `delete_k8s_resource`
+
+## When to Use
+
+- Multiple teams sharing a single GKE cluster
+- Isolating workloads by environment (dev/staging/prod) within one cluster
+- Implementing least-privilege access control
+- Cost allocation across teams or projects
+
+## Multi-Tenancy Models
+
+| Model | Isolation | Complexity | Cost |
+|-------|-----------|------------|------|
+| **Namespace-per-team** | Soft (RBAC + Network Policy) | Low | Lowest (shared cluster) |
+| **Namespace-per-environment** | Soft | Low | Low |
+| **Node pool-per-team** | Medium (dedicated compute) | Medium | Medium |
+| **Cluster-per-team** | Hard (full isolation) | High | Highest |
+
+> **Golden path recommendation**: Start with namespace-per-team for cost efficiency. Escalate to stronger isolation only when compliance requires it.
+
+## Namespace Isolation Setup
+
+### 1. Create Namespaces
+
+```bash
+kubectl create namespace team-a
+kubectl create namespace team-b
+kubectl label namespace team-a team=a
+kubectl label namespace team-b team=b
+```
+
+### 2. RBAC Configuration
+
+**Principle**: Grant minimal permissions per namespace. Never bind to `system:authenticated`.
+
+```yaml
+# Namespace-scoped role for a team
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: team-a-developer
+  namespace: team-a
+rules:
+- apiGroups: ["", "apps", "batch"]
+  resources: ["pods", "deployments", "services", "configmaps", "jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: team-a-developers
+  namespace: team-a
+subjects:
+- kind: Group
+  name: "team-a@example.com"  # Google Group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: team-a-developer
+  apiGroup: rbac.authorization.k8s.io
+```
+
+**RBAC best practices:** Use Google Groups for subject bindings. Prefer namespace-scoped Roles over ClusterRoles. See [gke-security.md](./gke-security.md) for full RBAC hardening guidance.
+
+### 3. Resource Quotas
+
+Prevent any single team from consuming all cluster resources:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: team-a-quota
+  namespace: team-a
+spec:
+  hard:
+    requests.cpu: "10"
+    requests.memory: "20Gi"
+    limits.cpu: "20"
+    limits.memory: "40Gi"
+    pods: "50"
+    services: "10"
+    persistentvolumeclaims: "10"
+```
+
+### 4. LimitRanges
+
+Set default and maximum resource constraints per container:
+
+```yaml
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: team-a-limits
+  namespace: team-a
+spec:
+  limits:
+  - type: Container
+    default:
+      cpu: "500m"
+      memory: "512Mi"
+    defaultRequest:
+      cpu: "100m"
+      memory: "128Mi"
+    max:
+      cpu: "4"
+      memory: "8Gi"
+```
+
+### 5. Network Isolation
+
+Apply default-deny per namespace (see [gke-security.md](./gke-security.md)), then allow intra-team traffic:
+
+```yaml
+# Allow same-namespace pods to talk + DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: team-a
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}
+  - to:  # Allow DNS
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+```
+
+## Cost Allocation
+
+### Labels for Cost Attribution
+
+```bash
+# Label namespaces for billing
+kubectl label namespace team-a cost-center=engineering
+kubectl label namespace team-b cost-center=data-science
+```
+
+### GKE Cost Allocation
+
+Enable GKE cost allocation to break down costs by namespace and label:
+
+```bash
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-cost-allocation
+```
+
+View in Cloud Billing > GKE Cost Allocation.
+

--- a/cli-tool/components/skills/development/gke-basics/references/gke-networking.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-networking.md
@@ -1,0 +1,131 @@
+# GKE Networking
+
+This reference covers networking configuration for GKE clusters. The golden path enforces private, VPC-native clusters with Dataplane V2.
+
+> **MCP Tools:** `get_cluster`, `update_cluster`, `apply_k8s_manifest`, `get_k8s_resource`
+
+## Golden Path Networking Defaults
+
+| Setting | Golden Path Value | Day-0/1 | Notes |
+|---------|-------------------|---------|-------|
+| `privateClusterConfig.enablePrivateNodes` | `true` | Day-0 | Nodes have no public IPs |
+| `masterAuthorizedNetworksConfig.privateEndpointEnforcementEnabled` | `true` | Day-0 | Control plane only reachable via private endpoint or DNS |
+| `controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic` | `true` | Day-0 | Allows DNS-based access from outside VPC |
+| `networkConfig.datapathProvider` | `ADVANCED_DATAPATH` (Dataplane V2) | Day-0 | eBPF-based, built-in Network Policy |
+| `networkConfig.dnsConfig.clusterDns` | `CLOUD_DNS` | Day-0 | Managed DNS, more reliable than kube-dns |
+| `networkConfig.enableIntraNodeVisibility` | `true` | Day-1 | VPC Flow Logs for intra-node traffic |
+| `networkConfig.gatewayApiConfig.channel` | `CHANNEL_STANDARD` | Day-1 | Gateway API support |
+| `ipAllocationPolicy.autoIpamConfig.enabled` | `true` | Day-0 | Automatic IP range management |
+| `ipAllocationPolicy.createSubnetwork` | `true` | Day-0 | Auto-create dedicated subnet |
+| `defaultMaxPodsConstraint.maxPodsPerNode` | `48` | Day-0 | Conservative default; 110 for high density |
+
+## Private Cluster Access Patterns
+
+The golden path creates a private cluster. Users access it via:
+
+1. **DNS endpoint (default)**: `allowExternalTraffic: true` enables access via the cluster's DNS endpoint from outside the VPC. No VPN required.
+2. **Private endpoint**: Direct access from within the VPC or via Cloud VPN/Interconnect.
+3. **Authorized networks**: Add specific CIDRs to `masterAuthorizedNetworksConfig` for IP-based access control.
+
+```bash
+# Access private cluster via DNS endpoint (golden path default)
+gcloud container clusters get-credentials <CLUSTER_NAME> \
+  --region <REGION> --dns-endpoint \
+  --quiet
+
+# Access via private endpoint (from within VPC)
+gcloud container clusters get-credentials <CLUSTER_NAME> \
+  --region <REGION> --internal-ip \
+  --quiet
+```
+
+## Bring-Your-Own VPC/Subnet
+
+If the customer has existing network infrastructure:
+
+```bash
+gcloud container clusters create-auto <CLUSTER_NAME> \
+  --region <REGION> \
+  --network <VPC_NAME> \
+  --subnetwork <SUBNET_NAME> \
+  --cluster-secondary-range-name <POD_RANGE> \
+  --services-secondary-range-name <SVC_RANGE> \
+  --enable-private-nodes \
+  --enable-master-authorized-networks \
+  --quiet
+```
+
+> **Day-0 Warning**: VPC, subnet, and IP ranges cannot be changed after cluster creation.
+
+## IP Planning
+
+| Resource | Golden Path | Notes |
+|----------|-------------|-------|
+| Pod CIDR | `/17` (auto) | ~32K pod IPs; size based on maxPodsPerNode |
+| Service CIDR | `/20` (auto) | ~4K service IPs |
+| Node subnet | auto-created | /20 recommended for growth |
+| Max pods/node | 48 | Each node gets a /25 pod range; set to 110 for /24 per node |
+
+**Pod CIDR sizing rule of thumb:**
+- `maxPodsPerNode=48` -> each node uses a `/25` (128 IPs) from pod CIDR
+- `maxPodsPerNode=110` -> each node uses a `/24` (256 IPs) from pod CIDR
+- Larger maxPodsPerNode = fewer nodes fit in a given CIDR
+
+## Ingress
+
+**Gateway API** (golden path, enabled via `gatewayApiConfig.channel: CHANNEL_STANDARD`):
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-http
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+```
+
+**Alternatives:**
+- `gke-l7-regional-external-managed` — regional external
+- `gke-l7-rilb` — internal load balancer
+- Istio service mesh — for advanced traffic management, mTLS
+
+## Egress
+
+- Default: nodes use Cloud NAT for outbound internet access (private nodes have no public IPs)
+- For static egress IPs: configure Cloud NAT with manual IP allocation
+- For restricted egress: route through a firewall appliance via custom routes
+
+## Network Policy
+
+Dataplane V2 (golden path) provides built-in Network Policy enforcement — no additional addon needed. Apply default-deny per namespace, then allow specific flows.
+
+> See [gke-security.md](./gke-security.md) for default-deny policy and [gke-multitenancy.md](./gke-multitenancy.md) for per-team allow policies.
+
+## Cloud Armor (Recommended for Public-Facing Services)
+
+Cloud Armor provides WAF and DDoS protection. **Not a golden path default** — recommended for any service with public ingress. Link via `BackendConfig`:
+
+```yaml
+# 1. Create BackendConfig referencing your Cloud Armor policy
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: my-backend-config
+spec:
+  securityPolicy:
+    name: my-cloud-armor-policy
+---
+# 2. Annotate your Service
+# cloud.google.com/backend-config: '{"default": "my-backend-config"}'
+```
+
+## SSL, Container-Native LB, and PSC
+
+- **Google-managed SSL certificates**: Use `ManagedCertificate` CRD with Gateway API. Auto-provisions and renews.
+- **Container-native LB**: Enabled by default on VPC-native clusters (golden path). Targets pods via NEGs, bypassing iptables. Annotation: `cloud.google.com/neg: '{"ingress": true}'`.
+- **Private Service Connect (PSC)**: Use `ServiceAttachment` CRD to expose services across VPCs without peering.
+

--- a/cli-tool/components/skills/development/gke-basics/references/gke-observability.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-observability.md
@@ -1,0 +1,168 @@
+# GKE Observability
+
+This reference covers monitoring, logging, and metrics configuration for GKE. The golden path enables comprehensive observability including control-plane metrics.
+
+> **MCP Tools:** `get_cluster`, `list_k8s_events`, `get_k8s_logs`, `get_k8s_cluster_info`, `describe_k8s_resource`. **CLI-only:** `gcloud container clusters update --monitoring=...`, `gcloud logging read`
+
+## Golden Path Observability Defaults
+
+| Setting | Golden Path Value | Notes |
+|---------|-------------------|-------|
+| `loggingConfig` components | SYSTEM_COMPONENTS, WORKLOADS | Full workload logging |
+| `monitoringConfig` components | SYSTEM_COMPONENTS, STORAGE, POD, DEPLOYMENT, STATEFULSET, DAEMONSET, HPA, JOBSET, CADVISOR, KUBELET, DCGM, APISERVER, SCHEDULER, CONTROLLER_MANAGER | Full suite including control-plane |
+| `managedPrometheusConfig.enabled` | `true` | Google-managed Prometheus |
+| `advancedDatapathObservabilityConfig.enableMetrics` | `true` | Dataplane V2 flow metrics |
+| `loggingService` | `logging.googleapis.com/kubernetes` | Cloud Logging |
+| `monitoringService` | `monitoring.googleapis.com/kubernetes` | Cloud Monitoring |
+
+### Control-Plane Metrics (Golden Path Addition)
+
+The golden path adds three control-plane monitoring components not present in default clusters:
+
+| Component | What It Monitors |
+|-----------|-----------------|
+| `APISERVER` | API server request latency, error rates, admission webhook performance |
+| `SCHEDULER` | Scheduling latency, pending pods, scheduling failures |
+| `CONTROLLER_MANAGER` | Controller work queue depth, reconciliation latency |
+
+These are critical for diagnosing cluster-level issues (slow API responses, scheduling delays, stuck controllers).
+
+## Enabling Full Monitoring
+
+```bash
+# Enable golden path monitoring suite
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --monitoring=SYSTEM,API_SERVER,SCHEDULER,CONTROLLER_MANAGER,STORAGE,POD,DEPLOYMENT,STATEFULSET,DAEMONSET,HPA,CADVISOR,KUBELET,DCGM \
+  --quiet
+
+# Enable Managed Prometheus
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-managed-prometheus \
+  --quiet
+
+# Enable Dataplane V2 observability metrics
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-dataplane-v2-flow-observability \
+  --quiet
+```
+
+## Managed Prometheus
+
+Golden path enables Google Managed Prometheus for metrics collection and querying.
+
+**Querying metrics:**
+- Use Cloud Monitoring Metrics Explorer in the console
+- Use PromQL via the Prometheus UI or API
+- Grafana dashboards via Managed Grafana
+
+**Key GKE metrics:**
+
+| Metric | Source | Use |
+|--------|--------|-----|
+| `container_cpu_usage_seconds_total` | cAdvisor | Pod CPU usage |
+| `container_memory_working_set_bytes` | cAdvisor | Pod memory usage |
+| `kube_pod_status_phase` | kube-state-metrics | Pod lifecycle |
+| `apiserver_request_duration_seconds` | API Server | Control plane latency |
+| `scheduler_scheduling_duration_seconds` | Scheduler | Scheduling performance |
+| `node_cpu_seconds_total` | Kubelet | Node CPU |
+| `DCGM_FI_DEV_GPU_UTIL` | DCGM | GPU utilization |
+
+## Live Resource Usage (kubectl-only)
+
+No MCP or gcloud equivalent exists for live resource usage. Use `kubectl top`:
+
+```bash
+kubectl top pods --all-namespaces --sort-by=cpu
+kubectl top nodes
+kubectl top pods --containers -n <NAMESPACE>  # per-container breakdown
+```
+
+## Cloud Logging (gcloud-only)
+
+**Querying cluster logs** (no MCP equivalent — use `gcloud logging read`):
+
+```bash
+# System component logs
+gcloud logging read \
+  'resource.type="k8s_cluster" AND resource.labels.cluster_name="<CLUSTER_NAME>"' \
+  --project <PROJECT_ID> --limit 50 \
+  --quiet
+
+# Workload logs for a specific namespace
+gcloud logging read \
+  'resource.type="k8s_container" AND resource.labels.cluster_name="<CLUSTER_NAME>" AND resource.labels.namespace_name="<NAMESPACE>"' \
+  --project <PROJECT_ID> --limit 50 \
+  --quiet
+
+# Audit logs (who did what)
+gcloud logging read \
+  'resource.type="k8s_cluster" AND logName:"cloudaudit.googleapis.com"' \
+  --project <PROJECT_ID> --limit 50 \
+  --quiet
+```
+
+## Diagnostic Settings
+
+For security monitoring and troubleshooting, enable control-plane audit logs:
+
+```bash
+# View current logging config
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="yaml(loggingConfig)" \
+  --quiet
+```
+
+## Alerting
+
+Set up alerts for critical conditions:
+
+| Condition | Metric | Threshold |
+|-----------|--------|-----------|
+| High API server latency | `apiserver_request_duration_seconds` | P99 > 5s |
+| Pod crash loops | `kube_pod_container_status_restarts_total` | > 5 in 10min |
+| Node not ready | `kube_node_status_condition` | condition=Ready, status!=True |
+| High GPU utilization | `DCGM_FI_DEV_GPU_UTIL` | > 95% sustained |
+| PVC near capacity | `kubelet_volume_stats_used_bytes / capacity` | > 85% |
+| Scheduling failures | `scheduler_schedule_attempts_total{result="error"}` | > 0 |
+
+## Cost Considerations
+
+Monitoring and logging have associated costs:
+
+- **Cloud Logging**: Charged per GiB ingested beyond free tier (50 GiB/project/month)
+- **Cloud Monitoring**: Free for GKE system metrics; custom metrics charged per time series
+- **Managed Prometheus**: Charged per samples ingested
+
+To reduce costs in non-production:
+```bash
+# Reduce to system-only monitoring
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --monitoring=SYSTEM \
+  --quiet
+```
+
+## Distributed Tracing & Continuous Profiling (Recommended)
+
+**Not golden path defaults** — recommended for production microservice architectures and performance-sensitive workloads.
+
+- **Cloud Trace**: Add OpenTelemetry SDK to your app with the `opentelemetry-operations-go` (or equivalent) exporter. Traces appear in Cloud Trace console. Identifies cross-service latency bottlenecks.
+- **Cloud Profiler**: Add the Cloud Profiler agent to your app. Profiles CPU and memory usage in production with low overhead. Identifies hotspots and compares across versions.
+
+## LQL Query Examples
+
+Common Logging Query Language patterns for GKE troubleshooting:
+
+```
+# Error logs for a specific container
+resource.type="k8s_container" AND resource.labels.container_name="my-app" AND severity>=ERROR
+
+# OOMKilled events
+resource.type="k8s_event" AND jsonPayload.reason="OOMKilling"
+
+# Pod scheduling failures
+resource.type="k8s_event" AND jsonPayload.reason="FailedScheduling"
+
+# Audit logs (who did what)
+resource.type="k8s_cluster" AND logName:"cloudaudit.googleapis.com"
+```
+

--- a/cli-tool/components/skills/development/gke-basics/references/gke-reliability.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-reliability.md
@@ -1,0 +1,169 @@
+# GKE Reliability
+
+This reference covers high availability and reliability configuration for GKE clusters and workloads.
+
+> **MCP Tools:** `get_cluster`, `get_k8s_resource`, `describe_k8s_resource`, `apply_k8s_manifest`, `list_k8s_events`
+
+## Golden Path Reliability Defaults
+
+| Setting | Golden Path Value | Notes |
+|---------|-------------------|-------|
+| Cluster type | Regional (4 zones: us-central1-a/b/c/f) | Control plane replicated across zones |
+| Upgrade strategy | SURGE (`maxSurge: 1`) | Rolling upgrades with extra capacity |
+| Auto-repair | `true` | Unhealthy nodes replaced automatically |
+| Auto-upgrade | `true` | Nodes follow control plane version |
+| Release channel | REGULAR | Balanced freshness and stability |
+| Stateful HA | Enabled | Leader election for stateful workloads |
+
+## Workflows
+
+### 1. Verify Cluster High Availability
+
+```
+# MCP (preferred)
+get_cluster(name="projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>",
+  readMask="location,locations,nodePools.locations")
+
+# gcloud fallback
+gcloud container clusters describe <CLUSTER> --region <REGION> \
+  --format="json(location, locations)" \
+  --quiet
+```
+
+- If `location` is a region (e.g., `us-central1`), the control plane is regional
+- If `locations` has multiple entries, nodes span multiple zones
+
+### 2. Pod Disruption Budgets (PDBs)
+
+PDBs ensure minimum pod availability during voluntary disruptions (node upgrades, autoscaler scale-down).
+
+**Check existing PDBs:**
+
+```
+# MCP (preferred)
+get_k8s_resource(parent="...", resourceType="poddisruptionbudget")
+
+# kubectl fallback
+kubectl get pdb --all-namespaces
+```
+
+**Create PDB:**
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: my-app-pdb
+  namespace: default
+spec:
+  minAvailable: 2       # Or use maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: my-app
+```
+
+> Every production Deployment with 2+ replicas should have a PDB.
+
+### 3. Health Probes
+
+Every production container should have liveness and readiness probes. Startup probes are recommended for slow-starting apps.
+
+**Check existing probes:**
+
+```
+# MCP (preferred)
+describe_k8s_resource(parent="...", resourceType="deployment", name="<APP>", namespace="<NS>")
+
+# kubectl fallback
+kubectl get deployment <APP> -n <NS> -o yaml | grep -E "livenessProbe|readinessProbe|startupProbe"
+```
+
+**Recommended probe configuration:**
+
+```yaml
+spec:
+  containers:
+  - name: app
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 3
+    startupProbe:             # For slow-starting apps
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      failureThreshold: 30    # 30 * 5s = 150s max startup time
+```
+
+- **Readiness**: Determines when a pod can accept traffic
+- **Liveness**: Determines when to restart a container
+- **Startup**: Disables liveness/readiness until the app is ready (prevents premature restarts)
+
+### 4. Graceful Shutdown
+
+Ensure applications handle `SIGTERM` and drain in-flight requests:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 30    # Default; increase for long-running requests
+  containers:
+  - name: app
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 5"]  # Allow LB to deregister
+```
+
+### 5. Topology Spread Constraints
+
+Distribute pods across zones and nodes to survive failures:
+
+```yaml
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app: my-app
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: my-app
+```
+
+- **Zone spread** (`DoNotSchedule`): Hard requirement -- pods must be balanced across zones
+- **Node spread** (`ScheduleAnyway`): Best-effort -- prefer distribution but don't block scheduling
+
+### 6. Replicas
+
+| Workload Type | Minimum Replicas | Reason |
+|--------------|-----------------|--------|
+| Stateless web/API | 2 | Survive single pod/node failure |
+| Critical services | 3 | Survive zone failure with zone spread |
+| Stateful (databases) | 3 (with replication) | Application-level quorum |
+| Batch/jobs | 1 | Ephemeral by nature |
+
+## Best Practices
+
+1. **Regional clusters for production**: Always use regional clusters to survive zone failures
+2. **PDBs for everything**: Every production workload with 2+ replicas needs a PDB
+3. **Probes for all containers**: At minimum, readiness probes on every production container
+4. **Zone spreading**: Use topology spread constraints to distribute pods across failure domains
+5. **Graceful shutdown**: Handle SIGTERM and set appropriate `terminationGracePeriodSeconds`
+6. **Maintenance windows**: Schedule upgrades during low-traffic periods (see [gke-upgrades.md](./gke-upgrades.md))

--- a/cli-tool/components/skills/development/gke-basics/references/gke-scaling.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-scaling.md
@@ -1,0 +1,149 @@
+# GKE Workload Scaling
+
+This reference covers scaling workloads on GKE. The golden path enables VPA, OPTIMIZE_UTILIZATION autoscaling profile, and Node Auto Provisioning by default.
+
+> **MCP Tools:** `get_k8s_resource`, `describe_k8s_resource`, `apply_k8s_manifest`, `patch_k8s_resource`, `get_cluster`, `update_cluster`, `update_node_pool`
+
+## Golden Path Scaling Defaults
+
+| Setting | Golden Path Value | Notes |
+|---------|-------------------|-------|
+| `autoscaling.autoscalingProfile` | `OPTIMIZE_UTILIZATION` | Aggressive scale-down for cost savings |
+| `verticalPodAutoscaling.enabled` | `true` | VPA recommendations available |
+| `autoscaling.enableNodeAutoprovisioning` | `true` | NAP creates node pools on demand |
+| GPU resource limits (T4, A100) | `1000000000` each | NAP can provision GPU nodes |
+
+## Scaling Mechanisms
+
+### 1. Manual Scaling
+
+> **kubectl-only** — no MCP equivalent for `kubectl scale`. Use kubectl directly.
+
+```bash
+kubectl scale deployment <DEPLOYMENT> --replicas=<N> -n <NAMESPACE>
+```
+
+### 2. Horizontal Pod Autoscaling (HPA)
+
+Scales the number of pods based on metrics.
+
+**Quick setup (kubectl-only — no MCP equivalent for `kubectl autoscale`):**
+
+```bash
+kubectl autoscale deployment <DEPLOYMENT> --cpu-percent=50 --min=1 --max=10
+```
+
+**Manifest approach (recommended — use MCP `apply_k8s_manifest`):**
+
+See [assets/hpa-example.yaml](../assets/hpa-example.yaml) for a template.
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: <DEPLOYMENT>-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <DEPLOYMENT>
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+```
+
+### 3. Vertical Pod Autoscaling (VPA)
+
+Adjusts CPU and memory requests to match actual usage. Enabled by default on golden path.
+
+**Update modes:**
+- `Off` — recommendations only (safest, start here)
+- `Initial` — sets resources only at pod creation
+- `Auto` — restarts pods to apply new resource values
+- `InPlaceOrRecreate` — updates resources without restart when possible (GKE 1.34+)
+
+**Create VPA in recommendation mode:**
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: <DEPLOYMENT>-vpa
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <DEPLOYMENT>
+  updatePolicy:
+    updateMode: "Off"
+```
+
+**Read recommendations (prefer MCP `describe_k8s_resource`):**
+
+```
+# MCP (preferred)
+describe_k8s_resource(parent="...", resourceType="verticalpodautoscaler", name="<DEPLOYMENT>-vpa", namespace="<NAMESPACE>")
+
+# kubectl fallback
+kubectl get vpa <DEPLOYMENT>-vpa -o jsonpath='{.status.recommendation}'
+```
+
+See [assets/vpa-example.yaml](../assets/vpa-example.yaml) for a full template.
+
+### 4. Cluster Autoscaler / Node Auto Provisioning (NAP)
+
+On Autopilot (golden path), node scaling is fully managed. NAP automatically creates and sizes node pools based on workload demands.
+
+**For Standard clusters:**
+
+```bash
+# Enable cluster autoscaler on a node pool
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-autoscaling --node-pool <POOL_NAME> \
+  --min-nodes <MIN> --max-nodes <MAX> \
+  --quiet
+
+# Enable NAP
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-autoprovisioning \
+  --min-cpu <MIN_CPU> --max-cpu <MAX_CPU> \
+  --min-memory <MIN_MEM> --max-memory <MAX_MEM> \
+  --quiet
+```
+
+**Autoscaling profiles:**
+
+| Profile | Behavior | Golden Path? |
+|---------|----------|-------------|
+| `BALANCED` | Default GKE; conservative scale-down | No |
+| `OPTIMIZE_UTILIZATION` | Aggressive scale-down; lower idle resources | **Yes** |
+
+## Best Practices
+
+1. **Define resource requests**: HPA and VPA rely on accurate requests. Always set them.
+2. **Avoid metric conflicts**: Do not use HPA and VPA on the same metric. Typical pattern: HPA on CPU, VPA on memory.
+3. **Pod Disruption Budgets**: Define PDBs for all production workloads to ensure availability during scaling events.
+4. **HPA stabilization**: HPA has a default 5-minute stabilization window. Tune `behavior` for faster response if needed.
+5. **VPA "Auto" caution**: Auto mode restarts pods. Ensure your app handles SIGTERM gracefully. VPA requires at least 2 replicas for evictions by default.
+6. **Use ComputeClasses**: For workload-specific node targeting (Spot fallback, GPU, specific machine families), use ComputeClasses instead of node selectors.
+
+## Rightsizing Workflow
+
+1. Deploy VPA in `Off` mode for 24+ hours
+2. Read recommendations: `kubectl describe vpa <NAME>`
+3. Compare `target` values against current `requests`
+4. Apply with 20% buffer: `new_request = target * 1.2`
+5. Use patch format to update Deployment
+
+| Condition | Recommendation | Risk |
+|-----------|----------------|------|
+| CPU request >5x P95 actual | Reduce to `P95 * 1.2` | Medium |
+| Memory request >3x P95 actual | Reduce to `P95 * 1.2` | Medium |
+| CPU request >2x P95 actual | Rightsizing with 20% buffer | Low |
+| No resource limits set | Add limits to prevent noisy-neighbor | Low |

--- a/cli-tool/components/skills/development/gke-basics/references/gke-security.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-security.md
@@ -1,0 +1,226 @@
+# GKE Security
+
+This reference covers security configuration for GKE clusters. The golden path enforces a hardened security posture by default.
+
+> **MCP Tools:** `get_cluster`, `check_k8s_auth`, `get_k8s_resource`, `apply_k8s_manifest`, `update_cluster`
+
+## Golden Path Security Defaults
+
+| Setting | Golden Path Value | Day-0/1 | Notes |
+|---------|-------------------|---------|-------|
+| `workloadIdentityConfig.workloadPool` | `<PROJECT>.svc.id.goog` | Day-0 | Workload Identity Federation for Pods |
+| `secretManagerConfig.enabled` | `true` | Day-1 | Google Secret Manager integration |
+| `secretManagerConfig.rotationConfig` | `enabled: true, rotationInterval: 120s` | Day-1 | Automatic secret rotation |
+| `rbacBindingConfig.enableInsecureBindingSystemAuthenticated` | `false` | Day-0 | Blocks legacy `system:authenticated` bindings |
+| `rbacBindingConfig.enableInsecureBindingSystemUnauthenticated` | `false` | Day-0 | Blocks legacy `system:unauthenticated` bindings |
+| `nodeConfig.shieldedInstanceConfig.enableSecureBoot` | `true` | Day-0 | Verifiable boot integrity |
+| `nodeConfig.shieldedInstanceConfig.enableIntegrityMonitoring` | `true` | Day-0 | Runtime integrity checks |
+| `nodeConfig.workloadMetadataConfig.mode` | `GKE_METADATA` | Day-0 | Blocks legacy metadata API, enforces Workload Identity |
+| Private cluster + Dataplane V2 settings | See [gke-networking.md](./gke-networking.md) | Day-0 | Private nodes, private endpoint enforcement, ADVANCED_DATAPATH |
+
+## Workload Identity Federation
+
+Workload Identity is the recommended way for pods to access Google Cloud APIs. It eliminates the need for static service account keys.
+
+### Setup
+
+```bash
+# 1. Create a Google Service Account (GSA)
+gcloud iam service-accounts create <GSA_NAME> \
+  --project <PROJECT_ID> \
+  --display-name "Workload Identity SA" \
+  --quiet
+
+# 2. Grant IAM roles to the GSA
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member "serviceAccount:<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role "<ROLE>" \
+  --quiet
+
+# 3. Create Kubernetes Service Account (KSA)
+kubectl create namespace <NAMESPACE>
+kubectl create serviceaccount <KSA_NAME> --namespace <NAMESPACE>
+
+# 4. Bind KSA to GSA
+gcloud iam service-accounts add-iam-policy-binding \
+  <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:<PROJECT_ID>.svc.id.goog[<NAMESPACE>/<KSA_NAME>]" \
+  --quiet
+
+# 5. Annotate KSA
+kubectl annotate serviceaccount <KSA_NAME> \
+  --namespace <NAMESPACE> \
+  iam.gke.io/gcp-service-account=<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com
+```
+
+> See [assets/workload-identity-pod.yaml](../assets/workload-identity-pod.yaml) for a test pod.
+
+### Verification
+
+```bash
+kubectl run workload-identity-test \
+  --image=gcr.io/google.com/cloudsdktool/cloud-sdk:slim \
+  --serviceaccount=<KSA_NAME> --namespace=<NAMESPACE> \
+  --rm -it -- gcloud auth list --quiet
+```
+
+## Secret Manager Integration
+
+The golden path enables Secret Manager with automatic rotation. Secrets are synced to Kubernetes Secrets.
+
+```bash
+# Verify Secret Manager is enabled on cluster
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="value(secretManagerConfig.enabled)" \
+  --quiet
+
+# Enable if not already (Day-1 change)
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-secret-manager \
+  --secret-manager-rotation-interval=120s \
+  --quiet
+```
+
+## RBAC Hardening
+
+The golden path disables insecure legacy RBAC bindings that grant broad access to `system:authenticated` and `system:unauthenticated` groups.
+
+```bash
+# Verify insecure bindings are disabled
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="yaml(rbacBindingConfig)" \
+  --quiet
+```
+
+**Best practices for RBAC:**
+- Use namespace-scoped Roles over cluster-wide ClusterRoles
+- Bind to specific Groups or ServiceAccounts, never to `system:authenticated`
+- Audit permissions via MCP: `check_k8s_auth(parent="...", verb="list", resourceType="pods", namespace="...")` (or `kubectl auth can-i --list --as=<user>`)
+- Review bindings via MCP: `get_k8s_resource(parent="...", resourceType="clusterrolebinding")` (or `kubectl get clusterrolebindings,rolebindings --all-namespaces`)
+
+> See [gke-multitenancy.md](./gke-multitenancy.md) for enterprise RBAC planning and https://docs.cloud.google.com/kubernetes-engine/docs/best-practices/rbac
+
+## Binary Authorization
+
+Not enabled in golden path by default but recommended for production image provenance:
+
+```bash
+# Enable Binary Authorization
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --binauthz-evaluation-mode=PROJECT_SINGLETON_POLICY_ENFORCE \
+  --quiet
+```
+
+## Network Policies
+
+Dataplane V2 (golden path) provides built-in Network Policy enforcement. Apply default-deny per namespace:
+
+```
+# MCP (preferred)
+apply_k8s_manifest(parent="...", yamlManifest="<contents of default-deny-netpol.yaml>")
+
+# kubectl fallback
+kubectl apply -f skills/gke/assets/default-deny-netpol.yaml -n <NAMESPACE>
+```
+
+## GKE Sandbox (gVisor)
+
+For running untrusted workloads in an isolated sandbox:
+
+```bash
+# Enable on cluster (Standard clusters)
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> --enable-gke-sandbox --quiet
+
+# Use in pod spec
+# Add: runtimeClassName: gvisor
+```
+
+## Pod Security Standards (Golden Path)
+
+Pod Security Standards define three profiles that restrict what pods can do. The **`restricted` profile is the golden path default** for production namespaces.
+
+| Profile | Level | Use Case |
+|---------|-------|----------|
+| `privileged` | Unrestricted | System namespaces (`kube-system`), infrastructure controllers |
+| `baseline` | Minimally restrictive | Shared/dev namespaces, legacy apps being migrated |
+| `restricted` | **Golden path** | Production workloads -- blocks privilege escalation, host access, root |
+
+**Enforce via namespace labels (Pod Security Admission):**
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
+```
+
+**Gradual rollout strategy:**
+1. Start with `warn` + `audit` on existing namespaces to identify violations
+2. Fix non-compliant workloads (remove `privileged`, `hostNetwork`, root user, etc.)
+3. Enable `enforce` once all workloads pass
+
+`restricted` blocks: running as root, privilege escalation, host networking/PID/IPC, host path volumes, and most capabilities. The golden path `workload-identity-pod.yaml` already complies.
+
+## Network Policy Logging (Recommended)
+
+With Dataplane V2 (golden path), you can enable logging for Network Policy decisions. **Not a golden path default** -- recommended for security auditing.
+
+```bash
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --enable-network-policy-logging \
+  --quiet
+```
+
+This logs allowed and denied connections, useful for troubleshooting Network Policy rules and auditing traffic flows.
+
+## Common IAM Roles
+
+The five most common predefined IAM roles for GKE:
+
+| Role | Purpose | When to Use |
+|------|---------|-------------|
+| `roles/container.admin` | Full control over clusters and Kubernetes resources | Platform team admins managing cluster lifecycle |
+| `roles/container.clusterAdmin` | Manage clusters but not project-level IAM | Cluster operators who create/delete clusters |
+| `roles/container.developer` | Deploy workloads (pods, services, deployments) | Application developers deploying to existing clusters |
+| `roles/container.viewer` | Read-only access to clusters and Kubernetes resources | Monitoring, auditing, or read-only dashboards |
+| `roles/container.clusterViewer` | List and get cluster details only | CI/CD pipelines that need cluster metadata |
+
+> **Principle of least privilege**: Start with `roles/container.viewer` or `roles/container.developer` and escalate only as needed. Avoid granting `roles/container.admin` broadly.
+
+## Service Accounts & Agents
+
+- **GKE Service Agent** (`service-<PROJECT_NUMBER>@container-engine-robot.iam.gserviceaccount.com`): Automatically created. Manages nodes, networking, and cluster operations on your behalf. Do not remove or modify its permissions.
+- **Node Service Account**: By default, nodes use the Compute Engine default service account. For production, create a dedicated SA with minimal permissions and assign it via node pool config.
+- **Workload Identity**: The recommended way for pods to access Google Cloud APIs. Maps a Kubernetes ServiceAccount to a Google IAM ServiceAccount — see [Workload Identity setup](#workload-identity-federation) above.
+
+## Cross-Service Authentication Patterns
+
+Common patterns for granting GKE workloads access to other Google Cloud services:
+
+```bash
+# Grant a GKE workload access to Cloud Storage
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member "serviceAccount:<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role "roles/storage.objectViewer" \
+  --quiet
+
+# Grant a GKE workload access to Cloud SQL
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member "serviceAccount:<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role "roles/cloudsql.client" \
+  --quiet
+
+# Grant a GKE workload access to Pub/Sub
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member "serviceAccount:<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
+  --role "roles/pubsub.subscriber" \
+  --quiet
+```
+
+In all cases, the GSA must be bound to a KSA via Workload Identity (see setup above). The pod then uses the KSA to authenticate as the GSA.
+

--- a/cli-tool/components/skills/development/gke-basics/references/gke-storage.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-storage.md
@@ -1,0 +1,136 @@
+# GKE Storage
+
+This reference covers storage configuration for GKE clusters including persistent disks, file storage, and cloud storage integration.
+
+> **MCP Tools:** `apply_k8s_manifest`, `get_k8s_resource`, `describe_k8s_resource`, `get_cluster`
+
+## Golden Path Storage Defaults
+
+The golden path Autopilot config enables these CSI drivers:
+
+| Driver | Golden Path | Access Mode | Use Case |
+|--------|-------------|-------------|----------|
+| Compute Engine Persistent Disk CSI | Enabled (default) | ReadWriteOnce | Block storage for databases, single-pod workloads |
+| Google Cloud Filestore CSI | Enabled | ReadWriteMany | Shared NFS for multi-pod access |
+| Cloud Storage FUSE CSI | Enabled | ReadWriteMany / ReadOnlyMany | Mount GCS buckets as volumes |
+| Parallelstore CSI | Enabled | ReadWriteMany | High-performance parallel file system |
+| Boot disk type | `pd-balanced` | N/A | Node boot disks |
+
+## StorageClasses
+
+### Default StorageClasses
+
+GKE provides built-in StorageClasses:
+
+| StorageClass | Disk Type | Use Case |
+|-------------|-----------|----------|
+| `standard-rwo` | `pd-standard` | Cost-effective, low IOPS |
+| `premium-rwo` | `pd-ssd` | High IOPS, databases |
+| `standard-rwx` | Filestore (Basic HDD) | Shared NFS |
+| `premium-rwx` | Filestore (Basic SSD) | Shared NFS, higher performance |
+
+### Custom StorageClass
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-regional
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-ssd
+  replication-type: regional-pd    # Replicate across 2 zones
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true         # Always enable for production
+```
+
+## PersistentVolumeClaims
+
+### Block Storage (ReadWriteOnce)
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: database-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: premium-rwo
+  resources:
+    requests:
+      storage: 100Gi
+```
+
+### Shared File Storage (ReadWriteMany via Filestore)
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-data
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: standard-rwx
+  resources:
+    requests:
+      storage: 1Ti    # Filestore minimum is 1 TiB for Basic tier
+```
+
+### GCS Bucket Mount (Cloud Storage FUSE)
+
+Mount a GCS bucket as a volume without a PVC:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gcs-reader
+  annotations:
+    gke-gcsfuse/volumes: "true"
+spec:
+  containers:
+  - name: reader
+    image: busybox
+    command: ["ls", "/data"]
+    volumeMounts:
+    - name: gcs-bucket
+      mountPath: /data
+  volumes:
+  - name: gcs-bucket
+    csi:
+      driver: gcsfuse.csi.storage.gke.io
+      readOnly: true
+      volumeAttributes:
+        bucketName: <BUCKET_NAME>
+```
+
+> Requires Workload Identity for the pod's service account to have `storage.objectViewer` on the bucket.
+
+## Volume Expansion
+
+If `allowVolumeExpansion: true` is set on the StorageClass, resize by updating the PVC:
+
+```bash
+# kubectl
+kubectl patch pvc <PVC_NAME> -p '{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}'
+```
+
+```
+# MCP (preferred)
+patch_k8s_resource(parent="...", resourceType="persistentvolumeclaim", name="<PVC_NAME>",
+  patch='{"spec":{"resources":{"requests":{"storage":"200Gi"}}}}')
+```
+
+Kubernetes automatically resizes the filesystem.
+
+## Best Practices
+
+1. **Always enable volume expansion**: Set `allowVolumeExpansion: true` on all StorageClasses
+2. **Use regional PDs for production**: `replication-type: regional-pd` replicates across 2 zones for HA
+3. **Use `WaitForFirstConsumer`**: Ensures the PV is provisioned in the same zone as the pod
+4. **Choose the right disk type**: `pd-ssd` for databases, `pd-balanced` (golden path default) for general use, `pd-standard` for cold storage
+5. **Use Filestore for shared access**: When multiple pods need to read/write the same files
+6. **Use GCS FUSE for data pipelines**: Mount buckets directly for ML training data, logs, etc.
+7. **Back up PVCs**: Use Backup for GKE (see [gke-backup-dr.md](./gke-backup-dr.md)) to protect persistent data

--- a/cli-tool/components/skills/development/gke-basics/references/gke-upgrades.md
+++ b/cli-tool/components/skills/development/gke-basics/references/gke-upgrades.md
@@ -1,0 +1,142 @@
+# GKE Upgrades & Maintenance
+
+This reference covers upgrade strategy, maintenance windows, and release channel management for GKE clusters.
+
+> **MCP Tools:** `get_cluster`, `get_k8s_version`, `update_cluster`, `update_node_pool`, `list_operations`, `get_operation`, `cancel_operation`, `get_k8s_resource`
+> **CLI-only**: `gcloud container get-server-config` (available versions), `gcloud container clusters update --maintenance-window-*` (maintenance windows)
+
+## Golden Path Upgrade Defaults
+
+| Setting | Golden Path Value | Notes |
+|---------|-------------------|-------|
+| `releaseChannel.channel` | `REGULAR` | Balanced between freshness and stability |
+| Maintenance exclusion | `NO_MINOR_UPGRADES`, 1 year | Prevents surprise minor version bumps |
+| `upgradeSettings.strategy` | `SURGE` | Rolling upgrades with `maxSurge: 1` |
+| Auto-repair | `true` | Unhealthy nodes are automatically replaced |
+| Auto-upgrade | `true` | Nodes follow control plane version |
+
+## Release Channels
+
+| Channel | Cadence | Best For |
+|---------|---------|----------|
+| `RAPID` | Weeks after release | Dev/test, early access to features |
+| `REGULAR` (golden path) | 2-3 months after Rapid | Production workloads |
+| `STABLE` | 2-3 months after Regular | Risk-averse, highly regulated |
+
+```bash
+# Check current channel
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="value(releaseChannel.channel)" \
+  --quiet
+
+# Change channel (Day-1)
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --release-channel <CHANNEL> \
+  --quiet
+```
+
+## Maintenance Windows
+
+Control when GKE can perform automatic maintenance (upgrades, patches).
+
+```bash
+# Set maintenance window (e.g., weekends 2am-6am UTC)
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --maintenance-window-start "2026-01-01T02:00:00Z" \
+  --maintenance-window-end "2026-01-01T06:00:00Z" \
+  --maintenance-window-recurrence "FREQ=WEEKLY;BYDAY=SA,SU" \
+  --quiet
+```
+
+### Maintenance Exclusions
+
+The golden path includes a 1-year `NO_MINOR_UPGRADES` exclusion to prevent automatic minor version changes.
+
+```bash
+# Add maintenance exclusion
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --add-maintenance-exclusion-name "freeze-1" \
+  --add-maintenance-exclusion-start "2026-04-11T00:00:00Z" \
+  --add-maintenance-exclusion-end "2027-04-11T00:00:00Z" \
+  --add-maintenance-exclusion-scope NO_MINOR_UPGRADES \
+  --quiet
+
+# Remove exclusion
+gcloud container clusters update <CLUSTER_NAME> --region <REGION> \
+  --remove-maintenance-exclusion "freeze-1" \
+  --quiet
+```
+
+**Exclusion scopes:**
+- `NO_UPGRADES` — blocks all upgrades (max 30 days)
+- `NO_MINOR_UPGRADES` — allows patch upgrades, blocks minor version changes (max 1 year)
+- `NO_MINOR_OR_NODE_UPGRADES` — blocks minor and node upgrades (max 1 year)
+
+## Upgrade Strategy
+
+### SURGE (Golden Path)
+
+Rolling upgrade with configurable surge capacity:
+
+```bash
+# Default: maxSurge=1 (one extra node during upgrade)
+gcloud container node-pools update <POOL_NAME> \
+  --cluster <CLUSTER_NAME> --region <REGION> \
+  --max-surge-upgrade 1 --max-unavailable-upgrade 0 \
+  --quiet
+```
+
+### Blue-Green (For Zero-Downtime Critical Workloads)
+
+```bash
+gcloud container node-pools update <POOL_NAME> \
+  --cluster <CLUSTER_NAME> --region <REGION> \
+  --enable-blue-green-upgrade \
+  --node-pool-soak-duration "3600s" \
+  --quiet
+```
+
+## Pre-Upgrade Checklist
+
+1. **Check deprecations**: Review Kubernetes API deprecations between current and target version
+2. **Review PDBs**: Ensure all production workloads have PodDisruptionBudgets
+3. **Test in non-prod**: Upgrade a staging cluster first
+4. **Check addon compatibility**: Verify third-party controllers support the target version
+5. **Review node pool versions**: All node pools should be within 2 minor versions of the control plane
+
+```bash
+# Check current versions
+gcloud container clusters describe <CLUSTER_NAME> --region <REGION> \
+  --format="table(currentMasterVersion, nodePools[].version)" \
+  --quiet
+
+# Check available upgrades
+gcloud container get-server-config --region <REGION> \
+  --format="yaml(channels)" \
+  --quiet
+
+# List deprecation warnings
+kubectl get --raw /metrics | grep apiserver_requested_deprecated_apis
+```
+
+## Manual Upgrade (When Needed)
+
+```bash
+# Upgrade control plane
+gcloud container clusters upgrade <CLUSTER_NAME> --region <REGION> \
+  --master --cluster-version <VERSION> \
+  --quiet
+
+# Upgrade node pool
+gcloud container clusters upgrade <CLUSTER_NAME> --region <REGION> \
+  --node-pool <POOL_NAME> \
+  --quiet
+```
+
+## Best Practices
+
+1. **Stay on a release channel**: Manual version management is error-prone. Let GKE manage versions.
+2. **Use maintenance windows**: Schedule upgrades during low-traffic periods.
+3. **Set PDBs on everything**: Protects workloads during node drains.
+4. **Monitor during upgrades**: Watch for pod eviction failures, CrashLoopBackOff, and scheduling issues.
+5. **Don't skip minor versions**: Upgrade incrementally (1.28 -> 1.29 -> 1.30, not 1.28 -> 1.30).

--- a/cli-tool/components/skills/development/gke-basics/references/iac-usage.md
+++ b/cli-tool/components/skills/development/gke-basics/references/iac-usage.md
@@ -1,0 +1,77 @@
+# GKE Infrastructure as Code
+
+GKE resources, including clusters and Kubernetes objects, can be provisioned and
+managed using Terraform.
+
+## Terraform
+
+Terraform uses two main providers for GKE:
+*   The **Google Cloud provider** connects to the Google Cloud API to manage
+    GKE cluster infrastructure using Terraform resources such as
+    `google_container_cluster` for the cluster itself, and
+    `google_container_node_pool` for nodes in Standard mode.
+*   The **Kubernetes provider** connects to the Kubernetes API to manage
+    workloads inside the cluster using Kubernetes resources such as
+    Deployments and Services.
+
+
+### GKE Autopilot Cluster Example
+
+```hcl
+resource "google_container_cluster" "primary" {
+  name     = "my-gke-cluster"
+  location = "us-central1"
+
+  enable_autopilot = true
+
+  # Do NOT specify node configurations (like initial_node_count or node_config)
+  # in Autopilot mode; doing so causes a Terraform provider error.
+
+  # Deletion protection should be set to false for testing
+  deletion_protection = false
+}
+```
+
+### Deploying a Workload Example (Kubernetes Provider)
+
+```hcl
+resource "kubernetes_deployment_v1" "default" {
+  metadata {
+    name = "hello-app"
+  }
+  spec {
+    replicas = 2
+    selector {
+      match_labels = {
+        app = "hello-app"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "hello-app"
+        }
+      }
+      spec {
+        container {
+          image = "us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0"
+          name  = "hello-app"
+        }
+      }
+    }
+  }
+}
+```
+
+### Reference Documentation
+
+- [Terraform Google Provider - Container Cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster)
+
+- [Terraform Google Provider - Kubernetes Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
+
+## YAML Samples
+
+GKE cluster configurations and Kubernetes manifests can also be defined using
+YAML for use with `kubectl apply` or Deployment Manager.
+
+- [GKE YAML Samples](https://docs.cloud.google.com/docs/samples?product=googlekubernetesengine)

--- a/cli-tool/components/skills/development/gke-basics/references/mcp-usage.md
+++ b/cli-tool/components/skills/development/gke-basics/references/mcp-usage.md
@@ -1,0 +1,72 @@
+# GKE MCP Server Usage
+
+The GKE MCP server provides 23 structured tools for cluster management, Kubernetes resource operations, and diagnostics — without requiring shell access or kubeconfig setup.
+
+## Connecting to the GKE MCP Server
+
+The GKE remote MCP server is available for AI clients that support the Model Context Protocol. For setup instructions, see https://docs.cloud.google.com/kubernetes-engine/docs/how-to/use-gke-mcp.
+
+## Available Tools
+
+All tools use hierarchical resource paths:
+
+```
+Project+Region:  projects/{PROJECT}/locations/{REGION}
+Cluster:         projects/{PROJECT}/locations/{REGION}/clusters/{CLUSTER}
+Node Pool:       projects/{PROJECT}/locations/{REGION}/clusters/{CLUSTER}/nodePools/{POOL}
+Operation:       projects/{PROJECT}/locations/{REGION}/operations/{OP_ID}
+```
+
+Use `locations/-` to match all regions when listing.
+
+### Cluster Management
+
+| Tool | Mode | Purpose |
+|------|------|---------|
+| `list_clusters` | READ | Discover clusters in a project/region |
+| `get_cluster` | READ | Inspect cluster config. Use `readMask` to select fields |
+| `create_cluster` | MUTATE | Create a cluster from JSON config |
+| `update_cluster` | DESTRUCTIVE | Change Day-1 cluster settings |
+
+### Node Pool Management
+
+| Tool | Mode | Purpose |
+|------|------|---------|
+| `list_node_pools` | READ | List pools in a cluster |
+| `get_node_pool` | READ | Get pool details |
+| `create_node_pool` | MUTATE | Add a pool (Standard clusters) |
+| `update_node_pool` | DESTRUCTIVE | Modify a pool |
+
+### Kubernetes Resources
+
+| Tool | Mode | Purpose |
+|------|------|---------|
+| `get_k8s_resource` | READ | List/get any K8s resource (supports label/field selectors) |
+| `describe_k8s_resource` | READ | Detailed info with events and conditions |
+| `apply_k8s_manifest` | DESTRUCTIVE | Apply YAML manifests (supports `dryRun`) |
+| `patch_k8s_resource` | DESTRUCTIVE | JSON patch resource fields |
+| `delete_k8s_resource` | DESTRUCTIVE | Remove resources (supports `cascade`, `dryRun`) |
+| `list_k8s_api_resources` | READ | Discover available resource types |
+
+### Diagnostics & Observability
+
+| Tool | Mode | Purpose |
+|------|------|---------|
+| `list_k8s_events` | READ | Scheduling failures, OOM kills, evictions |
+| `get_k8s_logs` | READ | Container logs (supports `tail`, `since`, `previous`) |
+| `get_k8s_cluster_info` | READ | Control plane and service endpoints |
+| `get_k8s_version` | READ | Kubernetes server version |
+| `get_k8s_rollout_status` | READ | Deployment/StatefulSet rollout progress |
+| `check_k8s_auth` | READ | Verify RBAC permissions for a user/SA |
+
+### Operations
+
+| Tool | Mode | Purpose |
+|------|------|---------|
+| `list_operations` | READ | Pending/running cluster operations |
+| `get_operation` | READ | Track create/upgrade progress |
+| `cancel_operation` | DESTRUCTIVE | Abort stuck operations |
+
+## Tool Preference
+
+Default: **MCP tools > gcloud CLI > kubectl**. See [cli-reference.md](./cli-reference.md) for the full coverage comparison, CLI fallback commands, and user preference override options.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/SKILL.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: google-cloud-networking-observability
+description: Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.
+source: google/skills (Apache 2.0)
+---
+
+# Google Cloud Networking Observability Expert
+
+## Core Directive: Results First
+
+1.  **Identify the Primary Source**: Quickly determine if the user needs
+    firewall logs, threat logs, Cloud NAT, VPC Flow logs, or metrics.
+2.  **Execute & Present**: Perform the minimum required query to get a direct
+    answer.
+3.  **Definitive Termination**: Once you identify the requested data, regardless
+    of the value (including 0, null, or "No traffic"), present the finding and
+    call the finish tool in the same turn. Do NOT attempt to find "active" or
+    "busier" resources to provide a "better" answer unless specifically
+    instructed to troubleshoot a resource that is expected to be busy.
+
+## Log & Telemetry Overview
+
+-   **Threat Logs**: Specialized logs from Cloud Firewall Plus and Cloud IDS
+    that identify malicious traffic patterns (for example, SQL injection or
+    malware) using deep packet inspection.
+-   **VPC Flow Logs**: Capture sample IP traffic to and from network interfaces.
+    Use for traffic analysis, volume trends, and top talkers.
+-   **Firewall Logs**: Record connection attempts matched by firewall rules. Use
+    to identify "DENY" events or verify "ALLOW" rules.
+-   **Cloud NAT Logs**: Audit NAT translations. Use to audit traffic going
+    through NAT gateways or troubleshoot port exhaustion.
+-   **Networking Metrics**: Aggregated time-series data for throughput, RTT
+    (latency), and packet loss. Use for historical trends and performance
+    monitoring.
+-   **Connectivity Tests**: Static analysis tool for path diagnostics. Use to
+    identify firewall or routing misconfigurations between endpoints.
+
+## Procedures
+
+### 0. Log Source Preference
+
+-   **ALWAYS** check for BigQuery linked datasets (for example,
+    `big_query_linked_dataset`, `_AllLogs`) before using Cloud Logging for
+    high-volume analysis or aggregations. This is the preferred method for
+    finding trends or top-blocking rules.
+-   **Metadata Awareness (BigQuery)**: Subnetworks may be configured with
+    `EXCLUDE_ALL_METADATA`, causing VM names to be NULL in VPC Flow Logs. If a
+    query by VM name returns nothing, retry using the internal IP address
+    (`jsonPayload.connection.src_ip`).
+
+### 1. Tool Selection & Discovery
+
+-   **MCP Servers First**: Use
+    [Cloud Monitoring MCP](references/mcp-usage.md#cloud-monitoring-mcp),
+    [BigQuery MCP](references/mcp-usage.md#bigquery-mcp), or
+    [Cloud Logging MCP](references/mcp-usage.md#cloud-logging-mcp).
+-   **Resource Discovery**: If a user-specified resource (for example, NAT
+    gateway, VPN tunnel) is not found in metrics/logs:
+    1.  Use `run_shell_command` with `gcloud` to list resources in the project.
+    2.  Search [Cloud Logging MCP](references/mcp-usage.md#cloud-logging-mcp)
+        for the resource name to find correct labels.
+-   **CLI Fallback**: Use `gcloud` or `bq` only if MCP servers are unavailable.
+    DO NOT use gcloud monitoring; it is restricted. Immediately use the curl
+    templates in [metrics-analysis.md](references/metrics-analysis.md).
+
+### 2. Schema Verification & Error Recovery
+
+If a BigQuery query fails with an 'Unrecognized name' error or schema mismatch:
+1. **Validate Schema**: Run `bq show --schema --format=json
+{project_id}:{dataset_id}.{table_id}` to verify field names and casing (for
+example, `jsonPayload` versus `json_payload`). 2. **Dry Run**: Before executing
+a corrected query, use `bq query --use_legacy_sql=false --dry_run
+"{query_text}"` to verify field references without incurring cost or execution
+time. 3. **Retry**: Apply identified fixes to the original query and execute.
+
+### 3. Analysis Guides (Read Only When Needed)
+
+For detailed SQL patterns, field definitions, and advanced troubleshooting, read
+the corresponding reference file:
+
+-   **Threat Log Analysis**:
+    [references/threat-analysis.md](references/threat-analysis.md)
+-   **VPC Flow Analysis**:
+    [references/vpc-flow-analysis.md](references/vpc-flow-analysis.md)
+-   **Cloud NAT Analysis**:
+    [references/cloud-nat-analysis.md](references/cloud-nat-analysis.md)
+-   **Firewall Rule Analysis**:
+    [references/firewall-analysis.md](references/firewall-analysis.md)
+-   **Networking Metrics**:
+    [references/metrics-analysis.md](references/metrics-analysis.md)
+-   **Connectivity Test Analysis**:
+    [references/connectivity-tests.md](references/connectivity-tests.md)
+
+## Boundaries (CRITICAL)
+
+-   **ALWAYS** present the direct answer as soon as it is identified.
+-   **NEVER** run more than 2 exploratory queries before showing results.
+-   **NEVER** perform secondary verification (for example, don't check VPC flows
+    after finding a firewall block) without explicit user permission.
+-   **ALWAYS** print the generated SQL for review before execution.
+-   **ALWAYS** include a link to the Flow Analyzer in the
+    [Google Cloud Console](https://console.cloud.google.com/net-intelligence/flow-analyzer).
+-   **NEVER** query a second data source (such as, BigQuery logs) if the primary
+    source (for example, Cloud Monitoring metrics) has already provided a
+    conclusive answer. **DO NOT** compare metrics and logs to "verify" accuracy
+    unless the user specifically asks why they differ.
+-   **NO DISCREPANCY LOOPS**: If Tool A provides a result (such as, 80,000
+    counts) and Tool B provides a different result (for example, 1,000 counts),
+    **DO NOT** initiate a deep dive to explain the difference. Present the
+    result from the primary tool and STOP.
+-   **ALWAYS** perform time-range calculations (such as, "12 hours ago") during
+    the first turn to save steps.
+-   **Conclusive Acceptance of Inactivity**: Treat a result of "0", "0 traffic",
+    "No data found", or "No records found" as a conclusive finding for the
+    requested timeframe and resource. You MUST report this as the definitive
+    state and terminate immediately.
+-   **Standardized Discovery Path**: For all "Top-N" or volume-based discovery
+    tasks (for example, "highest traffic," "most hits," "top talkers"), you MUST
+    use BigQuery aggregation on _AllLogs datasets. Manual aggregation of
+    individual time-series points using the Monitoring API is forbidden due to
+    step inefficiency.
+-   **Ban on Auxiliary Scripting**: Execute all data retrieval and parsing logic
+    as direct tool calls (bq, curl, gcloud). Do NOT write or execute local shell
+    scripts (.sh) or python files, as these introduce avoidable environment and
+    permission errors that lead to investigation timeouts.
+-   **Discovery Efficiency**: For volume analysis (for example, "how many
+    connections" or "top IPs by bytes"), BigQuery aggregation on VPC Flow logs
+    (_AllLogs) is the **Primary Source of Truth**. If BigQuery data is
+    available, it is conclusive. Do NOT query Monitoring API to "double check"
+    BigQuery counts.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/cloud-nat-analysis.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/cloud-nat-analysis.md
@@ -1,0 +1,96 @@
+# Cloud NAT Analysis Reference
+
+Use Cloud NAT logs (`compute.googleapis.com/nat_flows`) to audit traffic going
+through NAT gateways or troubleshoot port exhaustion.
+
+## 🤖 Agent / Gemini CLI Instructions (MCP)
+
+You should use [Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp) for
+exploratory analysis or [BigQuery MCP](mcp-usage.md#bigquery-mcp) for
+high-volume trends. Fallback to the CLI if the MCP tools are not available.
+
+### 1. View Logs ([Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp))
+
+**Tool**: `list_log_entries`
+
+**Filter**:
+
+```text
+resource.type="nat_gateway"
+logName="projects/{project_id}/logs/compute.googleapis.com%2Fnat_flows"
+```
+
+Filter for dropped packets (potential port exhaustion):
+
+```text
+jsonPayload.allocation_status="DROPPED"
+```
+
+### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
+
+**Tool**: `execute_sql_readonly`
+
+**SQL Pattern**:
+
+```sql
+SELECT
+JSON_VALUE(json_payload.gateway_details.internal_ip) AS internal_ip, COUNT(*) AS
+drop_count FROM `{project_id}.{dataset_id}._AllLogs` WHERE log_name LIKE
+'%nat_flows%' AND JSON_VALUE(json_payload.allocation_status) = 'DROPPED' GROUP BY
+1 ORDER BY drop_count DESC LIMIT 10
+```
+
+### 3. CLI Fallback
+
+If MCP tools are unavailable, use the following `gcloud` and `bq` commands:
+
+**View Logs (gcloud)**
+
+```bash
+gcloud logging read 'resource.type="nat_gateway" AND logName="projects/{project_id}/logs/compute.googleapis.com%2Fnat_flows"' --project {project_id} --limit 10 --format json --quiet
+```
+
+To filter for dropped packets:
+
+```bash
+gcloud logging read 'resource.type="nat_gateway" AND logName="projects/{project_id}/logs/compute.googleapis.com%2Fnat_flows" AND jsonPayload.allocation_status="DROPPED"' --project {project_id} --limit 10 --format json --quiet
+```
+
+**Aggregate Trends (bq)**
+
+```bash
+bq query --use_legacy_sql=false --project_id {project_id} '
+SELECT
+  JSON_VALUE(json_payload.gateway_details.internal_ip) AS internal_ip,
+  COUNT(*) AS drop_count
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_name LIKE "%nat_flows%"
+  AND JSON_VALUE(json_payload.allocation_status) = "DROPPED"
+GROUP BY 1
+ORDER BY drop_count DESC
+LIMIT 10
+'
+```
+
+### gcloud
+
+To get the status of the router used by the NAT gateway:
+
+```bash
+gcloud compute
+routers get-status {router_name} --region {region} --quiet
+```
+
+## Key Fields
+
+-   `jsonPayload.gateway_details.external_ip` / `external_port`: NAT exit point.
+-   `jsonPayload.gateway_details.internal_ip` / `internal_port`: Source VM.
+-   `jsonPayload.allocation_status`: `DROPPED` indicates failure to allocate a
+    NAT port.
+
+## Scenarios
+
+-   **Audit Traffic**: Link internal sources to external destinations.
+-   **Port Exhaustion**: Use `jsonPayload.allocation_status="DROPPED"` to
+    identify impacted VMs.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/connectivity-tests.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/connectivity-tests.md
@@ -1,0 +1,36 @@
+# Connectivity Tests Reference
+
+## Connectivity Tests (Path Diagnostics)
+
+Use Connectivity Tests to identify firewall or routing blocks along a network
+path.
+
+### Critical Verification: Instance State
+
+**CRITICAL**: Always verify if the source and destination instances are
+`RUNNING`. A `REACHABLE` path analysis result (which is a static configuration
+analysis) does not mean traffic will flow if the VM is powered off.
+
+-   Check the `status` field in the instance details.
+-   Review step metadata in the connectivity test traces.
+
+**CRITICAL**: You MUST execute the delete command as your final tool call before
+providing the result to the user. Do not simply state that it was deleted;
+provide the command output as proof.
+
+### Tooling
+
+-   **Primary**: [NetworkManagement MCP](mcp-usage.md#networkmanagement-mcp)
+    (`create_connectivity_test`)
+-   **Polling**: [NetworkManagement MCP](mcp-usage.md#networkmanagement-mcp)
+    (`get_connectivity_test`)
+-   **Cleanup**: ALWAYS delete the test resource after use with
+    [NetworkManagement MCP](mcp-usage.md#networkmanagement-mcp)
+    (`delete_connectivity_test`).
+
+#### Fallback: gcloud
+
+-   **Create**: `gcloud network-management connectivity-tests create`
+-   **Polling**: `gcloud network-management connectivity-tests describe`
+-   **Cleanup**: ALWAYS delete the test resource after use with `gcloud
+    network-management connectivity-tests delete`.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/firewall-analysis.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/firewall-analysis.md
@@ -1,0 +1,96 @@
+# Firewall Rule Logging Analysis Reference
+
+Use firewall logs (`compute.googleapis.com/firewall`) to verify if traffic is
+allowed or denied.
+
+## 🤖 Agent / Gemini CLI Instructions (MCP)
+
+You should use [Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp) for
+exploratory analysis or [BigQuery MCP](mcp-usage.md#bigquery-mcp) for
+high-volume trends. Fallback to the CLI if the MCP tools are not available.
+
+-   **Exploratory Analysis**: Typically involves looking at individual log
+    entries or a small set of logs to understand specific events, debug issues,
+    or investigate anomalies. This often requires filtering and examining the
+    full details of log records.
+-   **High-Volume Trends**: Focuses on aggregating large datasets of logs over
+    time to identify patterns, measure traffic volumes, analyze latency
+    distributions, or find "top talkers." This usually involves SQL queries to
+    summarize data rather than inspecting individual logs.
+
+### 1. View Logs ([Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp))
+
+**Tool**: `list_log_entries`
+
+**Filter**:
+
+```text
+resource.type="gce_subnetwork"
+logName="projects/{project_id}/logs/compute.googleapis.com%2Ffirewall"
+```
+
+Filter for denied packets:
+
+```
+text jsonPayload.rule_details.action="DENY"
+```
+
+### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
+
+**Tool**: `execute_sql`
+
+**SQL Pattern**:
+
+```sql
+SELECT JSON_VALUE(json_payload.rule_details.reference) AS
+rule_name, COUNT(*) AS block_count FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE log_name LIKE '%firewall%' AND
+JSON_VALUE(json_payload.rule_details.action) = 'DENY' GROUP BY 1 ORDER BY
+block_count DESC LIMIT 10
+```
+
+### 3. CLI Fallback
+
+If MCP tools are unavailable, use the following `gcloud` and `bq` commands:
+
+**View Logs (gcloud)**
+
+```bash
+gcloud logging read 'resource.type="gce_subnetwork" AND logName="projects/{project_id}/logs/compute.googleapis.com%2Ffirewall"' --project {project_id} --limit 10 --format json --quiet
+```
+
+To filter for denied packets:
+
+```bash
+gcloud logging read 'resource.type="gce_subnetwork" AND logName="projects/{project_id}/logs/compute.googleapis.com%2Ffirewall" AND jsonPayload.rule_details.action="DENY"' --project {project_id} --limit 10 --format json --quiet
+```
+
+**Aggregate Trends (bq)**
+
+```bash
+bq query --use_legacy_sql=false --project_id {project_id} '
+SELECT
+  JSON_VALUE(json_payload.rule_details.reference) AS rule_name,
+  COUNT(*) AS block_count
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_name LIKE "%firewall%"
+  AND JSON_VALUE(json_payload.rule_details.action) = "DENY"
+GROUP BY 1
+ORDER BY block_count DESC
+LIMIT 10
+'
+```
+
+## Key Fields
+
+-   `jsonPayload.rule_details.action`: `ALLOW` or `DENY`.
+-   `jsonPayload.rule_details.reference`: The firewall rule name (for example,
+    `default-deny-all`).
+-   `jsonPayload.connection.src_ip` / `dest_ip`: The source and destination of
+    the connection.
+
+## Common Use Cases
+
+-   **Identify Blocks**: Find which `DENY` rule is causing connection failures.
+-   **Security Audit**: Detect unexpected traffic patterns.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/mcp-usage.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/mcp-usage.md
@@ -1,0 +1,81 @@
+# MCP Server Usage Reference
+
+This document describes the Model Context Protocol (MCP) servers used for GCP
+networking observability.
+
+## BigQuery MCP
+
+BigQuery is supported by a remote MCP server that provides tools for automated
+data management and analysis.
+
+### Key Tools
+
+-   **list_dataset_ids**: List BigQuery dataset IDs in a project.
+-   **list_table_ids**: List table IDs in a BigQuery dataset.
+-   **get_table_info**: Get schema and metadata for a specific table.
+-   **execute_sql_readonly**: Run `SELECT` queries to analyze logs (such as, VPC Flow,
+    Firewall) stored in BigQuery. This is the preferred tool for high-volume
+    aggregations and trend analysis.
+
+### Usage Pattern
+
+1.  Use `list_dataset_ids` to find the logging dataset (for example,
+    `_AllLogs`).
+2.  Use `list_table_ids` to find the relevant log table.
+3.  Use `get_table_info` to verify field names (for example, `jsonPayload`
+    versus `json_payload`).
+4.  Use `execute_sql_readonly` for the final analysis.
+
+## Cloud Logging MCP
+
+The Cloud Logging MCP server provides access to log entries across various
+Google Cloud resources.
+
+### Key Tools
+
+-   **list_log_entries**: Search and retrieve log entries using advanced
+    filters.
+-   **list_log_names**: Discover available logs in a project.
+
+### Usage Pattern
+
+-   Use for quick, real-time identification of recent events or exploratory
+    analysis where BigQuery datasets are not linked.
+-   Use specific filters for `resource.type` and `logName` to narrow down
+    results.
+
+## NetworkManagement MCP
+
+The Network Management MCP server allows for reachability analysis and path
+diagnostics.
+
+### Key Tools
+
+-   **create_connectivity_test**: Start a simulated packet path analysis between
+    two endpoints.
+-   **get_connectivity_test**: Poll for the results of a running test.
+-   **delete_connectivity_test**: Cleanup the test resource after analysis is
+    complete.
+
+### Usage Pattern
+
+-   Use when static path analysis is needed to identify firewall or routing
+    blocks.
+-   **CRITICAL**: Always delete the test resource after retrieving the result.
+
+## Cloud Monitoring MCP
+
+The GcpMon MCP server provides access to Cloud Monitoring metrics and
+time-series data.
+
+### Key Tools
+
+-   **list_metric_descriptors**: Discover available metrics using filters.
+-   **list_timeseries**: Retrieve aggregated data points for performance
+    analysis (such as RTT or throughput).
+
+### Usage Pattern
+
+-   Use for analyzing performance trends, packet loss, and latency.
+-   Prefer `ALIGN_MEAN` or `ALIGN_PERCENTILE_50` for distribution metrics like
+    RTT to simplify parsing.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/metrics-analysis.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/metrics-analysis.md
@@ -1,0 +1,67 @@
+# Networking Metrics Reference
+
+## Common Troubleshooting Metrics
+
+-   **RTT (Latency)**:
+    `networking.googleapis.com/cloud_netslo/active_probing/rtt`
+-   **Packet Loss**:
+    `networking.googleapis.com/cloud_netslo/active_probing/probe_count`
+-   **VM Throughput**:
+    `compute.googleapis.com/instance/network/received_bytes_count`
+-   **VM Sent Packets**:
+    `compute.googleapis.com/instance/network/sent_packets_count`
+-   **VM Received Packets**:
+    `compute.googleapis.com/instance/network/received_packets_count`
+-   **NAT Port Exhaustion**:
+    `compute.googleapis.com/nat/dropped_sent_packets_count`
+-   **NAT Sent Packets**: `compute.googleapis.com/nat/sent_packets_count`
+-   **VPN Dropped Received Packets**:
+    `vpn.googleapis.com/network/dropped_received_packets_count`
+-   **VPN Dropped Sent Packets**:
+    `vpn.googleapis.com/network/dropped_sent_packets_count`
+-   **Internal Latency (RTT)**: `networking.googleapis.com/vm_flow/rtt`.
+    Measures internal VM-to-VM traffic within Google Cloud.
+-   **External Latency (RTT)**:
+    `networking.googleapis.com/vm_flow/external_rtt`. Measures traffic to and
+    from the internet.
+
+## Distribution Parsing Standard
+
+When querying metrics of type DISTRIBUTION (like RTT), align the data with
+`ALIGN_PERCENTILE_50` to ensure the output can be parsed as a simple numeric
+value.
+
+## Dynamic Discovery
+
+-   **Primary ([Cloud Monitoring MCP](mcp-usage.md#cloud-monitoring-mcp))**: Use
+    `list_metric_descriptors` with a filter.
+
+    -   **Prefix**: Filter by prefix, using `starts_with()`. Common prefixes:
+        -   `metric.type = starts_with("networking.googleapis.com/")`
+        -   `metric.type = starts_with("router.googleapis.com/")`
+        -   `metric.type = starts_with("vpn.googleapis.com/")`
+        -   `metric.type = starts_with("compute.googleapis.com/")`
+    -   **Substring**: `metric.type = has_substring("network") OR metric.type =
+        has_substring("packet") OR metric.type = has_substring("nat")`
+
+-   **Fallback (CLI/CURL)**: If MCP tools not available, use `gcloud` or `curl`.
+
+    ```bash
+    curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)"
+    "https://monitoring.googleapis.com/v3/projects/{project_id}/metricDescriptors?filter=metric.type=starts_with(%22{prefix}%22)"
+    | jq -r '.metricDescriptors[] | "\(.type): \(.description)"'
+
+    curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    "https://monitoring.googleapis.com/v3/projects/{project_id}/timeSeries?" \
+    "filter=metric.type%3D%22{metric_name}%22&" \
+    "interval.startTime={start_time}&" \
+    "interval.endTime={end_time}&" \
+    "aggregation.alignmentPeriod=3600s&" \
+    "aggregation.perSeriesAligner=ALIGN_PERCENTILE_50" \
+    | jq '.timeSeries[] | {metric: .metric.type, points: .points[:5]}'
+    ```
+
+-   **Detailed Schema**: ALWAYS query the full descriptor for a specific metric
+    before use to identify available labels. Metric types like `vm_flow/rtt`
+    often use `resource.labels.zone` for the local zone and
+    `metric.labels.remote_zone` for the peer.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/threat-analysis.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/threat-analysis.md
@@ -1,0 +1,151 @@
+# Threat Log Analysis Reference
+
+Use Firewall Threat Logs and Cloud IDS logs to identify, analyze, and
+troubleshoot security incidents in your VPC network.
+
+## 🤖 Agent / Gemini CLI Instructions (MCP)
+
+Agents should use [Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp) for quick
+identification of recent alerts or [BigQuery MCP](mcp-usage.md#bigquery-mcp) for
+analyzing trends and identifying top attackers. Fallback to the CLI if the MCP
+tools are not available.
+
+### 1. View Threat Alerts ([Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp))
+
+**Tool**: `list_log_entries`
+
+**Filter**: Search for both Cloud Firewall Plus and Cloud IDS threat log
+sources:
+
+```text
+logName:(
+"projects/{project_id}/logs/networksecurity.googleapis.com%2Ffirewall_threat" OR
+"projects/{project_id}/logs/ids.googleapis.com%2Fthreat")
+```
+
+To filter for high-severity blocked threats: `
+
+```text
+logName:(
+"projects/{project_id}/logs/networksecurity.googleapis.com%2Ffirewall_threat" OR
+"projects/{project_id}/logs/ids.googleapis.com%2Fthreat")
+jsonPayload.threatDetails.severity=("HIGH" OR "CRITICAL")
+jsonPayload.action="DENY"
+```
+
+### 2. Aggregate Threat Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
+
+**Tool**: `execute_sql_readonly`
+
+**SQL Pattern**: **Note**: In BigQuery, the top-level column name is
+`json_payload` (snake_case). However, fields extracted from inside the JSON
+payload are case-sensitive and retain the camelCase format of the original log
+(for example, `threatDetails`, `clientIp`). Do not use snake_case for nested
+fields.
+
+```sql
+SELECT
+  timestamp,
+  JSON_VALUE(json_payload.threatDetails.threat) AS threat_name,
+  JSON_VALUE(json_payload.threatDetails.severity) AS severity,
+  JSON_VALUE(json_payload.threatDetails.category) AS category,
+  JSON_VALUE(json_payload.action) AS action,
+  JSON_VALUE(json_payload.connection.clientIp) AS src_ip,
+  JSON_VALUE(json_payload.connection.serverIp) AS dest_ip,
+  JSON_VALUE(json_payload.connection.serverPort) AS dest_port,
+  JSON_VALUE(json_payload.threatDetails.description) AS description
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_id IN ('networksecurity.googleapis.com/firewall_threat',
+             'ids.googleapis.com/threat')
+  AND JSON_VALUE(json_payload.threatDetails.severity) IN ('HIGH', 'CRITICAL')
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+ORDER BY timestamp DESC
+LIMIT 20
+```
+
+To find top sources of attacks:
+
+```sql
+SELECT
+JSON_VALUE(json_payload.connection.clientIp) AS attacker_ip, COUNT(*) AS
+attack_count, ARRAY_AGG(DISTINCT JSON_VALUE(json_payload.threatDetails.threat)
+LIMIT 5) AS sample_threats FROM `{project_id}.{dataset_id}._AllLogs` WHERE
+log_id IN ('networksecurity.googleapis.com/firewall_threat',
+'ids.googleapis.com/threat') AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(),
+INTERVAL 7 DAY) GROUP BY 1 ORDER BY attack_count DESC LIMIT 10
+```
+
+### 3. CLI Fallback
+
+If MCP tools are unavailable, use the following `gcloud` and `bq` commands:
+
+**View Threat Alerts (gcloud)**
+
+```bash
+gcloud logging read 'logName:("projects/{project_id}/logs/networksecurity.googleapis.com%2Ffirewall_threat" OR "projects/{project_id}/logs/ids.googleapis.com%2Fthreat")' --project {project_id} --limit 10 --format json --quiet
+```
+
+To filter for high-severity blocked threats:
+
+```bash
+gcloud logging read 'logName:("projects/{project_id}/logs/networksecurity.googleapis.com%2Ffirewall_threat" OR "projects/{project_id}/logs/ids.googleapis.com%2Fthreat") AND jsonPayload.threatDetails.severity=("HIGH" OR "CRITICAL") AND jsonPayload.action="DENY"' --project {project_id} --limit 10 --format json --quiet
+```
+
+**Aggregate Threat Trends (bq)**
+
+```bash
+bq query --use_legacy_sql=false --project_id {project_id} '
+SELECT
+  timestamp,
+  JSON_VALUE(json_payload.threatDetails.threat) AS threat_name,
+  JSON_VALUE(json_payload.threatDetails.severity) AS severity,
+  JSON_VALUE(json_payload.threatDetails.category) AS category,
+  JSON_VALUE(json_payload.action) AS action,
+  JSON_VALUE(json_payload.connection.clientIp) AS src_ip,
+  JSON_VALUE(json_payload.connection.serverIp) AS dest_ip,
+  JSON_VALUE(json_payload.connection.serverPort) AS dest_port,
+  JSON_VALUE(json_payload.threatDetails.description) AS description
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_id IN ("networksecurity.googleapis.com/firewall_threat",
+             "ids.googleapis.com/threat")
+  AND JSON_VALUE(json_payload.threatDetails.severity) IN ("HIGH", "CRITICAL")
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+ORDER BY timestamp DESC
+LIMIT 20
+'
+```
+
+To find top sources of attacks:
+
+```bash
+bq query --use_legacy_sql=false --project_id {project_id} '
+SELECT
+  JSON_VALUE(json_payload.connection.clientIp) AS attacker_ip,
+  COUNT(*) AS attack_count,
+  ARRAY_AGG(DISTINCT JSON_VALUE(json_payload.threatDetails.threat)
+            LIMIT 5) AS sample_threats
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_id IN ("networksecurity.googleapis.com/firewall_threat",
+             "ids.googleapis.com/threat")
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+GROUP BY 1
+ORDER BY attack_count DESC
+LIMIT 10
+'
+```
+
+### Key Fields (Cloud Logging Filter Names)
+
+-   **jsonPayload.threatDetails.threat**: Human-readable name of the threat.
+-   **jsonPayload.threatDetails.severity**: Severity level (CRITICAL, HIGH,
+    MEDIUM, LOW, INFORMATIONAL).
+-   **jsonPayload.threatDetails.category**: The category of threat.
+-   **jsonPayload.action**: Action taken (for example, "ALLOW", "DENY",
+    "ALERT").
+-   **jsonPayload.connection.clientIp**: The true source IP.
+-   **jsonPayload.connection.serverIp**: The destination IP.
+-   **jsonPayload.threatDetails.cves**: List of CVE IDs.
+-   **jsonPayload.threatDetails.description**: Attack payload details.

--- a/cli-tool/components/skills/development/google-cloud-networking-observability/references/vpc-flow-analysis.md
+++ b/cli-tool/components/skills/development/google-cloud-networking-observability/references/vpc-flow-analysis.md
@@ -1,0 +1,124 @@
+# VPC Flow Analysis Reference
+
+Use VPC Flow Logs to analyze traffic patterns, volume, and latency.
+
+## 🤖 Agent / Gemini CLI Instructions (MCP)
+
+Agents should use [Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp) for
+exploratory analysis or [BigQuery MCP](mcp-usage.md#bigquery-mcp) for
+high-volume trends. Fallback to the CLI if the MCP tools are not available.
+
+-   **Exploratory Analysis**: Typically involves looking at individual log
+    entries or a small set of logs to understand specific events, debug issues,
+    or investigate anomalies. This often requires filtering and examining the
+    full details of log records.
+-   **High-Volume Trends**: Focuses on aggregating large datasets of logs over
+    time to identify patterns, measure traffic volumes, analyze latency
+    distributions, or find "top talkers." This usually involves SQL queries to
+    summarize data rather than inspecting individual logs.
+
+### 1. View Logs ([Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp))
+
+**Tool**: `list_log_entries`
+
+**Filter**: ALWAYS search for both VPC flow log sources:
+
+```text
+(logName:"projects/{project_id}/logs/compute.googleapis.com%2Fvpc_flows" OR
+logName:"projects/{project_id}/logs/networkmanagement.googleapis.com%2Fvpc_flows")
+resource.type="gce_subnetwork"
+```
+
+### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
+
+**Tool**: `execute_sql`
+
+**SQL Pattern**:
+
+```sql
+SELECT timestamp,
+JSON_VALUE(jsonPayload.connection.src_ip) AS src_ip,
+JSON_VALUE(jsonPayload.connection.dest_ip) AS dest_ip,
+CAST(JSON_VALUE(jsonPayload.bytes_sent) AS INT64) AS bytes_sent FROM
+`{project_id}.{dataset_id}._AllLogs` WHERE log_name IN (
+'projects/{project_id}/logs/compute.googleapis.com%2Fvpc_flows',
+'projects/{project_id}/logs/networkmanagement.googleapis.com%2Fvpc_flows' ) AND
+timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR) ORDER BY
+timestamp DESC LIMIT 10
+```
+
+### 3. CLI Fallback
+
+If MCP tools are unavailable, use the following `gcloud` and `bq` commands:
+
+**View Logs (gcloud)**
+
+```bash
+gcloud logging read '(logName:"projects/{project_id}/logs/compute.googleapis.com%2Fvpc_flows" OR logName:"projects/{project_id}/logs/networkmanagement.googleapis.com%2Fvpc_flows") AND resource.type="gce_subnetwork"' --project {project_id} --limit 10 --format json --quiet
+```
+
+**Aggregate Trends (bq)**
+
+```bash
+bq query --use_legacy_sql=false --project_id {project_id} '
+SELECT
+  timestamp,
+  JSON_VALUE(json_payload.connection.src_ip) AS src_ip,
+  JSON_VALUE(json_payload.connection.dest_ip) AS dest_ip,
+  CAST(JSON_VALUE(json_payload.bytes_sent) AS INT64) AS bytes_sent
+FROM `{project_id}.{dataset_id}._AllLogs`
+WHERE
+  log_name IN (
+    "projects/{project_id}/logs/compute.googleapis.com%2Fvpc_flows",
+    "projects/{project_id}/logs/networkmanagement.googleapis.com%2Fvpc_flows"
+  )
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+ORDER BY timestamp DESC
+LIMIT 10
+'
+```
+
+### Flow Analyzer (Visual Analysis)
+
+For visual traffic analysis and identifying "top talkers," use
+[Flow Analyzer](https://console.cloud.google.com/net-intelligence/flow-analyzer).
+It allows you to:
+
+-   Visualize traffic flows between regions, VPCs, and instances.
+-   Filter by source or destination dimensions.
+-   Identify high-bandwidth or high-latency connections.
+
+### Generic BigQuery Guidelines
+
+-   **Schema Verification**: Before executing a BigQuery query, if you are
+    uncertain of the casing (for example, `jsonPayload` versus `json_payload`),
+    you MUST run `bq show --schema <source>`.
+-   **Latency Aggregation**: The primary field for RTT analysis in VPC Flow logs
+    is `json_payload.round_trip_time.median_msec`. This field offers
+    sub-millisecond precision and covers both TCP and Falcon traffic. Filter by
+    `reporter` (`SRC` or `DEST`) to avoid double-counting traffic volume.
+
+    For TCP-only traffic, you can also use `json_payload.rtt_msec`, which
+    provides RTT in whole milliseconds. While less precise and with narrower
+    coverage than `round_trip_time.median_msec`, it can be aggregated as
+    follows:
+
+    ```sql
+    SELECT
+      AVG(json_payload.rtt_msec) AS average_rtt_msec,
+      MAX(json_payload.rtt_msec) AS max_rtt_msec
+    FROM ...
+    ```
+
+## Key Fields
+
+-   **src_ip / dest_ip**: Source and destination IP addresses.
+-   **bytes_sent / packets_sent**: Volume of traffic.
+-   **round_trip_time.median_msec**: The primary field for RTT analysis. This
+    `double` field provides the *median* latency in milliseconds with
+    sub-millisecond precision. It is populated for both TCP and Falcon traffic.
+-   **rtt_msec**: An `int64` field representing Round-trip time in whole
+    milliseconds. Populated only for TCP traffic. Generally,
+    `round_trip_time.median_msec` is preferred due to higher precision and
+    broader coverage.
+-   **reporter**: Usually `src` or `dest` indicating which side logged the flow.

--- a/cli-tool/components/skills/development/google-cloud-onboarding/SKILL.md
+++ b/cli-tool/components/skills/development/google-cloud-onboarding/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: google-cloud-onboarding
+description: Guides developers through their first steps on Google Cloud, covering account creation, billing setup, project management, CLI installation, and deploying a first resource.
+source: google/skills (Apache 2.0)
+---
+
+# Onboarding to Google Cloud
+
+This skill provides a streamlined "happy path" for a singleton developer to get
+started with [Google Cloud](https://cloud.google.com/). It covers everything
+from initial account setup to deploying your first cloud resource.
+
+## Overview
+
+For an individual developer, onboarding to Google Cloud involves establishing a
+personal identity, setting up a billing method, and creating a workspace
+([Project](https://docs.cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy#projects))
+where resources can be managed. Google Cloud offers a Free Tier and Free Trial
+for multiple products. [Learn more
+here](https://docs.cloud.google.com/free/docs/free-cloud-features).
+
+## Clarifying Questions
+
+Before proceeding, the agent should clarify the user's current status:
+
+1.  Do you already have a [Google Account](https://accounts.google.com/) (Gmail
+    or [Google Workspace](https://workspace.google.com/))?
+2.  Are you looking to set up a personal account for learning/experimentation,
+    or are you part of an organization with existing infrastructure?
+3.  Are you an IT admin within a larger enterprise, setting up Google Cloud for
+    your organization?
+4.  What is the first type of resource or application you are interested in
+    building (e.g., a website, a data pipeline, a virtual machine)?
+5.  Do you prefer to use the command line (CLI), an IDE (e.g. VSCode,
+    Antigravity), or do you prefer using the web-based [Google Cloud
+    console](https://console.cloud.google.com/)?
+
+## Prerequisites
+
+-   A [Google Account](https://accounts.google.com/) (e.g., @gmail.com).
+-   A valid payment method (credit card or bank account) for billing
+    verification (even for the free trial).
+
+## Steps
+
+### 1. Sign Up and Activate Free Credit
+
+1.  Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2.  Sign in with your Google Account. This will "Activate" [your $300 free
+    credit](https://docs.cloud.google.com/free/docs/free-cloud-features#free-trial).
+
+### 2. Create Your First Google Cloud Project
+
+Google Cloud resources are organized into
+**[Projects](https://docs.cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy#projects)**.
+
+1.  In the Google Cloud console, click the project picker dropdown at the top of
+    the page.
+2.  Click **New Project**.
+3.  Enter a **Project Name** (e.g., `my-first-gcp-project`).
+4.  Note the generated **Project ID**; you will use this for CLI and API
+    interactions.
+5.  Click **Create**.
+
+### 3. Set Up Billing
+
+Ensure your project is linked to your Free Trial [Cloud
+Billing](https://docs.cloud.google.com/billing/docs/how-to/manage-billing-account)
+account.
+
+1.  Go to the **Billing** section in the console.
+2.  Confirm that your new project is listed under "Projects linked to this
+    billing account."
+
+### 4. Install and Initialize the Google Cloud CLI
+
+The **[Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk)**
+(`gcloud` CLI) is the primary tool for interacting with Google Cloud from your
+local machine.
+
+1.  [Download and install the Google Cloud
+    CLI](https://cloud.google.com/sdk/docs/install).
+2.  Open your terminal and run: `gcloud init`
+3.  Follow the prompts to log in and select your project.
+
+### 5. Enable Necessary APIs
+
+Most services require their specific
+[API](https://docs.cloud.google.com/apis/docs/overview) to be enabled before
+use. For example, to use [Cloud
+Run](https://docs.cloud.google.com/run/docs/overview/what-is-cloud-run), run:
+`gcloud services enable run.googleapis.com`
+
+Note that [some Google Cloud APIs, including Cloud Logging, are enabled by
+default](https://docs.cloud.google.com/service-usage/docs/enabled-service#default).
+
+### 6. Deploy Your First Resource
+
+Choose a simple entry point based on your needs:
+- **[Cloud Run](https://docs.cloud.google.com/run/docs) (Recommended for Apps):**
+Deploy a containerized "Hello World" app.
+- **[Compute Engine](https://docs.cloud.google.com/compute/docs):** Create a
+small Linux VM (e.g., `e2-micro` which is part of the Always Free tier in
+certain regions).
+- **[Cloud Storage](https://docs.cloud.google.com/storage/docs):** Create a
+bucket to store files.
+
+Example (Cloud Run):
+
+```bash
+    gcloud run deploy hello-world \
+    --image=gcr.io/cloudrun/hello \ --platform=managed \ --region=us-central1 \
+    --allow-unauthenticated --quiet
+```
+
+This command will output a public URL, that you can reach in a web browser.
+Congrats - you just deployed your first Google Cloud resource!
+
+### 7. Next Steps
+
+-   Explore the [Google Cloud Free Program](https://cloud.google.com/free) to
+    see what else you can do with your free credit.
+-   Read the [Google Cloud Overview](https://cloud.google.com/docs/overview)
+-   See the [full list of 150+ Google Cloud products](https://cloud.google.com/products)
+-   Explore the [Enterprise Setup Guide](https://docs.cloud.google.com/docs/enterprise/cloud-setup)
+    for information on setting up Google Cloud for a team or organization.
+-   Compare [AWS and Azure products to Google Cloud](https://docs.cloud.google.com/docs/get-started/aws-azure-gcp-service-comparison)
+
+## Reference Directory
+
+-   [Google Cloud Setup Guide](reference/google-cloud-setup.md): Detailed
+    setup instructions and reference for Google Cloud onboarding.
+
+## Validation Logic
+
+Use this logic to determine if the user has successfully completed the Google
+Cloud onboarding process:
+
+-   **Project Created:** Does the user have a Project ID?
+-   **Billing Linked:** Is the project associated with a billing account (check
+    via `gcloud beta billing projects describe PROJECT_ID`)?
+-   **CLI Authenticated:** Does `gcloud config list` show the correct account
+    and project?
+-   **Resource Verified:** Can the user access the URL or IP of the deployed
+    resource?

--- a/cli-tool/components/skills/development/google-cloud-onboarding/reference/google-cloud-setup.md
+++ b/cli-tool/components/skills/development/google-cloud-onboarding/reference/google-cloud-setup.md
@@ -1,0 +1,115 @@
+# Google Cloud Setup
+
+This guide provides an overview of the enterprise-level setup process for
+[Google Cloud](https://cloud.google.com/), focusing on creating a secure,
+scalable foundation.
+
+## Overview
+
+Enterprise onboarding requires more than just a single project. It involves
+establishing an
+**[Organization](https://docs.cloud.google.com/resource-manager/docs/creating-managing-organization)**
+resource, setting up a [resource
+hierarchy](https://docs.cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+(Folders and Projects), managing identities centrally, and configuring shared
+networking and security policies.
+
+## Phases of Enterprise Setup
+
+### 1. Establish Your Organization
+
+The Organization resource is the root node of your resource hierarchy.
+
+-   **Identity Provider:** Set up **[Cloud
+    Identity](https://cloud.google.com/identity)** or **[Google
+    Workspace](https://workspace.google.com/)**.
+-   **Domain Verification:** [Verify your domain](https://knowledge.workspace.google.com/admin/domains/verify-your-domain-for-google-workspace)
+    (e.g., `example.com`) to automatically create the Organization resource.
+-   **Super Administrator:** Assign a [super administrator](https://knowledge.workspace.google.com/admin/users/prebuilt-administrator-roles)
+    to manage the identity service.
+
+### 2. Configure Billing
+
+-   **Billing Account:** Create a **[Cloud
+    Billing](https://docs.cloud.google.com/billing/docs)** account at the
+    Organization level.
+-   **Payment Method:** Connect your corporate payment method.
+-   **FinOps:** Set up [budgets and spending
+    notifications](https://docs.cloud.google.com/billing/docs/how-to/budgets).
+-   **Exporting Data:** Enable [billing data export to BigQuery](https://docs.cloud.google.com/billing/docs/how-to/export-data-bigquery)
+    for custom cost reporting.
+
+### 3. Identity and Access (IAM)
+
+-   **Centralized Management:** Use **[Google
+    Groups](https://docs.cloud.google.com/iam/docs/groups-in-cloud-console)** to
+    manage permissions rather than assigning roles directly to individual users.
+-   **Administrative Access:** Assign core [IAM
+    roles](https://docs.cloud.google.com/iam/docs/roles-overview):
+    -   **Organization Administrator:** Full control over all resources.
+    -   **Billing Administrator:** Manage billing accounts and link projects.
+    -   **Network Administrator:** Manage VPC networks, firewalls, and VPNs.
+    -   **Security Administrator:** Manage security policies and SCC.
+
+### 4. Resource Hierarchy
+
+Organize your projects using
+**[Folders](https://docs.cloud.google.com/resource-manager/docs/creating-managing-folders)**
+to reflect your business structure or environments (e.g., Production,
+Development).
+
+-   **Folders:** Group projects by department or environment.
+-   **Projects:** The base unit for resource management.
+
+### 5. Networking (VPC)
+
+-   **[Shared VPC](https://docs.cloud.google.com/vpc/docs/shared-vpc):** Allows
+    multiple service projects to share a common VPC network managed by a host
+    project.
+-   **Subnets:** Create regional subnets with non-overlapping IP ranges.
+-   **Connectivity:** Set up **[High Availability (HA)
+    VPN](https://cloud.google.com/network-connectivity/docs/vpn)** or **[Cloud
+    Interconnect](https://cloud.google.com/network-connectivity/docs/interconnect)**
+    for hybrid connectivity to on-premises data centers.
+
+### 6. Security and Compliance
+
+-   **[Organization
+    Policies](https://docs.cloud.google.com/resource-manager/docs/organization-policy/overview):**
+    Apply constraints at the organization or folder level (e.g., restrict
+    allowed regions, disable public IP creation).
+-   **[Security Command Center
+    (SCC)](https://cloud.google.com/security-command-center/docs):** Enable SCC
+    for threat detection and security health analytics.
+-   **Encryption:** Use **[Cloud KMS](https://cloud.google.com/kms/docs)** (Key
+    Management Service) for managing encryption keys.
+
+### 7. Centralized Logging and Monitoring
+
+-   **[Cloud Logging](https://docs.cloud.google.com/logging/docs):** Use [Log
+    Sinks](https://docs.cloud.google.com/logging/docs/export/configure_export_v2)
+    to export logs from across the organization to a central BigQuery dataset or
+    Pub/Sub topic. Routing logs to a centralized bucket helps users centrally
+    manage compliance with data retention and data residency requirements.
+-   **[Cloud Monitoring](https://docs.cloud.google.com/monitoring/docs):** Set
+    up a scoping project to monitor metrics from multiple projects in one place.
+
+## Best Practices
+
+-   **Infrastructure as Code (IaC):** Use
+    **[Terraform](https://docs.cloud.google.com/docs/terraform)** to manage and
+    deploy your foundation. Google Cloud provides [Terraform
+    blueprints](https://cloud.google.com/docs/terraform/blueprints/terraform-blueprints)
+    for enterprise setup.
+-   **[Principle of Least
+    Privilege](https://docs.cloud.google.com/iam/docs/using-iam-securely#least_privilege):**
+    Start with minimal permissions and expand as needed.
+-   **Separation of Duties:** Ensure that network, security, and application
+    administrators have distinct roles.
+
+## Links
+
+-   [Google Cloud Setup Checklist](https://docs.cloud.google.com/docs/enterprise/cloud-setup)
+-   [Best Practices for Planning Accounts and Organizations](https://docs.cloud.google.com/architecture/identity/best-practices-for-planning)
+-   [Landing zone design in Google Cloud](https://docs.cloud.google.com/architecture/landing-zones)
+-   [Google Cloud Well-Architected Framework](https://docs.cloud.google.com/architecture/framework)

--- a/cli-tool/components/skills/development/google-cloud-waf-cost-optimization/SKILL.md
+++ b/cli-tool/components/skills/development/google-cloud-waf-cost-optimization/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: google-cloud-waf-cost-optimization
+description: Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for building cost-efficient workloads on Google Cloud.
+source: google/skills (Apache 2.0)
+---
+
+# Google Cloud Well-Architected Framework skill for the Cost Optimization pillar
+
+## Overview
+
+The Cost Optimization pillar of the Google Cloud Well-Architected Framework
+provides a structured approach to optimize the costs of your cloud workloads
+while maximizing business value. Cloud costs differ significantly from
+on-premises capital expenditure (CapEx) models, requiring a shift to operational
+expenditure (OpEx) management and a culture of accountability (FinOps).
+
+## Core principles
+
+The recommendations in the cost optimization pillar of the Well-Architected
+Framework are aligned with the following core principles:
+
+-  **Align cloud spending with business value**: Ensure that your cloud
+   resources deliver measurable business value by aligning IT spending with
+   business objectives. Prioritize investments that directly contribute to
+   revenue, customer satisfaction, or operational efficiency. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/align-cloud-spending-business-value
+
+-  **Foster a culture of cost awareness**: Ensure that people across your
+   organization consider the cost impact of their decisions and activities.
+   Provide teams with the visibility and information they need to make informed,
+   cost-conscious choices. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/foster-culture-cost-awareness
+
+-  **Optimize resource usage**: Provision only the resources that you need and
+   pay only for what you consume. Select the most cost-effective resource types,
+   sizes, and locations that meet your technical and business requirements.
+   Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/optimize-resource-usage
+
+-  **Optimize continuously**: Continuously monitor your cloud resource usage and
+   costs, and proactively make adjustments as needed to optimize your spending.
+   This iterative approach helps identify and address inefficiencies before they
+   become significant. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/cost-optimization/optimize-continuously
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to cost optimization:
+
+- **Visibility and monitoring**:
+
+  - **Cloud Billing reports**: Native dashboards for visualizing spending and
+    trends.
+  - **BigQuery billing export**: Enables granular, custom analysis of billing
+    data using SQL and BI tools.
+  - **Looker Studio**: Used for creating detailed, shared cost dashboards and
+    reports.
+  - **Billing alerts and budgets**: Automated notifications when spending
+    reaches predefined thresholds.
+
+- **Automation and optimization tools**:
+
+  - **Recommender / Active Assist**: Automatically identifies idle resources,
+    rightsizing opportunities, and unused commitments.
+  - **Cloud Hub Optimization**: Integrates billing and resource utilization data
+    to help developers and application owners quickly identify their most
+    expensive, fluctuating, or underutilized cloud resources.
+  - **FinOps hub**: Presents active savings and optimization opportunities in
+    one dashboard.
+  - **Billing quotas**: Limits on resource consumption to prevent unexpected
+    cost spikes.
+
+- **Efficient infrastructure**:
+
+  - **Managed services and serverless services**: Services like Cloud Run, Cloud
+    Run functions, and GKE Autopilot reduce operational overhead and pay-per-use
+    scaling.
+  - **Compute Engine**: Use of Spot VMs for fault-tolerant workloads and
+    Committed Use Discounts (CUDs) for stable workloads.
+  - **Cloud Storage Lifecycle Policies**: Automatically moves data to lower-cost
+    storage classes (Nearline, Coldline, Archive) based on age or access.
+
+- **Organization and governance**:
+
+  - **Resource Manager**: Logical structure (Organizations, Folders, Projects)
+    for cost attribution.
+  - **Labels**: Metadata tags for categorizing and filtering costs by
+    environment, team, or application.
+  - **Organization Policy Service**: Enforces constraints (e.g., restricted
+    regions or machine types) to control costs.
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the cost-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- How do you incorporate cost considerations into your cloud architecture design
+  process?
+- How do you foster a culture of cost awareness among your development teams?
+- How do you monitor and manage cloud costs across different projects or
+  departments?
+- What strategies do you use to optimize the cost of your compute resources?
+- How do you balance cost optimization with the need for agility and innovation?
+- How do you ensure that you are not over-provisioning cloud resources?
+- How do you use data and analytics to drive cost optimization decisions?
+- How do you optimize costs in different environments (e.g., development,
+  testing, production)?
+- How do you ensure that your cost optimization efforts are sustainable and
+  ongoing?
+- How do you measure the success of your cloud cost optimization initiatives?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+cost-optimization recommendations:
+
+- **Cost Attribution**: 100% of resources are labeled with key metadata
+  (e.g., `env`, `team`, `app`).
+- **Granular Visibility**: BigQuery billing export is enabled and used for
+  regular cost reviews.
+- **Budgets and Alerts**: Every project or business unit has defined budgets
+  and active alerts.
+- **Rightsizing**: Resources are regularly adjusted based on rightsizing
+  suggestions provided by Active Assist Recommender.
+- **Commitment Strategy**: Spend is reviewed monthly to optimize Committed
+  Use Discount coverage.
+- **Idle Resource Management**: Unused disks, IP addresses, and idle VMs are
+  identified and removed monthly.
+- **Managed Services**: Serverless options are preferred for new workloads
+  unless specific technical constraints exist.
+- **Storage Tiers**: Lifecycle policies are active for all major storage
+  buckets to minimize archival costs.

--- a/cli-tool/components/skills/development/google-cloud-waf-reliability/SKILL.md
+++ b/cli-tool/components/skills/development/google-cloud-waf-reliability/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: google-cloud-waf-reliability
+description: Generates reliability-focused guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework. Use to evaluate a workload, identify reliability requirements, and provide actionable recommendations for building resilient, highly available systems.
+source: google/skills (Apache 2.0)
+---
+
+# Google Cloud Well-Architected Framework skill for the Reliability pillar
+
+## Overview
+
+The Reliability pillar of the Google Cloud Well-Architected Framework provides
+principles and recommendations to help you design, deploy, and manage reliable,
+resilient, and highly available workloads in Google Cloud. A reliable system
+consistently performs its intended functions under defined conditions, is
+resilient to failures, and recovers gracefully from disruptions, thereby
+minimizing downtime, enhancing user experience, and ensuring data integrity.
+
+## Core principles
+
+The recommendations in the reliability pillar of the Well-Architected Framework
+are aligned with the following core principles:
+
+-  **Define reliability based on user-experience goals**: Measurement of
+   reliability should reflect the actual experience of the system's users rather
+   than merely relying on infrastructure metrics. Focus on outcomes that matter
+   most to users. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/define-reliability-based-on-user-experience-goals
+
+-  **Set realistic targets for reliability**: Determine appropriate Service
+   Level Objectives (SLOs) that balance the cost and complexity of maximizing
+   availability against business requirements. Utilize error budgets to manage
+   feature velocity. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/set-targets
+
+-  **Build highly available systems through resource redundancy**: Eliminate
+   single points of failure by duplicating critical components across zones and
+   regions to maintain operations during localized outages. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/build-highly-available-systems
+
+-  **Take advantage of horizontal scalability**: Design system architectures to
+   scale horizontally (adding more instances) to seamlessly accommodate load
+   fluctuations and improve overall fault tolerance. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/horizontal-scalability
+
+-  **Detect potential failures by using observability**: Implement thorough
+   monitoring, logging, and alerting systems to proactively detect, diagnose,
+   and address anomalies before they cause user-facing issues. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/observability
+
+-  **Design for graceful degradation**: Architect systems to maintain critical
+   functionality, even if at reduced performance or with limited features, when
+   dependencies fail or the system experiences extreme stress. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/graceful-degradation
+
+-  **Perform testing for recovery from failures**: Build confidence in system
+   resilience by continuously simulating failures and verifying the
+   effectiveness of automated and manual recovery procedures. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/reliability/perform-testing-for-recovery-from-failures
+
+-  **Perform testing for recovery from data loss**: Regularly test backup and
+   restore protocols to ensure rapid recovery from data corruption or loss,
+   remaining within the defined Recovery Time Objective (RTO) and Recovery Point
+   Objective (RPO). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/perform-testing-for-recovery-from-data-loss
+
+-  **Conduct thorough postmortems**: Foster a blameless culture by investigating
+   outages comprehensively to understand root causes, followed by implementing
+   measures that prevent recurrence. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/reliability/conduct-postmortems
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to reliability:
+
+- **Compute**: Compute Engine Managed Instance Groups (MIGs), Google Kubernetes
+  Engine (GKE), Cloud Run
+- **Networking**: Cloud Load Balancing, Cloud CDN, Cloud DNS
+- **Storage and databases**: Cloud Storage (multi-region), Cloud SQL High
+  Availability, Spanner, Filestore, Firestore
+- **Operations**: Cloud Monitoring, Cloud Logging, Google Cloud Managed Service
+  for Prometheus
+- **Disaster recovery**: Backup and DR Service, Filestore backups
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the reliability-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- How does your organization define and measure the reliability of your systems
+  in relation to user experience?
+- How does your organization approach setting reliability targets for your
+  services?
+- What is your organization's strategy for ensuring high availability through
+  resource redundancy?
+- How does your organization leverage horizontal scalability to maintain
+  performance and reliability?
+- How does your organization utilize observability (metrics, logs, traces) to
+  gain insights and detect potential failures?
+- How does your organization manage alerting based on observability data to
+  ensure timely responses to significant issues without causing alert fatigue?
+- What measures does your organization take to ensure systems can gracefully
+  degrade during high load or partial failures?
+- How frequently and comprehensively does your organization test for recovery
+  from system failures (e.g., regional failovers, release rollbacks)?
+- What is your organization's approach to testing for recovery from data loss?
+- How does your organization conduct and utilize postmortems after incidents?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+reliability recommendations:
+
+- User-focused SLIs and SLOs are explicitly defined and actively monitored.
+- The architecture avoids single points of failure through cross-zone or
+  cross-region redundancy.
+- Autoscaling is enabled to handle variable demand without manual intervention.
+- Application and infrastructure health checks are configured to trigger
+  automated failovers.
+- Regular backup schedules are in place, and restoration processes are routinely
+  tested.
+- The system architecture incorporates patterns like circuit breakers, retries
+  with exponential backoff, and rate limiting to support graceful degradation.
+- Game days or chaos engineering practices are regularly held to validate
+  failure recovery.
+- A formalized, blameless postmortem process exists to ensure organizational
+  learning from operational incidents.

--- a/cli-tool/components/skills/security/google-cloud-auth/SKILL.md
+++ b/cli-tool/components/skills/security/google-cloud-auth/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: google-cloud-auth
+description: Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.
+source: google/skills (Apache 2.0)
+---
+
+# Authenticating to Google Cloud
+
+[Authentication](https://docs.cloud.google.com/docs/authentication) is the
+process of proving **who you are**. In Google Cloud, you represent a
+**Principal** (an identity like a user or a service). This is the first step
+before [Authorization](https://docs.cloud.google.com/iam/docs/overview)
+(determining **what you can do**).
+
+## Authentication
+
+### Clarifying Questions for the Agent
+
+Before providing a specific solution, clarify the following with the user:
+
+1.  **Who or what is authenticating?** (A human developer, a local script, or an
+    application running in production?)
+2.  **Where is the code running?** (Local laptop, [Compute
+    Engine](https://docs.cloud.google.com/compute/docs),
+    [GKE](https://docs.cloud.google.com/kubernetes-engine/docs), [Cloud
+    Run](https://docs.cloud.google.com/run/docs), or another cloud like
+    AWS/Azure?)
+3.  **What is the target?** (A Google Cloud API like Storage/BigQuery, or a
+    custom application you built?)
+4.  **Are you using a high-level client library?** (e.g., Python, Go, Node.js
+    libraries usually handle ADC automatically.)
+
+---
+
+## Human Authentication
+
+For users to access Google Cloud, they need an identity that Google Cloud can
+recognize.
+
+### Types of User Identities
+
+Google Cloud supports several ways to configure identities for your internal
+workforce (developers, administrators, employees):
+
+*   **[Google-Managed
+    Accounts](https://docs.cloud.google.com/iam/docs/user-identities#google-accounts)**:
+    You can use Cloud Identity or Google Workspace to create managed user
+    accounts. These are called managed accounts because your organization
+    controls their lifecycle and configuration.
+*   **[Federation using Cloud Identity or Google
+    Workspace](https://docs.cloud.google.com/iam/docs/user-identities#synced-federation)**:
+    You can federate identities to allow users to use their existing identity
+    and credentials to sign in to Google services. Users authenticate against an
+    external identity provider (IdP), but you must keep accounts synchronized
+    into Google Cloud using tools like Google Cloud Directory Sync (GCDS) or an
+    external authoritative source like Active Directory or Microsoft Entra ID.
+*   **[Workforce Identity
+    Federation](https://docs.cloud.google.com/iam/docs/user-identities#workforce)**:
+    This lets you use an external IdP to authenticate and authorize a workforce
+    using IAM directly. Unlike standard federation, you do not need to
+    synchronize user identities from your existing IdP to Google Cloud
+    identities. It supports syncless, attribute-based single sign-on.
+
+### Methods of Access for Developers and Administrators
+
+Used for interacting with Google Cloud resources and APIs during development and
+management.
+
+*   **[Google Cloud Console](https://console.cloud.google.com/)**: The primary
+    web interface. You authenticate using your Google Account (Gmail or [Google
+    Workspace](https://workspace.google.com/)).
+*   **[gcloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk) (`gcloud
+    auth login`)**: Used to authenticate the CLI itself so you can run
+    management commands (e.g., `gcloud compute instances list`). It uses a
+    **Credential** (like an OAuth 2.0 refresh token) stored locally.
+*   **Local Development with [App Default Credentials
+    (ADC)](https://docs.cloud.google.com/docs/authentication/application-default-credentials)
+    (`gcloud auth application-default login`)**: This is different from CLI
+    auth. It creates a local JSON file that Google Cloud **Client Libraries**
+    (Python, Java, etc.) use to act as "you" when you run code on your laptop.
+*   **[Service Account
+    Impersonation](https://docs.cloud.google.com/docs/authentication/use-service-account-impersonation)**:
+    For security reasons, developers should avoid downloading Service Account
+    keys entirely. Instead, they should authenticate as humans (`gcloud auth
+    login`) and use Service Account Impersonation to run CLI commands or
+    generate short-lived credentials. This is a critical best practice for local
+    development and troubleshooting.
+
+### For End-Users and Customers
+
+Used when a human (who is not a developer) needs to access a web application
+you've deployed on Google Cloud. Note: These are distinct from workforce
+identities.
+
+*   **[Identity-Aware Proxy (IAP)](https://docs.cloud.google.com/iap/docs)**:
+    Acts as a central authorization layer for web applications. It intercepts
+    web requests and verifies the user's identity (via Google Workspace, Cloud
+    Identity, or external providers) before letting them reach the application.
+    It's often used to protect internal apps without a VPN, or secure customer
+    portals.
+*   **[Identity
+    Platform](https://docs.cloud.google.com/identity-platform/docs)**: A
+    Customer Identity and Access Management (CIAM) solution for adding consumer
+    sign-in (email/password, phone, social) directly into the code of your
+    custom-built applications.
+
+---
+
+## Service-to-Service Authentication
+
+When code runs in production, it should use a **Service Account** rather than a
+human user account.
+
+### Service Accounts and Service Agents
+
+*   **[Service
+    Account](https://docs.cloud.google.com/iam/docs/service-account-overview)**:
+    A special identity intended for non-human users. It's like a "robot
+    identity" with its own email address.
+*   **[Service Agent](https://docs.cloud.google.com/iam/docs/service-agents)**:
+    A service account managed by Google that allows a service (like Pub/Sub) to
+    access your resources on your behalf.
+
+### Best Practice: Attaching Service Accounts
+
+Instead of using **Service Account Keys** (dangerous JSON files), you should
+**attach** a custom service account to the Google Cloud resource. The resource's
+environment then provides a **Token** (a short-lived digital object) via a local
+metadata server.
+
+*   **[Compute
+    Engine](https://docs.cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)**:
+    Assign a service account during VM creation.
+*   **[Cloud
+    Run](https://docs.cloud.google.com/run/docs/securing/service-identity)**:
+    Assign a service account in the service configuration.
+
+### Special Cases & Advanced Topics
+
+#### Kubernetes Engine (GKE)
+
+Use **[Workload Identity Federation for
+GKE](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)**
+to map Kubernetes identities to IAM principal identifiers. This grants specific
+Kubernetes workloads access to specific Google Cloud APIs. [Learn more
+here.](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#configure-authz-principals)
+
+#### External Workloads ([Workload Identity Federation](https://docs.cloud.google.com/iam/docs/workload-identity-federation))
+
+For code running **outside** Google Cloud (e.g., AWS, Azure, or on-prem), do not
+use keys. Instead, use Workload Identity Federation to exchange an external
+token (like an AWS IAM role) for a short-lived Google Cloud access token.
+
+#### [API Keys](https://docs.cloud.google.com/docs/authentication/api-keys)
+
+API keys are encrypted strings used for public data (e.g., Google Maps) or
+simplified access like **[Vertex AI Express
+Mode](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview)**,
+which allows fast testing of Gemini models without complex setup. Both humans
+and services (e.g., Cloud Run-based AI agent) can use API keys, for the services
+that support it.
+
+Note: API keys should be
+[restricted](https://docs.cloud.google.com/api-keys/docs/add-restrictions-api-keys)
+to specific APIs and projects to minimize security risks. Store API keys in a
+secrets manager like [Secret
+Manager](https://docs.cloud.google.com/secret-manager/docs) to prevent
+accidental exposure.
+
+#### OAuth 2.0 Access Scopes
+
+While IAM is the modern way to handle authorization, legacy Compute Engine VMs
+and GKE node pools still rely on **Access Scopes** alongside IAM. If a VM's
+scope is restricted, the attached service account will fail to make API calls
+even if it has the correct IAM permissions. Check this first if attached service
+accounts are failing unexpectedly.
+
+#### Short-Lived Credentials
+
+The underlying mechanism for impersonation and secure service-to-service
+communication is the **IAM Service Account Credentials API**. This API generates
+short-lived access tokens, OpenID Connect (OIDC) ID tokens, or self-signed JSON
+Web Tokens (JWTs) dynamically, removing the need for static credentials.
+
+---
+
+## Authorization
+
+After Authentication, Google Cloud uses **[Identity and Access Management
+(IAM)](https://docs.cloud.google.com/iam/docs/overview)** to determine what the
+authenticated principal can do.
+
+*   **Allow Policy**: A record that binds a **Principal** to a **Role** on a
+    **Resource**.
+*   **[Predefined
+    Roles](https://docs.cloud.google.com/iam/docs/understanding-roles)**:
+    Prebuilt roles like `roles/storage.objectViewer` or
+    `roles/bigquery.dataEditor`. **Always try to use these first.**
+*   **[Custom
+    Roles](https://docs.cloud.google.com/iam/docs/creating-custom-roles)**:
+    User-defined collections of specific permissions if predefined roles are too
+    broad.
+
+---
+
+## Examples
+
+### Human-to-Service (Local Python Development)
+
+1.  **Authn**: Run `gcloud auth application-default login` to create local
+    credentials (ADC).
+2.  **Authz**: Grant your email the `roles/storage.objectViewer` role on a
+    bucket.
+3.  **Code**: Use the Python `storage.Client()`. It automatically finds your
+    local credentials via ADC. *Note: ADC searches in a specific order—first
+    checking the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, then the
+    local gcloud JSON file, and finally the attached service account metadata
+    server.*
+
+### Service-to-Service (Cloud Run to Cloud SQL)
+
+1.  **Authn**: Attach a custom Service Account to your Cloud Run service.
+2.  **Authz**: Grant that Service Account the `roles/cloudsql.client` role on
+    the project.
+3.  **Code**: The Cloud Run environment provides the token automatically to the
+    connection driver.
+
+### Calling a Custom Application ([OIDC](https://docs.cloud.google.com/docs/authentication/get-id-token))
+
+When calling a private Cloud Run service from another service, the caller
+generates a Google-signed **OpenID Connect (OIDC) ID Token** and passes it in
+the `Authorization: Bearer <TOKEN>` header.
+
+---
+
+## Validation Checklist
+
+-   [ ] Is the user running code locally? Suggest `gcloud auth
+    application-default login` or **Service Account Impersonation**.
+-   [ ] Is the user attempting to use Service Account keys locally? Strongly
+    discourage this and recommend impersonation.
+-   [ ] Is the user running in production? Recommend attaching a custom,
+    least-privilege service account, NOT using keys.
+-   [ ] Is the user relying on the Compute Engine Default Service Account?
+    Recommend creating a custom service account instead.
+-   [ ] Is the user running on another cloud? Recommend Workload Identity
+    Federation.
+-   [ ] Is the user calling a custom app? Recommend OIDC ID Tokens.
+-   [ ] Has the user restricted their API Keys? Check for appropriate [API Key
+    Restrictions](https://docs.cloud.google.com/docs/authentication/api-keys#adding-application-restrictions).
+
+## References
+
+-   [Authentication Overview](https://docs.cloud.google.com/docs/authentication)
+-   [User Identities](https://docs.cloud.google.com/iam/docs/user-identities)
+-   [Application Default Credentials](https://docs.cloud.google.com/docs/authentication/provide-credentials-adc)
+-   [Service Account Best Practices](https://docs.cloud.google.com/iam/docs/best-practices-service-accounts)

--- a/cli-tool/components/skills/security/google-cloud-waf-security/SKILL.md
+++ b/cli-tool/components/skills/security/google-cloud-waf-security/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: google-cloud-waf-security
+description: Generates security-focused guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.
+source: google/skills (Apache 2.0)
+---
+
+# Google Cloud Well-Architected Framework skill for the Security pillar
+
+## Overview
+
+The security pillar of the Google Cloud Well-Architected Framework provides
+design principles and best practices for building a robust security posture by
+integrating security into every layer of the architecture for cloud workloads.
+It focuses on maintaining confidentiality and integrity of data and systems
+while ensuring compliance and privacy. It provides a structured approach to risk
+management, threat defense, and identity control, enabling you to operate cloud
+workloads securely and at scale.
+
+## Core principles
+
+The recommendations in the security pillar of the Well-Architected Framework are
+aligned with the following core principles:
+
+-  **Implement security by design**: Integrate cloud security and network
+   security considerations starting from the initial design phase of your
+   applications and infrastructure. Google Cloud provides architecture
+   blueprints and recommendations to help you apply this principle. Grounding
+   document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-security-by-design
+
+-  **Implement zero trust**: Use a _never trust, always verify_ approach, where
+   access to resources is granted based on continuous verification of trust.
+   Google Cloud supports this principle through products like Chrome Enterprise
+   Premium and Identity-Aware Proxy (IAP). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-zero-trust
+
+-  **Implement shift-left security**: Implement security controls early in the
+   software development lifecycle. Avoid security defects before system changes
+   are made. Detect and fix security bugs early, fast, and reliably after the
+   system changes are committed. Google Cloud supports this principle through
+   products like Cloud Build, Binary Authorization, and Artifact Registry.
+   Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-shift-left-security
+
+-  **Implement preemptive cyber defense**: Adopt a proactive approach to
+   security by implementing robust fundamental measures like threat
+   intelligence. This approach helps you build a foundation for more effective
+   threat detection and response. Google Cloud's approach to layered security
+   controls aligns with this principle. Google Cloud supports this principle
+   through products like Security Command Center, Google Threat Intelligence,
+   and Google SecOps. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/implement-preemptive-cyber-defense
+
+-  **Use AI securely and responsibly**: Develop and deploy AI systems in a
+   responsible and secure manner. The recommendations for this principle are
+   aligned with guidance in the AI and ML perspective of the Well-Architected
+   Framework and in Google's Secure AI Framework (SAIF). Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/use-ai-securely-and-responsibly
+
+-  **Use AI for security**: Use AI capabilities to improve your existing
+   security systems and processes through Gemini in Security and overall
+   platform-security capabilities. Use AI as a tool to increase the automation
+   of remedial work and ensure security hygiene to make other systems more
+   secure. Google Cloud supports this principle through products like Google
+   Threat Intelligence and Google SecOps. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/use-ai-for-security
+
+-  **Meet regulatory, compliance, and privacy needs**: Adhere to
+   industry-specific regulations, compliance standards, and privacy
+   requirements. Google Cloud helps you meet these obligations through products
+   like Assured Workloads, Organization Policy Service, and our compliance
+   resource center. Grounding document:
+   https://docs.cloud.google.com/architecture/framework/security/meet-regulatory-compliance-and-privacy-needs
+
+## Relevant Google Cloud products
+
+The following are _examples_ of Google Cloud products and features that are
+relevant to security:
+
+- **Identity and access management**
+
+  - **Identity and Access Management (IAM)**: Fine-grained access control for
+    Google Cloud resources.
+  - **Identity-Aware Proxy (IAP)**: Secure access to applications without a VPN.
+  - **Chrome Enterprise Premium**: Endpoint security and context-aware access.
+
+- **Network security**
+
+  - **Google Cloud Armor**: DDoS protection and Web Application Firewall (WAF).
+  - **VPC Service Controls**: Define security perimeters to prevent data
+    exfiltration.
+  - **Cloud Next-Generation Firewall (NGFW)**: Advanced threat protection for
+    network traffic.
+  - **Shared VPC**: Centralized network management across projects.
+  - **Cloud Interconnect and IPsec VPN**: Secure, private connectivity.
+
+- **Data security**
+
+  - **Cloud Key Management Service (KMS)**: Manage encryption keys.
+  - **Sensitive Data Protection (formerly Cloud DLP)**: Discover and redact
+    sensitive data.
+  - **Confidential Computing**: Encrypt data in use (memory).
+
+- **Security operations (SecOps)**
+
+  - **Google SecOps (Chronicle)**: Threat detection and security analytics.
+  - **Security Command Center (SCC)**: Centralized vulnerability and threat
+    management.
+  - **Cloud Logging and Cloud Monitoring**: Visibility into system activity.
+
+- **Automation and supply chain**
+
+  - **Cloud Build**: Secure CI/CD pipelines.
+  - **Artifact Analysis**: Vulnerability scanning for container images.
+  - **Binary Authorization**: Deploy-time policy enforcement.
+  - **Assured open source software**: Use secured OSS packages.
+
+## Workload assessment questions
+
+Ask appropriate questions to understand the security-related requirements and
+constraints of the workload and the user's organization. Choose questions from
+the following list:
+
+- **Security by design**:
+
+  - How do you incorporate security considerations into your project's initial
+    planning and design phases?
+  - How do you define and document security requirements for new applications
+    and services?
+  - How do you ensure that security is integrated into your development
+    lifecycle?
+  - What tools and techniques do you use to perform threat modeling during the
+    design phase?
+  - How do you manage and prioritize security vulnerabilities discovered during
+    the design and development process?
+  - How do you handle security updates and patches for your applications and
+    infrastructure?
+  - How do you document and communicate security design decisions to your team
+    and stakeholders?
+  - How do you ensure that security configurations are consistently applied
+    across your environments?
+  - How do you validate the effectiveness of your security controls and
+    measures?
+  - How do you handle security exceptions and deviations from your security
+    design?
+
+- **Zero trust**:
+
+  - How do you verify and authenticate users and devices accessing your Google
+    Cloud resources?
+  - How do you implement the principle of least privilege for access control?
+  - How do you monitor and control network traffic within your Google Cloud
+    environment?
+  - How do you secure data in transit and at rest in your Google Cloud
+    environment?
+  - How do you implement continuous monitoring and logging of user and device
+    activity?
+  - How do you handle and respond to security incidents and breaches in a Zero
+    Trust environment?
+  - How do you manage and update security policies and controls in a Zero Trust
+    environment?
+  - How do you ensure that third-party applications and services comply with
+    your Zero Trust principles?
+  - How do you handle remote access and BYOD devices in a Zero Trust
+    environment?
+  - How do you educate and train your employees on Zero Trust principles and
+    practices?
+
+- **Shift-left security**:
+
+  - How do you integrate security testing into your development pipeline early
+    in the process?
+  - What types of security testing do you perform during the development phase?
+  - How do you provide developers with feedback on security vulnerabilities and
+    best practices?
+  - How do you empower developers to take ownership of security in their code?
+  - How do you ensure that security requirements are clearly defined and
+    communicated to developers?
+  - How do you measure the effectiveness of your Shift Left security
+    initiatives?
+  - How do you handle security dependencies and third-party libraries in your
+    code?
+  - How do you manage and update security configurations in your development
+    environment?
+  - How do you handle security exceptions and deviations from your security
+    policies in development?
+  - How do you promote a culture of security awareness and responsibility among
+    developers?
+
+- **Preemptive cyber defense**:
+
+  - How do you proactively identify and mitigate potential security threats
+    before they impact your systems?
+  - What tools and techniques do you use for continuous security monitoring and
+    analysis?
+  - How do you respond to and remediate security alerts and incidents?
+  - How do you simulate and test your incident response plans?
+  - How do you stay up-to-date with the latest security threats and
+    vulnerabilities?
+  - How do you handle and mitigate DDoS attacks against your applications and
+    services?
+  - How do you protect your sensitive data from insider threats?
+  - How do you ensure that your security controls are effective against advanced
+    persistent threats (APTs)?
+  - How do you handle security vulnerabilities in your supply chain?
+  - How do you adapt your security posture to evolving threats and technologies?
+
+- **Security of AI workloads**:
+
+  - How do you ensure the security of your AI models and data?
+  - How do you address potential biases and ethical concerns in your AI models?
+  - How do you protect your AI models from adversarial attacks and data
+    poisoning?
+  - How do you ensure the privacy of data used in your AI models?
+  - How do you explain and interpret the decisions made by your AI models?
+  - How do you manage and control access to your AI models and data?
+  - How do you ensure compliance with regulations and standards related to
+    AI and ML?
+  - How do you monitor and detect anomalies in the behavior of your AI models?
+  - How do you handle and respond to security incidents involving your AI
+    models?
+  - How do you educate and train your employees on the secure and responsible
+    use of AI and ML?
+
+- **AI for security**:
+
+  - How do you leverage AI and ML to enhance your security posture?
+  - What types of AI models do you use for security purposes?
+  - How do you train and validate your AI models for security applications?
+  - How do you ensure the accuracy and reliability of AI-based security
+    systems?
+  - How do you handle false positives and false negatives from AI-based
+    security systems?
+  - How do you integrate AI-based security systems with your existing security
+    infrastructure?
+  - How do you manage and update your AI models for security applications?
+  - How do you explain and interpret the decisions made by your AI models for
+    security applications?
+  - How do you ensure the ethical and responsible use of AI and ML for security
+    purposes?
+  - How do you measure the effectiveness of AI and ML in improving your security
+    posture?
+
+- **Regulatory compliance and privacy**:
+
+  - What regulatory compliance frameworks and privacy standards do you need to
+    adhere to?
+  - How do you assess and manage compliance risks in your Google Cloud
+    environment?
+  - How do you ensure the privacy of sensitive data stored and processed in
+    Google Cloud?
+  - How do you handle data subject requests (DSRs) related to privacy
+    regulations?
+  - How do you document and track compliance activities and evidence?
+  - How do you ensure that third-party vendors and partners comply with your
+    regulatory and privacy requirements?
+  - How do you handle data breaches and security incidents related to compliance
+    regulations?
+  - How do you stay up-to-date with changes in regulatory compliance and privacy
+    standards?
+  - How do you educate and train your employees on regulatory compliance and
+    privacy requirements?
+  - How do you demonstrate and prove compliance to auditors and regulators?
+
+## Validation checklist
+
+Use the following checklist to evaluate the architecture's alignment with
+security recommendations:
+
+- **Security by design**:
+
+  - Are system components selected based on their security features and
+    hardening?
+  - Is defense-in-depth implemented at the network, host, and application
+    layers?
+  - Are safe libraries and application frameworks used to prevent common
+    vulnerabilities?
+  - Is a risk assessment performed using industry standards?
+
+- **Zero trust**:
+
+  - Is access control enforced based on user identity and context (device,
+    location)?
+  - Are private connectivity methods (Cloud Interconnect, VPN) used for internal
+    traffic?
+  - Are default networks disabled in all projects?
+  - Are VPC Service Controls perimeters established around sensitive data?
+
+- **Shift-left security**:
+
+  - Is infrastructure provisioned using Infrastructure as Code
+    (e.g., Terraform)?
+  - Are automated security scans integrated into the CI/CD pipeline?
+  - Is there a process for scanning and patching vulnerabilities in
+    dependencies?
+  - Is Binary Authorization used to ensure only trusted images are deployed?
+
+- **Preemptive cyber defense**:
+
+  - Is threat intelligence integrated into security operations?
+  - Is security logging enabled and centralized for all critical resources?
+  - Are automated responses configured for common security threats?
+  - Are defenses validated through periodic testing or red-teaming?
+
+- **AI security and governance**:
+
+  - Are AI pipelines secured against tampering and data poisoning?
+  - Is differential privacy or data masking used for training data where
+    appropriate?
+  - Are Vertex Explainable AI and fairness indicators used for model governance?


### PR DESCRIPTION
## Summary

Migrates 13 Apache 2.0-licensed skills from [google/skills](https://github.com/google/skills) covering Google Cloud platform services and well-architected practices. Each skill is added as a new entry with a `source: google/skills (Apache 2.0)` frontmatter line for attribution. None of these are migrated from upstream today — existing similarly-named entries (`firebase`, `gemini`, `gcp-cloud-run`, `kubernetes-architect`) come from `vibeship-spawner-skills` and are left untouched.

## Skills added (13)

**ai-research**
- `gemini-api-agent-platform`

**database**
- `alloydb-basics`
- `bigquery-basics`
- `cloud-sql-basics`

**development**
- `cloud-run-basics`
- `firebase-basics`
- `gke-basics`
- `google-cloud-onboarding`
- `google-cloud-networking-observability`
- `google-cloud-waf-reliability`
- `google-cloud-waf-cost-optimization`

**security**
- `google-cloud-auth`
- `google-cloud-waf-security`

Each skill preserves the upstream `SKILL.md` plus its supporting `references/` (and `assets/` for GKE) directories. The component catalog was regenerated and copied to `dashboard/public/components.json`.

## Test plan

- [ ] Verify each new skill loads via `npx claude-code-templates@latest --skill <name>`
- [ ] Confirm catalog entries render correctly on www.aitmpl.com
- [ ] Spot-check `SKILL.md` frontmatter has `source: google/skills (Apache 2.0)` on each
- [ ] Confirm no existing skill (`firebase`, `gemini`, `gcp-cloud-run`, `kubernetes-architect`) was modified

https://claude.ai/code/session_01TzH6kveVv8jxFjg8oMMtkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzH6kveVv8jxFjg8oMMtkZ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates 13 Apache 2.0–licensed Google Cloud skills from `google/skills` into our catalog and refreshes the component index (including download stats) so the CLI and website surface them.

- Areas affected: components (`cli-tool/components/`), website (`docs/`)
- New components added: 13 skills (Gemini API, AlloyDB, BigQuery, Cloud SQL, Cloud Run, Firebase, GKE, onboarding, networking observability, WAF reliability/cost/security, Google Cloud auth)
- Catalog regenerated and download stats refreshed: `docs/components.json` and `dashboard/public/components.json`
- Attribution: each skill has `source: google/skills (Apache 2.0)`; existing similarly named skills (`firebase`, `gemini`, `gcp-cloud-run`, `kubernetes-architect`) unchanged
- No new environment variables or secrets

<sup>Written for commit 6c140f90d919c759de72fa1cfaeb532ff5b65cdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

