### PR TITLE
Add Quill Meetings marketplace to plugins listing

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -59,6 +59,7 @@ REPOS = [
     ("Piebald-AI/claude-code-lsps", None),
     ("chu2bard/pinion-os", None),
     ("Airtable/skills", None),
+    ("quillmeetings/claude-plugins", None),
 ]
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")


### PR DESCRIPTION
This PR adds the **Quill Meetings** marketplace (`quillmeetings/claude-plugins`) to the `REPOS` list in `scripts/generate_plugins_json.py`, on behalf of Quill, so it gets picked up and listed on the aitmpl.com plugins page.

### What it exposes
The marketplace exposes the **`quill-deep-analysis`** skill — it turns months of meetings in Quill into a deeply researched, drill-down report with every claim linked back to where it was said.

### Validity
The repo has a valid `.claude-plugin/marketplace.json` with `name`, `owner` (author), `description`, and a plugin entry (`quill-deep-analysis`). It's a public repo, so the generator's `gh api` reads will resolve.

### Change scope
One-line addition to the `REPOS` list, matching the existing `("owner/repo", None)` tuple format. No changes to `cli-tool/components/**`, so the component security-validation workflow does not apply. `plugins.json` is regenerated by the scheduled `update-json-data` workflow, so no generated output is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - manual review by @mpdaugherty 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Quill Meetings marketplace to the plugins generator so it appears on the plugins page. This lets users discover the `quill-deep-analysis` skill.

- **Changes**
  - Added `("quillmeetings/claude-plugins", None)` to `REPOS` in `scripts/generate_plugins_json.py`.
  - Area: CLI (scripts/).
  - No new components; `docs/components.json` does not need regeneration.
  - No new environment variables or secrets.

<sup>Written for commit 8b60d7921528f7511980b033061e70048a74d14b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

