### PR TITLE
feat(pulse): replace Vercel source with Cloudflare Pages + harden Telegram delivery

### DIFF
--- a/.claude/rules/cloudflare.md
+++ b/.claude/rules/cloudflare.md
@@ -10,7 +10,7 @@ Independent worker projects, deployed separately from Vercel.
 ## Projects
 
 - **docs-monitor**: Monitors code.claude.com/docs changes hourly, sends Telegram notifications
-- **pulse**: Weekly KPI report (GitHub, Discord, Supabase, Vercel, GA) every Sunday 14:00 UTC via Telegram
+- **pulse**: Weekly KPI report (GitHub, Discord, Supabase, npm, Cloudflare Pages, GA) every Sunday 14:00 UTC via Telegram
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ npx wrangler deploy  # Deploy
 
 ### pulse (Weekly KPI Report)
 
-Collects metrics from GitHub, Discord, Supabase, Vercel, and Google Analytics every Sunday at 14:00 UTC and sends a consolidated report via Telegram.
+Collects metrics from GitHub, Discord, Supabase, npm, Cloudflare Pages, and Google Analytics every Sunday at 14:00 UTC and sends a consolidated report via Telegram.
 
 **Architecture:** Single `index.js` file (no npm dependencies at runtime). All source collectors, formatter, and Telegram sender in one file.
 
@@ -284,8 +284,9 @@ SUPABASE_URL                # Supabase project URL
 SUPABASE_SERVICE_ROLE_KEY   # Supabase service role key
 DISCORD_BOT_TOKEN           # Discord bot token
 DISCORD_GUILD_ID            # Discord server ID
-VERCEL_TOKEN                # Vercel personal access token (optional)
-VERCEL_PROJECT_ID           # Vercel project ID (optional)
+CLOUDFLARE_API_TOKEN        # Cloudflare API token (Account > Pages > Read)
+CLOUDFLARE_ACCOUNT_ID       # Cloudflare account ID
+CLOUDFLARE_PAGES_PROJECT    # Cloudflare Pages project name (aitmpl-dashboard)
 TRIGGER_SECRET              # For manual /trigger endpoint
 GA_PROPERTY_ID              # GA4 property ID (optional)
 GA_SERVICE_ACCOUNT_JSON     # Base64 service account (optional)

--- a/cloudflare-workers/pulse/README.md
+++ b/cloudflare-workers/pulse/README.md
@@ -31,9 +31,10 @@ wrangler secret put SUPABASE_SERVICE_ROLE_KEY
 wrangler secret put DISCORD_BOT_TOKEN
 wrangler secret put DISCORD_GUILD_ID
 
-# Vercel
-wrangler secret put VERCEL_TOKEN          # Personal access token
-wrangler secret put VERCEL_PROJECT_ID     # aitmpl project ID
+# Cloudflare Pages (dashboard deploy metrics)
+wrangler secret put CLOUDFLARE_API_TOKEN      # API token with Account > Pages > Read
+wrangler secret put CLOUDFLARE_ACCOUNT_ID     # Cloudflare account ID
+wrangler secret put CLOUDFLARE_PAGES_PROJECT  # Pages project name (aitmpl-dashboard)
 
 # Manual trigger auth
 wrangler secret put TRIGGER_SECRET
@@ -107,9 +108,9 @@ npm run test             # Test cron trigger locally
 ├ By type: agents 65% | commands 20% | settings 15%
 └ Countries: US 40% | DE 15% | BR 10% | UK 8% | CL 5%
 
-🚀 VERCEL
-├ Deploys: 12 (11 ✅ 1 ❌)
-└ Latest: 2h ago ✅
+🚀 CLOUDFLARE (Pages)
+├ Deploys: 12 (11 ok, 1 failed)
+└ Latest: 2h ago [OK]
 
 📈 ANALYTICS
 ├ Visitors: 3,456

