### PR TITLE
feat: Skill Improvement Loop (PoC) — auto-grade and improve marketplace skills

### DIFF
--- a/.github/workflows/skill-improvement-loop.yml
+++ b/.github/workflows/skill-improvement-loop.yml
@@ -76,20 +76,23 @@ jobs:
 
       - name: Grade skills (heuristic rubric triage)
         id: grade
+        env:
+          # Pass untrusted workflow_dispatch inputs through the environment so
+          # they are never interpolated into the shell command itself.
+          INPUT_CATEGORY: ${{ inputs.category }}
+          INPUT_TOP: ${{ inputs.top }}
+          INPUT_MAX_QUALITY: ${{ inputs.max_quality }}
         run: |
-          SARIF_ARG=""
-          if [ -f skillspector.sarif ]; then
-            SARIF_ARG="--skillspector-sarif skillspector.sarif"
-          fi
-          if [ -n "${{ inputs.category }}" ]; then
-            SCOPE="--category ${{ inputs.category }}"
+          args=(--top "$INPUT_TOP" --max-quality "$INPUT_MAX_QUALITY")
+          if [ -n "$INPUT_CATEGORY" ]; then
+            args+=(--category "$INPUT_CATEGORY")
           else
-            SCOPE="--all"
+            args+=(--all)
           fi
-          python scripts/skill_rubric_grade.py $SCOPE \
-            --top "${{ inputs.top }}" \
-            --max-quality "${{ inputs.max_quality }}" \
-            $SARIF_ARG \
+          if [ -f skillspector.sarif ]; then
+            args+=(--skillspector-sarif skillspector.sarif)
+          fi
+          python scripts/skill_rubric_grade.py "${args[@]}" \
             --output-json skill-shortlist.json \
             --output-md skill-rubric-report.md
 

