### PR TITLE
Add flatten-mcp to devtools MCPs

### DIFF
--- a/cli-tool/components/mcps/devtools/flatten-mcp.json
+++ b/cli-tool/components/mcps/devtools/flatten-mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "flatten": {
+      "description": "Flatten Claude Code sessions: moves bulky tool output into a sidecar file and keeps every prompt and event verbatim, so the same conversation resumes at a lower token count instead of being compacted into a lossy summary. Reversible and crash-safe. Optional ANTHROPIC_API_KEY enables exact token counting.",
+      "command": "npx",
+      "args": ["-y", "flatten-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
Adds flatten-mcp as a devtools MCP component.

flatten-mcp is an MCP server that flattens Claude Code sessions: it moves bulky tool output into a sidecar file and keeps every prompt and event verbatim, so the same conversation resumes at a lower token count instead of being compacted into a lossy summary. Reversible and crash-safe.

No required configuration. TypeScript, runs locally over stdio, MIT licensed: https://github.com/shayaShav/flatten-mcp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `flatten-mcp` as a devtools MCP to keep prompts verbatim and move bulky tool output to a sidecar, reducing token usage without lossy summarization. Runs via `npx` with no setup; optional `ANTHROPIC_API_KEY` enables exact token counting.

- **New Features**
  - Area: components (cli-tool/components/)
  - Added `cli-tool/components/mcps/devtools/flatten-mcp.json` registering the `flatten` MCP via `npx -y flatten-mcp@latest`
  - Catalog: regenerate docs/components.json
  - Env: optional `ANTHROPIC_API_KEY` for precise token counting

<sup>Written for commit ffe0d5227ecf298191a428d7d28954ff5500d0d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

