### PR TITLE
Add BrainGrid to Featured Integrations cards

### DIFF
--- a/dashboard/src/components/FeaturedSection.astro
+++ b/dashboard/src/components/FeaturedSection.astro
@@ -1,6 +1,10 @@
 ---
 import FeaturedCard from './FeaturedCard.astro';
 import { FEATURED_ITEMS } from '../lib/constants';
+
+const gridColsClass = FEATURED_ITEMS.length % 2 === 0
+  ? 'md:grid-cols-2'
+  : 'md:grid-cols-3';
 ---
 
 <section class="px-6 py-5 mb-2">
@@ -11,7 +15,7 @@ import { FEATURED_ITEMS } from '../lib/constants';
       </svg>
       <h2 class="text-[15px] font-semibold text-[var(--color-text-primary)]">Featured Integrations</h2>
     </div>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+    <div class={`grid grid-cols-1 ${gridColsClass} gap-3`}>
       {FEATURED_ITEMS.map((item) => (
         <FeaturedCard item={item} />
       ))}

--- a/dashboard/src/lib/constants.ts
+++ b/dashboard/src/lib/constants.ts
@@ -74,6 +74,25 @@ export const FEATURED_ITEMS: FeaturedItem[] = [
       { label: 'claudekit.cc', url: 'https://claudekit.cc' },
     ],
   },
+  {
+    name: 'BrainGrid',
+    description: 'Plan. Build. Verify. Repeat.',
+    logo: '/braingrid-logo.png',
+    url: '/featured/braingrid',
+    tag: 'Planning',
+    tagColor: '#c5e063',
+    category: 'Product Planning',
+    ctaLabel: 'Try BrainGrid',
+    ctaUrl: 'https://www.braingrid.ai?utm_source=aitmpl&utm_medium=featured&utm_campaign=partner',
+    websiteUrl: 'https://www.braingrid.ai',
+    metadata: {
+      Integration: 'MCP, CLI',
+      Stage: 'Battle-tested',
+    },
+    links: [
+      { label: 'braingrid.ai', url: 'https://www.braingrid.ai' },
+    ],
+  },
 ];
 
 export const NAV_LINKS = {


### PR DESCRIPTION
## Summary

- Adds BrainGrid as a fourth entry in `FEATURED_ITEMS` (`dashboard/src/lib/constants.ts`)
- The `/featured/braingrid` page was already in place; this just makes the card visible on the homepage Featured Integrations grid

## Test plan

- [ ] Verify the BrainGrid card appears in the Featured Integrations section on the homepage
- [ ] Verify clicking the card navigates to `/featured/braingrid`
- [ ] Verify the logo (`/braingrid-logo.png`) renders correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01UexeVgCnfEwCAnTWfDdKbM)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BrainGrid to the Featured Integrations on the dashboard and adjusts the grid to keep a balanced layout when the item count is even.

- Area: website (dashboard/)
- Added BrainGrid to FEATURED_ITEMS in dashboard/src/lib/constants.ts; card links to /featured/braingrid and uses /braingrid-logo.png
- Updated FeaturedSection to use 2 columns on md+ when FEATURED_ITEMS.length is even; 3 columns when odd (dashboard/src/components/FeaturedSection.astro)
- No new components; no docs/components.json regeneration
- No new environment variables or secrets

<sup>Written for commit 76d04834b54b052e49b95d5a2dd551492519b3df. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

