### PR TITLE
feat: add DOS kernel MCP server (devtools)

### DIFF
--- a/cli-tool/components/mcps/devtools/dos-kernel.json
+++ b/cli-tool/components/mcps/devtools/dos-kernel.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "dos": {
+      "description": "DOS — the trust substrate for fleets of autonomous agents; the kernel is the part that doesn't believe the agents. Verify what an agent ACTUALLY shipped from git evidence instead of its self-report (dos_verify), audit whether a commit's message matches its own diff (dos_commit_audit), arbitrate file-tree collisions before parallel workers race on shared state (dos_arbitrate), refuse with a structured, verifiable reason from a closed vocabulary (dos_refuse_reasons / dos_check_reason), fold a run's real state without trusting a 'done' claim (dos_status), re-check a recalled memory against the live tree (dos_recall), and confirm a cited legal case actually exists before relying on it (dos_citation_resolve). Requires uv (https://docs.astral.sh/uv); pulls the package from PyPI on first launch.",
+      "command": "uvx",
+      "args": ["--from", "dos-kernel[mcp]", "dos-kernel"]
+    }
+  }
+}


### PR DESCRIPTION
## Add the DOS kernel MCP server (devtools)

Adds a new MCP component: **DOS — the trust substrate for fleets of autonomous agents**.

DOS is a small, deterministic kernel that adjudicates ground truth across many unreliable, self-narrating workers — and serializes their effects on shared state — *without believing what they say they did*. This MCP server exposes its syscalls as tools any MCP-speaking host can call:

- `dos_verify` — did `(plan, phase)` actually ship? From git evidence, never a worker's self-report. Works against a bare git repo with no plan.
- `dos_commit_audit` — does a commit's message match its own diff? Catches a `fix:` that touched only a README, or a "tests pass" that deleted assertions.
- `dos_arbitrate` — may this worker take this lane right now? Refuses when a worker's file-tree collides with a live lease, so parallel workers don't race on shared state.
- `dos_refuse_reasons` / `dos_check_reason` — refuse with a structured, verifiable reason from a closed vocabulary instead of free text.
- `dos_status` — fold a run's real state (liveness + ledger-verified progress) without trusting a "done" claim.
- `dos_recall` — re-verify a recalled memory against the live tree at read time.
- `dos_citation_resolve` — does a cited legal case actually exist (and does the quote match) before you rely on it?

### Launch

The entry uses `uvx`, so there is no global install step — it pulls `dos-kernel[mcp]` from PyPI on first launch:

```json
{
  "mcpServers": {
    "dos": {
      "command": "uvx",
      "args": ["--from", "dos-kernel[mcp]", "dos-kernel"]
    }
  }
}
```

Requires [uv](https://docs.astral.sh/uv). The package is published on PyPI as `dos-kernel`; source and docs: https://github.com/anthony-chaudhary/dos-kernel

### Checklist
- [x] New file under `cli-tool/components/mcps/devtools/`
- [x] Valid JSON, matches the existing `mcpServers` entry shape
- [x] Description explains what the server does and its tools


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new DOS kernel MCP server to devtools. It verifies what agents actually shipped, audits commits, and prevents state races. Runs via `uvx` pulling `dos-kernel[mcp]` from PyPI.

- Area: components (`cli-tool/components/`)
- Added `cli-tool/components/mcps/devtools/dos-kernel.json` registering `dos` via `uvx --from dos-kernel[mcp] dos-kernel`
- Exposes tools like `dos_verify`, `dos_commit_audit`, `dos_arbitrate` (plus status/refusal helpers)
- New component added; regenerate catalog (`docs/components.json`)
- Requires `uv`; no new env vars or secrets

<sup>Written for commit 2a4ae749d070af5afff00a20e280939bb9836bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

