### PR TITLE
fix: replace VS Code Copilot tool names with valid Claude Code tools in 14 devops agents

### DIFF
--- a/cli-tool/components/agents/devops-infrastructure/azure-iac-generator.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-iac-generator.md
@@ -1,7 +1,7 @@
 ---
 name: azure-iac-generator
 description: Central hub for generating Infrastructure as Code (Bicep, ARM, Terraform, Pulumi) with format-specific validation and best practices. Use this skill when the user asks to generate, create, write, or build infrastructure code, deployment code, or IaC templates in any format (Bicep, ARM Templates, Terraform, Pulumi).
-tools: vscode, execute, read, edit, search, web, agent, azure-mcp/azureterraformbestpractices, azure-mcp/bicepschema, azure-mcp/search, pulumi-mcp/get-type, runSubagent
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, Agent, azure-mcp/azureterraformbestpractices, azure-mcp/bicepschema, azure-mcp/search, pulumi-mcp/get-type
 model: Claude Sonnet 4.5
 ---
 

--- a/cli-tool/components/agents/devops-infrastructure/azure-logic-apps-expert.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-logic-apps-expert.md
@@ -1,7 +1,7 @@
 ---
 name: azure-logic-apps-expert
 description: Expert guidance for Azure Logic Apps development focusing on workflow design, integration patterns, and JSON-based Workflow Definition Language.
-tools: codebase, changes, edit/editFiles, search, runCommands, microsoft.docs.mcp, azure_get_code_gen_best_practices, azure_query_learn
+tools: Read, Edit, Write, Bash, Grep, Glob, microsoft.docs.mcp, azure_get_code_gen_best_practices, azure_query_learn
 ---
 
 # Azure Logic Apps Expert Mode

--- a/cli-tool/components/agents/devops-infrastructure/azure-principal-architect.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-principal-architect.md
@@ -1,7 +1,7 @@
 ---
 name: azure-principal-architect
 description: Provide expert Azure Principal Architect guidance using Azure Well-Architected Framework principles and Microsoft best practices.
-tools: changes, codebase, edit/editFiles, extensions, fetch, findTestFiles, githubRepo, new, openSimpleBrowser, problems, runCommands, runTasks, runTests, search, searchResults, terminalLastCommand, terminalSelection, testFailure, usages, vscodeAPI, microsoft.docs.mcp, azure_design_architecture, azure_get_code_gen_best_practices, azure_get_deployment_best_practices, azure_get_swa_best_practices, azure_query_learn
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, microsoft.docs.mcp, azure_design_architecture, azure_get_code_gen_best_practices, azure_get_deployment_best_practices, azure_get_swa_best_practices, azure_query_learn
 ---
 
 # Azure Principal Architect mode instructions

--- a/cli-tool/components/agents/devops-infrastructure/azure-saas-architect.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-saas-architect.md
@@ -1,7 +1,7 @@
 ---
 name: azure-saas-architect
 description: Provide expert Azure SaaS Architect guidance focusing on multitenant applications using Azure Well-Architected SaaS principles and Microsoft best practices.
-tools: changes, search/codebase, edit/editFiles, extensions, fetch, findTestFiles, githubRepo, new, openSimpleBrowser, problems, runCommands, runTasks, runTests, search, search/searchResults, runCommands/terminalLastCommand, runCommands/terminalSelection, testFailure, usages, vscodeAPI, microsoft.docs.mcp, azure_design_architecture, azure_get_code_gen_best_practices, azure_get_deployment_best_practices, azure_get_swa_best_practices, azure_query_learn
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, microsoft.docs.mcp, azure_design_architecture, azure_get_code_gen_best_practices, azure_get_deployment_best_practices, azure_get_swa_best_practices, azure_query_learn
 ---
 
 # Azure SaaS Architect mode instructions

--- a/cli-tool/components/agents/devops-infrastructure/azure-verified-modules-bicep.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-verified-modules-bicep.md
@@ -1,7 +1,7 @@
 ---
 name: azure-verified-modules-bicep
 description: Create, update, or review Azure IaC in Bicep using Azure Verified Modules (AVM).
-tools: changes, codebase, edit/editFiles, extensions, fetch, findTestFiles, githubRepo, new, openSimpleBrowser, problems, runCommands, runTasks, runTests, search, searchResults, terminalLastCommand, terminalSelection, testFailure, usages, vscodeAPI, microsoft.docs.mcp, azure_get_deployment_best_practices, azure_get_schema_for_Bicep
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, microsoft.docs.mcp, azure_get_deployment_best_practices, azure_get_schema_for_Bicep
 ---
 
 # Azure AVM Bicep mode

