### PR TITLE
Add RunAPI MCP server for AI image, video, music, and LLM generation

### DIFF
--- a/cli-tool/components/mcps/creative/runapi.json
+++ b/cli-tool/components/mcps/creative/runapi.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "runapi": {
+      "description": "Unified AI model API with 130+ models for image, video, music, audio, and LLM generation from 18 providers. Browse models, check pricing, create tasks, and call LLM endpoints. Free catalog tools work without an API key.",
+      "command": "npx",
+      "args": ["-y", "@runapi.ai/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Adds RunAPI MCP server config to the creative category. 130+ AI models from 18 providers. Free catalog tools work without an API key. npm: @runapi.ai/mcp. GitHub: https://github.com/runapi-ai/mcp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@runapi.ai/mcp` to the creative MCP catalog to browse and run 130+ image, video, music, audio, and LLM models from 18 providers. Enables unified access via `npx`; catalog tools work without an API key.

- Area: components (`cli-tool/components/`), new file `mcps/creative/runapi.json`
- New component added; regenerate catalog (`docs/components.json`)
- Command: `npx -y @runapi.ai/mcp` as `runapi` MCP server
- No new env vars; provider API keys may be needed for specific models

<sup>Written for commit 63d41b633e9f3026d7058a004459ecd130e64086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

