### PR TITLE
feat(mcps): add Local MCP — 160+ native macOS app integrations

### DIFF
--- a/cli-tool/components/mcps/productivity/local-mcp.json
+++ b/cli-tool/components/mcps/productivity/local-mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "local-mcp": {
+      "description": "Connect Claude Code to 160+ native macOS apps — Mail, Calendar, Contacts, Messages, Notes, Reminders, Finder, Safari, Teams, Slack, WhatsApp, OneDrive, Google Drive, Microsoft 365, Outlook, Word, Excel, PowerPoint, and more. All tools run locally with no API keys or cloud data copies. Requires the free Local MCP tray app (local-mcp.com, macOS only).",
+      "command": "npx",
+      "args": ["-y", "local-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

Adds **Local MCP** (`local-mcp`) to the `productivity` MCP category.

Local MCP is a free macOS tray app that gives Claude Code direct access to 160+ native macOS apps and services — all running locally, no API keys or cloud data copies required.

## Tools available after install

| Category | Apps |
|---|---|
| Communication | Mail, Messages, WhatsApp, Slack, Teams |
| Productivity | Calendar, Reminders, Notes, OmniFocus |
| Files & Docs | Finder, OneDrive, Google Drive, Word, Excel, PowerPoint, PDF |
| Web | Safari (automation + bookmarks) |
| Microsoft 365 | Outlook, Exchange email/calendar, M365 contacts & directory |
| More | Contacts, Stocks, Zoom transcripts, Notion, NordVPN, image generation |

160+ tools total. Read-only operations run immediately; destructive actions (send/delete) always show a preview/confirm step.

## Installation

```bash
# macOS only — installs the tray app + configures Claude Code automatically
curl -fsSL https://local-mcp.com/install | bash

# Or use npx directly (requires tray app already running)
npx claude-code-templates@latest --mcp productivity/local-mcp --yes
```

## Why it fits `productivity/`

Same category as Notion, Google Workspace, and Monday.com — Local MCP sits at the intersection of personal productivity apps and AI-native workflows.

**Repo:** https://github.com/lanchuske/office-mcp  
**Website:** https://local-mcp.com  
**npm:** https://www.npmjs.com/package/local-mcp  
**License:** MIT (client CLI) / commercial (tray app, free until 1,000 DAU)

---

Happy to add an `agents/` entry for the Local MCP expert pattern or a dedicated command if that fits your roadmap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `local-mcp` to the productivity MCP catalog so Claude Code can use 160+ native macOS apps via a local tray app. No cloud access or API keys needed.

- **New Features**
  - Added `local-mcp` MCP server config for 160+ macOS apps (Mail, Calendar, Messages, Finder, Safari, M365, etc.).
  - Area: components (`cli-tool/components/`), new file `cli-tool/components/mcps/productivity/local-mcp.json`.
  - Requires the Local MCP macOS tray app; runs via `npx local-mcp@latest`. No new env vars or secrets.
  - New component added; regenerate `docs/components.json` catalog.

<sup>Written for commit 1f27d3d94f2e93ead436d47856cb448864771a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

