### PR TITLE
Add ml-research plugin (krasserm/ml-plugins) to the plugins directory

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -1,5 +1,29 @@
 [
   {
+    "slug": "ml-plugins",
+    "name": "ml-research",
+    "author": "krasserm",
+    "description": "Native Claude Code port of Hugging Face's ml-intern: research-first autonomous ML engineering and fine-tuning (SFT/DPO/GRPO/LoRA) on HF Jobs, with dataset/repo/paper tooling and an optional budget-bounded autonomous experiment loop.",
+    "github": "https://github.com/krasserm/ml-plugins",
+    "stars": 1,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "agents",
+      "hooks"
+    ],
+    "contains": {
+      "skills": 2,
+      "agents": 2,
+      "hooks": 1
+    },
+    "highlights": [
+      "No LLM API key: every model call runs on your Claude Code subscription",
+      "Research-first fine-tuning (SFT/DPO/GRPO/LoRA) on Hugging Face Jobs",
+      "Optional budget-bounded autonomous experiment sweep"
+    ]
+  },
+  {
     "slug": "mercadopago-claude-marketplace",
     "name": "Mercado Pago",
     "author": "mercadopago",


### PR DESCRIPTION
## Summary
Adds the **ml-research** plugin to the plugins directory by appending one entry to `dashboard/public/plugins.json` (same pattern as #576).

- Area: website (`dashboard/`)
- Change: one new entry in `dashboard/public/plugins.json` with slug, metadata, tags, contains, and highlights
- No components added to `cli-tool/`; no `docs/components.json` regeneration needed
- No new environment variables or secrets

## About the plugin
[krasserm/ml-plugins](https://github.com/krasserm/ml-plugins) is a native Claude Code port of Hugging Face's [ml-intern](https://github.com/huggingface/ml-intern): research-first autonomous ML engineering and fine-tuning (SFT/DPO/GRPO/LoRA) on HF Jobs, with dataset/repo/paper tooling and an optional budget-bounded autonomous experiment loop. Every model call runs on the user's Claude Code subscription (no LLM API key).

- Valid `.claude-plugin/marketplace.json` and `plugin.json`
- Licensed Apache-2.0
- Contains 2 skills, 2 agents, 1 hook

Install: `claude plugin marketplace add krasserm/ml-plugins` then `claude plugin install ml-research@ml-plugins`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `ml-research` plugin from `krasserm/ml-plugins` to the marketplace so users can discover and install it from the dashboard.

- Area: website (`dashboard/`)
- Added entry in dashboard/public/plugins.json with slug, metadata, tags, contains, and highlights
- No new components; no docs/components.json regeneration
- No new environment variables or secrets

<sup>Written for commit 9721973f2771bebbe7c53727d235d56961469744. Summary will update on new commits. <a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