--- a/.github/workflows/skill-improvement-loop.yml
+++ b/.github/workflows/skill-improvement-loop.yml
@@ -1,0 +1,163 @@
+name: Skill Improvement Loop
+
+# Outer optimization loop for marketplace skills, inspired by the "observer
+# skill" pattern (run the inner skill, grade it, open a diff, repeat).
+#
+# How it works:
+#   1. (Cheap, deterministic, token-free) A heuristic rubric + SkillSpector
+#      triage every skill and pick the N most in need of work. This runs in CI
+#      and needs no API key.
+#   2. (Smart, LLM) The shortlist is handed to a Claude managed agent via a
+#      GitHub issue. The agent runs the existing `component-researcher` ->
+#      `component-improver` agents to apply the full rubric and open a focused
+#      DRAFT pull request per skill.
+#   3. The existing `skill-security-scan.yml` PR gate then validates each draft
+#      PR with SkillSpector, closing the loop.
+#
+# Manual trigger only (PoC). Tune inputs, inspect the triage report artifact,
+# and only let it open the issue once the shortlist looks right.
+
+on:
+  workflow_dispatch:
+    inputs:
+      category:
+        description: 'Limit to one skill category (e.g. git, development). Blank = all skills.'
+        required: false
+        default: ''
+      top:
+        description: 'How many skills to shortlist for improvement.'
+        required: false
+        default: '5'
+      max_quality:
+        description: 'Only shortlist skills scoring at or below this quality (0-100).'
+        required: false
+        default: '75'
+      run_skillspector:
+        description: 'Run SkillSpector and fold its security findings into the triage.'
+        type: boolean
+        required: false
+        default: true
+      create_issue:
+        description: 'Open a GitHub issue for the Claude managed agent. Off = dry-run (report only).'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+jobs:
+  triage:
+    name: Triage skills and dispatch improvement
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run SkillSpector (security signal)
+        id: skillspector
+        if: ${{ inputs.run_skillspector }}
+        continue-on-error: true
+        run: |
+          pip install "git+https://github.com/NVIDIA/skillspector.git@main"
+          # SkillSpector scans the whole catalog; the rubric grader narrows the
+          # scope to the requested category afterwards.
+          python scripts/skillspector_scan.py --all \
+            --output-md skillspector-report.md \
+            --output-sarif skillspector.sarif || true
+
+      - name: Grade skills (heuristic rubric triage)
+        id: grade
+        run: |
+          SARIF_ARG=""
+          if [ -f skillspector.sarif ]; then
+            SARIF_ARG="--skillspector-sarif skillspector.sarif"
+          fi
+          if [ -n "${{ inputs.category }}" ]; then
+            SCOPE="--category ${{ inputs.category }}"
+          else
+            SCOPE="--all"
+          fi
+          python scripts/skill_rubric_grade.py $SCOPE \
+            --top "${{ inputs.top }}" \
+            --max-quality "${{ inputs.max_quality }}" \
+            $SARIF_ARG \
+            --output-json skill-shortlist.json \
+            --output-md skill-rubric-report.md
+
+      - name: Publish triage report to run summary
+        if: always()
+        run: |
+          if [ -f skill-rubric-report.md ]; then
+            cat skill-rubric-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload triage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: skill-improvement-triage
+          path: |
+            skill-rubric-report.md
+            skill-shortlist.json
+            skillspector-report.md
+            skillspector.sarif
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Open improvement issue for Claude managed agent
+        if: ${{ inputs.create_issue && steps.grade.outputs.candidate_count != '0' }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('skill-rubric-report.md')
+              ? fs.readFileSync('skill-rubric-report.md', 'utf8')
+              : '_No triage report produced._';
+            const shortlist = JSON.parse(
+              fs.readFileSync('skill-shortlist.json', 'utf8')
+            );
+
+            const tasks = shortlist
+              .map((s, i) => `- [ ] ${i + 1}. \`${s.path}\` — quality ${s.quality_score}/100 (${s.reasons[0]})`)
+              .join('\n');
+
+            const body = [
+              '@claude please run the **skill improvement loop** on the skills below.',
+              '',
+              'For **each** skill in the shortlist, working one skill per draft PR:',
+              '1. Run the `component-researcher` agent on the skill to produce a prioritized improvement report (this is the real LLM rubric grade).',
+              '2. Run the `component-improver` agent to apply the improvements, validate with `component-reviewer`, and open a **draft** PR titled `improve: <skill-name>`.',
+              '3. Do not over-engineer — preserve each skill\'s existing value; apply only the researched improvements.',
+              '',
+              '**Exit criteria:** stop once a skill\'s issues are resolved or the remaining diff would be cosmetic. One focused PR per skill.',
+              '',
+              '### Shortlist',
+              tasks,
+              '',
+              '<details><summary>Full triage report</summary>',
+              '',
+              report,
+              '',
+              '</details>',
+              '',
+              '---',
+              '_Opened automatically by the Skill Improvement Loop workflow._',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `Skill improvement loop — ${shortlist.length} skill(s) to improve`,
+              body,
+              labels: ['skill-improvement', 'automation'],
+            });

