### PR TITLE
Add HikerAPI, LamaTok and DataLikers MCP servers to web-data

### DIFF
--- a/cli-tool/components/mcps/web-data/datalikers.json
+++ b/cli-tool/components/mcps/web-data/datalikers.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "datalikers": {
+      "description": "DataLikers hosted MCP — 50+ Instagram & TikTok data tools: user search by demographics (gender, age, country, city), engagement analytics, posts, comments, hashtags, stories, highlights and trending tracks. Get an API key at https://datalikers.com/tokens (100 free requests on signup, no credit card). Prefer a local server? Run `npx -y datalikers-mcp` with DATALIKERS_API_KEY instead.",
+      "url": "https://mcp.datalikers.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer <YOUR_DATALIKERS_API_KEY>"
+      }
+    }
+  }
+}

--- a/cli-tool/components/mcps/web-data/hikerapi.json
+++ b/cli-tool/components/mcps/web-data/hikerapi.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "hikerapi": {
+      "description": "HikerAPI MCP — Instagram data API with 105+ read-only tools auto-generated from the OpenAPI spec: profiles, posts, reels, stories, highlights, hashtags, locations, followers and comments. Get an API key at https://hikerapi.com/tokens (100 free requests on signup, no credit card).",
+      "command": "npx",
+      "args": ["-y", "hikerapi-mcp"],
+      "env": {
+        "HIKERAPI_KEY": "<YOUR_HIKERAPI_KEY>"
+      }
+    }
+  }
+}

--- a/cli-tool/components/mcps/web-data/lamatok.json
+++ b/cli-tool/components/mcps/web-data/lamatok.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "lamatok": {
+      "description": "LamaTok MCP — TikTok data API tools auto-generated from the OpenAPI spec: users, videos, hashtags, comments, followers/following, playlists, search, plus music and watermark-free video downloads. Get an API key at https://lamatok.com (100 free requests on signup, no credit card).",
+      "command": "npx",
+      "args": ["-y", "lamatok-mcp"],
+      "env": {
+        "LAMATOK_KEY": "<YOUR_LAMATOK_KEY>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds three MCP servers to `cli-tool/components/mcps/web-data/`, alongside the existing Apify / Bright Data / Explorium entries:

- **HikerAPI** (`hikerapi.json`) — Instagram data API with 105+ read-only tools auto-generated from the OpenAPI spec ([npm](https://www.npmjs.com/package/hikerapi-mcp), [GitHub](https://github.com/subzeroid/hikerapi-mcp))
- **LamaTok** (`lamatok.json`) — TikTok data API tools: users, videos, hashtags, comments, playlists, downloads ([npm](https://www.npmjs.com/package/lamatok-mcp), [GitHub](https://github.com/subzeroid/lamatok-mcp))
- **DataLikers** (`datalikers.json`) — hosted MCP (Streamable HTTP) with 50+ Instagram & TikTok data tools ([server card](https://datalikers.com/.well-known/mcp/server-card.json), [GitHub](https://github.com/subzeroid/datalikers-mcp))

## Notes

- HikerAPI and LamaTok follow the same npx shape as `apify.json`; DataLikers follows the hosted url+headers shape of `explorium.json`.
- All three servers are maintained by us (subzeroid), MIT-licensed and published on npm.
- Each service offers 100 free requests on signup (no credit card), so users can evaluate before committing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HikerAPI, LamaTok, and DataLikers MCP servers to the web-data catalog to enable Instagram and TikTok data tools. Expands coverage with both local (`npx`) and hosted options.

- Area: components (cli-tool/components/); added hikerapi.json, lamatok.json, datalikers.json
- New components: regenerate docs/components.json
- Usage: local via `hikerapi-mcp` and `lamatok-mcp`; DataLikers via hosted URL (optional local `datalikers-mcp`)
- Secrets: HIKERAPI_KEY, LAMATOK_KEY; DataLikers uses Authorization: Bearer DATALIKERS_API_KEY

<sup>Written for commit 2ffdd3bb842ec861af9f8a3afff85889e8be5ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

