### PR TITLE
fix(tdd-gate): match dot-prefixed .config dirs in skip glob

### DIFF
--- a/cli-tool/components/hooks/quality-gates/tdd-gate.sh
+++ b/cli-tool/components/hooks/quality-gates/tdd-gate.sh
@@ -51,7 +51,7 @@ case "$FILE_PATH" in
   */spec/*|*/specs/*|*/Spec/*|*/Specs/*) exit 0 ;;
   */fixtures/*|*/mocks/*|*/stubs/*|*/fakes/*) exit 0 ;;
   */migrations/*|*/Migrations/*|*/seeds/*) exit 0 ;;
-  */config/*|*/Config/*|*/scripts/*) exit 0 ;;
+  */.config/*|*/config/*|*/Config/*|*/scripts/*) exit 0 ;;
 esac
 
 # Search for corresponding test file in the same directory first, then nearby


### PR DESCRIPTION
The skip case `*/config/*` does not match `.config` (dot-prefixed), so editing hook/config files under `~/.config/...` misfires the gate as 'production code needs tests'. Widen to also match `*/.config/*`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TDD quality gate to skip files under dot-prefixed ".config" directories. This stops false "production code needs tests" alerts when editing config files like ~/.config/*.

- **Bug Fixes**
  - Area: components (`cli-tool/components/hooks/quality-gates/tdd-gate.sh`)
  - Skip glob now matches "*/.config/*" in addition to "*/config/*"
  - No new components; `docs/components.json` does not need regeneration
  - No new environment variables or secrets

<sup>Written for commit 54068dd1d4dcd09ca0dbaffa135785410695e49c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

