### PR TITLE
Add ultracost skill (per-stage model routing for ultracode workflows)

### DIFF
--- a/cli-tool/components/skills/workflow-automation/ultracost/SKILL.md
+++ b/cli-tool/components/skills/workflow-automation/ultracost/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ultracost
+description: "Quality-first per-stage model routing and a pre-flight cost gate for Claude Code ultracode dynamic workflows. Pin the right model and effort on every agent() stage, estimate cost, and confirm before launching."
+risk: low
+source: community
+date_added: "2026-06-15"
+---
+
+# ultracost
+
+Per-stage model routing for Claude Code `ultracode` dynamic workflows. It applies to
+**any** kind of work a dynamic workflow does — frontend, backend, research, refactors,
+audits — not one domain.
+
+## Purpose
+
+When `ultracode` is on, the session runs on Opus @ `xhigh` and a single dynamic workflow
+fans out to dozens of subagents that **inherit that session model** unless every `agent()`
+stage is pinned. The built-in guidance even tells Claude to omit the per-agent model, so
+the whole fan-out silently lands on Opus. This skill makes the per-stage routing explicit
+and verifiable, keeping quality on the work that matters while dropping mechanical work to
+a cheaper tier.
+
+## Use this skill when
+
+- Authoring or running an `ultracode` / dynamic-workflow script.
+- Spawning subagents or writing `agent()` / `pipeline()` stages.
+- You want to estimate and confirm a workflow's cost before it fans out.
+
+## Routing policy
+
+Route every subagent and every dynamic-workflow stage **explicitly**. Never let a stage
+inherit the session model by default. Never use `haiku`.
+
+### Tiers
+
+- **`opus` @ `xhigh`** — Coding & reasoning: anything requiring judgment or a decision:
+  writing/editing/refactoring code, debugging, designing APIs/schemas/architecture,
+  non-trivial tests, code review, security/performance analysis, planning, synthesis,
+  final consolidation.
+- **`sonnet` @ `high`** — Pre-planned mechanical & support: applying a specified edit
+  across files, search/grep/glob, file discovery, collecting/listing/extracting,
+  reformatting, running tests and reporting results, routine git operations, gathering
+  context for an opus stage to consume.
+
+**Decision rule:** if a stage must DECIDE how to write or change code, use `opus`. If the
+"how" is already planned and the stage only executes it mechanically — or it's
+search/collection/formatting — use `sonnet`. When in doubt, use `opus`.
+
+### Hard rules
+
+- Never use `haiku`, ever.
+- Pin the model per stage via the per-invocation `model` param, e.g.
+  `agent(task, { model: 'sonnet' })`.
+- These stages are always `opus`: `orchestrator`, `planner`, `final-synthesis`,
+  `consolidation`.
+
+### Effort per stage
+
+Set `effort` per stage, choosing the lowest level that fits, bounded by model (`sonnet`
+up to `high`, `opus` up to `xhigh`): `low` (trivial deterministic), `medium` (light
+judgment), `high` (standard coding/analysis), `xhigh` (hard cross-file reasoning,
+adversarial review, planning, final synthesis). e.g.
+`agent(task, { model: 'sonnet', effort: 'low' })` for a mechanical scan.
+
+### Pre-flight cost gate
+
+Before launching a dynamic workflow: draft the script with per-stage `model` and `effort`
+set, verify pins with `/ultracost:check <file>`, estimate it with
+`/ultracost:estimate <file>` (agent count, model mix, cost vs an all-opus baseline), then
+Approve / Cancel / Modify before launch.
+
+## Full plugin
+
+This is the self-contained routing-policy skill. The complete ultracost plugin — the
+Workflow Guard, a deterministic `PreToolUse` cost gate, the closed-loop
+`usage`/`reconcile`/`calibrate`/`ledger` commands, and the `/ultracost:*` slash commands —
+installs from the canonical marketplace:
+
+```text
+/plugin marketplace add danielkremen818/ultracost
+/plugin install ultracost@ultracost
+```
+
+Or via npm for CI/scripting: `npx ultracost init`.
+
+- **Repository:** https://github.com/danielkremen818/ultracost
+- **License:** MIT · zero dependencies · no telemetry · no network on the hot path
+- **Author:** [danielkremen818](https://github.com/danielkremen818)


### PR DESCRIPTION
## What

Adds a community **skill** — `ultracost` — under `skills/workflow-automation/`.

`cli-tool/components/skills/workflow-automation/ultracost/SKILL.md`

## Why

When Claude Code's `ultracode` mode is on, a dynamic workflow fans out to dozens of subagents that **inherit the session's Opus @ xhigh model** unless every `agent()` stage is pinned — so a fan-out can silently run grep sweeps and per-file scans on the most expensive model. This skill gives Claude an explicit, quality-first per-stage routing policy (Opus for reasoning, Sonnet for mechanical work, never Haiku) and a pre-flight cost gate. It applies to any workflow domain (frontend, backend, research, refactors, audits).

## Component

- **Type:** Skill
- **Category:** workflow-automation
- **Frontmatter:** `name`, `description`, `risk: low`, `source: community`, `date_added` — matches the existing skill format in this directory.
- **Self-contained:** the SKILL.md carries the full routing policy. The complete plugin (Workflow Guard, `PreToolUse` cost gate, `/ultracost:*` commands) lives at the canonical repo, linked from the skill.

## Source / trust

- Repository: https://github.com/danielkremen818/ultracost
- MIT, zero dependencies, no telemetry, no network on the hot path, Snyk Open Source clean, signed npm provenance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `ultracost` community skill for per-stage model routing and a pre-flight cost gate for Claude Code `ultracode` workflows to reduce accidental Opus fan-outs and control cost.

- Area: components (`cli-tool/components/`)
- New component: `skills/workflow-automation/ultracost/SKILL.md`; regenerate catalog (`docs/components.json`)
- Provides explicit per-stage model pins (`opus` for reasoning, `sonnet` for mechanical; never `haiku`) and an estimate/confirm flow; SKILL links to the canonical plugin
- No new environment variables or secrets
- No changes to CLI, API, website, or workers

<sup>Written for commit 0929869ae69fa60c015edeb0047e7646c6980d71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

