### PR TITLE
Add Explorium MCP to web-data

### DIFF
--- a/cli-tool/components/mcps/web-data/explorium.json
+++ b/cli-tool/components/mcps/web-data/explorium.json
@@ -1,8 +1,11 @@
 {
   "mcpServers": {
     "explorium": {
-      "description": "Explorium MCP — live B2B company and contact data (150M+ businesses, 800M+ professionals, 4,000+ signals, 50+ data sources) for lead-list building, prospect enrichment, executive discovery, firmographics, technographics, funding signals, and multi-step GTM workflows. OAuth authentication.",
-      "url": "https://mcp.explorium.ai/mcp"
+      "description": "Explorium MCP — live B2B company and contact data (150M+ businesses, 800M+ professionals, 4,000+ signals, 50+ data sources) for lead-list building, prospect enrichment, executive discovery, firmographics, technographics, funding signals, and multi-step GTM workflows. Supports two auth modes: (1) API key — set it in the api_key header below (get one at https://developers.explorium.ai/reference/setup/getting_your_api_key), or (2) OAuth — remove the headers block and the MCP client will trigger a browser sign-in on first use.",
+      "url": "https://mcp.explorium.ai/mcp",
+      "headers": {
+        "api_key": "<YOUR_EXPLORIUM_API_KEY>"
+      }
     }
   }
 }

--- a/cli-tool/components/mcps/web-data/explorium.json
+++ b/cli-tool/components/mcps/web-data/explorium.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "explorium": {
+      "description": "Explorium MCP — live B2B company and contact data (150M+ businesses, 800M+ professionals, 4,000+ signals, 50+ data sources) for lead-list building, prospect enrichment, executive discovery, firmographics, technographics, funding signals, and multi-step GTM workflows. OAuth authentication.",
+      "url": "https://mcp.explorium.ai/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Adds the Explorium MCP server to `cli-tool/components/mcps/web-data/`, alongside the existing brightdata and apify entries.

**Explorium MCP** provides live B2B company and contact data — 150M+ businesses, 800M+ professional profiles, 4,000+ signals, 50+ data sources — for lead-list building, prospect enrichment, executive discovery, firmographics, technographics, funding signals, and multi-step GTM workflows.

- **Endpoint:** `https://mcp.explorium.ai/mcp`
- **Auth:** OAuth (browser sign-in after connect)
- **Category:** `web-data` (closest fit; matches brightdata's remote URL + B2B-data pattern)

### File added
`cli-tool/components/mcps/web-data/explorium.json`

```json
{
  "mcpServers": {
    "explorium": {
      "description": "Explorium MCP — live B2B company and contact data ...",
      "url": "https://mcp.explorium.ai/mcp"
    }
  }
}
```

**Disclosure:** I'm the CEO of Explorium.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Explorium MCP server to the web-data catalog for live B2B company and contact data. Supports API key auth via `api_key` header or OAuth by removing the headers.

- **New Features**
  - Area: components (`cli-tool/components/`)
  - Added `cli-tool/components/mcps/web-data/explorium.json`
  - Auth: API key via `api_key` header or OAuth (remove headers); no new env vars or secrets
  - Catalog: regenerate `docs/components.json`

<sup>Written for commit bf367f09d79b47dc933583855be65ba12c549461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

