### PR TITLE
Add ArmorClaude plugin (intent-based security for Claude Code)

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -1,5 +1,36 @@
 [
   {
+    "slug": "armoriq-armorclaude",
+    "name": "ArmorClaude",
+    "author": "ArmorIQ",
+    "description": "Intent-based security enforcement for Claude Code. Registers the LLM's plan via MCP before any tool fires, mints a signed intent JWT, then blocks tool calls that drift from the plan. Policies managed in natural language via the policy_update MCP tool. Optional CSRG cryptographic proofs. Central audit at platform.armoriq.ai. Same enforcement model also ships for OpenAI Codex (ArmorCodex) and GitHub Copilot CLI (ArmorCopilot).",
+    "github": "https://github.com/armoriq/armorClaude",
+    "stars": 3,
+    "type": "plugin",
+    "tags": [
+      "security",
+      "policy",
+      "audit",
+      "intent",
+      "hooks",
+      "mcp"
+    ],
+    "contains": {
+      "agents": 0,
+      "commands": 0,
+      "skills": 0,
+      "hooks": 5,
+      "mcp_servers": 1
+    },
+    "highlights": [
+      "Intent-aware: registers the plan first, then blocks tool calls that drift from it",
+      "Natural-language policy updates ('block any webfetch') via MCP tool",
+      "Optional CSRG cryptographic proofs (Merkle-tree-bound policy)",
+      "Cross-product: same model also ships on OpenAI Codex + GitHub Copilot CLI"
+    ],
+    "website": "https://armoriq.ai"
+  },
+  {
     "slug": "mercadopago-claude-marketplace",
     "name": "Mercado Pago",
     "author": "mercadopago",


### PR DESCRIPTION
## What

Adds **ArmorClaude** to \`dashboard/public/plugins.json\` — the official ArmorIQ Claude Code plugin for intent-based security enforcement.

## Plugin details

| | |
|---|---|
| **Slug** | armoriq-armorclaude |
| **Name** | ArmorClaude |
| **Author** | ArmorIQ |
| **Repo** | https://github.com/armoriq/armorClaude |
| **License** | MIT |
| **Website** | https://armoriq.ai |

## What it does

- **Plan-first intent capture**: MCP \`register_intent_plan\` tool fires before any tool execution. Plan-and-action match is required.
- **Block on intent drift**: tools the LLM didn't declare get \`permissionDecision: "deny"\`, even if policy would have allowed them.
- **Natural-language policy**: \`policy_update\` MCP tool accepts phrases like "block any webfetch", "deny any tool that writes to .env".
- **Optional CSRG cryptographic proofs**: Merkle-tree-bound policy hashes for tamper detection.
- **Audit pipeline**: every tool call lands at \`platform.armoriq.ai\` audit dashboard.

## Counts

- 5 hooks (PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, PermissionRequest)
- 1 MCP server (\`armorclaude-policy\`) with 3 tools

## Cross-product note

Same enforcement model also ships for OpenAI Codex (ArmorCodex, github.com/armoriq/armorCodex) and GitHub Copilot CLI (ArmorCopilot, github.com/armoriq/armorCopilot). Adding only the Claude version here.

## Diff

Single 31-line entry inserted at the top of \`dashboard/public/plugins.json\`, matching the exact pattern of PR #576 (Mercado Pago marketplace). No other lines modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ArmorClaude plugin to the dashboard plugin catalog so users can discover intent-based security for Claude Code. Visible in the plugin list; no app logic changes.

- Area: website (dashboard/public) — updated plugins catalog at dashboard/public/plugins.json
- Added plugin `armoriq-armorclaude` (ArmorClaude) with metadata, tags, highlights, and counts (5 hooks, 1 MCP server)
- No new components; docs/components.json regeneration not needed
- No new environment variables or secrets

<sup>Written for commit 3e199fbb36d9da84d0ab2bf959ea2249c8a69f8e. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/611?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