--- a/cli-tool/components/loops/engineering/skill-improvement-loop.md
+++ b/cli-tool/components/loops/engineering/skill-improvement-loop.md
@@ -1,0 +1,70 @@
+---
+name: skill-improvement-loop
+description: Continuously grades the quality of your skills against a rubric and opens a focused pull request to improve the weakest one on every pass.
+category: engineering
+interval: 7d
+stop-condition: Every skill scores at or above the quality threshold and the diffs produced by a pass become cosmetic (no meaningful improvement remains).
+components: [agent:expert-advisors/research-technical-spike, agent:expert-advisors/architect-review, command:git-workflow/create-pr]
+tags: [skills, quality, automation, ci, evaluation, loop, self-improvement]
+---
+
+# Skill Improvement Loop
+
+> **Loop Engineering** — an *outer* optimization loop for your skills. Instead of
+> hand-editing skills one by one, you let an observer grade them, pick the weakest,
+> open a small diff to improve it, and repeat until the diffs stop mattering. This
+> is the marketplace adaptation of the "observer skill" pattern: run the inner
+> skill, record its weaknesses, make a diff to improve it, repeat.
+
+## 🎯 Goal
+Keep a library of skills consistently high quality as it grows. Each pass surfaces
+the single weakest skill and proposes a focused, reviewable improvement — rather
+than a giant batch nobody reviews.
+
+## ⏱️ Schedule
+Suggested interval: `7d` (weekly), or run manually after importing a batch of new skills.
+
+## ▶️ Run it
+```
+/loop 1w "Grade every skill against the quality rubric, pick the lowest-scoring one, research best practices for it, apply a focused improvement, validate it, and open a draft PR. Continue until all skills clear the quality bar and further diffs would be cosmetic."
+```
+
+## 🔁 Iteration steps
+1. **Perceive (cheap triage)** — score every skill with a deterministic rubric (frontmatter completeness, description clarity and trigger cues, presence of examples, body depth) and a security scan. This is token-free and ranks the whole catalog.
+2. **Select** — pick the lowest-scoring skill (highest improvement priority) that is below the quality threshold.
+3. **Reason (real grade)** — run `component-researcher` to apply the full LLM rubric and produce a prioritized improvement report with sources.
+4. **Act** — run `component-improver` to apply the researched changes, preserving the skill's existing value.
+5. **Observe** — `component-reviewer` and a security scan validate the change; open a focused **draft** PR titled `improve: <skill-name>`.
+6. **Repeat** — on the next pass the triage re-ranks and the loop moves to the next weakest skill.
+
+## 🛑 Stopping condition
+Every skill scores at or above the quality threshold, and the diffs a pass would
+produce are cosmetic. Bake an exit criterion into the loop (quality bar + a cap on
+PRs per pass) so it does not burn tokens optimizing toward a local maximum forever.
+
+## 🧩 Referenced components
+- `agent:expert-advisors/research-technical-spike` — investigates best practices and grades the skill (the observer).
+- `agent:expert-advisors/architect-review` — reviews the proposed change before it ships.
+- `command:git-workflow/create-pr` — opens the focused, reviewable draft PR.
+
+## ⚙️ Automating it with GitHub Actions
+This repo ships a manual workflow, `.github/workflows/skill-improvement-loop.yml`,
+that runs the cheap triage in CI (heuristic rubric via `scripts/skill_rubric_grade.py`
+plus SkillSpector) and hands the shortlist to a Claude managed agent through a
+GitHub issue. The managed agent then drives the research → improve → review → PR
+steps. No API key lives in the repo — the managed agent does the LLM work. Start
+with `create_issue: false` to inspect the triage report, then flip it on once the
+shortlist looks right.
+
+> **Note on this repo's CI path:** internally this project drives those steps with
+> repo-only agents (`component-researcher`, `component-improver`, `component-reviewer`)
+> that live in `.claude/agents/`. They are maintainer tooling, not installable
+> catalog components, so they are intentionally not listed in `components:` above.
+> When you install this loop elsewhere, the catalog agents in `components:` fill
+> those roles.
+
+## 💡 Example
+The weekly pass grades 870 skills, finds one with a vague description and no usage
+examples, researches how similar skills phrase their triggers, rewrites the
+description and adds a worked example, and opens `improve: humanizer` as a draft PR
+for review. Next week it moves on to the next weakest skill.

