### PR TITLE
Add Airtable Skills marketplace

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -12644,5 +12644,41 @@
         "pinion"
       ]
     }
+  },
+  {
+    "slug": "airtable",
+    "name": "Airtable Skills",
+    "author": "Airtable",
+    "description": "Official Airtable plugins for AI agents.",
+    "github": "https://github.com/Airtable/skills",
+    "stars": 20,
+    "type": "marketplace",
+    "tags": [
+      "skills",
+      "mcps"
+    ],
+    "contains": {
+      "plugins": 1,
+      "components": {
+        "skills": 3,
+        "mcps": 1
+      }
+    },
+    "highlights": [
+      "Official Airtable release",
+      "1 plugin in marketplace"
+    ],
+    "plugins_list": [
+      {
+        "name": "airtable",
+        "description": "Airtable is the database and operations layer for your agents — whether running product, marketing, sales, ops, HR, or a custom business app. It combines structured data with multiplayer visual surfaces (grid, kanban, calendar, gallery, timeline) humans and agents share — plus sync integrations to Jira, Salesforce, Zendesk, Google Drive, and Databricks. Makes Claude fluent in Airtable: bases and schema, records, and collaboration UI. Bundles the official Airtable MCP server.",
+        "source": "./plugins/airtable",
+        "author": "Airtable",
+        "components": {
+          "skills": 3,
+          "mcps": 1
+        }
+      }
+    ]
   }
 ]

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -58,6 +58,7 @@ REPOS = [
     ("777genius/claude-notifications-go", None),
     ("Piebald-AI/claude-code-lsps", None),
     ("chu2bard/pinion-os", None),
+    ("Airtable/skills", None),
 ]
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")


### PR DESCRIPTION
## Summary
Adds the official Airtable marketplace ([Airtable/skills](https://github.com/Airtable/skills)) to the /plugins page.

## Changes
- `scripts/generate_plugins_json.py` — add `("Airtable/skills", None)` to the REPOS list so future regenerations pick it up automatically.
- `dashboard/public/plugins.json` — manual entry following the format used by recent direct additions (e.g. Mercado Pago, #576).

## What's in the marketplace
- 1 plugin: `airtable`
- 3 skills: `airtable-cli`, `airtable-filters`, `airtable-overview`
- 1 MCP server: official `https://mcp.airtable.com/mcp` (streamable-http)
- Also published in the official MCP Registry as [`com.airtable/mcp`](https://registry.modelcontextprotocol.io/v0/servers?search=com.airtable).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the official Airtable Skills marketplace to the /plugins page and wires it into the generator for future updates. This makes the Airtable plugin, three skills, and the MCP server discoverable immediately.

- **New Features**
  - Added manual entry to dashboard/public/plugins.json so Airtable appears now on /plugins.
  - Included `Airtable/skills` in scripts/generate_plugins_json.py REPOS for automatic future regenerations.
  - Area: dashboard/ (plugins page) and scripts/ (generator).
  - New components: none; catalog docs/components.json: no regeneration needed.
  - New environment variables or secrets: none.

<sup>Written for commit a599540ee9e176961fbee095f00bcad7ed5b34d7. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/612?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

