### PR TITLE
Fix grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This collection includes components from multiple sources:
 - **move-code-quality-skill** - MIT License
 - **cocoindex-claude** - Apache 2.0
 
-Each of these resources retains its **original license and attribution**, as defined by their respective authors.
+Each of these resources retains its **original license and attribution**, as defined by its respective author.
 We respect and credit all original creators for their work and contributions to the Claude ecosystem.
 
 ## 📄 License


### PR DESCRIPTION
Corrected the wording from 'authors' to 'author' for consistency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected a grammar issue in README by changing “authors” to “author” for consistent license attribution. Documentation only; no functional changes.

- Area: website (docs/) — README.md
- No new components; no catalog (docs/components.json) regeneration needed
- No new environment variables or secrets

<sup>Written for commit 0a047781c751ea1042b43c2bec3265e48eaba8b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

