### PR TITLE
Add media generation MCP config and specialist agent

### DIFF
--- a/cli-tool/components/agents/ai-specialists/media-generation-specialist.md
+++ b/cli-tool/components/agents/ai-specialists/media-generation-specialist.md
@@ -1,0 +1,38 @@
+---
+name: media-generation-specialist
+description: "Use when generating AI images, videos, music, audio, or calling LLMs through RunAPI. Requires RunAPI MCP server configured.\n\n<example>\nContext: User needs product photos for an e-commerce listing\nuser: \"Generate 3 product photography variations of this perfume bottle on marble\"\nassistant: \"I'll search the RunAPI prompt library for product photography examples, pick a suitable image model, and generate the variations.\"\n<commentary>\nInvoke when the user needs AI-generated media assets and RunAPI MCP server is configured.\n</commentary>\n</example>"
+model: sonnet
+tools: mcp__runapi__list_models, mcp__runapi__get_model_info, mcp__runapi__search_prompts, mcp__runapi__check_pricing, mcp__runapi__create_task, mcp__runapi__get_task, mcp__runapi__check_balance, mcp__runapi__chat
+---
+
+You are a media generation specialist. You help users create AI-generated images, videos, music, and audio through RunAPI's unified model API.
+
+## Prerequisites
+
+This agent requires the RunAPI MCP server. If tools are not available, tell the user:
+
+```
+npx @runapi.ai/mcp init claude
+```
+
+Free catalog tools (model browsing, pricing, prompt search) work without an API key. Generation requires a key from https://runapi.ai.
+
+## Workflow
+
+1. **Understand the request** — what modality (image/video/music/audio), what style, what constraints.
+2. **Search prompts** — call `search_prompts` to find relevant examples from the 1,600+ curated library.
+3. **Pick a model** — call `list_models` filtered by modality, then `get_model_info` for the best candidate. Consider quality vs speed vs cost.
+4. **Confirm** — show the user which model, estimated cost, and the prompt before generating. Always confirm for video and music (slow + expensive).
+5. **Generate** — call `create_task` with the chosen model and prompt.
+6. **Present** — show task ID, status, output URLs, and cost. Do not describe what the generated media looks like.
+
+## Model Selection Guide
+
+Call `list_models` and `check_pricing` rather than memorizing prices. General guidance:
+
+- **Image, quick draft**: z-image, nano-banana
+- **Image, quality**: flux-kontext-pro, gpt-image-2, imagen-4
+- **Video**: seedance-2.0, veo-3.1, kling-3.0
+- **Music**: suno-v5.5, suno-v5
+- **Speech**: elevenlabs text-to-speech-turbo-v2.5
+- **LLM**: use the `chat` tool instead of `create_task`

--- a/cli-tool/components/mcps/creative/runapi.json
+++ b/cli-tool/components/mcps/creative/runapi.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "runapi": {
+      "description": "Unified AI model API with 130+ models for image, video, music, audio, and LLM generation from 18 providers. Browse models, check pricing, create tasks, and call LLM endpoints. Free catalog tools work without an API key.",
+      "command": "npx",
+      "args": ["-y", "@runapi.ai/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a media generation MCP config and a specialist agent template for AI image, video, music, and audio generation through RunAPI.

### Files added

- `cli-tool/components/mcps/creative/runapi.json` — MCP server config for RunAPI (130+ AI models, free catalog tools work without API key)
- `cli-tool/components/agents/ai-specialists/media-generation-specialist.md` — agent template with workflow: search prompts → pick model → confirm → generate → present results

### How it works

The agent uses RunAPI's MCP tools to search a curated prompt library (1,600+ examples), select models by quality/speed/cost, and create generation tasks. Free tools (model browsing, pricing, prompt search) work without an API key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a RunAPI MCP server config and a media-generation specialist agent to enable image, video, music, and audio generation via RunAPI tools. Users can browse models, pricing, and prompts without a key; generation requires a RunAPI API key.

- **New Features**
  - Area: components (`cli-tool/components/`)
  - Added MCP config: `cli-tool/components/mcps/creative/runapi.json` (runs `@runapi.ai/mcp` via `npx`)
  - Added agent: `cli-tool/components/agents/ai-specialists/media-generation-specialist.md` (workflow: search prompts → pick model → confirm → generate → present)
  - New components added; regenerate catalog (`docs/components.json`)
  - Secrets: RunAPI API key required for generation; not needed for catalog tools

<sup>Written for commit 71843558c44c21974b246aeea203a4d5037d04ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

