### PR TITLE
Add pdf-fill-studio skill (local PDF form filling)

### DIFF
--- a/cli-tool/components/skills/document-processing/pdf-fill-studio/SKILL.md
+++ b/cli-tool/components/skills/document-processing/pdf-fill-studio/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: pdf-fill-studio
+description: Fill any PDF locally and place each value precisely in a visual editor. Use when the user wants to fill out a PDF form, enter data into a PDF, complete a tax/insurance/bank form, or position text on a flat/scanned PDF. Handles flat (field-less) PDFs, per-character (comb) fields, and native AcroForm fields; leaves the signature blank for the user to sign.
+---
+
+# pdf-fill-studio
+
+Fill a PDF locally, place the values precisely, then export. Flat PDFs use a browser editor;
+AcroForm PDFs fill natively; the signature is always left blank for the user to sign.
+
+## When to use
+The user gives you a PDF to fill (form, claim, tax/bank/insurance document).
+
+## Setup (once)
+`pip install pdf-fill-studio` (provides the `pdf-fill-studio` command).
+From source instead: `python3 -m venv .venv && .venv/bin/pip install -e .`, then use
+`.venv/bin/pdf-fill-studio`.
+
+## Flow
+1. Start: `pdf-fill-studio <input.pdf> -o out/<name>_filled.pdf`. It detects the form type.
+2. **AcroForm (native fields):** re-run with a profile of known facts:
+   `pdf-fill-studio <input.pdf> -o out/<name>_filled.pdf --profile <profile.json>`.
+   Matched fields fill automatically; it prints "Needs manual input: [...]" for the rest. Ask the
+   user for each listed field, add them to the profile, re-run, then render to verify.
+3. **Flat (no fields):** a local browser editor opens. Tell the user to type values, drag boxes
+   onto the lines, nudge with arrow keys, and click "Export PDF". Comb fields (one box per
+   character, e.g. postal code) are detected and filled one character per cell automatically.
+4. **XFA:** tell the user this form type is not supported yet (open it in free Adobe Reader).
+5. The filled PDF is written to `out/`. The user signs it themselves.
+
+## Self-check (before declaring done)
+Render and look: `python -m pdf_fill_studio.render_page out/<name>_filled.pdf out/preview`.
+Check each value sits on its line / inside its cell, not too low or spilling outside. Apply
+minimal coordinate corrections and re-bake if needed.
+
+## Rules
+- Never fill a signature field.
+- Never store or hard-code a SIN, bank account, or card number (the profile matcher skips them).
+- Everything runs locally; no document is uploaded.

--- a/cli-tool/components/skills/document-processing/pdf-fill-studio/SKILL.md
+++ b/cli-tool/components/skills/document-processing/pdf-fill-studio/SKILL.md
@@ -17,9 +17,10 @@ From source instead: `python3 -m venv .venv && .venv/bin/pip install -e .`, then
 `.venv/bin/pdf-fill-studio`.
 
 ## Flow
-1. Start: `pdf-fill-studio <input.pdf> -o out/<name>_filled.pdf`. It detects the form type.
+(Replace `form.pdf` and `profile.json` with the user's actual file paths.)
+1. Start: `pdf-fill-studio form.pdf -o out/form_filled.pdf`. It detects the form type.
 2. **AcroForm (native fields):** re-run with a profile of known facts:
-   `pdf-fill-studio <input.pdf> -o out/<name>_filled.pdf --profile <profile.json>`.
+   `pdf-fill-studio form.pdf -o out/form_filled.pdf --profile profile.json`.
    Matched fields fill automatically; it prints "Needs manual input: [...]" for the rest. Ask the
    user for each listed field, add them to the profile, re-run, then render to verify.
 3. **Flat (no fields):** a local browser editor opens. Tell the user to type values, drag boxes
@@ -29,7 +30,7 @@ From source instead: `python3 -m venv .venv && .venv/bin/pip install -e .`, then
 5. The filled PDF is written to `out/`. The user signs it themselves.
 
 ## Self-check (before declaring done)
-Render and look: `python -m pdf_fill_studio.render_page out/<name>_filled.pdf out/preview`.
+Render and look: `python -m pdf_fill_studio.render_page out/form_filled.pdf out/preview`.
 Check each value sits on its line / inside its cell, not too low or spilling outside. Apply
 minimal coordinate corrections and re-bake if needed.
 


### PR DESCRIPTION
Adds **pdf-fill-studio** under document-processing.

Fills PDF forms locally and places each value precisely: flat PDFs (text overlay snapped to the line), per-character (comb) fields, and native AcroForm fields with profile autofill. A visual browser editor lets the user drag values into place; the signature is always left blank. Runs fully offline, no cloud.

- Repo: https://github.com/KevinDoremy/pdf-fill-studio (MIT)
- PyPI: https://pypi.org/project/pdf-fill-studio/ (`pip install pdf-fill-studio`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `pdf-fill-studio` skill for local PDF form filling with precise placement and a visual editor. Supports flat PDFs, comb fields, and native AcroForms; signature fields stay blank.

- **New Features**
  - Area: components (`cli-tool/components/`)
  - New skill: `document-processing/pdf-fill-studio` with `SKILL.md` (install, flow, rules; copy-paste-safe placeholders)
  - Catalog: regenerate `docs/components.json`
  - Env/secrets: none

<sup>Written for commit dd81ba1549eca43c5f1b3c70c2d048a803857c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

