### PR TITLE
feat: add 10 pluginpool commands across categories

### DIFF
--- a/cli-tool/components/commands/documentation/changelog-forge.md
+++ b/cli-tool/components/commands/documentation/changelog-forge.md
@@ -1,0 +1,16 @@
+---
+description: Group conventional commits since last tag into a CHANGELOG entry
+allowed-tools: Bash
+---
+
+Role: act as a release scribe. Turn conventional commits into a clean `## [Unreleased]` block plus a semver-bump recommendation.
+
+Run the helper:
+
+```bash
+python3 scripts/forge.py --format md
+```
+
+Useful flags: `--from v1.2.0`, `--to HEAD`, `--write` (prepend to `CHANGELOG.md`, idempotent), `--format json`.
+
+The helper groups commits by type (feat / fix / perf / refactor / docs / test / build / ci / chore / revert), surfaces `BREAKING CHANGE` markers, and suggests `major | minor | patch`. Read the output, then briefly justify the bump (or push back if the heuristic missed nuance). Only run `--write` when the user explicitly asks for it.

--- a/cli-tool/components/commands/git-workflow/standup-gen.md
+++ b/cli-tool/components/commands/git-workflow/standup-gen.md
@@ -1,0 +1,16 @@
+---
+description: Generate daily standup notes from git activity
+allowed-tools: Bash
+---
+
+Role: act as a standup-note author. Produce Yesterday / Today / Blockers sections grounded only in the user's git activity.
+
+Run the helper:
+
+```bash
+python3 scripts/standup.py --format md
+```
+
+Useful flags: `--since 2026-05-15`, `--since yesterday`, `--repos /path/repoA,/path/repoB`, `--author all`, `--format json`.
+
+The helper fills "Yesterday" from commit subjects and leaves "Today (planned)" and "Blockers" as placeholders. Read the commit list, then propose 1–3 candidate "Today" items derived from in-flight files (e.g. files with WIP or follow-up commits). Mark blockers only if the diffs or commit messages clearly evidence one. Print the final markdown.

--- a/cli-tool/components/commands/git/commit-narrator.md
+++ b/cli-tool/components/commands/git/commit-narrator.md
@@ -1,0 +1,16 @@
+---
+description: Generate a conventional commit message from the staged diff
+allowed-tools: Bash
+---
+
+Role: act as the commit-message author responsible only for producing one conventional commit message for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+git diff --staged --binary | python3 scripts/narrate.py --diff -
+```
+
+The helper accepts an empty diff and returns no text. For non-empty diffs, it prints `type(scope): subject`, a blank line, and a body with changed files plus a placeholder WHY line. Valid types are `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, and `perf`.
+
+Read the helper output and the staged diff, then replace the placeholder WHY line with a concise rationale grounded only in the diff. Preserve the conventional-commit subject unless the diff clearly proves a better one. Print only the final commit message.

--- a/cli-tool/components/commands/git/pr-storyteller.md
+++ b/cli-tool/components/commands/git/pr-storyteller.md
@@ -1,0 +1,20 @@
+---
+description: Generate a PR title, body, and test plan from commits and diff
+allowed-tools: Bash
+---
+
+Role: act as the PR description author responsible only for producing a PR title and markdown body for the current repository.
+
+Run the local helper with Bash:
+
+```bash
+python3 scripts/story.py --base main
+```
+
+If the result has no commits and no changed files, rerun with:
+
+```bash
+python3 scripts/story.py --base master
+```
+
+The helper returns JSON with `commits`, `files_changed`, and `suggested_title`. Use only that JSON plus local diff evidence. Write a PR title from `suggested_title`, then a markdown PR body with exactly these sections: Summary, Changes, Test plan, Risk. Print only the PR title and markdown body.