--- a/cli-tool/components/agents/devops-infrastructure/azure-verified-modules-terraform.md
+++ b/cli-tool/components/agents/devops-infrastructure/azure-verified-modules-terraform.md
@@ -1,7 +1,7 @@
 ---
 name: azure-verified-modules-terraform
 description: Create, update, or review Azure IaC in Terraform using Azure Verified Modules (AVM).
-tools: changes, codebase, edit/editFiles, extensions, fetch, findTestFiles, githubRepo, new, openSimpleBrowser, problems, runCommands, runTasks, runTests, search, searchResults, terminalLastCommand, terminalSelection, testFailure, usages, vscodeAPI, microsoft.docs.mcp, azure_get_deployment_best_practices, azure_get_schema_for_Bicep
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, microsoft.docs.mcp, azure_get_deployment_best_practices, azure_get_schema_for_Bicep
 ---
 
 # Azure AVM Terraform mode

--- a/cli-tool/components/agents/devops-infrastructure/bicep-implement.md
+++ b/cli-tool/components/agents/devops-infrastructure/bicep-implement.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-implement
 description: Act as an Azure Bicep Infrastructure as Code coding specialist that creates Bicep templates.
-tools: edit/editFiles, fetch, runCommands, terminalLastCommand, get_bicep_best_practices, azure_get_azure_verified_module, todos
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, get_bicep_best_practices, azure_get_azure_verified_module
 ---
 
 # Azure Bicep Infrastructure as Code coding Specialist

--- a/cli-tool/components/agents/devops-infrastructure/bicep-plan.md
+++ b/cli-tool/components/agents/devops-infrastructure/bicep-plan.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-plan
 description: Act as implementation planner for your Azure Bicep Infrastructure as Code task.
-tools: edit/editFiles, fetch, microsoft-docs, azure_design_architecture, get_bicep_best_practices, bestpractices, bicepschema, azure_get_azure_verified_module, todos
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, microsoft-docs, azure_design_architecture, get_bicep_best_practices, bestpractices, bicepschema, azure_get_azure_verified_module
 ---
 
 # Azure Bicep Infrastructure Planning

--- a/cli-tool/components/agents/devops-infrastructure/devops-expert.md
+++ b/cli-tool/components/agents/devops-infrastructure/devops-expert.md
@@ -1,7 +1,7 @@
 ---
 name: devops-expert
 description: DevOps specialist following the infinity loop principle (Plan → Code → Build → Test → Release → Deploy → Operate → Monitor) with focus on automation, collaboration, and continuous improvement
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo, runCommands, runTasks
+tools: Read, Edit, Write, Bash, Grep, Glob
 ---
 
 # DevOps Expert

--- a/cli-tool/components/agents/devops-infrastructure/kusto-assistant.md
+++ b/cli-tool/components/agents/devops-infrastructure/kusto-assistant.md
@@ -1,7 +1,7 @@
 ---
 name: kusto-assistant
 description: Expert KQL assistant for live Azure Data Explorer analysis via Azure MCP server
-tools: changes, codebase, editFiles, extensions, fetch, findTestFiles, githubRepo, new, openSimpleBrowser, problems, runCommands, runTasks, runTests, search, searchResults, terminalLastCommand, terminalSelection, testFailure, usages, vscodeAPI
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch
 ---
 
 # Kusto Assistant: Azure Data Explorer (Kusto) Engineering Assistant

--- a/cli-tool/components/agents/devops-infrastructure/se-gitops-ci-specialist.md
+++ b/cli-tool/components/agents/devops-infrastructure/se-gitops-ci-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: se-gitops-ci-specialist
 description: DevOps specialist for CI/CD pipelines, deployment debugging, and GitOps workflows focused on making deployments boring and reliable
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo
+tools: Read, Edit, Write, Bash, Grep, Glob
 ---
 
 # GitOps & CI Specialist

--- a/cli-tool/components/agents/devops-infrastructure/terraform-azure-implement.md
+++ b/cli-tool/components/agents/devops-infrastructure/terraform-azure-implement.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-azure-implement
 description: Act as an Azure Terraform Infrastructure as Code coding specialist that creates and reviews Terraform for Azure resources.
