### PR TITLE
feat(mcp): add memex temporal knowledge-graph MCP

### DIFF
--- a/cli-tool/components/mcps/integration/memex-mcp.json
+++ b/cli-tool/components/mcps/integration/memex-mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "memex": {
+      "type": "stdio",
+      "description": "Developer context continuity for AI coding agents. Watches your git repos and builds a temporal knowledge graph of modules, symbols, decisions, and open problems via Graphiti + Neo4j, then serves it over MCP. Every edge carries a validity window and a confidence score that decays over time. 12 tools across read and write. Requires NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, and GEMINI_API_KEY (set in your repo's .env).",
+      "command": "npx",
+      "args": ["-y", "stifler-memex-mcp", "serve", "--repo", "."]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds the **memex** MCP server as a new component under `cli-tool/components/mcps/integration/memex-mcp.json`.

memex gives AI coding agents persistent, time-aware project context. It watches your git repos and builds a **temporal knowledge graph** of modules, symbols, decisions, and open problems (Graphiti + Neo4j), then serves it over MCP. Every edge carries a validity window and a confidence score that decays over time, so agents get context that knows what's current vs. stale.

- **12 tools** across read (get_project_context, get_recent_decisions, get_open_problems, get_stale_context, get_symbol_context, search_context, predict_impact, explain_change) and write (record_decision, record_problem, resolve_problem, invalidate_edge).
- Published to npm as [`stifler-memex-mcp`](https://www.npmjs.com/package/stifler-memex-mcp).
- MIT licensed · repo: https://github.com/STiFLeR7/memex

## Component

```json
{
  "mcpServers": {
    "memex": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "stifler-memex-mcp", "serve", "--repo", "."]
    }
  }
}
```

Backends are configured via the repo's `.env` (`NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `GEMINI_API_KEY`).

## Install

```bash
npx claude-code-templates@latest --mcp integration/memex-mcp
```

Placed in `integration/` alongside the existing `memory-integration` component. JSON validated; `components.json` is generated by `scripts/generate_components_json.py`, so no manual index edit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `memex` MCP server as a new component to provide temporal, repo-backed project context over MCP. It watches your git repo to build a knowledge graph that tools can read and update.

- Area: components (`cli-tool/components/`).
- New component: `cli-tool/components/mcps/integration/memex-mcp.json` running `npx -y stifler-memex-mcp serve --repo .`.
- Catalog: Regenerate `docs/components.json` (run `scripts/generate_components_json.py`).
- New env vars: `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `GEMINI_API_KEY`.

<sup>Written for commit 5622bfba701de2ef1a78a2e0742455f76f5aa1f2. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/609?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

