### PR TITLE
Add status-line (PremPrakashCodes/claude-code-plugins) to plugins directory

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -1,5 +1,25 @@
 [
   {
+    "slug": "claude-code-plugins",
+    "name": "status-line",
+    "author": "PremPrakashCodes",
+    "description": "Configurable status-line HUD for Claude Code: model, project, git branch/dirty state, a context-usage bar, and 5h/7d rate-limit windows. Pure-Python (stdlib only, no dependencies), with selectable bar styles, themes, and custom labels.",
+    "github": "https://github.com/PremPrakashCodes/claude-code-plugins",
+    "stars": 0,
+    "type": "plugin",
+    "tags": [
+      "commands"
+    ],
+    "contains": {
+      "commands": 2
+    },
+    "highlights": [
+      "One-line or expanded multi-line HUD with model, project, git, and context usage",
+      "5-hour and 7-day rate-limit windows with reset countdowns",
+      "Themes, custom colors, labels, and selectable progress-bar styles; fail-silent rendering"
+    ]
+  },
+  {
     "slug": "ml-plugins",
     "name": "ml-research",
     "author": "krasserm",


### PR DESCRIPTION
## Summary

Adds the **status-line** plugin from [`PremPrakashCodes/claude-code-plugins`](https://github.com/PremPrakashCodes/claude-code-plugins) to the plugins directory served by the dashboard (`dashboard/public/plugins.json`).

`status-line` is a configurable status-line HUD for Claude Code — it renders the active model, project, git branch/dirty state, a context-usage bar, and 5h/7d rate-limit windows on a single (or expanded multi-line) prompt. It is pure Python (standard library only, no dependencies) and ships two slash commands: `/status-line:setup` and `/status-line:configure`.

## Changes

Added one entry to the top of `dashboard/public/plugins.json`:

- **slug:** `claude-code-plugins`
- **name:** `status-line`
- **author:** `PremPrakashCodes`
- **type:** `plugin`
- **tags:** `["commands"]`
- **contains:** `2` commands (`setup`, `configure`)

## Plugin details

| Field | Value |
|-------|-------|
| Repo | https://github.com/PremPrakashCodes/claude-code-plugins |
| License | MIT |
| Runtime | Pure Python (stdlib only), requires Python 3.8+ or `uv` |
| Commands | `/status-line:setup`, `/status-line:configure` |

### Highlights

- One-line or expanded multi-line HUD with model, project, git, and context usage.
- 5-hour and 7-day rate-limit windows with reset countdowns.
- Themes, custom colors, labels, and selectable progress-bar styles; fail-silent rendering so prompt output is never interrupted by a traceback.

## Validation

- `dashboard/public/plugins.json` re-validated as well-formed JSON.
- Plugin metadata sourced directly from the repo's `.claude-plugin/marketplace.json`, `plugins/status-line/.claude-plugin/plugin.json`, and `README.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the `status-line` plugin from `PremPrakashCodes/claude-code-plugins` to the dashboard plugins catalog so users can install a configurable status HUD in Claude Code.

- Area: website (dashboard/public/)
- Added a new entry to `dashboard/public/plugins.json` with description, highlights, and 2 commands (`setup`, `configure`)
- No new components; `docs/components.json` does not need regeneration
- No new environment variables or secrets

<sup>Written for commit b0501c675a67f83545214c22a614a5806c0eff4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



