### PR TITLE
Add AugmentClaude best-claude-skills marketplace

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -12704,5 +12704,86 @@
         }
       }
     ]
+  },
+  {
+    "slug": "best-claude-skills",
+    "name": "AugmentClaude Best Claude Skills",
+    "author": "Nyanbalaji28",
+    "description": "Hand-picked best Claude Code skills curated by AugmentClaude — every skill credited and linked to its original author. Full catalog of 500+ skills, bundles, and MCP servers at augmentclaude.com",
+    "github": "https://github.com/Nyanbalaji28/best-claude-skills",
+    "stars": 0,
+    "type": "marketplace",
+    "tags": [
+      "skills"
+    ],
+    "contains": {
+      "plugins": 14,
+      "components": {
+        "skills": 14
+      }
+    },
+    "highlights": [
+      "14 hand-picked skills",
+      "Web UI: https://augmentclaude.com"
+    ],
+    "website": "https://augmentclaude.com/",
+    "plugins_list": [
+      {
+        "name": "superpowers",
+        "description": "Jesse Vincent's complete development methodology: TDD, brainstorming-before-coding, and git worktrees — all auto-triggering."
+      },
+      {
+        "name": "gstack",
+        "description": "Garry Tan's 23-role Claude Code stack — CEO, designer, eng, QA, security, release, all as slash commands."
+      },
+      {
+        "name": "mcp-builder",
+        "description": "Anthropic's official skill for building MCP servers that connect language models to external APIs and services."
+      },
+      {
+        "name": "webapp-testing",
+        "description": "Playwright-driven browser testing: verify UI behavior, debug, and capture screenshots of local web apps."
+      },
+      {
+        "name": "frontend-design",
+        "description": "Anthropic's official frontend-design skill — production-grade interfaces with distinctive, polished design."
+      },
+      {
+        "name": "impeccable",
+        "description": "Paul Bakaus's design framework — kills generic AI design, forces deliberate taste, motion, and polish."
+      },
+      {
+        "name": "emil-design-engineering",
+        "description": "Emil Kowalski's design engineering review — when to animate, what easing, how fast, with Before/After reviews."
+      },
+      {
+        "name": "design-taste",
+        "description": "Three sliders (variance, motion, density) that tune Claude's UI output. Stops the generic AI look."
+      },
+      {
+        "name": "xlsx",
+        "description": "Open, edit, and create Excel and CSV files with formulas, formatting, and data cleaning."
+      },
+      {
+        "name": "docx",
+        "description": "Create, edit, and format Word documents with tables, images, and tracked changes."
+      },
+      {
+        "name": "pptx",
+        "description": "Create, edit, read, and extract content from PowerPoint presentations."
+      },
+      {
+        "name": "pdf",
+        "description": "Read, merge, split, rotate, watermark, encrypt, and extract text from PDF files."
+      },
+      {
+        "name": "find-skills",
+        "description": "Vercel Labs' meta-skill — Claude searches the open skill ecosystem for existing solutions before improvising."
+      },
+      {
+        "name": "skill-creator",
+        "description": "Anthropic's official tool for creating, editing, and benchmarking your own Claude skills."
+      }
+    ]
   }
 ]

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -36,6 +36,7 @@ REPOS = [
     ("EveryInc/compound-engineering-plugin", None),
     ("alirezarezvani/claude-skills", None),
     ("davepoon/buildwithclaude", "https://buildwithclaude.com/"),
+    ("Nyanbalaji28/best-claude-skills", "https://augmentclaude.com/"),
     ("lackeyjb/playwright-skill", None),
     ("nyldn/claude-octopus", None),
     ("jeremylongshore/claude-code-plugins-plus-skills", None),


### PR DESCRIPTION
Adds the AugmentClaude curated marketplace, following the pattern of #612 (both files edited):

- `scripts/generate_plugins_json.py` — repo tuple added to `REPOS`
- `dashboard/public/plugins.json` — manual entry matching the existing schema

The repo ([Nyanbalaji28/best-claude-skills](https://github.com/Nyanbalaji28/best-claude-skills)) has a valid `.claude-plugin/marketplace.json` with 14 hand-picked Claude Code skills, each pointing at its original author's repo with attribution. Website: https://augmentclaude.com (free directory of 500+ skills, bundles, and MCP servers).

Disclosure: I'm the founder of AugmentClaude. Happy to adjust the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AugmentClaude marketplace entry (`best-claude-skills`) to the plugin directory and wires it into the generator so it shows 14 curated Claude Code skills in the UI.

- **New Features**
  - Added `best-claude-skills` to `dashboard/public/plugins.json` (14 curated skills, with attribution).
  - Included `("Nyanbalaji28/best-claude-skills", "https://augmentclaude.com/")` in `scripts/generate_plugins_json.py` for automated inclusion.
  - Area: website.
  - No new components; no `docs/components.json` regeneration needed.
  - No new environment variables or secrets.

<sup>Written for commit 93bd78cf26e66ddd0f433ac09428fd73563af31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

