### PR TITLE
feat: Add SkillSpector security scanning for skill components

### DIFF
--- a/.github/workflows/skill-security-scan-all.yml
+++ b/.github/workflows/skill-security-scan-all.yml
@@ -1,0 +1,64 @@
+name: Skill Security Scan (Full)
+
+# Scans EVERY skill component with SkillSpector (NVIDIA, Apache-2.0) static
+# analysis. Runs weekly and on demand. Reports only — never blocks. Uploads
+# an aggregated SARIF to code scanning and a Markdown summary to the run.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  skill-scan-all:
+    name: SkillSpector (all skills)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SkillSpector
+        run: pip install "git+https://github.com/NVIDIA/skillspector.git@main"
+
+      - name: Run SkillSpector on all skills
+        id: scan
+        continue-on-error: true
+        run: |
+          python scripts/skillspector_scan.py \
+            --all \
+            --threshold 50 \
+            --output-md skillspector-report.md \
+            --output-sarif skillspector.sarif
+
+      - name: Publish summary
+        if: always()
+        run: cat skillspector-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: skillspector-full-report
+          path: |
+            skillspector-report.md
+            skillspector.sarif
+          retention-days: 90
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: skillspector.sarif
+          category: skillspector-full

--- a/.github/workflows/skill-security-scan.yml
+++ b/.github/workflows/skill-security-scan.yml
@@ -1,0 +1,103 @@
+name: Skill Security Scan
+
+# Runs SkillSpector (NVIDIA, Apache-2.0) static analysis on skill components
+# changed in a PR. Posts a report comment and blocks the PR if any changed
+# skill scores HIGH/CRITICAL (risk score > 50).
+
+on:
+  pull_request:
+    paths:
+      - 'cli-tool/components/skills/**'
+      - 'scripts/skillspector_scan.py'
+      - '.github/workflows/skill-security-scan.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  skill-scan:
+    name: SkillSpector (changed skills)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history so git diff against the base ref works
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install SkillSpector
+        run: pip install "git+https://github.com/NVIDIA/skillspector.git@main"
+
+      - name: Run SkillSpector on changed skills
+        id: scan
+        continue-on-error: true
+        run: |
+          python scripts/skillspector_scan.py \
+            --changed \
+            --base-ref "origin/${{ github.base_ref }}" \
+            --fail-on-risk \
+            --threshold 50 \
+            --output-md skillspector-report.md \
+            --output-sarif skillspector.sarif
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: skillspector-report
+          path: |
+            skillspector-report.md
+            skillspector.sarif
+          retention-days: 30
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: skillspector.sarif
+          category: skillspector
+
+      - name: Comment PR with results
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'skillspector-report.md';
+            if (!fs.existsSync(reportPath)) {
+              console.log('No SkillSpector report found.');
+              return;
+            }
+            const body = fs.readFileSync(reportPath, 'utf8');
+            const marker = '<!-- skillspector-report:v1 -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const prev = existing.find(c => c.body && c.body.includes(marker));
+            if (prev) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: prev.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }
+
+      - name: Enforce gate
+        if: steps.scan.outputs.failed == 'true'
+        run: |
+          echo "::error::SkillSpector found HIGH/CRITICAL findings in changed skills (${{ steps.scan.outputs.high_critical_count }})."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,30 @@ The agent will provide prioritized feedback:
 - **⚠️ Warnings**: Should fix (clarity, best practices)
 - **📋 Suggestions**: Nice to have improvements
 
