### PR TITLE
feat: add dos-verify-gate quality-gate hook (audit commit claim vs diff on Stop)

### DIFF
--- a/cli-tool/components/hooks/quality-gates/dos-verify-gate.json
+++ b/cli-tool/components/hooks/quality-gates/dos-verify-gate.json
@@ -1,0 +1,22 @@
+{
+  "description": "Gate \"I'm done\" on ground truth instead of the agent's word. On Stop, audits the latest commit's subject against its actual diff using the DOS kernel (`dos commit-audit`) — a commit message is forgeable, but the files it touched are not. Catches a `fix:` that only touched a README, or a \"tests pass\" that deleted the assertions, before the agent declares the work complete. Advisory by default (exit 0 with a warning); set DOS_VERIFY_GATE_BLOCK=1 to refuse the stop on an unwitnessed claim (exit 2). Requires the DOS CLI (`pip install dos-kernel`); deterministic, no API key, no LLM, no network. Stays out of the way when DOS is not installed or the repo has no commits.",
+  "supportingFiles": [
+    {
+      "source": "dos-verify-gate.sh",
+      "destination": ".claude/hooks/dos-verify-gate.sh",
+      "executable": true
+    }
+  ],
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dos-verify-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli-tool/components/hooks/quality-gates/dos-verify-gate.sh
+++ b/cli-tool/components/hooks/quality-gates/dos-verify-gate.sh
@@ -37,6 +37,11 @@ fi
 dos commit-audit --workspace "$PROJECT_ROOT" HEAD >/dev/null 2>&1
 RC=$?
 
+if [ "$RC" = "0" ]; then
+  # Clean: the subject's claim is witnessed by its own diff. Stay silent.
+  exit 0
+fi
+
 if [ "$RC" = "1" ]; then
   echo "⚠️  dos-verify-gate: HEAD's commit subject is NOT backed by its diff (CLAIM_UNWITNESSED)." >&2
   echo "    The 'done' claim is unproven — review the commit before treating the work as complete." >&2
@@ -48,5 +53,11 @@ if [ "$RC" = "1" ]; then
   exit 0
 fi
 
-# 0 (clean) / 2 (unreadable ref) / anything else → advisory pass.
+# RC=2 (unreadable ref) or any other nonzero: the audit could NOT run, so the
+# claim is UNVERIFIED — not proven clean. Silently passing here would let a
+# could-not-verify masquerade as a clean pass, which is exactly the failure this
+# hook exists to catch. Surface it (always to stderr) but stay advisory: a
+# can't-adjudicate is not an unwitnessed claim, so it never blocks the stop.
+echo "⚠️  dos-verify-gate: could NOT audit HEAD (dos commit-audit exited $RC) — the 'done' claim is UNVERIFIED, not proven clean." >&2
+echo "    Re-run to see why: dos commit-audit --workspace \"$PROJECT_ROOT\" HEAD" >&2
 exit 0

--- a/cli-tool/components/hooks/quality-gates/dos-verify-gate.sh
+++ b/cli-tool/components/hooks/quality-gates/dos-verify-gate.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# dos-verify-gate.sh — Gate "I'm done" on ground truth, not the agent's word.
+# Source: dos-kernel (https://github.com/anthony-chaudhary/dos-kernel)
+# License: MIT
+#
+# Runs on Stop. Audits the latest commit's SUBJECT against its actual DIFF using
+# the DOS kernel (`dos commit-audit`). A commit message is forgeable (whoever
+# wrote it authored it); the files it touched are not (git did). So a `fix:` that
+# only touched a README, or a "tests pass" that deleted the assertions, is caught
+# here — before the agent declares the work done.
+#
+# `dos commit-audit` reports the verdict as its EXIT CODE (its documented
+# contract): 0 = clean, 1 = an unwitnessed claim found, 2 = unreadable ref.
+#
+# DOS is deterministic: no API key, no LLM, no network. Install once with
+#   pip install dos-kernel
+#
+# Advisory by default (exit 0 with a warning) so it never wedges a session. To
+# make it BLOCK the stop on an unwitnessed claim, set DOS_VERIFY_GATE_BLOCK=1.
+
+INPUT=$(cat)
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+# No DOS CLI installed → cannot adjudicate. Stay out of the way (advisory).
+if ! command -v dos >/dev/null 2>&1; then
+  exit 0
+fi
+
+# No commits yet → nothing to audit.
+if ! git -C "$PROJECT_ROOT" rev-parse HEAD >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Ask the kernel: does HEAD's subject match what its diff actually did?
+# The exit code is the verdict, so branch on it directly.
+dos commit-audit --workspace "$PROJECT_ROOT" HEAD >/dev/null 2>&1
+RC=$?
+
+if [ "$RC" = "1" ]; then
+  echo "⚠️  dos-verify-gate: HEAD's commit subject is NOT backed by its diff (CLAIM_UNWITNESSED)." >&2
+  echo "    The 'done' claim is unproven — review the commit before treating the work as complete." >&2
+  echo "    Inspect it with: dos commit-audit --workspace \"$PROJECT_ROOT\" HEAD" >&2
+  if [ "${DOS_VERIFY_GATE_BLOCK:-0}" = "1" ]; then
+    # Exit 2 asks the host to refuse the stop and surface the message to the agent.
+    exit 2
+  fi
+  exit 0
+fi
+
+# 0 (clean) / 2 (unreadable ref) / anything else → advisory pass.
+exit 0


### PR DESCRIPTION
## What

Adds a `dos-verify-gate` quality-gate hook component (`.json` + `.sh`) under `cli-tool/components/hooks/quality-gates/`. On **Stop**, it audits the latest commit's subject against its actual diff using the deterministic [DOS kernel](https://github.com/anthony-chaudhary/dos-kernel) (`dos commit-audit`), so an agent's "done" is checked against ground truth before it ends the session.

## Why

A commit subject is forgeable (whoever wrote the message authored it); the files it touched are not (git did). So a `fix:` that only touched a README, or a "tests pass" that deleted the assertions, is caught here — before the work is reported complete. This is the claim-vs-diff complement to the existing `plan-gate` / `scope-guard` / `tdd-gate` quality gates.

## How it works

- Hook event: `Stop`. Runs `dos commit-audit --workspace "$PROJECT_ROOT" HEAD`.
- Branches on the verb's **documented exit-code contract**: `0` clean / `1` an unwitnessed claim / `2` unreadable ref.
- **Advisory by default** (exit 0 with a warning to stderr) so it never wedges a session. Set `DOS_VERIFY_GATE_BLOCK=1` to refuse the stop on an unwitnessed claim (exit 2).
- Degrades gracefully: if the `dos` CLI is not installed, or the repo has no commits, the hook exits 0 and stays out of the way.

## Requirements & safety

- Requires the DOS CLI: `pip install dos-kernel` (the PyPI name is `dos-kernel`, not the unrelated `dos`). DOS is deterministic — no API key, no LLM, no network.
- The hook is **read-only**: `dos commit-audit` reads git history and the working tree; it does not mutate the repo, push, or reach the network.
- `bash -n` clean; tested end-to-end against a real Stop payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `dos-verify-gate` quality-gate hook that audits HEAD’s commit subject against its diff on Stop to verify “done” claims. It can block on unwitnessed claims and now warns when the audit can’t run instead of silently passing.

- New Features
  - Area: components (`cli-tool/components/`); adds `dos-verify-gate` Stop hook using `dos commit-audit` on `HEAD`.
  - Advisory by default; set `DOS_VERIFY_GATE_BLOCK=1` to block unwitnessed claims.
  - Requires `dos-kernel` CLI (`pip install dos-kernel`); new component added → regenerate `docs/components.json`; no new secrets.

- Bug Fixes
  - When `dos commit-audit` returns RC=2 or any unexpected nonzero, emit a stderr warning that the claim is UNVERIFIED (still advisory) instead of treating it as a clean pass.

<sup>Written for commit 903030b65e9302a699dac245c80a30b67eec18d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