--- a/cloudflare-workers/pulse/index.js
+++ b/cloudflare-workers/pulse/index.js
@@ -1,7 +1,7 @@
 /**
  * Cloudflare Worker: Pulse — Weekly KPI Report
  *
- * Collects metrics from GitHub, Discord, Supabase, npm, Vercel, and Google Analytics,
+ * Collects metrics from GitHub, Discord, Supabase, npm, Cloudflare Pages, and Google Analytics,
  * then sends a consolidated report via Telegram every Sunday at 14:00 UTC.
  *
  * All source collectors are in this single file (no npm dependencies).
@@ -11,7 +11,7 @@ const REPO = 'davila7/claude-code-templates';
 const NPM_PACKAGE = 'claude-code-templates';
 const GITHUB_API = 'https://api.github.com';
 const DISCORD_API = 'https://discord.com/api/v10';
-const VERCEL_API = 'https://api.vercel.com';
+const CLOUDFLARE_API = 'https://api.cloudflare.com/client/v4';
 const NPM_API = 'https://api.npmjs.org';
 const GA4_API = 'https://analyticsdata.googleapis.com/v1beta';
 const TELEGRAM_API = 'https://api.telegram.org';
@@ -48,7 +48,7 @@ export default {
         status: 'running',
         worker: 'pulse-weekly-report',
         schedule: 'Sundays 14:00 UTC',
-        sources: ['github', 'discord', 'downloads', 'npm', 'vercel', 'analytics']
+        sources: ['github', 'discord', 'downloads', 'npm', 'cloudflare', 'analytics']
       });
     }
 
@@ -72,7 +72,7 @@ async function runReport(env, opts = {}) {
       discord: collectDiscord,
       downloads: collectDownloads,
       npm: collectNpm,
-      vercel: collectVercel,
+      cloudflare: collectCloudflare,
       analytics: collectAnalytics
     };
     const collector = collectors[onlySource];
@@ -81,14 +81,14 @@ async function runReport(env, opts = {}) {
     }
     results[onlySource] = await collector(env);
   } else {
-    const [github, discord, downloads, npm, vercel] = await Promise.all([
+    const [github, discord, downloads, npm, cloudflare] = await Promise.all([
       collectGitHub(env),
       collectDiscord(env),
       collectDownloads(env),
       collectNpm(env),
-      collectVercel(env)
+      collectCloudflare(env)
     ]);
-    results = { github, discord, downloads, npm, vercel };
+    results = { github, discord, downloads, npm, cloudflare };
   }
 
   const reportText = formatReport(results);
@@ -354,63 +354,60 @@ async function collectDownloads(env) {
   }
 }
 
-// ─── Source: Vercel ──────────────────────────────────────────────────────────
+// ─── Source: Cloudflare Pages ────────────────────────────────────────────────
 
-async function collectVercel(env) {
+async function collectCloudflare(env) {
   try {
-    if (!env.VERCEL_TOKEN || !env.VERCEL_PROJECT_ID) {
-      return { error: 'VERCEL_TOKEN or VERCEL_PROJECT_ID not configured' };
+    if (!env.CLOUDFLARE_API_TOKEN || !env.CLOUDFLARE_ACCOUNT_ID || !env.CLOUDFLARE_PAGES_PROJECT) {
+      return { error: 'CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_PAGES_PROJECT not configured' };
     }
 
-    const headers = { Authorization: `Bearer ${env.VERCEL_TOKEN}` };
+    const headers = { Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}` };
     const since = weekAgo();
 
+    // Production deployments, newest first
     const data = await fetchJSON(
-      `${VERCEL_API}/v6/deployments?projectId=${env.VERCEL_PROJECT_ID}&since=${since.getTime()}&limit=100`,
+      `${CLOUDFLARE_API}/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/pages/projects/${env.CLOUDFLARE_PAGES_PROJECT}/deployments?env=production&per_page=100`,
       { headers }
     );
 
-    const deployments = data.deployments || [];
-    const successCount = deployments.filter(d => d.state === 'READY').length;
-    const errorCount = deployments.filter(d => d.state === 'ERROR').length;
+    const all = data.result || [];
+    const weekDeployments = all.filter(d => new Date(d.created_on) >= since);
+
+    // latest_stage.status: 'success' | 'failure' | 'active' | 'canceled' | 'skipped'
+    const successCount = weekDeployments.filter(d => d.latest_stage?.status === 'success').length;
+    const errorCount = weekDeployments.filter(d => d.latest_stage?.status === 'failure').length;
 
     let latestStatus = null;
     let latestAge = null;
-    if (deployments.length > 0) {
-      const latest = deployments[0];
-      latestStatus = latest.state;
+    let lastCommit = null;
+    if (all.length > 0) {
+      const latest = all[0];
+      latestStatus = latest.latest_stage?.status || 'unknown';
+      latestAge = formatAge(Date.now() - new Date(latest.created_on).getTime());
 
-      const age = Date.now() - latest.created;
-      const hours = Math.floor(age / (1000 * 60 * 60));
-      const days = Math.floor(hours / 24);
-      if (days > 0) {
-        latestAge = `${days}d ago`;
-      } else if (hours > 0) {
-        latestAge = `${hours}h ago`;
-      } else {
-        latestAge = `${Math.floor(age / (1000 * 60))}m ago`;
+      const msg = latest.deployment_trigger?.metadata?.commit_message;
+      if (msg) {
+        lastCommit = msg.length > 60 ? msg.substring(0, 57) + '...' : msg;
       }
     }
 
-    // Average build time
+    // Average build-stage duration (seconds)
     let avgBuildTime = null;
-    const buildTimes = deployments
-      .filter(d => d.ready && d.buildingAt)
-      .map(d => (d.ready - d.buildingAt) / 1000);
+    const buildTimes = [];
+    for (const d of weekDeployments) {
+      const build = (d.stages || []).find(s => s.name === 'build');
+      if (build?.started_on && build?.ended_on) {
+        buildTimes.push((new Date(build.ended_on) - new Date(build.started_on)) / 1000);
+      }
+    }
     if (buildTimes.length > 0) {
       avgBuildTime = Math.round(buildTimes.reduce((a, b) => a + b, 0) / buildTimes.length);
     }
 
-    // Last commit message
-    let lastCommit = null;
-    if (deployments.length > 0 && deployments[0].meta?.githubCommitMessage) {
-      lastCommit = deployments[0].meta.githubCommitMessage;
-      if (lastCommit.length > 60) lastCommit = lastCommit.substring(0, 57) + '...';
-    }
-
-    return { totalWeek: deployments.length, successCount, errorCount, latestStatus, latestAge, avgBuildTime, lastCommit };
+    return { totalWeek: weekDeployments.length, successCount, errorCount, latestStatus, latestAge, avgBuildTime, lastCommit };
   } catch (error) {
-    console.error('Vercel source error:', error.message);
+    console.error('Cloudflare source error:', error.message);
     return { error: error.message };
   }
 }
@@ -678,19 +675,19 @@ function formatReport(results) {
     ].join('\n'));
   }
 
-  // Vercel
-  if (results.vercel?.error) {
-    sections.push(`VERCEL\n└ Unavailable: ${results.vercel.error}`);
-  } else if (results.vercel) {
-    const v = results.vercel;
-    const status = v.latestStatus === 'READY' ? 'OK' : 'ERROR';
+  // Cloudflare Pages
+  if (results.cloudflare?.error) {
+    sections.push(`CLOUDFLARE (Pages)\n└ Unavailable: ${results.cloudflare.error}`);
+  } else if (results.cloudflare) {
+    const c = results.cloudflare;
+    const status = c.latestStatus === 'success' ? 'OK' : String(c.latestStatus || 'unknown').toUpperCase();
     const lines = [
-      `VERCEL`,
-      `├ Deploys: ${fmt(v.totalWeek)} (${fmt(v.successCount)} ok, ${fmt(v.errorCount)} failed)`,
-      `├ Latest: ${v.latestAge} [${status}]`
+      `CLOUDFLARE (Pages)`,
+      `├ Deploys: ${fmt(c.totalWeek)} (${fmt(c.successCount)} ok, ${fmt(c.errorCount)} failed)`,
+      `├ Latest: ${c.latestAge} [${status}]`
     ];
-    if (v.avgBuildTime != null) {
-      lines.push(`└ Avg build: ${v.avgBuildTime}s`);
+    if (c.avgBuildTime != null) {
+      lines.push(`└ Avg build: ${c.avgBuildTime}s`);
     } else {
       lines[lines.length - 1] = lines[lines.length - 1].replace('├', '└');
     }
@@ -720,7 +717,6 @@ async function sendToTelegram(env, text) {
       body: JSON.stringify({
         chat_id: chatId,
         text: msg,
-        parse_mode: 'HTML',
         disable_web_page_preview: true
       })
     });
@@ -788,6 +784,14 @@ function getWeekRange() {
   const start = weekAgo();
   const opts = { month: 'short', day: 'numeric', year: 'numeric' };
   return `${start.toLocaleDateString('en-US', opts)} - ${end.toLocaleDateString('en-US', opts)}`;
+}
+
+function formatAge(ms) {
+  const hours = Math.floor(ms / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  return `${Math.floor(ms / (1000 * 60))}m ago`;
 }
 
 function fmt(n) {

--- a/cloudflare-workers/pulse/package.json
+++ b/cloudflare-workers/pulse/package.json
@@ -16,8 +16,9 @@
     "secret:supabase-key": "wrangler secret put SUPABASE_SERVICE_ROLE_KEY",
     "secret:discord-bot": "wrangler secret put DISCORD_BOT_TOKEN",
     "secret:discord-guild": "wrangler secret put DISCORD_GUILD_ID",
-    "secret:vercel-token": "wrangler secret put VERCEL_TOKEN",
-    "secret:vercel-project": "wrangler secret put VERCEL_PROJECT_ID",
+    "secret:cloudflare-token": "wrangler secret put CLOUDFLARE_API_TOKEN",
+    "secret:cloudflare-account": "wrangler secret put CLOUDFLARE_ACCOUNT_ID",
+    "secret:cloudflare-project": "wrangler secret put CLOUDFLARE_PAGES_PROJECT",
     "secret:trigger": "wrangler secret put TRIGGER_SECRET"
   },
   "keywords": [

--- a/cloudflare-workers/pulse/wrangler.toml
+++ b/cloudflare-workers/pulse/wrangler.toml
@@ -18,8 +18,9 @@ crons = ["0 14 * * SUN"]
 # - SUPABASE_SERVICE_ROLE_KEY: Supabase service role key
 # - DISCORD_BOT_TOKEN: Discord bot token
 # - DISCORD_GUILD_ID: Discord server ID
-# - VERCEL_TOKEN: Vercel personal access token
-# - VERCEL_PROJECT_ID: Vercel project ID
+# - CLOUDFLARE_API_TOKEN: Cloudflare API token (Account > Pages > Read)
+# - CLOUDFLARE_ACCOUNT_ID: Cloudflare account ID
+# - CLOUDFLARE_PAGES_PROJECT: Cloudflare Pages project name (aitmpl-dashboard)
 # - TRIGGER_SECRET: Secret for manual /trigger endpoint
 #
 # Optional (add later):


### PR DESCRIPTION
## Context

The weekly **pulse** worker (`cloudflare-workers/pulse/`) sends a KPI report to Telegram every Sunday 14:00 UTC. It's confirmed live — the report still arrives. Two things needed fixing:

1. The dashboard **migrated off Vercel to Cloudflare Pages**, so the `VERCEL` section is obsolete and we need Cloudflare deploy metrics instead.
2. The latest report showed `GITHUB → HTTP 401 Bad credentials`. The report survived only because that error body had no HTML-special chars — but the worker was sending `parse_mode: 'HTML'` over **unescaped** text, so an error body containing `<`, `>` or `&` would make Telegram reject the message (HTTP 400) and drop the **entire** report.

## Changes

**Source swap — Vercel → Cloudflare Pages**
- Removed `collectVercel()`, the `VERCEL_API` constant, the `VERCEL` report section and the `VERCEL_TOKEN` / `VERCEL_PROJECT_ID` secrets.
- Added `collectCloudflare()` reading the Cloudflare Pages deployments API (`/accounts/{id}/pages/projects/{project}/deployments?env=production`): deploys this week, success/failure counts, latest status + age, and average build-stage duration.
- New report section renders as `CLOUDFLARE (Pages)` with the same `├`/`└` tree style.

**Delivery hardening**
- Dropped `parse_mode: 'HTML'` in `sendToTelegram()`. The report contains zero HTML markup, so HTML mode was gratuitous and only created a failure mode. Bare URLs still auto-link; `disable_web_page_preview` is kept.

**Docs / config**
- Updated `wrangler.toml`, `package.json` (secret scripts), `README.md` (setup + report example), `CLAUDE.md` and `.claude/rules/cloudflare.md` with the new secrets:
  - `CLOUDFLARE_API_TOKEN` — token with **Account › Cloudflare Pages › Read**
  - `CLOUDFLARE_ACCOUNT_ID`
  - `CLOUDFLARE_PAGES_PROJECT` — `aitmpl-dashboard`

## Required after merge (manual, not in code)

These are Cloudflare Worker secrets and must be set by the owner — they are **not** committed:

```bash
cd cloudflare-workers/pulse
# Rotate the expired GitHub PAT that caused the 401
npx wrangler secret put GITHUB_TOKEN
# New Cloudflare Pages source
npx wrangler secret put CLOUDFLARE_API_TOKEN      # Account > Pages > Read
npx wrangler secret put CLOUDFLARE_ACCOUNT_ID
npx wrangler secret put CLOUDFLARE_PAGES_PROJECT  # aitmpl-dashboard
npx wrangler deploy
```

Verify a single source without sending to Telegram:
```bash
curl -X POST "https://pulse-weekly-report.<SUBDOMAIN>.workers.dev/trigger?source=cloudflare&send=false" \
  -H "Authorization: Bearer <TRIGGER_SECRET>"
```

## Validation
- `node --check index.js` passes; no remaining `vercel` / `parse_mode` references.
- Report rendering of the new Cloudflare section verified with mock data (normal / no-build-time / source-error cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtLg6QCvmhnY5atgmYJhLM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtLg6QCvmhnY5atgmYJhLM)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Vercel deploy metrics with Cloudflare Pages in the weekly Pulse worker and removed Telegram HTML parse mode to prevent message drops. Keeps the Sunday report accurate after the dashboard moved to Cloudflare Pages.

- **Migration**
  - Area: workers (`cloudflare-workers/`) and docs (`CLAUDE.md`, `.claude/rules/cloudflare.md`, `cloudflare-workers/pulse/README.md`)
  - Swap Vercel → Cloudflare Pages: new collector reads deployments API (weekly deploys, success/failure, latest status/age, avg build time); removed Vercel section and code
  - Delivery: dropped `parse_mode: 'HTML'` so unescaped characters in error bodies no longer cause Telegram 400s
  - New secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_PAGES_PROJECT; removed: VERCEL_TOKEN, VERCEL_PROJECT_ID
  - No new components; catalog (`docs/components.json`) does not need regeneration

<sup>Written for commit 55741ad45b647c7a18ac3ed0d76d66083646daa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

