### PR TITLE
fix: replace invalid git diff --since with correct two-step approach

### DIFF
--- a/cli-tool/components/skills/enterprise-communication/session-handoff/scripts/check_staleness.py
+++ b/cli-tool/components/skills/enterprise-communication/session-handoff/scripts/check_staleness.py
@@ -102,27 +102,38 @@ def get_current_branch(project_path: str) -> str | None:
 
 
 def get_changed_files_since(timestamp: datetime, project_path: str) -> list[str]:
-    """Get files that changed since timestamp."""
+    """Get files that changed since timestamp.
+
+    Combines two sources:
+    1. Working-tree changes (unstaged + staged) via ``git diff --name-only HEAD``
+    2. Committed changes since *timestamp* via ``git log --since``
+
+    Note: ``git diff`` does not support ``--since``; the time filter only
+    applies to the commit log query.
+    """
     if not timestamp:
         return []
 
-    iso_time = timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+    files: set[str] = set()
+
+    # 1. Working-tree changes (uncommitted edits since last commit)
     success, output = run_cmd(
-        ["git", "diff", "--name-only", f"--since={iso_time}", "HEAD"],
+        ["git", "diff", "--name-only", "HEAD"],
         cwd=project_path
     )
-
-    # Fallback: get files changed in commits since timestamp
-    if not output:
-        success, output = run_cmd(
-            ["git", "log", f"--since={iso_time}", "--name-only", "--pretty=format:"],
-            cwd=project_path
-        )
-
     if success and output:
-        files = [f.strip() for f in output.split("\n") if f.strip()]
-        return list(set(files))  # Deduplicate
-    return []
+        files.update(f.strip() for f in output.split("\n") if f.strip())
+
+    # 2. Committed changes since the handoff timestamp
+    iso_time = timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+    success, output = run_cmd(
+        ["git", "log", f"--since={iso_time}", "--name-only", "--pretty=format:"],
+        cwd=project_path
+    )
+    if success and output:
+        files.update(f.strip() for f in output.split("\n") if f.strip())
+
+    return list(files)
 
 
 def check_files_exist(files: list[str], project_path: str) -> tuple[list[str], list[str]]:

--- a/cli-tool/components/skills/enterprise-communication/session-handoff/scripts/check_staleness.py
+++ b/cli-tool/components/skills/enterprise-communication/session-handoff/scripts/check_staleness.py
@@ -104,9 +104,10 @@ def get_current_branch(project_path: str) -> str | None:
 def get_changed_files_since(timestamp: datetime, project_path: str) -> list[str]:
     """Get files that changed since timestamp.
 
-    Combines two sources:
+    Combines three sources:
     1. Working-tree changes (unstaged + staged) via ``git diff --name-only HEAD``
-    2. Committed changes since *timestamp* via ``git log --since``
+    2. Untracked new files via ``git ls-files --others --exclude-standard``
+    3. Committed changes since *timestamp* via ``git log --since``
 
     Note: ``git diff`` does not support ``--since``; the time filter only
     applies to the commit log query.
@@ -116,7 +117,7 @@ def get_changed_files_since(timestamp: datetime, project_path: str) -> list[str]
 
     files: set[str] = set()
 
-    # 1. Working-tree changes (uncommitted edits since last commit)
+    # 1. Working-tree changes (uncommitted edits to tracked files)
     success, output = run_cmd(
         ["git", "diff", "--name-only", "HEAD"],
         cwd=project_path
@@ -124,7 +125,15 @@ def get_changed_files_since(timestamp: datetime, project_path: str) -> list[str]
     if success and output:
         files.update(f.strip() for f in output.split("\n") if f.strip())
 
-    # 2. Committed changes since the handoff timestamp
+    # 2. Untracked new files (not yet added to git)
+    success, output = run_cmd(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=project_path
+    )
+    if success and output:
+        files.update(f.strip() for f in output.split("\n") if f.strip())
+
+    # 3. Committed changes since the handoff timestamp
     iso_time = timestamp.strftime("%Y-%m-%dT%H:%M:%S")
     success, output = run_cmd(
         ["git", "log", f"--since={iso_time}", "--name-only", "--pretty=format:"],


### PR DESCRIPTION
﻿## Summary

- **Replaces invalid `git diff --since`** with a correct two-step approach that combines working-tree changes (`git diff --name-only HEAD`) with committed changes (`git log --since=... --name-only`)
- `git diff` does not support the `--since` flag — this caused the staleness checker to silently return no changed files, making every handoff appear "FRESH" regardless of actual codebase changes

## Details

The `get_changed_files_since()` function in `check_staleness.py` used `git diff --name-only --since=<timestamp> HEAD`, but `--since` is a `git log` option, not a `git diff` option. Git silently ignores the unknown flag and returns an empty diff (comparing HEAD to HEAD), so the function always reported zero changed files.

The fix splits detection into two sources:
1. **Working-tree changes** via `git diff --name-only HEAD` (uncommitted edits)
2. **Committed changes** via `git log --since=<timestamp> --name-only --pretty=format:` (commits since handoff)

Results are merged into a deduplicated set.

Fixes #600

## Test plan

- [ ] Run `check_staleness.py` on a handoff file in a repo with recent commits — verify `files_changed_count > 0`
- [ ] Run on a repo with uncommitted changes — verify those files appear in the report
- [ ] Run on a freshly-created handoff — verify `FRESH` staleness level
- [ ] Verify `git diff --name-only HEAD` alone returns working-tree changes
- [ ] Verify `git log --since=... --name-only` returns committed file paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the staleness checker so it correctly finds changed files since a handoff, including uncommitted and untracked files. Replaces the bad use of `git diff --since` with a three-source approach.

- **Bug Fixes**
  - Combines `git diff --name-only HEAD` (working tree), `git ls-files --others --exclude-standard` (untracked), and `git log --since ... --name-only` (commits); results are merged and deduped.
  - Ensures new, untracked files now trigger STALE instead of FRESH.
  - Area: components (`cli-tool/components/`), file `skills/enterprise-communication/session-handoff/scripts/check_staleness.py`.
  - No new components; `docs/components.json` does not need regeneration. No new environment variables or secrets.

<sup>Written for commit ce91b4e8c3b2629caae9e4feaeec7c43d8907e47. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/602?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