--- a/dashboard/public/components.json
+++ b/dashboard/public/components.json
@@ -44518,6 +44518,35 @@
       }
     },
     {
+      "name": "skill-improvement-loop",
+      "path": "engineering/skill-improvement-loop.md",
+      "category": "engineering",
+      "type": "loop",
+      "description": "Continuously grades the quality of your skills against a rubric and opens a focused pull request to improve the weakest one on every pass.",
+      "author": "",
+      "repo": "",
+      "version": "",
+      "license": "",
+      "keywords": [
+        "skills",
+        "quality",
+        "automation",
+        "ci",
+        "evaluation",
+        "loop",
+        "self-improvement"
+      ],
+      "downloads": 0,
+      "security": {
+        "validated": false,
+        "valid": null,
+        "score": null,
+        "errorCount": 0,
+        "warningCount": 0,
+        "lastValidated": null
+      }
+    },
+    {
       "name": "test-coverage-loop",
       "path": "engineering/test-coverage-loop.md",
       "category": "engineering",

--- a/docs/components.json
+++ b/docs/components.json
@@ -44518,6 +44518,35 @@
       }
     },
     {
+      "name": "skill-improvement-loop",
+      "path": "engineering/skill-improvement-loop.md",
+      "category": "engineering",
+      "type": "loop",
+      "description": "Continuously grades the quality of your skills against a rubric and opens a focused pull request to improve the weakest one on every pass.",
+      "author": "",
+      "repo": "",
+      "version": "",
+      "license": "",
+      "keywords": [
+        "skills",
+        "quality",
+        "automation",
+        "ci",
+        "evaluation",
+        "loop",
+        "self-improvement"
+      ],
+      "downloads": 0,
+      "security": {
+        "validated": false,
+        "valid": null,
+        "score": null,
+        "errorCount": 0,
+        "warningCount": 0,
+        "lastValidated": null
+      }
+    },
+    {
       "name": "test-coverage-loop",
       "path": "engineering/test-coverage-loop.md",
       "category": "engineering",

--- a/scripts/skill_rubric_grade.py
+++ b/scripts/skill_rubric_grade.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Triage grader for skill components (the cheap, deterministic half of the
+skill-improvement loop).
+
+This is NOT the final quality judge. It is a fast, token-free pre-filter that
+scores every skill against a heuristic rubric so the loop can pick the N skills
+most in need of work *before* spending any LLM tokens. The real LLM rubric grade
+(and the actual rewrite) is done afterwards by the Claude managed agent running
+the `component-researcher` -> `component-improver` agents on the shortlist.
+
+What it does:
+  * Discovers skill directories under cli-tool/components/skills/ (a dir that
+    directly contains a SKILL.md), reusing the same convention as
+    skillspector_scan.py.
+  * Scores each skill 0-100 against a structural rubric (frontmatter, description
+    quality, examples, body depth) and applies penalties for deprecated patterns
+    and absolute paths.
+  * Optionally folds in SkillSpector findings from an aggregated SARIF file so the
+    security signal raises a skill's improvement priority.
+  * Ranks skills by improvement priority and emits:
+      - a JSON shortlist (machine-readable, consumed by the workflow)
+      - a Markdown report (for the run summary / issue body)
+      - GitHub Action outputs (candidate_count, candidates_json)
+
+Stdlib only, runs on Python 3.9+ so it can be exercised locally without any
+dependency. Use --dry-run to list discovered skills without scoring.
+
+Usage:
+    skill_rubric_grade.py --all --top 5 --output-json shortlist.json
+    skill_rubric_grade.py --category git --top 3 --output-md report.md
+    skill_rubric_grade.py --all --skillspector-sarif skillspector.sarif --top 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Repo-relative root that holds every skill component.
+SKILLS_ROOT = Path("cli-tool/components/skills")
+
+# Accepted manifest filenames (case variants seen in the catalog).
+MANIFEST_NAMES = {"skill.md"}
+
+# Patterns that signal a skill is using outdated guidance.
+DEPRECATED_PATTERNS = re.compile(
+    r"\b(claude-2|claude-instant|claude-3(?:-|\b)|gpt-3\.5|text-davinci|davinci-00)",
+    re.IGNORECASE,
+)
+
+# Absolute paths should never appear in a portable component.
+ABSOLUTE_PATH_PATTERNS = re.compile(r"(/Users/|/home/|/root/|[A-Za-z]:\\\\)")
+
+# Cues that a description tells the model *when* to use the skill.
+TRIGGER_CUES = re.compile(
+    r"(use when|usage|should be used|when you|trigger|invoke|/[a-z][\w-]+)",
+    re.IGNORECASE,
+)
+
+
+def _has_manifest(directory: Path) -> bool:
+    try:
+        for entry in directory.iterdir():
+            if entry.is_file() and entry.name.lower() in MANIFEST_NAMES:
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def discover_all_skills(root: Path = SKILLS_ROOT) -> list[Path]:
+    """Find every skill directory (one that directly contains a SKILL.md)."""
+    if not root.is_dir():
+        return []
+    skills: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if any(name.lower() in MANIFEST_NAMES for name in filenames):
+            skills.append(Path(dirpath))
+    return sorted(set(skills))
+
+
+def _manifest_path(skill_dir: Path) -> Path | None:
+    for entry in skill_dir.iterdir():
+        if entry.is_file() and entry.name.lower() in MANIFEST_NAMES:
+            return entry
+    return None
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Return (frontmatter dict, body).
+
+    Minimal YAML parsing that handles single-line scalars and block scalars
+    (``key: |`` / ``key: >``) so multi-line descriptions are not mistaken for
+    empty ones.
+    """
+    fm: dict[str, str] = {}
+    body = text
+    if not text.startswith("---"):
+        return fm, body
+    end = text.find("\n---", 3)
+    if end == -1:
+        return fm, body
+    block = text[3:end].strip("\n")
+    body = text[end + 4 :]
+
+    lines = block.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        # Skip comments, blank lines, and indented continuation lines that are
+        # not the start of a new top-level key.
+        if not stripped or stripped.startswith("#") or line[:1] in (" ", "\t"):
+            i += 1
+            continue
+        if ":" not in line:
+            i += 1
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        value = value.strip()
+        if value in ("|", ">", "|-", ">-", "|+", ">+"):
+            # Block scalar: collect subsequent indented lines.
+            collected: list[str] = []
+            i += 1
+            while i < len(lines) and (lines[i][:1] in (" ", "\t") or not lines[i].strip()):
+                collected.append(lines[i].strip())
+                i += 1
+            fm[key] = " ".join(c for c in collected if c).strip()
+            continue
+        fm[key] = value.strip("\"'")
+        i += 1
+    return fm, body
+
+
+def _scaled(value: float, lo: float, hi: float, points: float) -> float:
+    """Linearly scale value in [lo, hi] to [0, points], clamped."""
+    if value <= lo:
+        return 0.0
+    if value >= hi:
+        return points
+    return round(points * (value - lo) / (hi - lo), 1)
+
+
+def grade_skill(skill_dir: Path) -> dict:
+    """Score a single skill against the structural rubric (0-100)."""
+    manifest = _manifest_path(skill_dir)
+    rel = str(skill_dir).replace("\\", "/")
+    if manifest is None:
+        return {
+            "path": rel,
+            "name": skill_dir.name,
+            "quality_score": 0,
+            "reasons": ["No SKILL.md found"],
+            "security_findings": 0,
+        }
+
+    text = manifest.read_text(encoding="utf-8", errors="replace")
+    fm, body = _split_frontmatter(text)
+    reasons: list[str] = []
+    score = 0.0
+
+    name = fm.get("name", "").strip()
+    description = fm.get("description", "").strip()
+
+    # name present (10)
+    if name:
+        score += 10
+    else:
+        reasons.append("Missing frontmatter `name`")
+
+    # description present (10)
+    if description:
+        score += 10
+    else:
+        reasons.append("Missing frontmatter `description`")
+
+    # description length: ideal 40-600 chars (20)
+    dlen = len(description)
+    if description:
+        if dlen < 40:
+            reasons.append(f"Description very short ({dlen} chars)")
+            score += _scaled(dlen, 0, 40, 20)
+        elif dlen > 600:
+            reasons.append(f"Description very long ({dlen} chars)")
+            score += 12
+        else:
+            score += 20
+
+    # description has a trigger/usage cue (10)
+    if description and TRIGGER_CUES.search(description):
+        score += 10
+    elif description:
+        reasons.append("Description lacks a clear trigger / usage cue")
+
+    # body has >= 2 markdown headings (15)
+    headings = len(re.findall(r"(?m)^#{1,6}\s", body))
+    if headings >= 2:
+        score += 15
+    else:
+        reasons.append(f"Only {headings} markdown heading(s) in body")
+        score += _scaled(headings, 0, 2, 15)
+
+    # body has a code example or explicit example/usage section (15)
+    has_code = "```" in body
+    has_example_word = re.search(r"(?i)\b(example|usage)\b", body) is not None
+    if has_code:
+        score += 15
+    elif has_example_word:
+        score += 8
+        reasons.append("Has an example section but no code block")
+    else:
+        reasons.append("No code examples or usage section")
+
+    # body depth: >= 400 chars (20)
+    blen = len(body.strip())
+    if blen >= 400:
+        score += 20
+    else:
+        reasons.append(f"Thin body ({blen} chars)")
+        score += _scaled(blen, 80, 400, 20)
+
+    # penalties
+    if DEPRECATED_PATTERNS.search(text):
+        score -= 10
+        reasons.append("References deprecated model IDs")
+    if ABSOLUTE_PATH_PATTERNS.search(text):
+        score -= 10
+        reasons.append("Contains absolute paths")
+
+    score = max(0, min(100, round(score)))
+
+    return {
+        "path": rel,
+        "manifest": str(manifest).replace("\\", "/"),
+        "name": name or skill_dir.name,
+        "quality_score": score,
+        "reasons": reasons or ["No structural issues detected"],
+        "security_findings": 0,
+    }
+
+
+def load_skillspector_findings(sarif_path: Path) -> dict[str, int]:
+    """Parse an aggregated SARIF file -> {normalized_path: finding_count}."""
+    counts: dict[str, int] = {}
+    try:
+        data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return counts
+    for run in data.get("runs", []):
+        for result in run.get("results", []):
+            for loc in result.get("locations", []):
+                uri = (
+                    loc.get("physicalLocation", {})
+                    .get("artifactLocation", {})
+                    .get("uri", "")
+                )
+                if not uri:
+                    continue
+                norm = uri.replace("\\", "/").lstrip("./")
+                counts[norm] = counts.get(norm, 0) + 1
+    return counts
+
+
+def _attach_security(graded: list[dict], findings: dict[str, int]) -> None:
+    """Fold SkillSpector finding counts into each graded skill in-place."""
+    for g in graded:
+        prefix = g["path"].lstrip("./")
+        hits = 0
+        for uri, count in findings.items():
+            if uri.startswith(prefix):
+                hits += count
+        g["security_findings"] = hits
+        if hits:
+            g["reasons"].append(f"SkillSpector findings: {hits}")
+
+
+def improvement_priority(g: dict) -> int:
+    """Higher = more in need of improvement."""
+    return (100 - g["quality_score"]) + g["security_findings"] * 5
+
+
+def render_markdown(shortlist: list[dict], total: int) -> str:
+    lines = [
+        "## 🔁 Skill Improvement Loop — triage report",
+        "",
+        f"Scanned **{total}** skills. Showing the **{len(shortlist)}** with the "
+        "lowest structural quality (highest improvement priority).",
+        "",
+        "| # | Skill | Quality | Security | Priority | Top issue |",
+        "|---|-------|:-------:|:--------:|:--------:|-----------|",
+    ]
+    for i, g in enumerate(shortlist, 1):
+        top_issue = g["reasons"][0] if g["reasons"] else "—"
+        lines.append(
+            f"| {i} | `{g['path']}` | {g['quality_score']}/100 | "
+            f"{g['security_findings']} | {improvement_priority(g)} | {top_issue} |"
+        )
+    lines += [
+        "",
+        "> This is a cheap heuristic triage. The Claude managed agent applies the "
+        "full LLM rubric and opens a draft PR per skill.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _set_output(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        return
+    with open(out, "a", encoding="utf-8") as fh:
+        if "\n" in value:
+            delim = "EOF_RUBRIC"
+            fh.write(f"{name}<<{delim}\n{value}\n{delim}\n")
+        else:
+            fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--all", action="store_true", help="Grade every skill.")
+    scope.add_argument(
+        "--category", help="Grade only skills under this category dir."
+    )
+    parser.add_argument("--top", type=int, default=5, help="Shortlist size.")
+    parser.add_argument(
+        "--max-quality",
+        type=int,
+        default=100,
+        help="Only shortlist skills scoring at or below this quality.",
+    )
+    parser.add_argument(
+        "--skillspector-sarif",
+        help="Optional aggregated SARIF from skillspector_scan.py.",
+    )
+    parser.add_argument("--output-json", default="skill-shortlist.json")
+    parser.add_argument("--output-md", default="skill-rubric-report.md")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List discovered skills and exit."
+    )
+    args = parser.parse_args()
+
+    if args.category:
+        root = SKILLS_ROOT / args.category
+        skills = discover_all_skills(root)
+    else:
+        skills = discover_all_skills()
+
+    if not skills:
+        print("No skills found.", file=sys.stderr)
+        _set_output("candidate_count", "0")
+        return 0
+
+    if args.dry_run:
+        for s in skills:
+            print(s)
+        print(f"\n{len(skills)} skill(s) discovered.", file=sys.stderr)
+        return 0
+
+    graded = [grade_skill(s) for s in skills]
+
+    if args.skillspector_sarif and Path(args.skillspector_sarif).is_file():
+        findings = load_skillspector_findings(Path(args.skillspector_sarif))
+        _attach_security(graded, findings)
+
+    graded.sort(key=improvement_priority, reverse=True)
+    eligible = [g for g in graded if g["quality_score"] <= args.max_quality]
+    shortlist = eligible[: args.top]
+
+    Path(args.output_json).write_text(
+        json.dumps(shortlist, indent=2), encoding="utf-8"
+    )
+    Path(args.output_md).write_text(
+        render_markdown(shortlist, len(graded)), encoding="utf-8"
+    )
+
+    _set_output("candidate_count", str(len(shortlist)))
+    _set_output(
+        "candidates_json",
+        json.dumps([g["path"] for g in shortlist]),
+    )
+
+    print(render_markdown(shortlist, len(graded)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

PoC that adapts the [skill optimization loop](https://x.com/zachlloydtweets) ("observer skill" pattern) to **our marketplace**, automated with **GitHub Actions + a Claude managed agent** (no API key in the repo).

The article's grader uses computer-use to visually diff a replatformed site. Our skills are markdown instruction files with no rendered output to diff, so the grader is adapted into a **two-stage hybrid**:

1. **Cheap, deterministic triage (CI, token-free):** a heuristic rubric + SkillSpector rank all ~870 skills and pick the N weakest. No tokens spent grading the whole catalog.
2. **Smart, LLM stage (managed agent):** only the shortlist is handed to a Claude managed agent, which applies the real rubric, researches improvements, and opens a focused **draft PR per skill**.

This directly addresses the cost/local-maximum concern from the article: the expensive LLM work only runs on a small shortlist, with baked-in exit criteria.

## Changes

| File | Role |
|------|------|
| `scripts/skill_rubric_grade.py` | Triage grader. Scores each `SKILL.md` 0–100 (frontmatter, description clarity + trigger cues, examples, body depth), penalizes deprecated model IDs / absolute paths, optionally folds in SkillSpector SARIF findings. Emits ranked JSON shortlist, markdown report, and GH Action outputs. Stdlib-only, Python 3.9+, handles YAML block scalars. |
| `.github/workflows/skill-improvement-loop.yml` | Manual `workflow_dispatch`. Runs SkillSpector + triage in CI, uploads the report, and (optionally) opens a GitHub issue tagging a Claude managed agent with the shortlist + task. `create_issue: false` = dry-run. |
| `cli-tool/components/loops/engineering/skill-improvement-loop.md` | Marketplace `loop` component documenting the full pattern with exit criteria. Validated with `component-reviewer`. |

## Validation

- Grader run live across **872 skills** — surfaced real candidates (vague descriptions, missing frontmatter, even a stray `+description:` typo in `agirails-agent-payments`). Fixed a frontmatter false-positive on block-scalar descriptions (e.g. `humanizer`).
- Workflow + loop frontmatter YAML validated.
- Loop component reviewed by `component-reviewer` (interval normalized to `7d`, CI-only agents clarified).

## How to try it

1. Actions → **Skill Improvement Loop** → Run workflow with `create_issue: false`.
2. Inspect the `skill-improvement-triage` artifact / run summary.
3. Re-run with `create_issue: true` to let the managed agent open draft PRs.

## Notes / follow-ups

- **Catalog not regenerated here on purpose** — `generate_components_json.py` pulls the entire `component_downloads` table from Supabase, which would add a huge unrelated download-count diff. The `update-json-data` job will pick up the new loop entry.
- Possible next steps: wire a weekly `schedule`, add a per-run PR budget cap, and (stretch) an execution-based grader for skills with objective success criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFn7YA1uEgrNdzXyvnLwy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFn7YA1uEgrNdzXyvnLwy5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PoC Skill Improvement Loop that triages marketplace skills with a token-free rubric, shortlists weak skills, and dispatches a managed agent to open focused draft PRs. Also secures the workflow inputs and updates the component catalog.

- **New Features**
  - Components: Added `cli-tool/components/loops/engineering/skill-improvement-loop.md` (new loop). Catalog entries added to `docs/components.json` and `dashboard/public/components.json`. Areas: components, website (docs). No changes to CLI (`src/`, `bin/`), API (`api/`), or workers (`cloudflare-workers/`).
  - CI + Scripts: Added `.github/workflows/skill-improvement-loop.yml` and `scripts/skill_rubric_grade.py` to run rubric triage, optionally fold in SkillSpector results, publish a report, and optionally open an agent-dispatch issue. Uses default `GITHUB_TOKEN`; no new env vars or secrets.

- **Security**
  - Prevented shell injection by passing `workflow_dispatch` inputs via environment variables and a quoted bash array before invoking the grader.

<sup>Written for commit fc1ffcc33f1af56e339064a8c2f613edd8e6d2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