-tools: edit/editFiles, search, runCommands, fetch, todos, azureterraformbestpractices, documentation, get_bestpractices, microsoft-docs
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, azureterraformbestpractices, documentation, get_bestpractices, microsoft-docs
 ---
 
 # Azure Terraform Infrastructure as Code Implementation Specialist

--- a/cli-tool/components/agents/devops-infrastructure/terraform-azure-planning.md
+++ b/cli-tool/components/agents/devops-infrastructure/terraform-azure-planning.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-azure-planning
 description: Act as implementation planner for your Azure Terraform Infrastructure as Code task.
-tools: edit/editFiles, fetch, todos, azureterraformbestpractices, cloudarchitect, documentation, get_bestpractices, microsoft-docs
+tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, azureterraformbestpractices, cloudarchitect, documentation, get_bestpractices, microsoft-docs
 ---
 
 # Azure Terraform Infrastructure Planning

--- a/cli-tool/components/agents/devops-infrastructure/terraform-iac-reviewer.md
+++ b/cli-tool/components/agents/devops-infrastructure/terraform-iac-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-iac-reviewer
 description: Terraform-focused agent that reviews and creates safer IaC changes with emphasis on state safety, least privilege, module patterns, drift detection, and plan/apply discipline
-tools: codebase, edit/editFiles, terminalCommand, search, githubRepo
+tools: Read, Edit, Write, Bash, Grep, Glob
 ---
 
 # Terraform IaC Reviewer


### PR DESCRIPTION
﻿## Summary

- **Replaces invalid VS Code Copilot tool names** with valid Claude Code tools across 14 devops-infrastructure agents
- Agents previously declared tool names like `codebase`, `edit/editFiles`, `terminalCommand`, `githubRepo`, `runCommands`, `runTasks`, `vscodeAPI`, etc. — these are GitHub Copilot tool identifiers that Claude Code silently ignores
- At runtime, affected agents had **zero tool access**, making them unable to read files, run commands, or edit code

## Mapping

| VS Code Copilot tool | Claude Code equivalent |
|---------------------|----------------------|
| `codebase`, `search`, `searchResults`, `usages` | `Read`, `Grep`, `Glob` |
| `edit/editFiles`, `editFiles`, `new` | `Edit`, `Write` |
| `terminalCommand`, `runCommands`, `runTasks`, `runTests` | `Bash` |
| `fetch`, `openSimpleBrowser` | `WebFetch` |
| `githubRepo` | `Bash` (git operations) |
| `vscodeAPI`, `extensions`, `problems`, `changes`, `testFailure`, `terminalLastCommand`, `terminalSelection`, `findTestFiles` | Removed (VS Code-specific, no Claude Code equivalent) |

MCP tool references (`microsoft.docs.mcp`, `azure_*`, `get_bicep_best_practices`, etc.) are preserved.

## Files changed (14)

All in `cli-tool/components/agents/devops-infrastructure/`:

- `azure-iac-generator.md`
- `azure-logic-apps-expert.md`
- `azure-principal-architect.md`
- `azure-saas-architect.md`
- `azure-verified-modules-bicep.md`
- `azure-verified-modules-terraform.md`
- `bicep-implement.md`
- `bicep-plan.md`
- `devops-expert.md`
- `kusto-assistant.md`
- `se-gitops-ci-specialist.md`
- `terraform-azure-implement.md`
- `terraform-azure-planning.md`
- `terraform-iac-reviewer.md`

Extends the fix from #534 (which covered 3 files) to all remaining affected agents.

Relates to #535

## Test plan

- [ ] Install any fixed agent via `claude-code-templates install devops-expert` and verify tool access works
- [ ] Confirm MCP tool references still resolve when the corresponding MCP server is connected
- [ ] Verify no regressions in agent behavior for agents that previously had zero tool access


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced VS Code Copilot tool names with valid Claude Code tools in 14 devops-infrastructure agents, restoring read/edit, grep, web fetch, and shell access. Fixes agents that previously had zero tool access.

- **Bug Fixes**
  - Components: updated tools in `cli-tool/components/agents/devops-infrastructure/*` to use `Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, `WebFetch`, `Agent`
  - Preserved all MCP tool references (e.g., `microsoft.docs.mcp`, `azure_*`)
  - No new components; no `docs/components.json` regeneration needed
  - No new environment variables or secrets

<sup>Written for commit b734ca06d4c3ea37f8f19f2b00eaa8f90d10d997. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/603?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

