### PR TITLE
perf: cut Neon/Supabase write volume on hot tracking endpoints

### DIFF
--- a/dashboard/src/pages/api/claude-code-check.ts
+++ b/dashboard/src/pages/api/claude-code-check.ts
@@ -167,8 +167,8 @@ async function handleCheck() {
       console.log(`Version saved to database (ID: ${versionId})`);
     }
 
-    for (const change of parsed.changes) {
-      await sql`
+    if (parsed.changes.length > 0) {
+      const changeStatements = parsed.changes.map((change) => sql`
         INSERT INTO claude_code_changes (
           version_id,
           change_type,
@@ -180,7 +180,8 @@ async function handleCheck() {
           ${change.description},
           ${change.category}
         )
-      `;
+      `);
+      await sql.transaction(changeStatements);
     }
     console.log(`Saved ${parsed.changes.length} individual changes`);
 

--- a/dashboard/src/pages/api/health-check.ts
+++ b/dashboard/src/pages/api/health-check.ts
@@ -90,10 +90,15 @@ export const GET: APIRoute = async () => {
   try {
     const results = await Promise.all(ENDPOINTS_TO_CHECK.map(checkEndpoint));
 
-    const sql = getNeonClient();
+    const failures = results.filter(
+      (r) => r.statusCode === 0 || r.statusCode >= 500 || r.responseTimeMs >= TIMEOUT_MS,
+    );
 
-    for (const result of results) {
-      await sql`
+    // Only log to Neon when there are failures. Healthy runs are the common
+    // case (~99%) and don't need a row each — avoids ~2K useless writes/month.
+    if (failures.length > 0) {
+      const sql = getNeonClient();
+      const statements = failures.map((result) => sql`
         INSERT INTO api_health_logs (
           endpoint, method, status_code, response_time_ms, error_message
         ) VALUES (
@@ -103,14 +108,8 @@ export const GET: APIRoute = async () => {
           ${result.responseTimeMs},
           ${result.errorMessage}
         )
-      `;
-    }
-
-    const failures = results.filter(
-      (r) => r.statusCode === 0 || r.statusCode >= 500 || r.responseTimeMs >= TIMEOUT_MS,
-    );
-
-    if (failures.length > 0) {
+      `);
+      await sql.transaction(statements);
       await sendDiscordAlert(failures);
     }
 

--- a/dashboard/src/pages/api/track-download-supabase.ts
+++ b/dashboard/src/pages/api/track-download-supabase.ts
@@ -70,26 +70,6 @@ export const POST: APIRoute = async ({ request }) => {
       throw new Error(`Database insert failed: ${insertError.message}`);
     }
 
-    const { error: upsertError } = await supabase
-      .from('download_stats')
-      .upsert(
-        {
-          component_type: type,
-          component_name: name,
-          total_downloads: 1,
-          last_download: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        },
-        {
-          onConflict: 'component_type,component_name',
-          ignoreDuplicates: false,
-        }
-      );
-
-    if (upsertError) {
-      console.error('Supabase upsert error:', upsertError);
-    }
-
     return jsonResponse({
       success: true,
       message: 'Download tracked successfully',

--- a/dashboard/src/pages/api/track-website-events.ts
+++ b/dashboard/src/pages/api/track-website-events.ts
@@ -50,32 +50,35 @@ export const POST: APIRoute = async ({ request }) => {
 
     const country = request.headers.get('x-vercel-ip-country') || null;
     const sql = getNeonClient();
+    const truncatedReferrer = referrer ? referrer.substring(0, 1000) : null;
 
-    let inserted = 0;
-    for (const event of events) {
-      await sql`
-        INSERT INTO website_events (
-          event_type, event_data, page_path,
-          referrer, session_id, visitor_id,
-          country, screen_width
-        ) VALUES (
-          ${event.event_type},
-          ${event.event_data ? JSON.stringify(event.event_data) : null},
-          ${event.page_path || null},
-          ${referrer ? referrer.substring(0, 1000) : null},
-          ${session_id || null},
-          ${visitor_id || null},
-          ${country},
-          ${screen_width || null}
-        )
-      `;
-      inserted++;
-    }
+    const statements = (events as Array<{
+      event_type: string;
+      event_data?: unknown;
+      page_path?: string;
+    }>).map((event) => sql`
+      INSERT INTO website_events (
+        event_type, event_data, page_path,
+        referrer, session_id, visitor_id,
+        country, screen_width
+      ) VALUES (
+        ${event.event_type},
+        ${event.event_data ? JSON.stringify(event.event_data) : null},
+        ${event.page_path || null},
+        ${truncatedReferrer},
+        ${session_id || null},
+        ${visitor_id || null},
+        ${country},
+        ${screen_width || null}
+      )
+    `);
+
+    await sql.transaction(statements);
 
     return jsonResponse({
       success: true,
-      message: `${inserted} events tracked`,
-      data: { count: inserted, timestamp: new Date().toISOString() },
+      message: `${statements.length} events tracked`,
+      data: { count: statements.length, timestamp: new Date().toISOString() },
     });
   } catch (error) {
     console.error('Website events tracking error:', error);


### PR DESCRIPTION
## Summary

Four targeted cuts on hot-path API endpoints to reduce database writes (Supabase + Neon HTTP calls). All changes preserve observable behavior; only wasteful or broken writes are removed.

### 1. `track-download-supabase.ts` — drop broken `download_stats` upsert
The second write was setting `total_downloads: 1` on conflict instead of incrementing, so the table was always 0 or 1 — meaningless. Removing it halves Supabase writes on the highest-volume endpoint (called on every CLI component install).

The real download counts already come from aggregating `component_downloads` (which is what `scripts/generate_components_json.py` does by default; it only falls back to `download_stats` if the primary query returns nothing, and that fallback was returning garbage anyway).

### 2. `track-website-events.ts` — batch INSERTs in one transaction
Was looping up to 50 serial `INSERT`s per request (50 separate HTTP round-trips to Neon). Now batched into a single `sql.transaction([...])`. Same rows written, one HTTP request.

### 3. `claude-code-check.ts` — same batching for changelog entries
Per-release changelog inserts (often 10–30 per release) now go in one transaction instead of serial round-trips.

### 4. `health-check.ts` — skip Neon writes when all healthy
The cron runs hourly and almost always succeeds, but wrote 3 rows to `api_health_logs` every run (~2,160 rows/month of "everything's fine"). Now only writes rows when an endpoint actually fails. Discord alert behavior unchanged.

## Not in this PR (worth follow-ups)

- **`components.json` is 15 MB raw / 4 MB gzipped** and is fetched by the sidebar, several detail pages, and the Discord interactions endpoint. Most consumers only need metadata, not the embedded `content` field (~11 KB × 421 agents). A split into a lite index + per-component lazy fetch would slash dashboard egress dramatically. Larger refactor — separate PR.
- **`claude-code-check` cron at every 30 min** for a project that releases ~1–2× per week. Dropping to every 2 hours would cut 75% of invocations and the matching NPM + Neon traffic. Skipped here because the change touches both `cloudflare-workers/crons/wrangler.toml` and `dashboard/vercel.json` and you may want a specific cadence.

## Test plan

- [x] `astro build` succeeds with no new errors
- [x] `astro check` adds 0 new errors/warnings (5 pre-existing errors in `github-callback.astro` unrelated)
- [ ] Smoke-test `/api/track-website-events` with a multi-event batch in preview
- [ ] Confirm `/api/health-check` still POSTs to Discord on a simulated failure
- [ ] Spot-check `download_stats` is no longer needed anywhere else before merging

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnTHPxBPcWvCE3sTWPLsaC)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces Neon and Supabase writes on hot API endpoints by batching inserts and removing a broken upsert, with no change to external behavior. This cuts HTTP calls and storage across website events, changelog writes, downloads, and health checks.

- Area: API (`dashboard/src/pages/api/`)
- Batch INSERTs for website events and changelog writes via `sql.transaction([...])` to cut Neon HTTP calls
- Remove broken `download_stats` upsert in `track-download-supabase` (counts come from `component_downloads`; halves Supabase writes)
- `health-check`: only log failures; Discord alerts unchanged
- No new components; no `docs/components.json` regeneration; no new env vars or secrets

<sup>Written for commit fc8292523e5922fbfca94dc1cf25a87c7749c2ce. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/608?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

