### PR TITLE
fix: resolve duplicate skill names for -official document processing skills

### DIFF
--- a/cli-tool/components/skills/document-processing/docx-official/SKILL.md
+++ b/cli-tool/components/skills/document-processing/docx-official/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: docx
+name: docx-official
 description: "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation."
 license: Proprietary. LICENSE.txt has complete terms
 ---

--- a/cli-tool/components/skills/document-processing/pdf-official/SKILL.md
+++ b/cli-tool/components/skills/document-processing/pdf-official/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pdf
+name: pdf-official
 description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
 license: Proprietary. LICENSE.txt has complete terms
 ---

--- a/cli-tool/components/skills/document-processing/pptx-official/SKILL.md
+++ b/cli-tool/components/skills/document-processing/pptx-official/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pptx
+name: pptx-official
 description: "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill."
 license: Proprietary. LICENSE.txt has complete terms
 ---

--- a/cli-tool/components/skills/document-processing/xlsx-official/SKILL.md
+++ b/cli-tool/components/skills/document-processing/xlsx-official/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: xlsx
+name: xlsx-official
 description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
 license: Proprietary. LICENSE.txt has complete terms
 ---


### PR DESCRIPTION
﻿## Summary

- **Renames 4 `-official` skill variants** to use unique `name` values matching their directory names
- Previously, `pptx-official`, `pdf-official`, `xlsx-official`, and `docx-official` all declared the same `name` as their non-official counterparts (`pptx`, `pdf`, `xlsx`, `docx`)
- Since Claude Code uses `name` as the install key, installing any `-official` variant silently overwrote the community version (or vice versa)

## Changes

| Directory | Before (`name:`) | After (`name:`) |
|-----------|-----------------|-----------------|
| `pptx-official/` | `pptx` | `pptx-official` |
| `pdf-official/` | `pdf` | `pdf-official` |
| `xlsx-official/` | `xlsx` | `xlsx-official` |
| `docx-official/` | `docx` | `docx-official` |

## Impact

Users can now install both the community and official variants simultaneously without silent overwrites.

Fixes #338

## Test plan

- [ ] Run `claude-code-templates install pptx` — should install community variant
- [ ] Run `claude-code-templates install pptx-official` — should install official variant without overwriting
- [ ] Verify both skills appear in `claude-code-templates list` after installing both


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the four document-processing `-official` skills to unique `name` values that match their directories, preventing silent overwrites during install. Official and community variants can now be installed side-by-side.

- **Area**: components (`cli-tool/components/`)
- Updated SKILL.md `name` fields: `pptx-official`, `pdf-official`, `xlsx-official`, `docx-official`
- Reason: `name` is the install key; duplicates caused overwrites
- Catalog: regenerate `docs/components.json`
- Env vars/secrets: none

<sup>Written for commit 12795830a26d19405678e201f5a135bf9e1839ae. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/604?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