+#### Skill Security Scanning (SkillSpector)
+
+Skills under `cli-tool/components/skills/**` are scanned for security
+vulnerabilities by [SkillSpector](https://github.com/NVIDIA/skillspector)
+(NVIDIA, Apache-2.0) — a static analyzer with 64 vulnerability patterns
+(prompt injection, data exfiltration, supply chain, dangerous code/AST, taint
+tracking, YARA signatures, etc.). It runs in static-only mode (`--no-llm`), so
+no API key or secret is required.
+
+Two GitHub Actions drive it, both via the batch orchestrator
+`scripts/skillspector_scan.py`:
+
+- **`.github/workflows/skill-security-scan.yml`** (PR) — scans only the skills
+  changed in the PR (`git diff`), posts an idempotent report comment, and
+  **blocks** the check if any changed skill scores HIGH/CRITICAL (risk score
+  > 50). Uploads an aggregated SARIF to the Security tab.
+- **`.github/workflows/skill-security-scan-all.yml`** (weekly + manual) — scans
+  all skills, reports to the run summary and SARIF, and **never blocks**.
+
+SkillSpector requires Python 3.12+ and is installed from NVIDIA's `main`
+branch (`pip install git+https://github.com/NVIDIA/skillspector.git@main`); it
+is not published to PyPI. Risk bands: 0-20 LOW, 21-50 MEDIUM, 51-80 HIGH,
+81-100 CRITICAL.
+
 #### Statuslines with Python Scripts
 
 Statuslines can reference Python scripts that are auto-downloaded to `.claude/scripts/`:

--- a/scripts/skillspector_scan.py
+++ b/scripts/skillspector_scan.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Batch-orchestrate SkillSpector scans over skill components.
+
+Discovers skill directories under cli-tool/components/skills/, runs the
+SkillSpector CLI (`skillspector scan <dir> --no-llm --format json`) on each,
+aggregates the per-skill JSON reports, and emits:
+
+  * a Markdown summary (for PR comments / step summaries)
+  * an aggregated SARIF 2.1.0 log (for GitHub code scanning)
+  * GitHub Action outputs (failed, high_critical_count, scanned, errors)
+
+SkillSpector itself requires Python 3.12+, but this orchestrator only uses the
+standard library and runs on 3.9+ so the discovery logic can be exercised
+locally without installing the scanner (see --dry-run).
+
+Usage:
+    skillspector_scan.py --all
+    skillspector_scan.py --changed --base-ref origin/main
+    skillspector_scan.py --all --dry-run            # list dirs, no scanning
+
+The CLI exit code of `skillspector scan` is intentionally ignored: it returns
+1 when a skill's risk score is high (a signal, not a failure) and 2 on real
+errors. We parse stdout JSON and classify per-skill instead, so one broken
+skill never aborts the whole batch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo-relative root that holds every skill component.
+SKILLS_ROOT = Path("cli-tool/components/skills")
+
+# Accepted manifest filenames (case variants seen in the catalog).
+MANIFEST_NAMES = {"skill.md"}
+
+# Risk score above which a skill is considered HIGH/CRITICAL.
+DEFAULT_THRESHOLD = 50
+
+# Keep PR comments under GitHub's ~65k character limit.
+MAX_COMMENT_CHARS = 60000
+
+# Marker so the PR comment can be found and updated idempotently.
+COMMENT_MARKER = "<!-- skillspector-report:v1 -->"
+
+
+def _has_manifest(directory: Path) -> bool:
+    """Return True if directory directly contains a SKILL.md (any case)."""
+    try:
+        for entry in directory.iterdir():
+            if entry.is_file() and entry.name.lower() in MANIFEST_NAMES:
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def discover_all_skills(root: Path = SKILLS_ROOT) -> list[Path]:
+    """Find every skill directory (one that directly contains a SKILL.md)."""
+    if not root.is_dir():
+        return []
+    skills: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if any(name.lower() in MANIFEST_NAMES for name in filenames):
+            skills.append(Path(dirpath))
+    return sorted(set(skills))
+
+
+def _changed_files(base_ref: str) -> list[Path]:
+    """Return repo-relative paths changed vs base_ref (three-dot diff)."""
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        # Fall back to two-dot if the merge base is unavailable (shallow clone).
+        out = subprocess.run(
+            ["git", "diff", "--name-only", base_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+    return [Path(line.strip()) for line in out.splitlines() if line.strip()]
+
+
+def discover_changed_skills(base_ref: str, root: Path = SKILLS_ROOT) -> list[Path]:
+    """Map changed files under the skills tree to their owning skill dirs."""
+    changed = _changed_files(base_ref)
+    skills: set[Path] = set()
+    root_resolved = root.resolve()
+    for rel in changed:
+        # Only consider files under the skills tree.
+        try:
+            rel.resolve().relative_to(root_resolved)
+        except ValueError:
+            if root not in rel.parents and rel != root:
+                continue
+        # Walk up from the file's directory until we find the skill dir.
+        current = (rel if rel.is_dir() else rel.parent)
+        while True:
+            if current == root or current == Path("."):
+                break
+            if current.is_dir() and _has_manifest(current):
+                skills.add(current)
+                break
+            # Stop once we climb above the skills root.
+            if root not in current.parents:
+                break
+            current = current.parent
+    return sorted(skills)
+
+
+def scan_skill(directory: Path) -> dict:
+    """Run skillspector on one skill dir; return a normalized result dict."""
+    result: dict = {"path": str(directory), "status": "ok"}
+    try:
+        proc = subprocess.run(
+            [
+                "skillspector",
+                "scan",
+                str(directory),
+                "--no-llm",
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        result["status"] = "error"
+        result["error"] = "skillspector CLI not found on PATH"
+        return result
+
+    # Exit code 2 == real error. 0/1 are both valid (1 == high score).
+    if proc.returncode == 2:
+        result["status"] = "error"
+        result["error"] = (proc.stderr or proc.stdout or "scan failed").strip()[:500]
+        return result
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        result["status"] = "error"
+        result["error"] = "could not parse skillspector JSON output"
+        result["raw"] = (proc.stdout or proc.stderr or "")[:500]
+        return result
+
+    risk = data.get("risk_assessment", {})
+    result["name"] = (data.get("skill") or {}).get("name") or directory.name
+    result["score"] = int(risk.get("score") or 0)
+    result["severity"] = (risk.get("severity") or "LOW").upper()
+    result["recommendation"] = risk.get("recommendation") or "SAFE"
+    result["issues"] = data.get("issues") or []
+    result["report"] = data
+    return result
+
+
+def _aggregate_sarif(results: list[dict]) -> dict:
+    """Merge per-skill SARIF-equivalent findings into one SARIF 2.1.0 log."""
+    sarif_results: list[dict] = []
+    severity_to_level = {
+        "CRITICAL": "error",
+        "HIGH": "error",
+        "MEDIUM": "warning",
+        "LOW": "note",
+    }
+    for res in results:
+        if res.get("status") != "ok":
+            continue
+        skill_dir = res["path"].rstrip("/")
+        for issue in res.get("issues", []):
+            file_rel = issue.get("file") or ""
+            # Prefix the issue's file (relative to the skill dir) with the
+            # repo-relative skill dir so code scanning links resolve.
+            if file_rel and not file_rel.startswith(skill_dir):
+                uri = f"{skill_dir}/{file_rel.lstrip('./')}"
+            else:
+                uri = file_rel or skill_dir
+            severity = (issue.get("severity") or "LOW").upper()
+            region: dict = {}
+            if issue.get("start_line"):
+                region["startLine"] = issue["start_line"]
+            if issue.get("end_line"):
+                region["endLine"] = issue["end_line"]
+            location = {"physicalLocation": {"artifactLocation": {"uri": uri}}}
+            if region:
+                location["physicalLocation"]["region"] = region
+            sarif_results.append(
+                {
+                    "ruleId": issue.get("rule_id") or "UNKNOWN",
+                    "level": severity_to_level.get(severity, "note"),
+                    "message": {"text": issue.get("message") or ""},
+                    "locations": [location],
+                }
+            )
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "skillspector",
+                        "informationUri": "https://github.com/NVIDIA/skillspector",
+                        "rules": [],
+                    }
+                },
+                "results": sarif_results,
+            }
+        ],
+    }
+
+
+def _severity_emoji(severity: str) -> str:
+    return {"LOW": "🟢", "MEDIUM": "🟡", "HIGH": "🔴", "CRITICAL": "🔴"}.get(severity, "")
+
+
+def build_markdown(results: list[dict], threshold: int) -> str:
+    """Produce the PR-comment Markdown summary."""
+    scanned = [r for r in results if r.get("status") == "ok"]
+    errors = [r for r in results if r.get("status") == "error"]
+    flagged = sorted(
+        [r for r in scanned if r["score"] > threshold],
+        key=lambda r: r["score"],
+        reverse=True,
+    )
+    high_critical = len(flagged)
+
+    sev_counts = {"LOW": 0, "MEDIUM": 0, "HIGH": 0, "CRITICAL": 0}
+    for r in scanned:
+        sev_counts[r["severity"]] = sev_counts.get(r["severity"], 0) + 1
+
+    status = "❌ ISSUES FOUND" if high_critical else "✅ PASSED"
+    emoji = "⚠️" if high_critical else "🎉"
+
+    lines = [COMMENT_MARKER]
+    lines.append(f"## {emoji} SkillSpector Security Scan")
+    lines.append("")
+    lines.append(
+        "Static analysis (`--no-llm`) by "
+        "[SkillSpector](https://github.com/NVIDIA/skillspector) (NVIDIA, Apache-2.0)."
+    )
+    lines.append("")
+    lines.append(f"**Status:** {status}")
+    lines.append("")
+    lines.append("| Metric | Count |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Skills scanned | {len(scanned)} |")
+    lines.append(f"| 🔴 HIGH/CRITICAL (score > {threshold}) | {high_critical} |")
+    lines.append(f"| 🟡 MEDIUM | {sev_counts['MEDIUM']} |")
+    lines.append(f"| 🟢 LOW / clean | {sev_counts['LOW']} |")
+    if errors:
+        lines.append(f"| ⚠️ Scan errors | {len(errors)} |")
+    lines.append("")
+
+    if flagged:
+        lines.append("### 🔴 Flagged skills")
+        lines.append("")
+        lines.append("| Skill | Score | Severity | Recommendation | Issues | Top findings |")
+        lines.append("|-------|-------|----------|----------------|--------|--------------|")
+        for r in flagged[:30]:
+            top_rules = ", ".join(
+                sorted({str(i.get("rule_id") or "?") for i in r.get("issues", [])})[:5]
+            )
+            rec = str(r.get("recommendation", "")).replace("_", " ")
+            lines.append(
+                f"| `{r['name']}` | {r['score']}/100 | "
+                f"{_severity_emoji(r['severity'])} {r['severity']} | {rec} | "
+                f"{len(r.get('issues', []))} | {top_rules} |"
+            )
+        if len(flagged) > 30:
+            lines.append("")
+            lines.append(f"_...and {len(flagged) - 30} more flagged skill(s)._")
+        lines.append("")
+
+    if errors:
+        lines.append("### ⚠️ Scan errors")
+        lines.append("")
+        for r in errors[:10]:
+            lines.append(f"- `{r['path']}` — {r.get('error', 'unknown error')}")
+        if len(errors) > 10:
+            lines.append(f"- _...and {len(errors) - 10} more._")
+        lines.append("")
+
+    if not flagged and not errors:
+        lines.append("No HIGH/CRITICAL findings. ✅")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        "_Generated by SkillSpector. Score bands: 0-20 LOW, 21-50 MEDIUM, "
+        "51-80 HIGH, 81-100 CRITICAL._"
+    )
+
+    text = "\n".join(lines)
+    if len(text) > MAX_COMMENT_CHARS:
+        text = text[: MAX_COMMENT_CHARS - 200] + "\n\n_...report truncated (too long)._"
+    return text
+
+
+def _write_output(name: str, value: str) -> None:
+    """Append a key=value pair to $GITHUB_OUTPUT (no-op if unset)."""
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a", encoding="utf-8") as fh:
+        if "\n" in value:
+            fh.write(f"{name}<<__EOF__\n{value}\n__EOF__\n")
+        else:
+            fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Batch SkillSpector scanner.")
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--all", action="store_true", help="Scan every skill dir.")
+    scope.add_argument(
+        "--changed", action="store_true", help="Scan only skills changed vs --base-ref."
+    )
+    parser.add_argument("--base-ref", default="origin/main", help="Base ref for --changed.")
+    parser.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    parser.add_argument(
+        "--fail-on-risk",
+        action="store_true",
+        help="Set output failed=true (and exit 1) if any skill exceeds threshold.",
+    )
+    parser.add_argument("--output-md", default="skillspector-report.md")
+    parser.add_argument("--output-sarif", default="skillspector.sarif")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List discovered skills without scanning."
+    )
+    args = parser.parse_args()
+
+    if args.changed:
+        skills = discover_changed_skills(args.base_ref)
+    else:
+        skills = discover_all_skills()
+
+    print(f"Discovered {len(skills)} skill director{'y' if len(skills) == 1 else 'ies'}.")
+
+    if args.dry_run:
+        for s in skills:
+            print(f"  {s}")
+        return 0
+
+    if not skills:
+        # Nothing to scan is a pass.
+        Path(args.output_md).write_text(
+            f"{COMMENT_MARKER}\n## 🎉 SkillSpector Security Scan\n\n"
+            "No skill components were changed in this PR.\n",
+            encoding="utf-8",
+        )
+        Path(args.output_sarif).write_text(json.dumps(_aggregate_sarif([]), indent=2))
+        _write_output("scanned", "0")
+        _write_output("high_critical_count", "0")
+        _write_output("errors", "0")
+        _write_output("failed", "false")
+        return 0
+
+    results: list[dict] = []
+    for idx, skill in enumerate(skills, 1):
+        print(f"[{idx}/{len(skills)}] scanning {skill}")
+        results.append(scan_skill(skill))
+
+    scanned = [r for r in results if r.get("status") == "ok"]
+    errors = [r for r in results if r.get("status") == "error"]
+    flagged = [r for r in scanned if r["score"] > args.threshold]
+
+    markdown = build_markdown(results, args.threshold)
+    Path(args.output_md).write_text(markdown, encoding="utf-8")
+    Path(args.output_sarif).write_text(
+        json.dumps(_aggregate_sarif(results), indent=2), encoding="utf-8"
+    )
+
+    print(
+        f"Scanned={len(scanned)} flagged={len(flagged)} errors={len(errors)} "
+        f"(threshold={args.threshold})"
+    )
+
+    failed = bool(flagged) and args.fail_on_risk
+    _write_output("scanned", str(len(scanned)))
+    _write_output("high_critical_count", str(len(flagged)))
+    _write_output("errors", str(len(errors)))
+    _write_output("failed", "true" if failed else "false")
+
+    if failed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Integrates [SkillSpector](https://github.com/NVIDIA/skillspector) (NVIDIA, Apache-2.0) — a static security analyzer for AI agent skills — so every skill under `cli-tool/components/skills/` is scanned for vulnerabilities and a report is delivered on the PR.

SkillSpector detects **64 vulnerability patterns** across 16 categories: prompt injection, data exfiltration, privilege escalation, supply chain, dangerous code (AST), taint tracking, YARA signatures, MCP poisoning, and more. It runs in static-only mode (`--no-llm`), so **no API key or secret is required**.

## How it works

A batch orchestrator (`scripts/skillspector_scan.py`) discovers skill directories (by their `SKILL.md`), runs `skillspector scan <dir> --no-llm --format json` on each, and aggregates the per-skill JSON into a Markdown PR report + an aggregated SARIF log. It tolerates per-skill scan failures and the CLI's non-zero exit on high scores without aborting the batch.

Two workflows drive it (hybrid design, since there are ~870 skills):

| Workflow | Trigger | Scope | Blocks? |
|----------|---------|-------|---------|
| `skill-security-scan.yml` | PR touching `skills/**` | **changed skills only** (`git diff`) | ✅ blocks on HIGH/CRITICAL (score > 50) |
| `skill-security-scan-all.yml` | weekly cron + manual | **all skills** | ❌ report only |

Both post results: the PR workflow comments an idempotent report (updated in place) and uploads SARIF to the **Security** tab; the full workflow writes to the run summary + SARIF.

## Decisions

- **Analysis mode:** static-only (`--no-llm`) — fast, deterministic, no secrets.
- **Gating:** changed skills block the PR on HIGH/CRITICAL; pre-existing skills never block unrelated PRs.
- **Install:** SkillSpector isn't on PyPI, so it's installed from NVIDIA's `main` branch (`pip install git+https://github.com/NVIDIA/skillspector.git@main`). Requires Python 3.12+.

## Files

- `scripts/skillspector_scan.py` — batch orchestrator / aggregator (stdlib-only, runs on 3.9+ for local discovery testing)
- `.github/workflows/skill-security-scan.yml` — PR, changed-only, blocking
- `.github/workflows/skill-security-scan-all.yml` — scheduled/manual, full, non-blocking
- `CLAUDE.md` — documentation

## Testing done

- Discovery: `--all --dry-run` finds 871 skill dirs and excludes root files like `ANTHROPIC_ATTRIBUTION.md`.
- `--changed --base-ref origin/main --dry-run` runs cleanly.
- Markdown + SARIF aggregation validated with synthetic skillspector output (URI prefixing, error rows, flagged-skill table, GitHub outputs).
- Workflow YAML validated; script byte-compiles.

The real `skillspector` install + scan happens in CI (the sandbox runner is Python 3.11; SkillSpector needs 3.12).

## Notes for review

- The full scan of ~870 skills takes ~15–40 min; it's scheduled weekly, not per-PR. A future optimization is a matrix per category.
- This PR touches workflows but not skills, so to see the PR workflow's gate/comment in action, a test commit touching a skill (or running the full workflow via `workflow_dispatch` once merged) is the way to validate end-to-end.

https://claude.ai/code/session_014XfWwVRWSLUF3j3C1sc8f3

---
_Generated by [Claude Code](https://claude.ai/code/session_014XfWwVRWSLUF3j3C1sc8f3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SkillSpector static security scanning for skills under `cli-tool/components/skills/`. Blocks PRs with high‑risk findings and publishes a PR report and SARIF to the Security tab.

- **New Features**
  - Area: components (`cli-tool/components/`) + CI; docs updated in `CLAUDE.md`.
  - Adds `scripts/skillspector_scan.py` to discover skills by `SKILL.md`, run `skillspector scan --no-llm`, and aggregate Markdown + SARIF.
  - Adds workflows: `skill-security-scan.yml` (PR, changed skills, blocks on score > 50) and `skill-security-scan-all.yml` (weekly/manual, all skills, non‑blocking).
  - Outputs: idempotent PR comment and SARIF upload to the Security tab.
  - No new components; no `docs/components.json` regen; no env vars or secrets.

<sup>Written for commit 235ead364dfcab350e1695ccf8c84f1804327b75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

