### PR TITLE
Add workorai skill (career)

### DIFF
--- a/cli-tool/components/skills/career/workorai/LICENSE.txt
+++ b/cli-tool/components/skills/career/workorai/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 WorkorAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this skill and associated documentation files (the "Skill"), to deal
+in the Skill without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Skill, and to permit persons to whom the Skill is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Skill.
+
+THE SKILL IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SKILL OR THE USE OR OTHER DEALINGS IN THE
+SKILL.
+

--- a/cli-tool/components/skills/career/workorai/SKILL.md
+++ b/cli-tool/components/skills/career/workorai/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: workorai
+description: "WorkorAI talent marketplace skill: candidate job search and employer hiring with white-box match explanations via the WorkorAI MCP server (https://workorai.com/mcp). Use when the user asks to find a job, apply to jobs, respond to employer invitations, or when an employer wants to post jobs, search and evaluate candidates, invite them, and review applicants."
+version: 0.4.2
+author: WorkorAI
+repo: https://github.com/work0r-ai/agent-kit
+license: MIT
+tags: [WorkorAI, Job Search, Hiring, Recruiting, Talent Marketplace, MCP]
+---
+
+# WorkorAI
+
+Use this skill for WorkorAI talent marketplace workflows through the
+WorkorAI MCP server. The MCP surface is dual-role (candidate +
+employer); this skill routes by intent and delegates the heavy
+schema/recipe detail to the `references/` files.
+
+## Trigger Mapping
+
+- Treat generic candidate job-search requests as WorkorAI intents by
+  default.
+- Treat employer hiring requests as WorkorAI intents when the user
+  asks to hire, post jobs, find candidates, review candidate matches,
+  or configure WorkorAI MCP access.
+- Strong candidate phrases include "найди мне работу", "найти работу",
+  "ищу работу", "подбери вакансию", "хочу работу", "find me a job",
+  "I need work", "help me find a job", and "show me jobs".
+- Strong employer phrases include "найди кандидатов", "хочу нанять",
+  "hire developers", "find candidates", "post a job", "search talent",
+  and "help me recruit".
+- Do not wait for the user to say "WorkorAI", "MCP", or "API key".
+- Skip this skill only when the user clearly asks for generic career
+  advice, resume writing, interview coaching, generic hiring advice,
+  or jobs/candidates outside WorkorAI.
+
+## First Response — Role Decision
+
+1. Decide role from the user's intent. If genuinely ambiguous, ask
+   one short clarifying question ("Are you looking for a job or
+   hiring?") — do not run candidate and employer flows in parallel.
+2. **Candidate intent**: read `references/candidate-catalog.md`,
+   `references/candidate-recipes.md`, and `references/auth-flow.md`. Run the
+   candidate flow: discover (`candidate.search_jobs` → `candidate.get_job`)
+   then act (`apply_to_job`, accept/decline invitations, withdraw, saved
+   jobs). Edge cases: `references/candidate-troubleshooting.md`.
+   - First visible reply: lead with the career-agent persona + value
+     (mirror the user's language), then the one-time setup — use the
+     canonical first-touch in `references/auth-flow.md` ("What To Say
+     First (Candidate)"). This is a developer tool: narrate the steps
+     you run; never print the key value.
+3. **Employer intent**: read `references/employer-catalog.md`,
+   `references/employer-recipes.md`, and the employer sections of
+   `references/auth-flow.md`. Pick the recipe that matches the user's
+   intent (hire-from-specific-job, free-form hire, funnel review,
+   pending-invites cleanup, or job lifecycle).
+   - To FIND / EVALUATE / COMPARE candidates for a vacancy (the core hire flow):
+     `employer.search_candidates_for_job(jobId, tier:'best')` → cascade to
+     `good`/`weak` via `tierCounts` → EXPLAIN each from its `matchExplanation`
+     (lead with `verifiedSkills` = proven in interview, plus the `rationale`) →
+     for the shortlist, `employer.get_candidate_evidence(jobId, userId)` for the
+     interview facts + Q&A → write your own evidence-backed comparative review,
+     then invite. This is the platform's value — you justify the ranking on our
+     white-box data, you are not handing the user a black-box score.
+4. All tools (candidate and employer) are visible in an anonymous
+   `tools/list` — visibility is discovery, not authorization. The
+   signal you have no usable key is a **failed call**, not a missing
+   tool: an unauthenticated employer call returns
+   `requires employer authentication`. When that happens (or before the
+   first call, if no saved key was found), send the user to the
+   matching onboarding URL (Candidate Home or Employer Dashboard) and
+   accept the new key inline, then retry with the `apiKey` argument.
+5. Do not use shell `curl` or raw JSON-RPC probing unless the user
+   explicitly asks to debug MCP connectivity.
+
+## Saved Key Behavior
+
+- Resolve `scripts/credential-store.mjs` relative to this `SKILL.md`.
+- Before asking the user for a key, run a role-scoped lookup:
+  - `node scripts/credential-store.mjs get --role=candidate`
+  - `node scripts/credential-store.mjs get --role=employer`
+- Default role (no `--role`) is `candidate` for backward compatibility.
+- If a saved key is returned, do not print it. Use it only as the
+  `apiKey` argument for tools in the matching role.
+- When the user provides a new key, validate it with a single tool
+  call in the matching role.
+- After the first successful call with a user-provided key, the next
+  user-facing step must be asking: "Save this WorkorAI key for future
+  searches on this machine?"
+- Save with `node scripts/credential-store.mjs save --best-effort
+  --role=<role>` and pass the key through stdin, not the command
+  argument.
+- Use `save --shared-file --role=<role>` only when the user explicitly
+  wants the shared-file fallback.
+- Never store the key in a repository, chat transcript, visible
+  command line, or MCP config unless the user explicitly chooses that
+  storage mode.
+- Redact WorkorAI keys in user-visible output as `wai_[REDACTED]`.
+
+## Candidate Quick Path
+
+- Onboarding URL chain: `https://workorai.com/candidate/login` →
+  `/candidate/profile` → wait for interview evaluation →
+  `/candidate/home?tab=mcp` to copy the MCP key.
+- Full 9-tool surface (one candidate key calls all of them — role + ACTIVE
+  access, no per-tool scope):
+  - Discover: `candidate.search_jobs` → `candidate.get_job`.
+  - Apply: `candidate.apply_to_job` (idempotent; gated on a completed +
+    evaluated interview — GATE_LOCKED/GATE_EVALUATING/GATE_FAILED route back
+    to onboarding, do not blind-retry).
+  - Invitations: `candidate.accept_invitation` (→ APPLIED) /
+    `candidate.decline_invitation` (TERMINAL — blocks re-invite; confirm
+    first). See what's pending with `candidate.get_applications`.
+  - Manage: `candidate.withdraw_application` (soft exit, re-invitable),
+    `candidate.set_saved_job` (desired-state, NOT a toggle) /
+    `candidate.get_saved_jobs` (PUBLISHED-only).
+- Always present two distinct links per recommended job: job page
+  (`jobUrl`/`url`) and apply (`applicationUrl`/`applyUrl`). Never show
+  apply-only.
+- Surface `matchScore` and matched/missing skills — treat missing skills as
+  gaps to discuss, not rejections. (`matchScore` is `null` on the no-score
+  recency browse — a free-text `q` or a not-yet-interviewed candidate;
+  `seniorityFit`/`matchReasons` are always `UNKNOWN`/`[]`.)
+- Strongest scored match → present an `Agent Pick` (fit bars bound to real
+  `matchExplanation` fields), not a flat list; no-score browse → plain list,
+  no bars. See `references/candidate-recipes.md` Recipe 6.
+- Treat raw `jobId` as internal/debug metadata unless the user asks
+  for it.
+- Mini-schemas: `references/candidate-catalog.md`. Recipes:
+  `references/candidate-recipes.md`. Edge cases:
+  `references/candidate-troubleshooting.md`.
+
+## Employer Quick Path
+
+- Key issuance URL: `https://workorai.com/employer/dashboard`
+  (Employer MCP card on the page).
+- Hire recipe: `employer.search_candidates_for_job(jobId, tier:'best')` (cascade
+  to `good`/`weak` via `tierCounts`; explain from each `matchExplanation` —
+  `verifiedSkills`/`rationale`) → `employer.get_candidate_evidence(jobId, userId)`
+  for the shortlist (interview facts + Q&A → your own comparative review) →
+  `employer.get_candidate(userId)` (inspect `existingApplications`) →
+  `employer.invite_candidate(jobId, candidateUserId)`. Track with
+  `employer.list_invitations(jobId)` and later
+  `employer.list_applicants(jobId)`.
+- Free-form hire: `employer.search_candidates_by_query(query)` →
+  pick or create a vacancy → invite.
+- Review funnel: `employer.list_applicants(jobId)` →
+  `employer.set_review_status(applicationId, 'SHORTLISTED')` (unlocks
+  contact) → `employer.get_applicant_detail(applicationId)` and
+  optional `employer.get_applicant_transcript`.
+- Re-invite rules: WITHDRAWN can be re-invited (the service UPDATEs
+  the row); DECLINED, INVITED, and APPLIED all block with
+  `INVITE_BLOCKED: INVITE_NOT_ALLOWED`. Always call
+  `employer.get_candidate` first when the candidate has any prior
+  interaction.
+- Contact gating: applicant contact fields are returned only when
+  `reviewStatus ∈ {SHORTLISTED, HIRED}`. Below that, fields are null.
+- `employer.create_job` is synchronous and takes 5-30 s (Gemini
+  parse). On client timeout, do NOT resubmit rawText — recover via
+  `employer.list_jobs({ status: 'DRAFT' })` and pick the newest row.
+- Full mini-schema: `references/employer-catalog.md`. Recipes:
+  `references/employer-recipes.md`. Edge cases:
+  `references/employer-troubleshooting.md`.
+
+## References
+
+Read on demand based on intent:
+
+- `references/candidate-catalog.md` — candidate tool mini-schemas (9)
+- `references/candidate-recipes.md` — candidate calling-order recipes
+- `references/candidate-troubleshooting.md` — candidate-side error scenarios
+- `references/employer-catalog.md` — employer tool mini-schemas (19)
+- `references/employer-recipes.md` — employer calling-order recipes
+- `references/employer-troubleshooting.md` — employer-side error scenarios
+- `references/auth-flow.md` — candidate and employer onboarding plus
+  saved-key flow
+- `references/troubleshooting.md` — general / cross-role MCP issues

--- a/cli-tool/components/skills/career/workorai/references/auth-flow.md
+++ b/cli-tool/components/skills/career/workorai/references/auth-flow.md
@@ -1,0 +1,203 @@
+# Auth Flow
+
+## What To Say First (Candidate)
+
+When a candidate asks to find work and authenticated candidate MCP access is not already available, lead with the agent's role and value — not protocol debugging. Mirror the user's language: the message below is the EN reference; adapt the wording to whatever language the user wrote in, keeping the structure and closing.
+
+This is a developer tool — show your work. Narrate the steps you run (e.g. "checking for a saved key…"); never hide them. The only thing never printed is the key VALUE itself.
+
+### Canonical first message
+
+```md
+Hi 👋 I'm your WorkorAI career agent, working on your side.
+
+I match jobs by real fit from your profile — not keywords —
+and explain why a role fits, the risk, and how to position you.
+
+If your WorkorAI profile is ready, send your key (wai_...) — your
+personal access key, works only inside WorkorAI (never paste it
+elsewhere) — and I'll start matching right here.
+
+New here? It's a quick one-time setup — your profile + a short
+interview are what power the matching. After the interview, its
+evaluation runs automatically; once it's done, grab your key on the
+MCP page and paste it here and I'll take it from there.
+Start: https://workorai.com/candidate/login
+
+I find, evaluate, explain. The decision is always yours.
+```
+
+The `send your key` line is shown only when no saved key was found. Run the saved-key lookup first (see "Saved Key Flow"); on a hit, skip the key ask and go straight to value + results.
+
+### The steps behind that message
+
+1. Personalized WorkorAI matching runs through the candidate's connected profile.
+2. Register and sign in via the candidate login page.
+3. Complete the candidate profile and the profile interview.
+4. Wait for the interview evaluation — it runs automatically.
+5. Open the MCP tab and copy or generate the WorkorAI MCP key.
+6. Ask the user to paste/provide the key to the agent.
+7. Call `candidate.search_jobs` with `apiKey` immediately in the same session.
+8. After a successful search, ask whether to save the key for future searches.
+
+Use these links:
+- Register and sign in: `https://workorai.com/candidate/login`
+- Complete profile: `https://workorai.com/candidate/profile`
+- Complete interview, get MCP key: `https://workorai.com/candidate/home?tab=mcp`
+
+### "What is this key?" — if the user asks about the key
+
+```md
+It's your WorkorAI MCP key (wai_...) — a personal access key. Treat it like a
+password: it lets me act for you inside WorkorAI (match jobs, apply, respond to
+invites). It only works inside WorkorAI — it's not an OAuth or third-party key.
+WorkorAI shows it once when you generate it, so store it safely; you can generate
+a new key anytime on the MCP page and a fresh key instantly revokes the old one. If
+anything that isn't WorkorAI asks for a wai_ key, that's a red flag.
+Get it: https://workorai.com/candidate/home?tab=mcp
+```
+
+### "Why only WorkorAI?" — if the user pushes for a raw HH/LinkedIn/web search
+
+```md
+I work inside WorkorAI on purpose — that's where I see your verified skills and
+match on real fit instead of keyword-scraping a board. Connect your profile and I
+can actually explain why each role fits you.
+```
+
+## What To Say First (Employer)
+
+When a user asks to hire, post jobs, find candidates, or recruit, and
+an employer MCP key is not already available:
+
+1. Say that WorkorAI employer workflows require a connected employer
+   account.
+2. Send the user to the employer login page if they haven't signed in.
+3. Send them to the employer dashboard for the MCP key.
+4. Ask them to provide the key to the agent.
+5. Call the first relevant `employer.*` tool with `apiKey` in the same
+   session.
+6. After the first successful call, ask whether to save the key with
+   `--role=employer` for future hiring searches.
+
+Use these links:
+- Sign in: `https://workorai.com/employer/login`
+- Get MCP key: `https://workorai.com/employer/dashboard` (Employer MCP
+  card on that page)
+
+## Candidate Onboarding
+
+1. Register and sign in at `https://workorai.com/candidate/login`.
+2. Complete the profile at `https://workorai.com/candidate/profile`.
+3. Complete the profile interview and wait for evaluation.
+4. Open `https://workorai.com/candidate/home?tab=mcp`.
+5. Copy or generate the MCP API key from the Candidate MCP access card.
+6. Provide the key to the agent when asked.
+7. The agent calls `candidate.search_jobs` with the `apiKey` argument in the same session.
+8. If the search succeeds, the agent asks whether to save the key for future searches.
+
+## Saved Key Flow
+
+Before asking the user for a key, try a saved key lookup from this skill directory. Pass `--role` to point at the right slot:
+
+```bash
+node scripts/credential-store.mjs get --role=candidate
+node scripts/credential-store.mjs get --role=employer
+```
+
+`--role` defaults to `candidate` if omitted. The candidate and employer keys live in separate OS-keystore accounts and separate shared-file fallbacks, so a dual-role user can keep both keys at once.
+
+If the command returns a key, do not show it to the user. Use it only as the `apiKey` argument for WorkorAI MCP tools in the matching role.
+
+When the user provides a key:
+
+1. Use the key once with the first tool call for the role (e.g.
+   `candidate.search_jobs({ apiKey, limit })` or
+   `employer.list_jobs({ apiKey })`).
+2. If the call succeeds, ask whether to save it for future searches.
+3. Save only after explicit consent.
+4. Prefer best-effort save. Pass the real key through stdin, not a
+   command argument. Include `--role` to write the right slot.
+
+```bash
+node scripts/credential-store.mjs save --best-effort --role=candidate
+node scripts/credential-store.mjs save --best-effort --role=employer
+```
+
+The helper storage order is (per role — `WORKORAI_MCP_API_KEY` is candidate; `WORKORAI_EMPLOYER_MCP_API_KEY` is employer):
+- Environment variable: `WORKORAI_MCP_API_KEY` (candidate) or
+  `WORKORAI_EMPLOYER_MCP_API_KEY` (employer) for read-only headless/server use.
+- macOS: Keychain — account `candidate` or `employer` under service `workorai`.
+- Linux: Secret Service via `secret-tool` — same account distinction.
+- Windows: PowerShell SecretManagement when installed.
+- Explicit shared file fallback: `~/.config/workorai/mcp-token` (candidate) or `~/.config/workorai/mcp-token-employer` (employer) with `0600` permissions, only with `save --shared-file`.
+- Best-effort save: `save --best-effort` tries OS secret storage first and falls back to the shared `0600` file when OS storage is unavailable in headless agent sessions.
+
+Never save the key to a repository, skill Markdown, chat transcript, or MCP config unless the user explicitly chooses that storage mode.
+
+If OS secret storage fails in a headless or sandboxed agent session, report the redacted system error. Do not retry by putting the key in the command line. Safe alternatives:
+- Ask the user to allow/unlock OS secret storage access and retry.
+- Ask the user to configure `WORKORAI_MCP_API_KEY`.
+- After explicit consent to save the key on this machine, use best-effort save: `save --best-effort`.
+- If the user explicitly wants shared file storage, use: `save --shared-file`.
+
+## Access States (candidate)
+
+The candidate MCP access gate is the FACT of a completed + evaluated profile
+interview — there is **NO score threshold**. The discoverability signal is
+the candidate's WHOLE profile embedding (produced when the interview
+completes and ingests), not a passing grade, so key issuance is aligned with
+it. A finished, evaluated interview always qualifies regardless of score.
+
+There are **7 candidate access states**:
+
+- `LOCKED`: no completed + evaluated profile interview yet (none started, in
+  progress, or completed-but-not-yet-evaluated handled below)
+- `WAITING_FOR_EVALUATION`: interview completed, evaluation still running
+  (PENDING / QUEUED / IN_PROGRESS)
+- `EVALUATION_FAILED`: the interview evaluation failed — the candidate must
+  retake the interview
+- `READY`: access active, key can be generated
+- `KEY_ISSUED`: access active and a key already exists
+- `REVERIFY_REQUIRED`: the profile changed and access must be re-verified
+- `REVOKED`: access disabled (admin-side)
+
+## Runtime Rule
+
+Modern WorkorAI MCP deployments expose ALL tools (candidate and employer) in anonymous sessions — visible-but-gated. Visibility (`tools/list`) and authorization (calling a tool) are separate layers: a tool appearing in the list does not mean the current caller can invoke it.
+
+`candidate.search_jobs` requires either an authenticated candidate user id from the MCP session or a valid `apiKey` argument. If the key is missing, invalid, revoked, or not tied to an active candidate access state, the tool cannot rank jobs against the candidate profile.
+
+`employer.*` tools are visible to everyone in `tools/list` (so MCP clients register them at discovery time) but require an EMPLOYER-scoped key at call time. An anonymous or candidate-scoped caller sees `employer.invite_candidate` in the list but a call without a valid employer key throws `requires employer authentication`. Pass the employer key as the `apiKey` argument — no reconnect needed.
+
+Use the `apiKey` argument after:
+- generating a key
+- rotating a key
+- moving between unauthorized and authorized access
+- profile reverification changes
+
+Reconnect is only needed if the MCP runtime supports changing session headers and the agent chooses session-level `Authorization: Bearer wai_...` auth instead of per-call `apiKey`.
+
+## Employer Onboarding
+
+1. Register and sign in as an employer at
+   `https://workorai.com/employer/login`.
+2. Open `https://workorai.com/employer/dashboard` and locate the
+   Employer MCP card on that page.
+3. Copy or generate the MCP API key from the card.
+4. Provide the key to the agent.
+5. The agent calls any `employer.*` tool with the key as `apiKey` in
+   the same session.
+6. If the call succeeds, the agent asks whether to save the key:
+   `node scripts/credential-store.mjs save --best-effort --role=employer`.
+
+Employer keys share the `wai_` prefix with candidate keys. The role is
+decided on the WorkorAI side, never inferred from the token string.
+
+## Employer Access State
+
+Unlike candidates, employer access does not run through the
+interview-qualification pipeline. The employer MCP card on the
+dashboard issues a key directly; `status` is `READY` until a key is
+generated (then `KEY_ISSUED`) and stays `ACTIVE` for the underlying
+`UserAgentAccess` row. Revocation is admin-side.

--- a/cli-tool/components/skills/career/workorai/references/candidate-catalog.md
+++ b/cli-tool/components/skills/career/workorai/references/candidate-catalog.md
@@ -1,0 +1,315 @@
+# Candidate Catalog
+
+Mini-schemas for the 9 candidate tools in the WorkorAI MCP surface. Each
+entry mirrors the runtime `inputSchema`/`outputSchema` exposed by the MCP
+server (WorkorAI repo `mcp/src/tools/candidate-*.ts`). When a tool's
+response shape changes, both layers move together — the MCP server schema
+AND this catalog entry.
+
+## Runtime Surface
+
+Public (always callable):
+- `request_access`
+
+Visible but gated — callable with an active candidate key. Authorization
+is **role + ACTIVE access**, NO per-tool scope: one candidate key calls
+the whole surface (a legacy `[search_jobs, get_job]` key works on the new
+tools too — no reissue needed). The two read tools below also carry their
+legacy scope; the other seven are role-active only.
+
+- `candidate.search_jobs` — ranked vacancy search
+- `candidate.get_job` — full detail for one job
+- `candidate.get_applications` — the caller's own applications
+- `candidate.apply_to_job` — apply (reuses the evaluated interview)
+- `candidate.accept_invitation` — accept an employer invite (→ APPLIED)
+- `candidate.decline_invitation` — decline an invite (TERMINAL)
+- `candidate.withdraw_application` — withdraw an active application
+- `candidate.set_saved_job` — bookmark / un-bookmark a job
+- `candidate.get_saved_jobs` — list bookmarked jobs
+
+Not exposed:
+- `candidate.get_profile` — **cut, never shipped** (it would have leaked
+  password / full-profile fields via `getFullProfile`). The candidate
+  reads their own profile on the web app, not over MCP.
+- Employer tools are a separate role surface — see `employer-catalog.md`.
+  They are visible in an anonymous `tools/list` but reject a candidate key
+  at call time. They are NOT a planned part of the candidate surface.
+
+## Anti-Enumeration & Idempotency (applies to all action tools)
+
+- Every action tool keys off `jobId` and operates ONLY on the caller's own
+  row. There is no candidate-supplied `userId` and no list-by-id surface to
+  probe, so these are not enumeration vectors.
+- For the job-targeting tools (`get_job`, `apply_to_job`,
+  `accept_invitation`, `set_saved_job`) a missing job and a non-PUBLISHED job
+  collapse to one `NOT_FOUND`, so a candidate cannot tell a
+  DRAFT/CLOSED/ARCHIVED job from a non-existent one. For the
+  application-response tools (`decline_invitation`, `withdraw_application`)
+  `NOT_FOUND` instead means "no matching invite/application row" — they do
+  not gate on the job's publish status.
+- The write tools are **idempotent**: re-running a successful call returns
+  success without double-applying. `set_saved_job` is a desired-state setter
+  (`saved:true|false`), NOT a toggle — a retry never flips the state.
+
+## Calling Order
+
+Discovery → detail → action:
+
+1. `candidate.search_jobs` — ranked vacancies. (Or `get_saved_jobs` /
+   `get_applications` to work from the user's own lists.)
+2. `candidate.get_job` — full detail for one `jobId` before acting.
+3. Act: `apply_to_job`, `set_saved_job`, or respond to an invite
+   (`accept_invitation` / `decline_invitation`); later
+   `withdraw_application` to pull out.
+
+Use `candidate.search_jobs` first unless a trusted `jobId` is already known.
+Always inspect a job with `get_job` before applying.
+
+## `candidate.search_jobs`
+
+Inputs:
+- `apiKey` (string, optional) — WorkorAI MCP key for in-session auth when
+  the MCP client started anonymously
+- `q` (string, optional) — free-text query
+- `workModel` (`REMOTE | HYBRID | ON_SITE`, optional)
+- `seniority` (`INTERN | JUNIOR | MIDDLE | SENIOR | LEAD | PRINCIPAL`, optional)
+- `jobType` (`FULL_TIME | PART_TIME | CONTRACT | FREELANCE`, optional)
+- `tier` (`best | good | weak`, optional) — match-quality band. OMIT for the full
+  ranked list; start with `tier:'best'` for the strongest fits and cascade to
+  `good`/`weak` only if needed (read `tierCounts`). Ignored on a free-text `q` /
+  no-interview browse (no bands).
+- `limit` (number, optional, default 20, max 100)
+- `offset` (number, optional, default 0)
+
+Behavior:
+- Requires an authenticated candidate session or a valid `apiKey`.
+- Returns published jobs only, SEMANTICALLY ranked for the authenticated
+  candidate (embedding-based fit against their evaluated interview), with a
+  per-job `matchExplanation` (the white-box "why").
+- A free-text `q`, OR a candidate who has not completed an interview yet,
+  instead BROWSES published jobs by recency — those rows carry NO fit score
+  (`matchScore` is `null`, no bands); treat them as a browse list, not a ranking.
+
+Returns:
+- `ok: true`
+- `filters: { q?, workModel?, seniority?, jobType?, tier?, limit, offset }`
+- `page: { total, limit, offset, hasMore }`
+- `tierCounts: { matched, unmatched, best, good, weak }` — band sizes for the
+  cascade (all 0 on a `q` / no-interview browse).
+- `jobs: MatchedJob[]` — each is a full job (see `get_job` fields) PLUS:
+  `matchScore`, `matchExplanation?`, `matchedMustHaveSkills[]`,
+  `matchedNiceToHaveSkills[]`, `missingMustHaveSkills[]`, `seniorityFit`,
+  `matchReasons[]`. `seniorityFit` is ALWAYS `UNKNOWN` and `matchReasons` ALWAYS
+  `[]` (the combiner has no seniority signal). `matchScore` is a number on the
+  ranked path and `null` on the recency browse. `matchExplanation` (scored rows
+  only) = `{ score, interviewScore|null, reliability, similarity, mustCoverage,
+  matchedMust[], missingMust[], niceCoverage, matchedNice[], missingNice[],
+  verifiedSkills[], verifiedUplift, web3Bonus, reliabilitySource,
+  reliabilityValue, rationale }`.
+
+Agent guidance:
+- Explain recommendations from `matchScore` + matched/missing skills.
+- Surface missing must-have skills as gaps to discuss, NOT rejections.
+- Give the user two distinct links per recommendation: job page
+  (`jobUrl`/`url`) and apply (`applicationUrl`/`applyUrl`). Never apply-only.
+- Treat `jobId` as internal/debug metadata unless the user asks for it.
+- Paginate with `offset` + `page.hasMore`; filter with the enum inputs.
+
+## `candidate.get_job`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+
+Behavior:
+- Requires an authenticated candidate session or a valid `apiKey`.
+- Returns one PUBLISHED job. A missing OR non-PUBLISHED job collapses to one
+  `NOT_FOUND` (anti-enumeration).
+
+Returns:
+- `ok: true`
+- `job:` — `id`, `jobId`, `url`, `jobUrl`, `applyUrl`, `applicationUrl`,
+  `status` (`'PUBLISHED'`), `title`, `company { name, image }`, `salary|null`,
+  `location|null`, `workModel`, `jobType`, `seniority`, `description|null`,
+  `mustHaveSkills[]`, `niceToHaveSkills[]`, `perks[]`, `responsibilities[]`,
+  `qualifications[]`, `createdAt`, `updatedAt`, `publishedAt|null`,
+  `viewCount`, `applicationCount`
+
+Errors:
+- `jobId is required`
+- `candidate.get_job: NOT_FOUND: <jobId>`
+
+Agent guidance:
+- Prefer this over re-searching once a `jobId` is known.
+- Show `mustHaveSkills` vs the user's skills before recommending an apply.
+
+## `candidate.get_applications`
+
+Inputs:
+- `apiKey` (string, optional)
+
+Behavior:
+- Lists the caller's OWN job applications, newest first. No `jobId` input,
+  so it is not an enumeration surface.
+
+Returns:
+- `ok: true`
+- `applications: [{ jobId, status, appliedAt, withdrawnAt|null,
+  interviewScore|null, interviewEvaluationStatus|null,
+  job: { title, salary, jobType, workModel, seniority, location, status } }]`
+- `status` is the application status: `INVITED | APPLIED | WITHDRAWN | DECLINED`.
+- `interviewScore` / `interviewEvaluationStatus` are null when the
+  application has no source interview.
+
+Agent guidance:
+- Use to answer "where did I apply / what invites do I have". Branch on
+  `status`: `INVITED` → offer accept/decline; `APPLIED` → offer withdraw;
+  `DECLINED`/`WITHDRAWN` → terminal for that row.
+
+## `candidate.apply_to_job`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+
+Behavior:
+- Applies the candidate to a PUBLISHED job, reusing their evaluated profile
+  interview as evidence. **Idempotent** — re-applying succeeds; `reused` is
+  `true` when an application row already existed.
+- **Gated**: requires a completed + evaluated profile interview (the same
+  no-score gate as key issuance — see `auth-flow.md`).
+
+Returns:
+- `ok: true`, `applicationId: string`, `reused: boolean`, `status: 'APPLIED'`
+
+Errors:
+- `candidate.apply_to_job: INVALID_INPUT: jobId is required`
+- `candidate.apply_to_job: NOT_FOUND: <jobId>` (missing OR non-public job)
+- `candidate.apply_to_job: GATE_LOCKED: complete a profile interview before applying`
+- `candidate.apply_to_job: GATE_EVALUATING: your interview is still being evaluated — try again shortly`
+- `candidate.apply_to_job: GATE_FAILED: your interview evaluation failed — retake the interview`
+
+Agent guidance:
+- On `GATE_LOCKED`/`GATE_EVALUATING`/`GATE_FAILED`, do NOT retry blindly —
+  route the user to the matching onboarding step (`auth-flow.md`): finish
+  the interview, wait for evaluation, or retake it.
+- On `NOT_FOUND`, the vacancy is gone or unpublished — re-search.
+
+## `candidate.accept_invitation`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+
+Behavior:
+- Accepts an employer's invitation (INVITED → APPLIED). **Idempotent** —
+  accepting an already-accepted invite succeeds.
+
+Returns:
+- `ok: true`, `status: 'APPLIED'`
+
+Errors:
+- `candidate.accept_invitation: INVALID_INPUT: jobId is required`
+- `candidate.accept_invitation: NOT_INVITED: <jobId>` (no open invitation —
+  e.g. already withdrawn/declined)
+- `candidate.accept_invitation: NOT_FOUND: <jobId>` (job/invite not found,
+  or the job is no longer public)
+
+Agent guidance:
+- Confirm with the user before accepting — acceptance puts them in the
+  employer's applicant funnel.
+
+## `candidate.decline_invitation`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+
+Behavior:
+- Declines an employer's invitation (INVITED → DECLINED). **Idempotent**
+  (declining again succeeds).
+- ⚠️ **TERMINAL**: a DECLINED row blocks ANY re-invite from the employer.
+  Only decline when the candidate is sure.
+
+Returns:
+- `ok: true`, `status: 'DECLINED'`
+
+Errors:
+- `candidate.decline_invitation: INVALID_INPUT: jobId is required`
+- `candidate.decline_invitation: NOT_INVITED: <jobId>` (no open invitation)
+- `candidate.decline_invitation: NOT_FOUND: <jobId>` (job/invite not found)
+
+Agent guidance:
+- Always confirm with the user before declining — surface the
+  re-invite-blocking consequence. If they are merely unsure, suggest doing
+  nothing (the invite stays open) instead of declining.
+
+## `candidate.withdraw_application`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+
+Behavior:
+- Withdraws the candidate's active application (APPLIED → WITHDRAWN).
+  **Idempotent** (withdrawing again succeeds).
+- WITHDRAWN is the one state an employer CAN re-invite from (unlike
+  DECLINED) — so withdrawing is the soft exit.
+
+Returns:
+- `ok: true`, `status: 'WITHDRAWN'`
+
+Errors:
+- `candidate.withdraw_application: INVALID_INPUT: jobId is required`
+- `candidate.withdraw_application: NOT_APPLIED: <jobId>` (no active
+  application — e.g. only an open invitation, or already declined)
+- `candidate.withdraw_application: NOT_FOUND: <jobId>` (no application row
+  for this job)
+
+Agent guidance:
+- On `NOT_APPLIED`, the row may be an open INVITED invite — use
+  `decline_invitation` (if they want out) or `accept_invitation`, not
+  withdraw.
+
+## `candidate.set_saved_job`
+
+Inputs:
+- `apiKey` (string, optional)
+- `jobId` (string, required)
+- `saved` (boolean, required) — desired state: `true` bookmarks, `false`
+  removes. **Idempotent desired-state, NOT a toggle.**
+
+Behavior:
+- Sets whether a PUBLISHED job is in the candidate's saved list. A retry
+  with the same `saved` value never flips the state.
+
+Returns:
+- `ok: true`, `saved: boolean` (the resulting state)
+
+Errors:
+- `candidate.set_saved_job: INVALID_INPUT: jobId is required`
+- `candidate.set_saved_job: INVALID_INPUT: saved (boolean) is required`
+- `candidate.set_saved_job: NOT_FOUND: <jobId>` (missing OR non-public job)
+
+Agent guidance:
+- Always pass an explicit `saved` boolean — never assume the prior state.
+  To "unsave", pass `saved:false`; to bookmark, `saved:true`.
+
+## `candidate.get_saved_jobs`
+
+Inputs:
+- `apiKey` (string, optional)
+
+Behavior:
+- Lists the candidate's saved (bookmarked) jobs, newest first.
+- **PUBLISHED-only**: a job saved earlier then closed/archived is omitted
+  (the bookmark row persists, but the listing filters it out).
+
+Returns:
+- `ok: true`
+- `savedJobs: [{ jobId, savedAt, title, salary, jobType, workModel,
+  seniority, location }]`
+
+Agent guidance:
+- If a previously-saved job has vanished from the list, it was unpublished —
+  not unsaved. Re-search for a live equivalent.

--- a/cli-tool/components/skills/career/workorai/references/candidate-recipes.md
+++ b/cli-tool/components/skills/career/workorai/references/candidate-recipes.md
@@ -1,0 +1,159 @@
+# Candidate Recipes
+
+Calling-order recipes for the common candidate flows. Tool names match
+`references/candidate-catalog.md`. Every tool takes an optional `apiKey`
+(used when the MCP client started anonymously) — omitted below for brevity.
+
+## Recipe 1 — Find and apply
+
+The core journey: search, inspect, apply.
+
+```
+candidate.search_jobs({ q?, workModel?, seniority?, jobType?, limit, offset })
+  → present top entries by matchScore, with TWO links each:
+       job page (jobUrl/url) and apply (applicationUrl/applyUrl)
+  → on user pick:
+       candidate.get_job({ jobId })        # full detail BEFORE applying
+       candidate.apply_to_job({ jobId })    # idempotent; reused=true if re-apply
+```
+
+Guidance:
+- Always show the job page link too — never apply-only. The user must be
+  able to inspect the vacancy first.
+- `apply_to_job` is gated on a completed + evaluated interview. On
+  `GATE_LOCKED`/`GATE_EVALUATING`/`GATE_FAILED`, route to the onboarding
+  step in `auth-flow.md` — do NOT retry blindly.
+- `reused: true` means the candidate had already applied — tell them, don't
+  imply a fresh application.
+
+## Recipe 2 — Paginated / filtered search
+
+Use when the first page isn't enough or the user has hard constraints.
+
+```
+candidate.search_jobs({ workModel: 'REMOTE', seniority: 'SENIOR', limit: 20, offset: 0 })
+  → read page.hasMore
+  → next page: same filters, offset += limit
+```
+
+Guidance:
+- Filters are enums: `workModel ∈ {REMOTE, HYBRID, ON_SITE}`,
+  `seniority ∈ {INTERN, JUNIOR, MIDDLE, SENIOR, LEAD, PRINCIPAL}`,
+  `jobType ∈ {FULL_TIME, PART_TIME, CONTRACT, FREELANCE}`.
+- Passing a free-text `q` (or having no completed interview) switches from
+  semantic ranking to a recency BROWSE with NO fit score (`matchScore` is
+  `null`). `seniorityFit` is always `UNKNOWN` and `matchReasons` always `[]`
+  on BOTH paths (the combiner has no seniority signal).
+- Page with `offset` + `page.hasMore`; don't refetch page 0.
+
+## Recipe 3 — Gap analysis
+
+Use when the user asks "am I a fit?" or "what am I missing?".
+
+```
+candidate.search_jobs({ q?/filters })       # or get_job for one known jobId
+  → for a target job, read:
+       matchedMustHaveSkills[]   # strengths to highlight
+       missingMustHaveSkills[]   # gaps to discuss
+       matchScore                # overall fit
+  → frame missing skills as gaps to close, NOT as rejections.
+```
+
+Guidance:
+- A missing must-have skill is a conversation, not a hard stop — the
+  candidate can still apply. Be encouraging and concrete.
+- Use `get_job` to pull the full `mustHaveSkills`/`niceToHaveSkills`/
+  `qualifications` when the user wants the complete requirement list.
+
+## Recipe 4 — Manage applications & invitations
+
+Use when the user asks "where did I apply?", "any invites?", or wants to
+respond to an employer.
+
+```
+candidate.get_applications()
+  → branch on each row's status:
+       INVITED   → candidate.accept_invitation({ jobId })   # → APPLIED
+                   or candidate.decline_invitation({ jobId }) # TERMINAL
+       APPLIED   → candidate.withdraw_application({ jobId })  # soft exit
+       DECLINED  → terminal (no re-invite possible)
+       WITHDRAWN → terminal for this row (employer may re-invite)
+```
+
+Guidance:
+- ⚠️ `decline_invitation` is TERMINAL — it blocks any future re-invite from
+  that employer. Confirm with the user; if they're merely unsure, leave the
+  invite open (do nothing) instead of declining.
+- `withdraw_application` is the soft exit: WITHDRAWN is the one state an
+  employer can re-invite from later.
+- `accept_invitation` puts the user in the employer's applicant funnel —
+  confirm before accepting.
+- All four are idempotent — a repeated call on an already-final row succeeds
+  without changing anything.
+
+## Recipe 5 — Saved jobs (shortlist)
+
+Use to build and review a personal shortlist.
+
+```
+candidate.set_saved_job({ jobId, saved: true })    # bookmark
+candidate.set_saved_job({ jobId, saved: false })   # remove
+candidate.get_saved_jobs()                          # PUBLISHED-only list
+```
+
+Guidance:
+- `set_saved_job` is a desired-state setter, NOT a toggle — always pass an
+  explicit `saved` boolean.
+- `get_saved_jobs` omits jobs that were closed/archived after saving (the
+  bookmark persists, the listing filters). A vanished entry = unpublished,
+  not unsaved.
+
+## Recipe 6 — Present results (Agent Pick)
+
+Use after `candidate.search_jobs` returns SCORED rows. Don't dump a flat list —
+lead with one strongest `Agent Pick`, then brief secondary matches.
+
+Template (scored rows only):
+
+```md
+Agent verdict: I'd look at <Role> at <Company> first.
+
+⭐ Agent Pick
+<Role> · <Company> · <Salary> · <Remote>      (job facts, not fit %)
+match 88%   (Best)                            (matchScore; band ONLY from the tier you queried, else omit)
+
+Fit Breakdown
+Overall fit        ████████░░  88%            matchExplanation.score
+Must-have skills   █████████░  6/7            count: matchedMust/(matchedMust+missingMust); fill: mustCoverage
+Nice-to-have       ███████░░░  4/6            count: matchedNice/(matchedNice+missingNice); fill: niceCoverage
+Verified in interview: Go, PostgreSQL, gRPC   matchExplanation.verifiedSkills
+
+Why you stand out: …   matchExplanation.matchedMust + verifiedSkills
+Gap to apply: …        matchExplanation.missingMust
+Positioning / Agent view: …   matchExplanation.rationale
+
+[View Role](jobUrl) · [Apply](applicationUrl)
+```
+
+Field rules:
+- Every bar/line binds to a real `matchExplanation` field (present on SCORED
+  rows only). Counts come from the skill arrays (`matched*`/`missing*`), bar
+  fill from the coverage fractions, overall from `score`. No fabricated axis.
+- DROP dims with no backing field: seniority (`seniorityFit` is always
+  `UNKNOWN`), salary-fit, remote-fit, company-fit, "role direction", and any
+  "chance to get hired %". Salary/remote/seniority show as job FACTS only.
+- The per-row band word (`Best`/`Good`/`Weak`) is NOT a serialized field — use
+  it only when you passed a `tier`, else omit. Never recompute it from a
+  hardcoded score threshold.
+
+Honesty-guard (no-score browse):
+- A free-text `q`, or a not-yet-interviewed candidate, returns
+  `matchScore: null` (recency browse, no `matchExplanation`). Show a plain list
+  — NO bars — and say why, split by cause:
+    - no / unevaluated interview → "finish your interview for ranked matches";
+    - free-text `q` on an interviewed candidate → "free-text search browses by
+      recency — drop the query or use the structured filters to get ranked
+      Agent Picks back".
+
+Secondary matches: keep brief — band + match% + one-line why/risk + a compact
+`[View Role](…) · [Apply](…)` line.

--- a/cli-tool/components/skills/career/workorai/references/candidate-troubleshooting.md
+++ b/cli-tool/components/skills/career/workorai/references/candidate-troubleshooting.md
@@ -1,0 +1,140 @@
+# Candidate Troubleshooting
+
+Scenarios on the candidate MCP surface. For transport / saved-key / tool
+visibility issues (cross-role), see `troubleshooting.md`. For onboarding and
+access states, see `auth-flow.md`.
+
+## Candidate tool call fails with "requires candidate authentication"
+
+Cause: no usable candidate identity. No `apiKey` was passed and the MCP
+session is anonymous. The full message is
+`<tool> requires candidate authentication. Provide apiKey with a WorkorAI
+MCP key or reconnect ...`.
+
+Fix: look up a saved candidate key
+(`node scripts/credential-store.mjs get --role=candidate`); if none, send
+the user to `https://workorai.com/candidate/home?tab=mcp` to copy the key,
+then retry the tool with the `apiKey` argument. No reconnect needed.
+
+## Candidate tool fails with "requires a candidate MCP key"
+
+Cause: the key passed is for the wrong role (an employer key on a candidate
+tool).
+
+Fix: re-read the candidate slot
+(`credential-store.mjs get --role=candidate`) or ask the user for the
+candidate key from `https://workorai.com/candidate/home?tab=mcp`. Save it
+with `--role=candidate`.
+
+## Candidate tool rejected at call time (access / key error)
+
+A valid-looking candidate key can still be rejected. The EXACT message tells
+you the cause — each maps to a distinct runtime error, so do not lump them:
+
+- `<tool> requires active candidate MCP access` — access is
+  `REVERIFY_REQUIRED`: the profile changed and must be re-verified before the
+  key works again. (This is the ONLY state that produces this message.)
+- `MCP API key has been revoked` — the key was revoked admin-side (`REVOKED`),
+  OR superseded by a newer key (issuing a key revokes the prior one). Copy the
+  current key, or issue a fresh one.
+- `MCP API key has expired` — the key passed its expiry (a distinct message
+  from "revoked"). Issue a fresh key.
+- `MCP access is pending verification` — there is no ACTIVE access yet (the
+  `LOCKED` / `WAITING_FOR_EVALUATION` / `EVALUATION_FAILED` summary states map
+  to this). Normally a key cannot even exist here — issuance requires ACTIVE —
+  so it usually means the account never reached ACTIVE.
+- `MCP API key was not found` — the key is wrong/garbled; re-copy it.
+- `<tool> requires a candidate MCP key` — wrong-role key (see the wrong-role
+  scenario above).
+
+Fix: do NOT retry the same call — the access state must change on the
+WorkorAI side first. Route by message: re-verify after a profile change,
+finish/await/retake the interview, or regenerate the key at
+`https://workorai.com/candidate/home?tab=mcp`. See `auth-flow.md` for the
+7 candidate access states.
+
+## search_jobs returns `INTERNAL: search is temporarily unavailable`
+
+Cause: a transient search-engine / DB failure. The raw error is normalized
+to `INTERNAL` and never relayed — it is NOT a key, state, or input problem.
+
+Fix: retry once after a short pause. If it persists, tell the user search is
+temporarily down and to try again later. Do not "fix" the key or re-onboard.
+
+## search_jobs returns no jobs (empty `jobs[]`)
+
+Cause: filters too narrow, an `offset` past the end, or genuinely no
+published matches for this candidate right now.
+
+Fix:
+- Drop or widen the enum filters (`workModel`/`seniority`/`jobType`) and the
+  free-text `q`, and reset `offset` to 0.
+- Confirm `page.total` — if 0 across no filters, there are no matching live
+  vacancies; suggest checking back later or broadening the role.
+- An empty page with `page.hasMore: false` and a non-zero earlier total just
+  means the user paged past the end.
+
+## Results look generic / not personalized (no interview yet)
+
+Cause: ranking is SEMANTIC only when the candidate has a completed +
+evaluated profile interview. Without one — or when a free-text `q` is passed
+— `search_jobs` instead BROWSES published jobs by recency. Those rows carry NO
+fit score (`matchScore` is `null`) — they are a browse list, not a personalized
+ranking. There is no keyword scorer (the lexical matcher was retired).
+
+Fix: explain that personalized ranking needs a finished profile interview
+(`auth-flow.md` onboarding). The same gate blocks `apply_to_job` until the
+interview is evaluated — so finishing it unlocks both.
+
+## apply_to_job returns GATE_LOCKED / GATE_EVALUATING / GATE_FAILED
+
+Cause: the apply gate requires a completed + evaluated profile interview.
+- `GATE_LOCKED` — no completed interview yet.
+- `GATE_EVALUATING` — interview finished, evaluation still running.
+- `GATE_FAILED` — the evaluation failed.
+
+Fix (do NOT blind-retry):
+- `GATE_LOCKED` → send the user to complete the profile interview.
+- `GATE_EVALUATING` → wait, then retry in a short while.
+- `GATE_FAILED` → tell the user to retake the interview.
+All paths start at `https://workorai.com/candidate/home?tab=mcp` /
+`/candidate/profile` — see `auth-flow.md`.
+
+## NOT_FOUND on a job the user just saw
+
+Cause: `get_job`, `apply_to_job`, `accept_invitation`, and `set_saved_job`
+collapse "missing job" and "non-PUBLISHED job" into one `NOT_FOUND`
+(anti-enumeration). The vacancy was likely closed/archived since the search,
+or the `jobId` is wrong. (`decline_invitation` and `withdraw_application`
+differ — their `NOT_FOUND` means "no matching invite/application row", NOT a
+publish-status collapse; they do not check the job's status at all.)
+
+Fix: re-run `search_jobs` for a live equivalent. Treat `NOT_FOUND` as
+terminal for that `jobId` — do not loop retrying it.
+
+## accept_invitation / decline_invitation returns NOT_INVITED
+
+Cause: there is no OPEN invitation for this job. The invite may have been
+withdrawn or already declined, or the candidate applied organically (no
+invite to respond to).
+
+Fix: call `get_applications` and read the row's `status`. `APPLIED` → use
+`withdraw_application` if they want out; `DECLINED`/`WITHDRAWN` → terminal,
+nothing to accept/decline.
+
+## withdraw_application returns NOT_APPLIED
+
+Cause: there is no ACTIVE (APPLIED) application — the row may be an open
+`INVITED` invite, or already DECLINED/WITHDRAWN.
+
+Fix: call `get_applications`. If the row is `INVITED`, the right action is
+`decline_invitation` (to opt out) or `accept_invitation` — not withdraw.
+
+## A saved job disappeared from get_saved_jobs
+
+Cause: `get_saved_jobs` lists PUBLISHED jobs only. A job saved earlier and
+then closed/archived is filtered out — the bookmark row still exists, the
+listing just hides it.
+
+Fix: the vacancy is no longer live. Re-search for a current equivalent. This
+is expected behavior, not a lost bookmark.

--- a/cli-tool/components/skills/career/workorai/references/employer-catalog.md
+++ b/cli-tool/components/skills/career/workorai/references/employer-catalog.md
@@ -1,0 +1,573 @@
+# Employer Catalog
+
+Mini-schemas for the 19 employer tools in the WorkorAI MCP surface.
+
+Each tool here mirrors the runtime `outputSchema` exposed by the MCP
+server (see WorkorAI repo `mcp/src/tools/shared/{employer-applications,
+employer-jobs,employer-candidates}.ts`). When a tool's response shape
+changes, both layers move together — the MCP server schema AND this
+catalog entry. See WorkorAI
+`docs/plans/2026-05-29-workorai-skill-employer-update-design.md`
+(Path D, dual-layer schema strategy).
+
+## Runtime surface
+
+Gated, requires `role === 'EMPLOYER'` on the MCP key:
+
+Jobs lifecycle (8):
+- `employer.list_jobs`
+- `employer.get_job`
+- `employer.create_job`
+- `employer.update_job`
+- `employer.publish_job`
+- `employer.close_job`
+- `employer.archive_job`
+- `employer.delete_job`
+
+Candidate discovery (4):
+- `employer.search_candidates_for_job`
+- `employer.search_candidates_by_query`
+- `employer.get_candidate`
+- `employer.get_candidate_evidence`
+
+Invitations (3):
+- `employer.invite_candidate`
+- `employer.list_invitations`
+- `employer.cancel_invitation`
+
+Applicants review (4):
+- `employer.list_applicants`
+- `employer.set_review_status`
+- `employer.get_applicant_detail`
+- `employer.get_applicant_transcript`
+
+## Jobs lifecycle
+
+### `employer.list_jobs`
+
+Inputs:
+- `apiKey` (string, optional)
+- `status` (string | string[], optional) — one or many of
+  `DRAFT | PUBLISHED | CLOSED | ARCHIVED`
+- `limit` (number, optional, default 50, max 100)
+- `offset` (number, optional, default 0)
+
+Behavior:
+- Returns the caller's own jobs, paginated. Never crosses employer boundaries.
+- Status filter is normalized (deduped, invalid values dropped).
+
+Returns:
+- `ok: true`
+- `filters: { status?, limit, offset }`
+- `page: { total, limit, offset, hasMore }`
+- `jobs: EmployerJob[]` where each entry has: `id, employerId, status,
+  title, seniority, salary, location, workModel, jobType, description,
+  rawInput, dataSource, mustHaveSkills[], niceToHaveSkills[], perks[],
+  responsibilities[], qualifications[], referralBonus, hiredCount,
+  viewCount, applicationCount, createdAt, updatedAt, publishedAt,
+  closedAt`
+
+Errors:
+- `INVALID_INPUT` — bad pagination values
+
+Agent guidance:
+- Default sort is `updatedAt desc`. Use `status: 'DRAFT'` to recover
+  after a `create_job` client timeout (pick the most recent row).
+
+### `employer.get_job`
+
+Inputs:
+- `apiKey` (optional), `jobId` (string, required)
+
+Behavior:
+- Returns one of the caller's jobs.
+- Collapses NOT_FOUND and FORBIDDEN into the same NOT_FOUND.
+
+Returns:
+- `ok: true`
+- `job: EmployerJob & { company: { name | null } }`
+
+Errors:
+- `INVALID_INPUT: jobId is required`
+- `NOT_FOUND: <jobId>`
+
+Agent guidance:
+- Prefer this over `list_jobs` once a `jobId` is known.
+
+### `employer.create_job`
+
+Inputs:
+- `apiKey` (optional)
+- `rawText` (string, required, ≤10000 chars) — free-form job description.
+
+Behavior:
+- Synchronous Gemini AI parse. Latency 5-30 seconds. Persists a DRAFT
+  job under the caller's employer.
+- `dataSource: AI_PARSED`. The agent can then call `update_job` to
+  refine fields and `publish_job` to make it live.
+
+Returns:
+- `ok: true`
+- `job: EmployerJob & { company }` (same shape as `get_job`)
+
+Errors:
+- `INVALID_INPUT: rawText is required` / `rawText exceeds 10000 characters`
+- `PARSE_FAILED: <gemini error>`
+- `CONFLICT: <db error>`
+
+Agent guidance:
+- On client timeout, do NOT resubmit rawText (would create duplicate
+  DRAFTs). Recover via `employer.list_jobs({ status: 'DRAFT' })` and
+  pick the newest row.
+
+### `employer.update_job`
+
+Inputs:
+- `apiKey` (optional)
+- `jobId` (string, required)
+- `fields` (object, required) — partial whitelist of 13 fields:
+  `title, seniority, salary, location, workModel, jobType, description,
+  mustHaveSkills[], niceToHaveSkills[], perks[], responsibilities[],
+  qualifications[], referralBonus`
+
+Behavior:
+- Whitelist enforced; unknown fields rejected with INVALID_INPUT.
+- Auto-flips `dataSource` to `USER_EDITED` on every update.
+- `rawInput` (audit-only, set at create) is not editable.
+
+Returns:
+- `ok: true`
+- `job: EmployerJob & { company }`
+
+Errors:
+- `INVALID_INPUT: jobId is required` / `fields not allowed: <names>` /
+  `no fields to update`
+- `NOT_FOUND: <jobId>`
+
+Agent guidance:
+- Use enum values from inputSchema. `seniority` is one of
+  `INTERN | JUNIOR | MIDDLE | SENIOR | LEAD | PRINCIPAL`; `workModel`
+  is `REMOTE | HYBRID | ON_SITE`; `jobType` is
+  `FULL_TIME | PART_TIME | CONTRACT | FREELANCE`.
+
+### `employer.publish_job`
+
+Inputs: `apiKey` (optional), `jobId` (required).
+
+Behavior:
+- Transitions DRAFT → PUBLISHED. Sets `publishedAt`.
+
+Returns: same as `get_job` (refreshed job).
+
+Errors:
+- `INVALID_INPUT`, `NOT_FOUND`, `CONFLICT: expected status DRAFT, found <X>`
+
+Agent guidance:
+- Use after `create_job` + optional `update_job`.
+
+### `employer.close_job`
+
+Inputs: `apiKey` (optional), `jobId` (required).
+
+Behavior:
+- Transitions PUBLISHED → CLOSED. Sets `closedAt`.
+
+Returns: refreshed job.
+
+Errors: `INVALID_INPUT`, `NOT_FOUND`, `CONFLICT: expected status PUBLISHED`.
+
+### `employer.archive_job`
+
+Inputs: `apiKey` (optional), `jobId` (required).
+
+Behavior:
+- Transitions CLOSED → ARCHIVED.
+
+Returns: refreshed job.
+
+Errors: `INVALID_INPUT`, `NOT_FOUND`, `CONFLICT: expected status CLOSED`.
+
+### `employer.delete_job`
+
+Inputs: `apiKey` (optional), `jobId` (required).
+
+Behavior:
+- DRAFT-only deletion. Removes the row permanently.
+
+Returns:
+- `ok: true`
+- `jobId: string`
+
+Errors: `INVALID_INPUT`, `NOT_FOUND`, `CONFLICT: expected status DRAFT`.
+
+Agent guidance:
+- For PUBLISHED jobs, use `close_job` then `archive_job` instead. Never
+  call `delete_job` on a non-DRAFT row.
+
+## Candidate discovery
+
+### `employer.search_candidates_for_job`
+
+Inputs:
+- `apiKey` (optional)
+- `jobId` (string, required)
+- `sort` (`bestMatch` | `newest`, optional, default `bestMatch`)
+- `tier` (`best` | `good` | `weak`, optional) — match-quality band filter. OMIT
+  for the full ranked pool (back-compat). To shortlist, START with `tier:'best'`
+  and cascade to `good` then `weak` ONLY if you need more — read `tierCounts` to
+  decide. (Ignored on `sort:'newest'` — a recency browse has no bands.)
+- `page` (number, optional, default 1)
+- `pageSize` (number, optional, default 24, max 100)
+
+Behavior:
+- SEMANTICALLY ranks interviewed (embedding-gated, discoverable) candidates
+  against the job's requirements and returns a per-candidate fit score
+  (`matchScore`) AND a white-box `matchExplanation` (the "why"). Every
+  interviewed candidate is discoverable — no privacy gate.
+- Includes any existing application overlay (`applicationStatus`,
+  `invitedAt`) when the candidate already touches this job.
+
+Returns:
+- `ok: true`
+- `jobId: string`
+- `page: { total, page, pageSize, hasMore }` — on a `tier`-filtered call `total`
+  is the FULL pool; paginate WITHIN the band using `hasMore` (not `total`).
+- `tierCounts: { matched, unmatched, best, good, weak }` — band sizes to plan the
+  cascade. `matched` = cover ≥1 required skill, `unmatched` = none;
+  `best+good+weak === matched` on a scored search (all bands 0 on a newest browse).
+- `advisory?: { code: 'EMPTY_BEST_REVIEW_MUST_HAVES', message }` — OPTIONAL,
+  present ONLY when NO candidate reached the Best tier (`tierCounts.best === 0`)
+  but candidates exist below. The vacancy's must-have requirements may be strict
+  enough that nobody is an exceptional match. RELAY `message` to the employer as a
+  suggestion — they may move the less-critical must-haves to nice-to-have to widen
+  the pool. A SUGGESTION only; never auto-edit the job.
+- `entries: CandidateEntry[]` where each entry has: `id, displayName,
+  avatarUrl, headline, location, seniority, summary, skills[],
+  matchScore, matchedMustHaveSkills[], missingMustHaveSkills[],
+  matchExplanation?, applicationStatus?, invitedAt?`
+- `matchExplanation` (scored rows only) = `{ score, interviewScore|null,
+  reliability, similarity, mustCoverage, matchedMust[], missingMust[],
+  niceCoverage, matchedNice[], missingNice[], verifiedSkills[], verifiedUplift,
+  web3Bonus, reliabilitySource, reliabilityValue, rationale }`.
+  `verifiedSkills` = skills the candidate PROVED in their interview (lead your
+  explanation with these; empty ≠ no interview — check `interviewScore`).
+  `rationale` = a ready-to-quote plain-English sentence.
+
+Errors:
+- `INVALID_INPUT: jobId is required`
+- `NOT_FOUND: <jobId>` (collapsed NOT_FOUND | FORBIDDEN — no existence leak)
+- `NOT_INDEXED: <jobId>` / `NO_CATEGORIES: <jobId>` — the job isn't indexed for
+  semantic search yet; re-save or republish it to index it, then retry
+
+Agent guidance:
+- To find the best hire: (1) `tier:'best'` for the strongest candidates, cascade
+  via `tierCounts`; (2) explain your shortlist from each `matchExplanation` —
+  cite `verifiedSkills` (proven in interview), `matchedMust`/`missingMust`, and
+  the `rationale` — this is our white-box evidence, not a black box; (3) for the
+  few you shortlist, call `employer.get_candidate_evidence(jobId, userId)` for the
+  interview facts + Q&A to write a deeper comparative review.
+- Use the `applicationStatus` overlay to skip already-applied/invited
+  candidates when running a bulk invite.
+- If `tier:'best'` (or `tierCounts.best`) is empty but candidates exist below,
+  there is no exceptional match for this vacancy. Surface the `advisory` (or, if
+  absent, say so plainly) and suggest the employer review the must-have skills —
+  moving the less-critical ones to nice-to-have widens the search. Do NOT promote
+  a Good/Weak candidate as if they were a Best.
+
+### `employer.search_candidates_by_query`
+
+Inputs:
+- `apiKey` (optional)
+- `query` (string, required, max 512 chars) — free-form natural-language
+  description of who you're looking for (skills, role, stack)
+- `page` (number, optional), `pageSize` (number, optional)
+
+Behavior:
+- SEMANTIC similarity search: the query is embedded and interviewed
+  (embedding-gated, discoverable) candidates are ranked by closeness to it.
+  No job context → this is a PRELIMINARY search with NO per-vacancy fit
+  score and no match metadata. For a scored ranking, use
+  `employer.search_candidates_for_job` with a job id.
+
+Returns:
+- `ok: true`
+- `query: string`
+- `page: { total, page, pageSize }`
+- `entries: CandidateEntry[]` (same shape as above but without
+  matchScore / matched/missing arrays)
+
+Errors:
+- `INVALID_INPUT: query is required`
+
+Agent guidance:
+- Use when the employer hasn't picked a vacancy yet (free-form hire).
+  Pair with `list_jobs` or `create_job` before invite.
+
+### `employer.get_candidate`
+
+Inputs: `apiKey` (optional), `userId` (string, required).
+
+Behavior:
+- Returns one candidate's full discoverable profile plus the full
+  `existingApplications` history on this employer's jobs (all 4
+  statuses × 4 job statuses).
+- `existingApplications` is the single source of truth for re-invite
+  decisions.
+
+Returns:
+- `ok: true`
+- `candidate: CandidateEntry & { interview, existingApplications[] }`
+- `interview: { overallScore, summary, completedAt, evaluatedAt } | null`
+- `existingApplications: { applicationId, jobId, jobTitle, jobStatus,
+  status, createdAt, invitedAt|null, withdrawnAt|null, declinedAt|null }[]`
+
+Errors:
+- `INVALID_INPUT: userId is required`
+- `NOT_FOUND: <userId>` (collapsed: missing user OR non-discoverable
+  privacy OR no matching profile)
+
+Agent guidance:
+- ALWAYS call this before `invite_candidate` when the candidate has
+  any prior interaction with the employer (the entries explain why a
+  re-invite might be blocked):
+  - WITHDRAWN: re-invite succeeds (service UPDATEs the row).
+  - DECLINED: terminal — do not re-invite.
+  - INVITED: already pending, do nothing.
+  - APPLIED: already in funnel, route to `list_applicants` not invite.
+
+### `employer.get_candidate_evidence`
+
+Inputs: `apiKey` (optional), `jobId` (string, required), `userId` (string, required).
+
+Behavior:
+- JOB-SCOPED interview EVIDENCE for ONE candidate against ONE of your published
+  jobs — the white-box basis to explain WHY a candidate ranks where they do. Use
+  it AFTER `search_candidates_for_job`: shortlist with the scorecard, then read the
+  evidence here for the few you care about and write your own comparative review.
+- Same data + gate as the in-app deep review (you must OWN the PUBLISHED job; the
+  candidate must be in that job's searchable pool). The candidate-authored text is
+  size-budgeted + sanitized.
+
+Returns:
+- `ok: true`
+- `evidence: { candidateId, headline, resumeSummary, experienceYears,
+  facts[], interview, github, linkedin, truncation[] }`
+  - `facts: { claim, factScore, mustLinked, qas: { question, answer }[] }[]` —
+    what the candidate claimed + the interview Q&A behind it; `mustLinked` flags a
+    fact tied to one of THIS job's required skills.
+  - `interview: { interviewId, overallScore, summary } | null` (null = no
+    evaluated interview → `facts` is `[]`).
+  - `github: { trustRank, web3Repos, mergedPrestigeLanguages[] } | null`,
+    `linkedin: { historyCoherence, recognizedCerts } | null`.
+  - `truncation[]` — which sections were budget-trimmed (be honest about gaps).
+
+Errors:
+- `INVALID_INPUT: jobId and userId are required`
+- `NOT_FOUND: <userId>` (collapsed: missing/foreign/unpublished job OR the
+  candidate is not in that job's searchable pool — no existence leak)
+
+Agent guidance:
+- This is the heavy artefact: call it ONLY for the handful you shortlisted from
+  `search_candidates_for_job` (not the whole list). Ground your verdict in the
+  `facts`/`qas` + the `matchExplanation` from the search row.
+
+## Invitations
+
+### `employer.invite_candidate`
+
+Inputs:
+- `apiKey` (optional)
+- `jobId` (string, required)
+- `candidateUserId` (string, required)
+
+Behavior:
+- Creates a `JobApplication { status: INVITED, invitedById: <employer> }`
+  for the (candidate, job) pair.
+- Re-invite after WITHDRAWN: the service UPDATEs the existing row back
+  to INVITED (same applicationId is preserved).
+- All other prior statuses (INVITED/APPLIED/DECLINED) block.
+
+Returns:
+- `ok: true`
+- `applicationId: string`
+- `status: 'INVITED'`
+
+Errors:
+- `INVALID_INPUT: jobId is required` / `candidateUserId is required`
+- `INVITE_BLOCKED: <reason>` — 5 sub-reasons:
+  - `JOB_NOT_FOUND` (job missing OR owned by a different employer — the
+    two collapse so you cannot probe foreign jobIds; anti-enumeration)
+  - `JOB_NOT_PUBLISHED` (your job is in DRAFT/CLOSED/ARCHIVED)
+  - `CANDIDATE_NOT_FOUND` (user missing or role ≠ CANDIDATE)
+  - `NOT_DISCOVERABLE` (candidate is not in the searchable pool — no
+    completed-and-ingested profile interview, so no embedding to match.
+    Every interviewed candidate is discoverable; there is NO privacy opt-out
+    gate)
+  - `INVITE_NOT_ALLOWED` (existing INVITED/APPLIED/DECLINED row)
+
+Agent guidance:
+- On `INVITE_NOT_ALLOWED`, follow up with `employer.get_candidate` to
+  inspect `existingApplications` and tell the user which prior status
+  is blocking.
+
+### `employer.list_invitations`
+
+Inputs: `apiKey` (optional), `jobId` (string, required).
+
+Behavior:
+- Lists pending invitations on a job (status = INVITED, not yet
+  accepted/declined/withdrawn).
+
+Returns:
+- `ok: true`
+- `jobId: string`
+- `invitations: { applicationId, invitedAt, candidate: { userId,
+  displayName, headline, avatarUrl, location } }[]`
+
+Errors:
+- `INVALID_INPUT: jobId is required`
+- `NOT_FOUND: <jobId>` (collapsed)
+
+Agent guidance:
+- Use to remind employers of pending invites before they invite again.
+  Once a candidate accepts, the row moves to `list_applicants` with
+  `source: 'INVITED'`.
+
+### `employer.cancel_invitation`
+
+Inputs:
+- `apiKey` (optional)
+- `jobId` (string, required)
+- `candidateUserId` (string, required)
+
+Behavior:
+- Cancels a pending invitation (only valid while status = INVITED).
+- After accept/decline/withdraw, this errors with `NOT_INVITED`.
+
+Returns:
+- `ok: true`
+- `jobId: string`
+- `candidateUserId: string`
+
+Errors:
+- `INVALID_INPUT`
+- `NOT_INVITED: <candidateUserId>` (status changed already)
+- `NOT_FOUND: <jobId>` (collapsed)
+
+## Applicants review
+
+### `employer.list_applicants`
+
+Inputs: `apiKey` (optional), `jobId` (string, required).
+
+Behavior:
+- Returns the applicant funnel for a job. Includes both organic
+  applicants (`source: 'APPLIED'`) and candidates that accepted an
+  earlier invitation (`source: 'INVITED'`, identified by
+  `invitedById` having been set).
+- Excludes DECLINED rows from the funnel view (those live in invite
+  history).
+- Contact gating: `contact` is `null` when `reviewStatus` is below
+  SHORTLISTED. The fields are not even transmitted to the client.
+
+Returns:
+- `ok: true`
+- `jobId: string`
+- `applicants: { applicationId, status, reviewStatus, appliedAt,
+  source ('APPLIED'|'INVITED'),
+  candidate: { userId, displayName, headline, avatarUrl, location },
+  interview: { overallScore, summary },
+  contact: { email|null, phone|null, linkedinUrl|null, githubUrl|null,
+  websiteUrl|null } | null }[]`
+
+Errors:
+- `INVALID_INPUT: jobId is required`
+- `NOT_FOUND: <jobId>` (collapsed)
+
+Agent guidance:
+- To unlock contact for a candidate, call
+  `set_review_status(applicationId, 'SHORTLISTED'|'HIRED')` first.
+
+### `employer.set_review_status`
+
+Inputs:
+- `apiKey` (optional)
+- `applicationId` (string, required)
+- `reviewStatus` (`NEW|REVIEWING|SHORTLISTED|REJECTED|HIRED`, required)
+
+Behavior:
+- Updates the employer review state on an application. Independent of
+  the candidate `status` (INVITED/APPLIED/WITHDRAWN/DECLINED).
+- SHORTLISTED and HIRED unlock contact in subsequent
+  `list_applicants` and `get_applicant_detail` calls.
+- INVITED applications cannot be reviewed (candidate hasn't accepted).
+
+Returns:
+- `ok: true`
+- `applicationId: string`
+- `reviewStatus: <new value>`
+
+Errors:
+- `INVALID_INPUT: applicationId is required` / `reviewStatus must be
+  one of NEW, REVIEWING, SHORTLISTED, REJECTED, HIRED`
+- `NOT_FOUND: <applicationId>` (collapsed)
+- `CONFLICT: WITHDRAWN` (candidate left; nothing to review)
+- `CONFLICT: NOT_APPLIED` (status is still INVITED — candidate has
+  not accepted the invitation yet)
+
+Agent guidance:
+- On NOT_APPLIED, explain to the user that the candidate is still
+  pending acceptance and review controls activate only after accept.
+- The default move on a fresh APPLIED row is `REVIEWING` (the UI
+  auto-advances when the employer opens the candidate card; the API
+  does not auto-advance).
+
+### `employer.get_applicant_detail`
+
+Inputs: `apiKey` (optional), `applicationId` (string, required).
+
+Behavior:
+- Returns the full applicant evidence bundle: resume (sanitized),
+  github analysis, linkedin analysis, interview overview, and the
+  current status pair. Transcript is intentionally stripped — call
+  `get_applicant_transcript` for the verbatim conversation.
+- Internal flags (`contactUnlocked`, `resumeFilePath`,
+  `resumeUploadedAt`, `isProfileInitialized`) are not exposed.
+
+Returns:
+- `ok: true`
+- `detail: { applicationId, jobId, jobTitle, status, reviewStatus,
+  appliedAt, resumeAvailable: boolean, resume: object (contact fields
+  blanked when reviewStatus < SHORTLISTED), github: object|null,
+  linkedin: object|null,
+  interview: { overallScore, summary, facts[] } | null }`
+
+Errors:
+- `INVALID_INPUT: applicationId is required`
+- `NOT_FOUND: <applicationId>` (collapsed)
+
+Agent guidance:
+- For contact info, advance the application to SHORTLISTED or HIRED
+  first via `set_review_status`, then re-read.
+
+### `employer.get_applicant_transcript`
+
+Inputs: `apiKey` (optional), `applicationId` (string, required).
+
+Behavior:
+- Returns the verbatim conversation turns from the candidate's profile
+  interview. Same ownership gate as the UI download button.
+
+Returns:
+- `ok: true`
+- `applicationId: string`
+- `transcript: { role: 'assistant'|'user', text: string }[]`
+
+Errors:
+- `INVALID_INPUT: applicationId is required`
+- `NOT_FOUND: <applicationId>` (collapsed)
+
+Agent guidance:
+- Combine with `get_applicant_detail` to give the employer a full
+  evidence view. The transcript can be long — the agent should
+  summarize on demand, not dump verbatim.

--- a/cli-tool/components/skills/career/workorai/references/employer-recipes.md
+++ b/cli-tool/components/skills/career/workorai/references/employer-recipes.md
@@ -1,0 +1,144 @@
+# Employer Recipes
+
+Calling-order recipes for the four common employer flows plus the job
+lifecycle. Tool names match `references/employer-catalog.md`.
+
+## Recipe 1 — Hire from a specific job (shortlist → explain → invite)
+
+Use when the employer has a vacancy in mind and wants the agent to
+find, evaluate, explain, and invite suitable candidates.
+
+```
+employer.search_candidates_for_job({ jobId, tier: 'best' })
+  # read tierCounts {best,good,weak}; cascade to tier:'good' then 'weak' only if
+  # you need more candidates. paginate WITHIN a band via page.hasMore (not total).
+  # if tierCounts.best === 0 (no exceptional match) the result carries `advisory` —
+  #   relay it: suggest the employer review/relax the must-have skills. do NOT
+  #   present a Good/Weak candidate as a Best.
+  → for each shortlisted entry, explain from entry.matchExplanation:
+       #  verifiedSkills[] = proven in the interview (lead with these)
+       #  matchedMust[] / missingMust[] = coverage + gaps to probe
+       #  rationale = a ready-to-quote sentence
+       employer.get_candidate_evidence({ jobId, userId })   # the few you shortlist
+         #  facts[] + qas[] + interview.summary → write a deeper comparative review
+       employer.get_candidate({ userId })
+         # inspect existingApplications:
+         #  - INVITED  → already pending, skip
+         #  - APPLIED  → already in funnel, route to list_applicants
+         #  - DECLINED → terminal, do not re-invite
+         #  - WITHDRAWN → re-invite is allowed (service UPDATEs row)
+         #  - (no entry) → fresh invite is fine
+       employer.invite_candidate({ jobId, candidateUserId })
+  → employer.list_invitations({ jobId })   # confirm pending state
+later, once the candidate has accepted:
+  → employer.list_applicants({ jobId })    # source='INVITED'
+```
+
+Guidance:
+- START with `tier:'best'` — these are the strongest (cover the required skills,
+  proven in interview). Cascading to `good`/`weak` is opt-in; do not dump the
+  whole pool. (Omit `tier` only for an explicit "show everyone" request.)
+- Explain every recommendation from `matchExplanation` (our white-box evidence),
+  and deepen with `get_candidate_evidence` facts/Q&A for the shortlist — this is
+  the platform's value: an evidence-backed ranking, not a black-box score.
+- `get_candidate_evidence` is the heavy artefact — call it ONLY for the handful
+  you shortlist, never the whole list.
+- Empty Best (`tierCounts.best === 0`) is an honest signal, not an error: the
+  vacancy's requirements are strict. Relay the returned `advisory` (suggest moving
+  less-critical must-haves to nice-to-have) and work from the Good band — never
+  re-label a Good/Weak candidate as Best.
+- Never invite more candidates than the user asked for in one batch.
+
+## Recipe 2 — Hire from a free-form description
+
+Use when the user describes the role in plain text but has not picked
+a specific vacancy yet.
+
+```
+employer.search_candidates_by_query({ query })
+  → present top entries to the user
+  → on user pick:
+       employer.get_candidate({ userId })   # check existingApplications
+       (vacancy selection branch:)
+         either employer.list_jobs({ status: 'PUBLISHED' })
+         or     employer.create_job({ rawText }) + employer.publish_job
+       employer.invite_candidate({ jobId, candidateUserId })
+```
+
+Guidance:
+- `search_candidates_by_query` does NOT return match metadata. Use
+  Recipe 1 once a vacancy id is selected to get ranking.
+
+## Recipe 3 — Funnel review
+
+Use when the employer wants to triage applicants on a published job.
+
+```
+employer.list_applicants({ jobId })
+  → for each row, surface status, reviewStatus, source, match
+    summary from candidate + interview slice.
+  → on triage action:
+       employer.set_review_status({ applicationId, reviewStatus })
+         # 'SHORTLISTED' or 'HIRED' unlocks contact in next reads.
+  → for shortlisted candidates:
+       employer.get_applicant_detail({ applicationId })
+         # full evidence bundle, contact now visible.
+       employer.get_applicant_transcript({ applicationId })
+         # optional, on user request.
+```
+
+Error guidance:
+- `CONFLICT: NOT_APPLIED` from `set_review_status` means the row is
+  still INVITED (candidate has not accepted). Tell the user to wait
+  for acceptance; review controls activate only after.
+- `CONFLICT: WITHDRAWN` means the candidate withdrew. Nothing to
+  review. Suggest `invite_candidate` to re-engage (allowed for
+  WITHDRAWN).
+- Contact gating: `email`/`phone`/`linkedinUrl`/`githubUrl`/
+  `websiteUrl` are null until `reviewStatus ∈ {SHORTLISTED, HIRED}`.
+  Don't promise contact details before moving the row.
+
+## Recipe 4 — Pending invites cleanup
+
+Use when the employer is auditing outstanding invites or wants to
+rescind an unanswered invitation.
+
+```
+employer.list_invitations({ jobId })
+  → for each pending row (status INVITED):
+       employer.cancel_invitation({ jobId, candidateUserId })
+         # errors NOT_INVITED if candidate accepted/declined meanwhile
+```
+
+Guidance:
+- After cancellation, the candidate disappears from `list_invitations`.
+- Re-inviting a previously cancelled candidate creates a brand-new
+  application row (no DB row exists after cancel — unlike WITHDRAWN
+  which preserves history).
+
+## Lifecycle recipe — Create through retire
+
+```
+employer.create_job({ rawText })
+  → returns DRAFT job (Gemini parse, 5-30 s sync)
+  → optional: employer.update_job({ jobId, fields: { ... } })
+employer.publish_job({ jobId })
+  → status DRAFT → PUBLISHED, publishedAt set
+running:
+  Recipe 1/2/3 against the job
+when filled or paused:
+employer.close_job({ jobId })
+  → status PUBLISHED → CLOSED, closedAt set
+later, when no longer needed in the active list:
+employer.archive_job({ jobId })
+  → status CLOSED → ARCHIVED
+to drop a DRAFT that was never published:
+employer.delete_job({ jobId })
+  → DRAFT-only; on non-DRAFT use close + archive instead.
+```
+
+Guidance:
+- `update_job` whitelist excludes `rawInput` (audit-only) and
+  `dataSource` (auto-flipped to `USER_EDITED` on every agent update).
+- `create_job` client timeout recovery: do NOT resubmit. Run
+  `employer.list_jobs({ status: 'DRAFT' })` and pick the newest row.

--- a/cli-tool/components/skills/career/workorai/references/employer-troubleshooting.md
+++ b/cli-tool/components/skills/career/workorai/references/employer-troubleshooting.md
@@ -1,0 +1,155 @@
+# Employer Troubleshooting
+
+Scenarios on the employer MCP surface. For candidate-side issues, see
+`troubleshooting.md` (cross-role) and the candidate flow in
+`auth-flow.md`.
+
+## Employer tool call fails with "requires employer authentication"
+
+Employer tools are always visible in `tools/list` (visible-but-gated),
+so a missing tool is NOT the signal — a failed *call* is. An employer
+tool invoked without a valid EMPLOYER key returns
+`employer.<tool> requires employer authentication. Provide apiKey with
+a WorkorAI MCP key...`.
+
+Cause: no key was passed, the key is candidate-scoped, the key is
+revoked, or the underlying user is not an EMPLOYER.
+
+Fix: ask the user to open
+`https://workorai.com/employer/dashboard`, locate the Employer MCP
+card, and copy or generate the key. Then save with:
+
+```bash
+node scripts/credential-store.mjs save --best-effort --role=employer
+```
+
+Subsequent calls use that key as the `apiKey` argument on every
+`employer.*` tool — no MCP reconnect required.
+
+## Employer tools missing entirely from tools/list
+
+If `employer.*` tools do not appear in `tools/list` at all (only
+`request_access` + the candidate tools), the client is connected to
+an OLDER MCP deployment that predates the visible-but-gated employer
+surface, or the session is stale. Reconnect to the latest deployment.
+This is a deployment/version issue, not a key issue — a current
+deployment lists all 28 tools anonymously (`request_access` + 9
+candidate + 18 employer).
+
+## INVITE_BLOCKED: INVITE_NOT_ALLOWED
+
+Cause: there is already a `JobApplication` row for this (candidate, job)
+pair. Statuses INVITED / APPLIED / DECLINED all block. WITHDRAWN is the
+only re-invite path and goes through automatically — the service
+UPDATEs the row back to INVITED.
+
+Fix:
+1. Call `employer.get_candidate({ userId })` and inspect
+   `existingApplications` for the (jobId) entry.
+2. Interpret:
+   - DECLINED → terminal. Do not re-invite. Suggest a different vacancy.
+   - INVITED → already pending. Wait for the candidate to accept, or
+     `employer.cancel_invitation` and re-invite later.
+   - APPLIED → already in the funnel. Use `employer.list_applicants`
+     instead of `invite_candidate`.
+
+## INVITE_BLOCKED: NOT_DISCOVERABLE
+
+Cause: the candidate is not in the searchable pool. The single
+discoverability gate is a WHOLE candidate embedding, produced only after
+a profile interview both completes AND ingests. No completed-and-ingested
+interview → no embedding → not invitable. There is NO privacy opt-out and
+NO separate matching-profile gate (search == invite: anyone you can find
+in `search_candidates_*`, you can invite).
+
+Fix: explain the candidate cannot be invited yet — they must finish their
+profile interview on the WorkorAI side. If the candidate DID appear in a
+search result, retry; a freshly-ingested embedding may have lagged the
+search index briefly.
+
+## INVITE_BLOCKED: JOB_NOT_PUBLISHED
+
+Cause: the job exists but is in DRAFT, CLOSED, or ARCHIVED status.
+
+Fix: call `employer.publish_job({ jobId })` if the user actually wants
+to invite candidates against this vacancy.
+
+## set_review_status: CONFLICT: NOT_APPLIED
+
+Cause: the application's `status` is INVITED. The candidate has not
+accepted the invitation yet. Review controls (NEW/REVIEWING/SHORTLISTED/
+REJECTED/HIRED) are decoupled from the invitation acceptance and are
+not allowed on pending invites.
+
+Fix: explain the gating to the user. Wait for the candidate to accept;
+when they do, the row appears in `list_applicants` with `source:
+'INVITED'` and is reviewable.
+
+## set_review_status: CONFLICT: WITHDRAWN
+
+Cause: the candidate withdrew the application.
+
+Fix: nothing to review. If the user wants to re-engage, run
+`employer.invite_candidate({ jobId, candidateUserId })` — WITHDRAWN is
+the only state where re-invite is allowed (the service preserves the
+application id by UPDATE).
+
+## Contact details missing in list_applicants / get_applicant_detail
+
+Cause: `reviewStatus` is below SHORTLISTED. Contact fields
+(`email`, `phone`, `linkedinUrl`, `githubUrl`, `websiteUrl`) are gated
+server-side and not transmitted.
+
+Fix: tell the user that contact unlocks at SHORTLISTED or HIRED. To
+unlock: `employer.set_review_status({ applicationId, reviewStatus:
+'SHORTLISTED' })`, then re-read.
+
+## cancel_invitation: NOT_INVITED
+
+Cause: the application is no longer in INVITED status (candidate may
+have accepted, declined, or withdrawn between the agent's earlier
+`list_invitations` and the current call).
+
+Fix: re-read `employer.list_invitations({ jobId })` to see the current
+state. The candidate has likely moved into `list_applicants` or out
+entirely.
+
+## create_job: PARSE_FAILED
+
+Cause: Gemini AI returned an error parsing `rawText` (rate limit,
+malformed prompt, network).
+
+Fix: surface the error message to the user. Suggest retry with a
+cleaner `rawText`. Do NOT silently retry — risk of duplicate DRAFTs.
+
+## create_job: client timeout
+
+Cause: the parse is synchronous and budgets 5-30 seconds. Some MCP
+clients have shorter timeouts.
+
+Fix: do NOT resubmit `rawText`. Run
+`employer.list_jobs({ status: 'DRAFT' })` and pick the most recent
+row by `createdAt`. That is the job that finished parsing on the
+server while the client gave up.
+
+## publish_job / close_job / archive_job: CONFLICT
+
+Cause: the job is in an unexpected source status for the requested
+transition.
+
+Fix: read the error suffix. `CONFLICT: expected status DRAFT, found
+PUBLISHED` for `publish_job` means the job is already published —
+nothing to do. For other mismatches, run `employer.get_job` to see
+the current state and pick the right transition.
+
+## NOT_FOUND on read tools you know exist
+
+Cause: read tools (`get_job`, `list_applicants`, `list_invitations`,
+`get_applicant_detail`, `get_applicant_transcript`, `get_candidate`)
+collapse NOT_FOUND and FORBIDDEN into a single NOT_FOUND. This
+prevents enumeration of other employers' jobs and applicants.
+
+Fix: never assume "this is my job but I lost access". If the user
+believes a job is theirs, ask them to verify the `jobId` (typo / wrong
+employer account). Otherwise treat NOT_FOUND as terminal — the row
+does not exist for this employer.

--- a/cli-tool/components/skills/career/workorai/references/troubleshooting.md
+++ b/cli-tool/components/skills/career/workorai/references/troubleshooting.md
@@ -1,0 +1,104 @@
+# Troubleshooting
+
+> Role-scoped references:
+> - Candidate-only scenarios: see also `candidate-catalog.md` agent guidance.
+> - Employer-side scenarios (INVITE_BLOCKED branching, contact gating,
+>   review-status conflicts, create_job timeouts): see
+>   `employer-troubleshooting.md`.
+>
+> This file covers general MCP transport, saved-key, and cross-role issues.
+
+## Do Not Debug First For Normal Users
+
+For normal job-search requests, do not run raw `curl` or JSON-RPC checks before giving the candidate onboarding path. Transport debugging is only appropriate when the user explicitly asks why MCP connection failed or asks to test the server.
+
+## Tool Visibility
+
+Modern WorkorAI MCP exposes ALL 28 tools in an anonymous `tools/list`:
+`request_access`, the 9 candidate tools, and all 18 `employer.*`
+tools — visible-but-gated. Visibility is discovery (so MCP clients
+register the names); authorization is enforced per call. A tool in the
+list is not proof the current caller can invoke it.
+
+If only `request_access` (or only the 2–3 candidate-era tools) is
+visible, the client is connected to an OLDER deployment that predates
+the visible-but-gated employer surface or the expanded candidate
+surface, or the session is stale — reconnect to the latest deployment.
+This is a version issue, not a key issue.
+
+If tools are visible but a call fails auth, common reasons:
+- no Bearer key was sent
+- no `apiKey` argument was provided for an anonymous session
+- the key is invalid
+- the key was revoked
+- the candidate account is not in an active access state (candidate-side only)
+- the saved local key is missing, unreadable, or stale
+- the saved key is for the wrong role (a candidate key on an employer call or vice versa) — re-save with the correct `--role`
+
+## Saved Key Problems
+
+Check whether the skill can read a saved key — pass `--role` to query the right slot:
+
+```bash
+node scripts/credential-store.mjs get --role=candidate
+node scripts/credential-store.mjs get --role=employer
+```
+
+Do not paste the returned key into user-visible output. If lookup fails:
+- For a candidate intent: ask the user to paste the current MCP key from `https://workorai.com/candidate/home?tab=mcp`.
+- For an employer intent: ask the user to paste the current MCP key from `https://workorai.com/employer/dashboard` (Employer MCP card).
+- Use the pasted key with the tool `apiKey` argument.
+- If the tool call succeeds, ask whether to save the replacement key (`save --best-effort --role=<role>`).
+
+If OS secret storage fails:
+- macOS requires `/usr/bin/security` and Keychain authorization.
+- Linux requires `secret-tool` and a running Secret Service provider.
+- Windows requires PowerShell SecretManagement.
+- Headless/server environments should prefer `WORKORAI_MCP_API_KEY`.
+- Shared file fallback requires explicit user consent: `save --shared-file`.
+
+## Protocol Gotchas
+
+- Use the local endpoint `http://127.0.0.1:3001/mcp` for Docker/dev smoke tests.
+- Use `https://workorai.com/mcp` only after production DNS/nginx/SSL and the prod MCP container are deployed.
+- Use `POST /mcp` with `Accept: application/json, text/event-stream`.
+- `GET /mcp` without a session id returning `405` is expected.
+- After auth changes, prefer per-call `apiKey`; reconnect only if the client relies on session-level `Authorization` headers.
+
+## Visible Tool Scopes
+
+All tools are visible-but-gated in an anonymous `tools/list`; the
+key determines what can be *called*, not what is *listed*:
+- Public (always callable): `request_access`
+- Candidate (visible to all, callable with a candidate key): 9 tools —
+  `candidate.search_jobs`, `candidate.get_job`, `candidate.get_applications`,
+  `candidate.apply_to_job`, `candidate.accept_invitation`,
+  `candidate.decline_invitation`, `candidate.withdraw_application`,
+  `candidate.set_saved_job`, `candidate.get_saved_jobs` — see
+  `candidate-catalog.md`
+- Employer (visible to all, callable with an EMPLOYER key): 18 tools —
+  see `employer-catalog.md`
+
+An anonymous or candidate-scoped caller seeing `employer.*` in the list
+is EXPECTED and correct — visibility is discovery. The call-time gate
+rejects an employer call made without a valid employer key. Once a
+session authenticates with a role key, `tools/list` narrows to that
+role's callable surface.
+
+If a candidate-scoped key sees employer tools (or vice versa), the server is misconfigured — please file an operator issue. The runtime filter is role-aware on `tools/list`.
+
+## Missing Match Metadata
+
+`candidate.search_jobs` returns these per-job fields:
+- `matchScore`
+- `matchedMustHaveSkills`
+- `matchedNiceToHaveSkills`
+- `missingMustHaveSkills`
+- `seniorityFit` — always `UNKNOWN` (the combiner has no seniority signal)
+- `matchReasons` — always `[]` (nothing synthesizes them)
+
+NOTE: a free-text `q` or a not-yet-interviewed candidate returns a recency
+BROWSE with `matchScore: null` (no fit score) — a browse list, not a scored
+ranking. A `null` `matchScore` on that path is correct, not a bug.
+
+If `matchScore` or the skill arrays are missing, the client may be reading stale cached output, using an unauthenticated session that cannot call the real tool, or connected to an older MCP deployment.

--- a/cli-tool/components/skills/career/workorai/scripts/credential-store.mjs
+++ b/cli-tool/components/skills/career/workorai/scripts/credential-store.mjs
@@ -1,0 +1,753 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const SERVICE = 'workorai';
+const CONFIG_HOME = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+const TOKEN_PATTERN = /^wai_\S{16,}$/;
+
+// Role-aware storage slots — see
+// `docs/plans/2026-05-29-workorai-skill-employer-update-design.md`
+// (Q4 in the WorkorAI repo).
+const ROLE_VALUES = new Set(['candidate', 'employer']);
+const DEFAULT_ROLE = 'candidate';
+const ENV_KEY_BY_ROLE = {
+  candidate: 'WORKORAI_MCP_API_KEY',
+  employer: 'WORKORAI_EMPLOYER_MCP_API_KEY',
+};
+const SHARED_FILE_BY_ROLE = {
+  candidate: join(CONFIG_HOME, 'workorai', 'mcp-token'),
+  employer: join(CONFIG_HOME, 'workorai', 'mcp-token-employer'),
+};
+// OS secret store account name. Distinguishes roles inside the same
+// service entry so candidate + employer keys coexist.
+const ACCOUNT_BY_ROLE = {
+  candidate: 'candidate',
+  employer: 'employer',
+};
+
+const extractRoleFlag = (argv) => {
+  let role = DEFAULT_ROLE;
+  let seen = false;
+  const rest = [];
+  for (const arg of argv) {
+    const match = /^--role(?:=(.+))?$/.exec(arg);
+    if (!match) {
+      rest.push(arg);
+      continue;
+    }
+    if (seen) {
+      // Two `--role=` flags would silently last-write-wins and route
+      // the call to the wrong storage slot. Surface it instead.
+      throw new Error(
+        '--role specified more than once. Pick one of: ' +
+          `${[...ROLE_VALUES].join(', ')}.`,
+      );
+    }
+    const value = match[1];
+    if (!value || !ROLE_VALUES.has(value)) {
+      throw new Error(
+        `--role requires one of: ${[...ROLE_VALUES].join(', ')}`,
+      );
+    }
+    role = value;
+    seen = true;
+  }
+  return { role, rest };
+};
+
+const rawArgs = process.argv.slice(2);
+const command = rawArgs[0];
+let role;
+let args;
+try {
+  const extracted = extractRoleFlag(rawArgs.slice(1));
+  role = extracted.role;
+  args = extracted.rest;
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+const ACCOUNT = ACCOUNT_BY_ROLE[role];
+const ENV_KEY = ENV_KEY_BY_ROLE[role];
+const SHARED_FILE_PATH = SHARED_FILE_BY_ROLE[role];
+
+// Test isolation hook — set `WORKORAI_DISABLE_OS_KEYSTORE=1` to short-
+// circuit the macOS/Linux/Windows secret-store paths so the tests can
+// exercise env + shared-file behaviour without touching the real
+// keystore (which would prompt for unlock or fail in CI).
+const OS_KEYSTORE_DISABLED = process.env.WORKORAI_DISABLE_OS_KEYSTORE === '1';
+
+const usage = () => {
+  console.error(`Usage:
+  node credential-store.mjs get [--role=candidate|employer]
+  node credential-store.mjs save [--role=candidate|employer] [--best-effort|--shared-file]
+  node credential-store.mjs delete [--role=candidate|employer] [--shared-file]
+
+save reads the WorkorAI MCP key from piped stdin or prompts in an interactive terminal.
+get prints the key to stdout only when found.
+Default read order: env(${ENV_KEY}) -> OS secret store -> shared file fallback.
+Default save backend: OS secret store.
+Default role is 'candidate'. Pass --role=employer to use the employer key slot
+(env WORKORAI_EMPLOYER_MCP_API_KEY, file ~/.config/workorai/mcp-token-employer,
+OS keystore account 'employer').
+Use --best-effort after explicit consent to save to OS secret store, then fall back to the shared 0600 file if OS storage is unavailable.
+Use --shared-file only when the user explicitly chooses file fallback.`);
+};
+
+const normalizeToken = (value) => value.trim();
+
+const redactSecrets = (value) => value.replace(/wai_\S+/g, 'wai_[REDACTED]');
+
+const assertValidToken = (token) => {
+  if (!TOKEN_PATTERN.test(token)) {
+    throw new Error('Invalid WorkorAI MCP key format. Expected wai_... token.');
+  }
+};
+
+const commandExists = (name) => {
+  const checker = platform() === 'win32' ? 'where' : 'command';
+  const checkerArgs = platform() === 'win32' ? [name] : ['-v', name];
+  const result = spawnSync(checker, checkerArgs, {
+    shell: platform() !== 'win32',
+    stdio: 'ignore',
+  });
+
+  return result.status === 0;
+};
+
+const readHiddenTtyToken = async () => {
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      'No WorkorAI MCP key provided on stdin. Run this command in an interactive terminal and paste the key when prompted, or pass it through stdin.'
+    );
+  }
+
+  process.stderr.write('Paste WorkorAI MCP key: ');
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+
+  const canUseRawMode = typeof process.stdin.setRawMode === 'function';
+
+  if (canUseRawMode) {
+    process.stdin.setRawMode(true);
+  }
+
+  let token = '';
+
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const cleanup = () => {
+      process.stdin.off('data', handleData);
+
+      if (canUseRawMode) {
+        process.stdin.setRawMode(false);
+      }
+
+      process.stdin.pause();
+    };
+
+    const handleData = (chunk) => {
+      for (const char of String(chunk)) {
+        if (char === '\u0003') {
+          cleanup();
+          process.stderr.write('\n');
+          rejectPromise(new Error('Cancelled.'));
+          return;
+        }
+
+        if (char === '\r' || char === '\n') {
+          cleanup();
+          process.stderr.write('\n');
+          resolvePromise(normalizeToken(token));
+          return;
+        }
+
+        if (char === '\u007f' || char === '\b') {
+          token = token.slice(0, -1);
+          continue;
+        }
+
+        token += char;
+      }
+    };
+
+    process.stdin.on('data', handleData);
+  });
+};
+
+const readTokenForSave = async () => {
+  if (!process.stdin.isTTY) {
+    const input = readFileSync(0, 'utf8');
+    const token = normalizeToken(input);
+
+    if (!token) {
+      throw new Error(
+        'No WorkorAI MCP key provided on stdin. Run this command in an interactive terminal/PTY and paste the key when prompted, or pass it through stdin.'
+      );
+    }
+
+    assertValidToken(token);
+    return token;
+  }
+
+  const token = await readHiddenTtyToken();
+  assertValidToken(token);
+  return token;
+};
+
+const tryGetFromEnv = () => {
+  const token = normalizeToken(process.env[ENV_KEY] ?? '');
+
+  if (!token) {
+    return null;
+  }
+
+  assertValidToken(token);
+  return token;
+};
+
+// Differentiate "not-found" (the normal fall-through case) from
+// "backend error" (locked vault, dismissed unlock prompt, missing
+// secret-tool daemon). Both still return null so the caller falls
+// through to the next backend, but the latter is logged to stderr
+// with redacted detail so users have a chance to see why the
+// keystore read missed.
+//
+// On Linux, `secret-tool lookup` exits 1 with NO stderr output when
+// the entry is missing — Node's execFileSync then throws with a
+// generic "Command failed: secret-tool lookup ..." message. The
+// patterns alone cannot disambiguate that from a real backend error;
+// the helper below also inspects exit code + stderr emptiness for the
+// Linux backend specifically.
+//
+// On Windows, PowerShell SecretManagement emits "The secret <name>
+// was not found." for normal misses, which the patterns now match.
+//
+// Track whether ANY OS-store read surfaced a real backend error so
+// handleGet can later flag that a shared-file fallback might be stale.
+const KEYSTORE_NOT_FOUND_PATTERNS = [
+  /The specified item could not be found in the keychain/i, // macOS security
+  /The secret .* was not found/i,                            // PowerShell SecretManagement
+  /Cannot find a secret with name/i,                         // PowerShell SecretManagement variant
+  /Cannot find any secret/i,                                 // older PowerShell SecretManagement
+  /No matching results/i,                                    // some secret-tool builds
+  /No secret found for/i,                                    // secret-tool variant
+  /could not be found/i,                                     // generic catch-all
+];
+
+let osStoreReadErrorSurfaced = false;
+
+const errorLooksLikeNotFound = (backendLabel, error) => {
+  const raw = error instanceof Error ? error.message : String(error);
+
+  // Linux secret-tool: exit code 1 with no stderr means "not present".
+  // Anything else (locked seahorse, missing D-Bus, etc.) carries
+  // non-empty stderr or a different exit code.
+  if (backendLabel === 'Linux Secret Service') {
+    const status = typeof error?.status === 'number' ? error.status : null;
+    const stderr = error?.stderr ? String(error.stderr).trim() : '';
+    if (status === 1 && stderr.length === 0) {
+      return true;
+    }
+  }
+
+  return KEYSTORE_NOT_FOUND_PATTERNS.some((re) => re.test(raw));
+};
+
+const surfaceKeystoreReadFailure = (backendLabel, error) => {
+  if (errorLooksLikeNotFound(backendLabel, error)) {
+    return; // ordinary "no entry" — stay silent
+  }
+  osStoreReadErrorSurfaced = true;
+  const raw = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    `credential-store: ${backendLabel} read failed (falling through): ${redactSecrets(raw)}\n`,
+  );
+};
+
+// Returns true when the error is a benign "no entry" miss (silent),
+// false when a real backend failure was surfaced to stderr. Callers
+// use the return value to propagate non-zero exit through
+// `deleteFromOsStore` → `handleDelete` so scripts piping `delete` into
+// follow-up commands can detect failure.
+const surfaceKeystoreDeleteFailure = (backendLabel, error) => {
+  if (errorLooksLikeNotFound(backendLabel, error)) {
+    return true; // "nothing to delete" — caller treats as success
+  }
+  const raw = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    `credential-store: ${backendLabel} delete failed: ${redactSecrets(raw)}\n`,
+  );
+  return false;
+};
+
+const getFromMacKeychain = () => {
+  if (platform() !== 'darwin') {
+    return null;
+  }
+
+  try {
+    return normalizeToken(
+      execFileSync('/usr/bin/security', [
+        'find-generic-password',
+        '-a',
+        ACCOUNT,
+        '-s',
+        SERVICE,
+        '-w',
+      ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  } catch (error) {
+    surfaceKeystoreReadFailure('macOS Keychain', error);
+    return null;
+  }
+};
+
+const saveToMacKeychain = (token) => {
+  const result = spawnSync('/usr/bin/security', [
+    'add-generic-password',
+    '-a',
+    ACCOUNT,
+    '-s',
+    SERVICE,
+    '-w',
+    token,
+    '-U',
+  ], { encoding: 'utf8' });
+
+  if (result.status === 0) {
+    return;
+  }
+
+  const details = redactSecrets(
+    normalizeToken(result.stderr || result.stdout || result.error?.message || 'No system error details.')
+  );
+
+  throw new Error(
+    `macOS Keychain save failed (exit ${result.status ?? 'unknown'}): ${details}. If this is a headless or sandboxed agent session, allow Keychain access, use ${ENV_KEY}, or explicitly approve shared file fallback with --shared-file.`
+  );
+};
+
+// Each platform delete helper returns true when its work succeeded
+// (including the wrong-platform no-op case) and false when a real
+// backend failure was surfaced to stderr. `deleteFromOsStore`
+// aggregates the three results.
+const deleteFromMacKeychain = () => {
+  if (platform() !== 'darwin') {
+    return true;
+  }
+  try {
+    execFileSync('/usr/bin/security', [
+      'delete-generic-password',
+      '-a',
+      ACCOUNT,
+      '-s',
+      SERVICE,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    return true;
+  } catch (error) {
+    return surfaceKeystoreDeleteFailure('macOS Keychain', error);
+  }
+};
+
+const getFromLinuxSecretService = () => {
+  if (platform() !== 'linux' || !commandExists('secret-tool')) {
+    return null;
+  }
+
+  try {
+    return normalizeToken(
+      execFileSync('secret-tool', [
+        'lookup',
+        'service',
+        SERVICE,
+        'account',
+        ACCOUNT,
+      ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  } catch (error) {
+    surfaceKeystoreReadFailure('Linux Secret Service', error);
+    return null;
+  }
+};
+
+const saveToLinuxSecretService = (token) => {
+  if (!commandExists('secret-tool')) {
+    throw new Error(`secret-tool is not installed. Use ${ENV_KEY} or --shared-file.`);
+  }
+
+  execFileSync('secret-tool', [
+    'store',
+    '--label',
+    'WorkorAI MCP key',
+    'service',
+    SERVICE,
+    'account',
+    ACCOUNT,
+  ], { input: token, stdio: ['pipe', 'ignore', 'ignore'] });
+};
+
+const deleteFromLinuxSecretService = () => {
+  if (platform() !== 'linux' || !commandExists('secret-tool')) {
+    return true;
+  }
+
+  try {
+    execFileSync('secret-tool', [
+      'clear',
+      'service',
+      SERVICE,
+      'account',
+      ACCOUNT,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    return true;
+  } catch (error) {
+    return surfaceKeystoreDeleteFailure('Linux Secret Service', error);
+  }
+};
+
+const findPowerShell = () => {
+  if (platform() !== 'win32') {
+    return null;
+  }
+
+  if (commandExists('pwsh')) {
+    return 'pwsh';
+  }
+
+  if (commandExists('powershell')) {
+    return 'powershell';
+  }
+
+  return null;
+};
+
+// PowerShell SecretManagement keys on a single Name; unlike macOS
+// Keychain and Linux Secret Service it does NOT expose a separate
+// "account" attribute. Embed the role in the secret name itself so
+// candidate and employer keys do not collide on the same Windows host.
+const powerShellSecretName = () => `${SERVICE}-${ACCOUNT}`;
+
+const getFromPowerShellSecretManagement = () => {
+  const powerShell = findPowerShell();
+
+  if (!powerShell) {
+    return null;
+  }
+
+  try {
+    return normalizeToken(
+      execFileSync(powerShell, [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Get-Secret -Name '${powerShellSecretName()}' -AsPlainText -ErrorAction Stop`,
+      ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  } catch (error) {
+    // Differentiate "secret not present" (normal — fall through to the
+    // next backend) from any other failure (vault locked, module not
+    // installed, dismissed prompt). The latter is silenced today; log
+    // the redacted detail so users have a chance to see why the read
+    // missed.
+    surfaceKeystoreReadFailure('PowerShell SecretManagement', error);
+    return null;
+  }
+};
+
+const saveToPowerShellSecretManagement = (token) => {
+  const powerShell = findPowerShell();
+
+  if (!powerShell) {
+    throw new Error(`PowerShell is not available. Use ${ENV_KEY} or --shared-file.`);
+  }
+
+  const result = spawnSync(powerShell, [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    `$secret = ConvertTo-SecureString -String $env:WORKORAI_SECRET_INPUT -AsPlainText -Force; Set-Secret -Name '${powerShellSecretName()}' -Secret $secret`,
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      WORKORAI_SECRET_INPUT: token,
+    },
+  });
+
+  if (result.status === 0) {
+    return;
+  }
+
+  const details = redactSecrets(
+    normalizeToken(result.stderr || result.stdout || result.error?.message || 'No system error details.')
+  );
+
+  throw new Error(`PowerShell SecretManagement save failed (exit ${result.status ?? 'unknown'}): ${details}`);
+};
+
+const removePowerShellSecretManagement = () => {
+  if (platform() !== 'win32') {
+    return true;
+  }
+
+  const powerShell = findPowerShell();
+  if (!powerShell) {
+    return true;
+  }
+
+  try {
+    execFileSync(powerShell, [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `Remove-Secret -Name '${powerShellSecretName()}' -ErrorAction SilentlyContinue`,
+    ], { stdio: ['ignore', 'ignore', 'pipe'] });
+    return true;
+  } catch (error) {
+    return surfaceKeystoreDeleteFailure('PowerShell SecretManagement', error);
+  }
+};
+
+const tryGetFromOsStore = () => {
+  if (OS_KEYSTORE_DISABLED) {
+    return null;
+  }
+
+  const token =
+    getFromMacKeychain() ??
+    getFromLinuxSecretService() ??
+    getFromPowerShellSecretManagement();
+
+  if (!token) {
+    return null;
+  }
+
+  assertValidToken(token);
+  return token;
+};
+
+const readTokenFile = (filePath) => {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const fileMode = statSync(filePath).mode & 0o777;
+
+  if (platform() !== 'win32' && fileMode !== 0o600) {
+    throw new Error(`${filePath} must have 0600 permissions.`);
+  }
+
+  const token = normalizeToken(readFileSync(filePath, 'utf8'));
+  assertValidToken(token);
+  return token;
+};
+
+const saveTokenFile = (filePath, token) => {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${token}\n`, { mode: 0o600 });
+
+  if (platform() !== 'win32') {
+    chmodSync(filePath, 0o600);
+  }
+
+  return filePath;
+};
+
+const deleteTokenFile = (filePath) => {
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+  }
+};
+
+const saveToOsStore = (token) => {
+  // Test hook: when BOTH `WORKORAI_DISABLE_OS_KEYSTORE=1` AND
+  // `WORKORAI_TEST_FAKE_KEYSTORE_ERROR=<text>` are set, throw an
+  // error carrying that message. Gating on the disable env var means
+  // the hook is unreachable in any production context where the user
+  // hasn't already opted into test-isolation mode — a wrapper that
+  // forgets to set DISABLE_OS_KEYSTORE cannot force a fake error.
+  // Lets the role-test suite exercise the `handleSave` catch path
+  // with a token-bearing message and assert the redaction contract.
+  if (OS_KEYSTORE_DISABLED) {
+    const fakeError = process.env.WORKORAI_TEST_FAKE_KEYSTORE_ERROR;
+    if (fakeError) {
+      throw new Error(fakeError);
+    }
+    throw new Error(
+      `OS keystore disabled via WORKORAI_DISABLE_OS_KEYSTORE. Use ${ENV_KEY} or --shared-file.`,
+    );
+  }
+
+  if (platform() === 'darwin') {
+    saveToMacKeychain(token);
+    return 'macOS Keychain';
+  }
+
+  if (platform() === 'linux') {
+    saveToLinuxSecretService(token);
+    return 'Secret Service';
+  }
+
+  if (platform() === 'win32') {
+    saveToPowerShellSecretManagement(token);
+    return 'PowerShell SecretManagement';
+  }
+
+  throw new Error(`No OS secret store backend for ${platform()}. Use ${ENV_KEY} or --shared-file.`);
+};
+
+const deleteFromOsStore = () => {
+  if (OS_KEYSTORE_DISABLED) {
+    // Test hook (gated identically to WORKORAI_TEST_FAKE_KEYSTORE_ERROR):
+    // simulate the aggregated-failure path so the C1 contract
+    // (handleDelete must exit 1 on a real keystore delete failure)
+    // can be tested without spinning up an actual keystore. Emits
+    // the same stderr line surfaceKeystoreDeleteFailure would.
+    if (process.env.WORKORAI_TEST_FAKE_DELETE_FAILURE === '1') {
+      process.stderr.write(
+        'credential-store: macOS Keychain delete failed: simulated keystore failure\n',
+      );
+      return false;
+    }
+    return true;
+  }
+  // Run all three; only the current platform's helper does real work,
+  // the other two short-circuit to `true`. Aggregate so a real backend
+  // failure on the active platform propagates to the exit code.
+  const macOk = deleteFromMacKeychain();
+  const linuxOk = deleteFromLinuxSecretService();
+  const winOk = removePowerShellSecretManagement();
+  return macOk && linuxOk && winOk;
+};
+
+// Surface the test-isolation kill-switch when the user has it set.
+// Silent skip of the OS keystore mid-production is a debugging trap
+// (the user thinks their keychain is being consulted; it isn't).
+// Emitted once per CLI invocation, only on a command that actually
+// would touch the keystore.
+const warnIfKeystoreDisabled = (command) => {
+  if (!OS_KEYSTORE_DISABLED) return;
+  if (command !== 'get' && command !== 'save' && command !== 'delete') return;
+  process.stderr.write(
+    'credential-store: WORKORAI_DISABLE_OS_KEYSTORE=1 — OS secret store ' +
+      'bypassed (test-isolation mode). Unset to use the system keychain.\n',
+  );
+};
+
+const handleGet = () => {
+  warnIfKeystoreDisabled('get');
+  const fromEnv = tryGetFromEnv();
+  if (fromEnv) {
+    process.stdout.write(`${fromEnv}\n`);
+    return;
+  }
+  const fromOs = tryGetFromOsStore();
+  if (fromOs) {
+    process.stdout.write(`${fromOs}\n`);
+    return;
+  }
+
+  // If the OS keystore read surfaced a real backend error (not a plain
+  // "no entry" miss), the shared file is a potentially-stale fallback:
+  // the keystore may carry a newer token that the file hasn't seen.
+  // Make that explicit so the user can debug an auth failure that
+  // would otherwise look like "I just saved the key, why doesn't it
+  // work" — see silent-failure HIGH F3.
+  const fromFile = readTokenFile(SHARED_FILE_PATH);
+  if (!fromFile) {
+    process.exit(1);
+  }
+
+  if (osStoreReadErrorSurfaced) {
+    process.stderr.write(
+      'credential-store: returning shared-file fallback token because the ' +
+        'OS keystore read errored above. Re-run `save` if authentication ' +
+        'against WorkorAI MCP fails.\n',
+    );
+  }
+
+  process.stdout.write(`${fromFile}\n`);
+};
+
+const handleSave = async () => {
+  // Only warn when the OS keystore is actually about to be touched.
+  // `--shared-file` short-circuits to the file fallback, so the
+  // disable env var is irrelevant — the warning would just train
+  // users to ignore credential-store stderr noise.
+  if (!args.includes('--shared-file')) warnIfKeystoreDisabled('save');
+  const token = await readTokenForSave();
+
+  if (args.includes('--shared-file')) {
+    const path = saveTokenFile(SHARED_FILE_PATH, token);
+    console.error(`Saved WorkorAI MCP key to shared file fallback at ${path}`);
+    return;
+  }
+
+  try {
+    const backend = saveToOsStore(token);
+    console.error(`Saved WorkorAI MCP key to ${backend}`);
+
+    if (args.includes('--best-effort')) {
+      const path = saveTokenFile(SHARED_FILE_PATH, token);
+      console.error(`Mirrored WorkorAI MCP key to shared file fallback at ${path}`);
+    }
+  } catch (error) {
+    if (!args.includes('--best-effort')) {
+      throw error;
+    }
+
+    const path = saveTokenFile(SHARED_FILE_PATH, token);
+    const details = redactSecrets(error instanceof Error ? error.message : String(error));
+
+    console.error(`OS secret store unavailable: ${details}`);
+    console.error(`Saved WorkorAI MCP key to shared file fallback at ${path}`);
+  }
+};
+
+const handleDelete = () => {
+  if (!args.includes('--shared-file')) warnIfKeystoreDisabled('delete');
+  if (args.includes('--shared-file')) {
+    deleteTokenFile(SHARED_FILE_PATH);
+    return;
+  }
+
+  const ok = deleteFromOsStore();
+  if (!ok) {
+    process.stderr.write(
+      'credential-store: delete reported failures on the OS keystore. The ' +
+        'entry may still be present in the keychain/vault. Re-run with ' +
+        '--shared-file to clear the file fallback explicitly, or resolve ' +
+        'the keystore error reported above before retrying.\n',
+    );
+    process.exit(1);
+  }
+};
+
+try {
+  if (command === 'get') {
+    handleGet();
+  } else if (command === 'save') {
+    await handleSave();
+  } else if (command === 'delete') {
+    handleDelete();
+  } else {
+    usage();
+    process.exit(2);
+  }
+} catch (error) {
+  console.error(redactSecrets(error instanceof Error ? error.message : String(error)));
+  process.exit(1);
+}


### PR DESCRIPTION
## What

Adds the **workorai** skill under `cli-tool/components/skills/career/`.

WorkorAI talent marketplace skill: candidate job search and employer hiring with white-box match explanations via the WorkorAI MCP server (https://workorai.com/mcp).

- **Candidate side (9 MCP tools):** search jobs, job detail, apply, accept/decline employer invitations, withdraw, saved jobs — with match scores and matched/missing skills surfaced to the user.
- **Employer side (19 MCP tools):** job lifecycle (create/publish/update/close/archive), tiered candidate search (best/good/weak) with a white-box `matchExplanation` per candidate (fit score, interview-verified skills, gaps, rationale), per-candidate interview evidence for comparative review, invitations, and applicant funnel review.

## Package structure

Follows the existing skill layout (`SKILL.md` + supporting files, as in `video/sora`, `creative-design/theme-factory`):

- `SKILL.md` — intent router with frontmatter metadata (`version`, `author`, `repo`, `license: MIT`, `tags`)
- `references/` — 8 on-demand files: tool mini-schemas, calling-order recipes, troubleshooting, auth/onboarding flow
- `scripts/credential-store.mjs` — helper the skill uses to save/look up the user's MCP key locally (key is passed via stdin, never printed; keychain first, shared-file fallback only on explicit opt-in)
- `LICENSE.txt` — MIT

Upstream canonical source: https://github.com/work0r-ai/agent-kit (MIT).

## Testing

```bash
npx claude-code-templates@latest --skill career/workorai --dry-run
```

Skill was developed and exercised against the live WorkorAI MCP server (candidate and employer flows).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `workorai` career skill for WorkorAI MCP workflows. Candidates can search and apply; employers can manage jobs and hire with clear match explanations.

- Area: components (`cli-tool/components/`); new `workorai` under `skills/career/` with `SKILL.md`, `references/`, and `scripts/credential-store.mjs`. No changes to CLI, website, API, or workers.
- New component added — regenerate `docs/components.json`.
- Includes 9 candidate tools and 19 employer tools via the WorkorAI MCP.
- Requires a WorkorAI MCP key; supports `WORKORAI_MCP_API_KEY` (candidate) and `WORKORAI_EMPLOYER_MCP_API_KEY` (employer). The credential store saves keys to the OS keychain with an opt-in file fallback.

<sup>Written for commit 7940d0931a93608474c4101b900e3b09a171b811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

