### PR TITLE
Fix Xquik MCP tool count

### DIFF
--- a/cli-tool/components/skills/business-marketing/x-twitter-scraper/SKILL.md
+++ b/cli-tool/components/skills/business-marketing/x-twitter-scraper/SKILL.md
@@ -185,7 +185,7 @@ To use Xquik as an MCP server in Claude Code, add to `.mcp.json` in the project 
 
 > **Security note:** The `${XQUIK_API_KEY}` syntax requires your MCP client to support environment variable substitution. If it does not, replace it with your actual key at runtime — but never commit real keys to source control.
 
-The MCP server exposes 22 tools covering all API capabilities.
+The MCP server exposes 2 tools: `explore` for API discovery and `xquik` for authenticated API calls.
 
 ## Common Workflow Patterns
 


### PR DESCRIPTION
## Summary
- Update the existing x-twitter-scraper skill to match the current Xquik MCP tool model.
- Replace the old 22-tool statement with the current `explore` and `xquik` tools.

## Validation
- git diff check
- npm test
- checked https://docs.xquik.com/mcp/tools returns 200
- scanned the public diff for blocked wording


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the x-twitter-scraper skill docs to match the current Xquik MCP tool model. Replaces the outdated “22 tools” claim with the two tools: `explore` and `xquik`.

- Area: components (`cli-tool/components/`), docs change in SKILL.md.
- No new components; catalog (`docs/components.json`) does not need regeneration.
- No new environment variables or secrets.
- Why: Keep docs accurate and avoid confusion about available MCP tools.

<sup>Written for commit 3ed1e9cc2248190bfc8e4c2e0c6a36a15eecf35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

