### PR TITLE
Add Septim Agents Pack to the templates collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **⭐ Found this useful? Give us a star to support the project!**
 
 [![Buy Me A Coffee](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=daniavila&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/daniavila)
+
+- [Septim Agents Pack](https://septimlabs.com/agents?utm_source=awesome-list&utm_campaign=davila7) - 15 templated Claude Code sub-agent files for the full exec layer (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip, Hart, Halo, Beacon, Loom, Lynx). Drops into `~/.claude/agents/`. Open-source sample: [github.com/septimlabs-code/septim-agents-pack-sample](https://github.com/septimlabs-code/septim-agents-pack-sample). $49 lifetime.


### PR DESCRIPTION
Adds Septim Agents Pack as a curated set of Claude Code sub-agent templates. 15 named roles, each pre-scoped with refusal conditions and tool allowlists.

Open-source sample (MIT): https://github.com/septimlabs-code/septim-agents-pack-sample

Full paid pack: $49 lifetime at https://septimlabs.com/agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Septim Agents Pack to the templates list in README. It links to 15 Claude Code sub-agent templates, with install path and a sample repo.

- Area: website (docs/) — README update only
- Change: Added bullet linking to Septim Agents Pack, install path, sample repo, and $49 lifetime note
- Why: Surface a curated set of sub-agent templates for quick setup
- Components/catalog: No new components; no docs/components.json regeneration needed
- Env/secrets: None

<sup>Written for commit 063b37decfbc8a06926f5df1109141c8cf95e0cd. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/595?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