--- a/cli-tool/components/commands/security/deps-doctor.md
+++ b/cli-tool/components/commands/security/deps-doctor.md
@@ -1,0 +1,16 @@
+---
+description: Run dependency health audits across supported ecosystems
+allowed-tools: Bash
+---
+
+Run `python3 scripts/doctor.py "$@"` from the deps-doctor plugin root.
+
+Purpose: detect supported dependency ecosystems, run available local audit tools, and summarize advisories without failing when tools are missing.
+
+Inputs: optional `--format`, `--severity`, and `--ecosystem` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network directly, and do not hide skipped tools.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/cli-tool/components/commands/security/secret-guard.md
+++ b/cli-tool/components/commands/security/secret-guard.md
@@ -1,0 +1,24 @@
+---
+description: Scan staged diff (or specified files) for leaked secrets with redacted output
+allowed-tools: Bash
+---
+
+Role: act as a pre-merge security gate. Detect leaked API keys, tokens, and high-entropy strings without ever surfacing the secret itself.
+
+Run the helper:
+
+```sh
+python3 scripts/guard.py --format md
+```
+
+Useful flags: `--files app.py config.txt` (scan explicit files instead of staged diff), `--allowlist .secret-allowlist` (suppress known false positives).
+
+The helper redacts every finding to `rule + first 4 chars + …` — the raw secret never appears in JSON or markdown output. This invariant is enforced by `tests/test_guard.py::test_redaction_contains_only_rule_and_first_four`.
+
+For pre-commit integration:
+
+```sh
+cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+Exit codes: `0` clean, `1` finding present. Read the report and recommend: rotate, allowlist, or fix.

--- a/cli-tool/components/commands/testing/env-lint.md
+++ b/cli-tool/components/commands/testing/env-lint.md
@@ -1,0 +1,18 @@
+---
+description: Validate .env files against .env.example without printing values
+allowed-tools: Bash
+---
+
+Role: act as an env-var auditor. Never echo or repeat the *values* of any environment variable — only the key names.
+
+Run the helper:
+
+```sh
+python3 scripts/envlint.py --format md
+```
+
+Useful flags: `--example .env.example --env .env.local`, `--format json`.
+
+The helper auto-detects common pairs (`.env` vs `.env.example`, `.env.local` vs `.env.example`, `.env.production` vs `.env.example`) or accepts an explicit pair. It reports missing keys, extra keys, and keys with empty values. The output never includes env values — that invariant is enforced by `tests/test_envlint.py::test_never_emits_values_in_json_or_markdown`.
+
+Read the helper output and propose a triage: which keys must be added before deploy, which are safe to leave, which look like cruft.

--- a/cli-tool/components/commands/testing/flaky-detector.md
+++ b/cli-tool/components/commands/testing/flaky-detector.md
@@ -1,0 +1,16 @@
+---
+description: Detect flaky tests by running a test command N times
+allowed-tools: Bash
+---
+
+Role: act as a flake hunter. Identify tests that don't always agree with themselves.
+
+Run the helper:
+
+```bash
+python3 scripts/flaky.py --cmd "pytest -q" --runs 10 --format md
+```
+
+Useful flags: `--parser pytest|jest|gotest|tap`, `--parallel N`, `--out report.json`.
+
+The helper reports `flakiness_pct = fail_count / total_runs * 100` per test, plus a summary. Exit codes: `0` clean, `1` flaky tests found, `2` always-failing tests found. Read the report, then suggest the next move for the worst 1–3 offenders (rerun, isolate, mark `@pytest.mark.flaky`, or root-cause). Don't speculate beyond what the output supports.

--- a/cli-tool/components/commands/testing/test-gap.md
+++ b/cli-tool/components/commands/testing/test-gap.md
@@ -1,0 +1,16 @@
+---
+description: Surface changed git diff lines that are not covered by tests
+allowed-tools: Bash
+---
+
+Run `python3 scripts/gap.py "$@"` from the test-gap plugin root.
+
+Purpose: compare the current git diff against the selected base branch, parse the selected or auto-detected coverage report, and report changed lines that are not covered by tests.
+
+Inputs: optional `--base`, `--report`, and `--format` arguments supplied by the user.
+
+Boundaries: do not edit files, do not install packages, do not use the network, and do not hide failures.
+
+Output contract: return either the helper output or a concise failure summary with command, exit status, and next step.
+
+Verification contract: accept success only when the helper exits 0 and prints JSON or markdown matching the requested format.

--- a/cli-tool/components/commands/utilities/todo-harvest.md
+++ b/cli-tool/components/commands/utilities/todo-harvest.md
@@ -1,0 +1,16 @@
+---
+description: List TODO/FIXME/HACK comments with author + age in days
+allowed-tools: Bash
+---
+
+Role: act as a debt-triage assistant. Surface the oldest, highest-cost TODOs first.
+
+Run the helper:
+
+```bash
+python3 scripts/harvest.py --format md
+```
+
+Useful flags: `--markers TODO,FIXME,HACK`, `--min-age 90`, `--format json`.
+
+The helper uses `git ls-files` (respecting .gitignore) and runs `git blame` per match for author + age. Read the table, then propose a short triage list: which TODOs are stale enough to delete, which need owners, which look like real bugs. Be specific — quote the file and line.


### PR DESCRIPTION
Adds 10 focused developer productivity commands from [mturac/pluginpool](https://github.com/mturac/pluginpool), distributed across existing component categories.

## Commands added

| Category | Command | Purpose |
|---|---|---|
| documentation | changelog-forge | Conventional commits → CHANGELOG section + semver bump |
| git | commit-narrator | Semantic commit message from staged diff, with the *why* |
| git | pr-storyteller | PR title + body + test plan from commits and diff vs base |
| git-workflow | standup-gen | Standup notes from git activity across repos |
| security | deps-doctor | Multi-ecosystem dependency audit (npm/pip/cargo/go) |
| security | secret-guard | Pre-commit secret scanner (pattern + entropy) |
| testing | env-lint | `.env` vs `.env.example` key parity |
| testing | flaky-detector | Per-test flakiness % from N runs |
| testing | test-gap | Diff lines lacking test coverage |
| utilities | todo-harvest | TODO/FIXME/HACK scan with git blame author + age |

Each command is a small slash command (with `name` + `description` + `allowed-tools` frontmatter) that calls a deterministic Python helper. The helper scripts live in the upstream pluginpool repos (mturac/pluginpool-<name>), each with its own hermetic test suite — 89 tests total across the suite.

## PR contents

- Adds 10 `.md` command files across 6 categories (documentation, git, git-workflow, security, testing, utilities)
- All slash command frontmatter follows the existing convention used by sibling commands in each category
- No new categories created; everything fits the existing taxonomy

MIT. Each command is independent and can be cherry-picked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 10 `pluginpool` commands to components to cover docs, git, security, testing, and utilities. Improves developer workflows for commits, PRs, dependency audits, env checks, flake detection, coverage gaps, and TODO triage.

- Area: components (`cli-tool/components/`) — 10 new command components across documentation, git, git-workflow, security, testing, and utilities
- New components added: yes — regenerate `docs/components.json`
- No new environment variables or secrets
- No new categories; all commands fit existing taxonomy

<sup>Written for commit fe7adb5a5042c9e2ecc9f8fed13a8ac294fbde4c. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/592?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

