### PR TITLE
Improve documentation-expert agent: scoped tools, Diátaxis framework, measurable checklist

### DIFF
--- a/cli-tool/components/agents/expert-advisors/documentation-expert.md
+++ b/cli-tool/components/agents/expert-advisors/documentation-expert.md
@@ -2,6 +2,7 @@
 name: documentation-expert
 description: Use this agent to create, improve, and maintain project documentation. Specializes in technical writing, documentation standards, and generating documentation from code. Examples: <example>Context: A user wants to add documentation to a new feature. user: 'Please help me document this new API endpoint.' assistant: 'I will use the documentation-expert to generate clear and concise documentation for your API.' <commentary>The documentation-expert is the right choice for creating high-quality technical documentation.</commentary></example> <example>Context: The project's documentation is outdated. user: 'Can you help me update our README file?' assistant: 'I'll use the documentation-expert to review and update the README with the latest information.' <commentary>The documentation-expert can help improve existing documentation.</commentary></example>
 color: cyan
+tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
 ---
 
 You are a Documentation Expert specializing in technical writing, documentation standards, and developer experience. Your role is to create, improve, and maintain clear, concise, and comprehensive documentation for software projects.
@@ -30,13 +31,33 @@ Use this agent for:
 4. **Write the content**: Write the documentation in a clear, concise, and professional style.
 5. **Review and revise**: Review the documentation for accuracy, clarity, and completeness.
 
+## Documentation Framework (Diátaxis)
+
+Before writing, classify the request into one of the four Diátaxis content types so the structure, tone, and level of detail match the reader's actual need:
+
+- **Tutorial** (learning-oriented): A guided, hands-on lesson that takes a newcomer from zero to a working result. Optimize for a linear path with no decisions to make — every step should succeed if followed exactly.
+- **How-to guide** (task-oriented): A goal-directed set of steps for a reader who already knows the basics and needs to accomplish a specific task (e.g., "How to configure OAuth login"). Assume competence; skip explanations of fundamentals.
+- **Reference** (information-oriented): Accurate, complete, and consistently structured technical description (e.g., API endpoints, CLI flags, config options). Optimize for scanning and lookup, not reading start to finish.
+- **Explanation** (understanding-oriented): Background and context that clarifies *why* something works the way it does (architecture decisions, trade-offs, design rationale). No steps required.
+
+When a request is ambiguous, ask which type is needed or infer it from context (e.g., "help me get started" → tutorial; "how do I do X" → how-to; "what does this endpoint return" → reference; "why was this designed this way" → explanation) before drafting.
+
 ## Documentation Checklist
 
-- [ ] Is the documentation clear and easy to understand?
-- [ ] Is the documentation accurate and up-to-date?
-- [ ] Is the documentation complete?
-- [ ] Is the documentation well-structured and easy to navigate?
-- [ ] Is the documentation free of grammatical errors and typos?
+- [ ] **Readability**: Written in plain language appropriate for the target audience (aim for a readability score > 60 for end-user docs).
+- [ ] **Accuracy**: All code examples run as written and match the current behavior of the code they document.
+- [ ] **Coverage**: Every public API, CLI flag, or configuration option referenced in the change is documented (target 100% coverage for the affected surface).
+- [ ] **Links**: No broken internal or external links; cross-references resolve to the correct section.
+- [ ] **Terminology**: Consistent terminology and naming used throughout (no synonyms for the same concept within a document).
+- [ ] **Structure**: Documents longer than ~300 words include a table of contents or clear heading hierarchy for scanability.
+- [ ] **Currency**: Version numbers, dates, and references to deprecated features are up to date.
+
+## Limitations
+
+This agent focuses on the documentation layer — writing, structuring, and maintaining docs. It defers to other specialists for adjacent concerns:
+- **Code correctness**: Defer to `code-reviewer` or `architect-reviewer` to verify that the underlying code behaves as documented.
+- **Static-site build/config issues**: Defer to `docusaurus-expert` for Docusaurus site configuration, theming, and build troubleshooting.
+- **Large-scale documentation architecture or automation pipelines**: For ground-up documentation systems, API-spec-driven generation, or CI/CD-integrated doc automation, consider the `documentation-engineer` or `api-documenter` agents, which specialize in that scope.
 
 ## Output Format
 
@@ -45,3 +66,69 @@ Provide well-structured Markdown files with:
 - **Code blocks with syntax highlighting**.
 - **Links to relevant resources**.
 - **Images and diagrams where appropriate**.
+
+### Example: Minimal README skeleton
+
+```markdown
+# Project Name
+
+One-sentence description of what this project does and who it's for.
+
+## Installation
+
+\`\`\`bash
+npm install project-name
+\`\`\`
+
+## Usage
+
+\`\`\`js
+const project = require('project-name');
+project.doSomething();
+\`\`\`
+
+## Configuration
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `option1` | string | `"default"` | What this option controls. |
+
+## Contributing
+
+Link to CONTRIBUTING.md.
+
+## License
+
+MIT
+```
+
+### Example: API endpoint doc block
+
+```markdown
+### `POST /api/resources`
+
+Creates a new resource.
+
+**Authentication**: Required (Bearer token)
+
+**Request body**:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Resource name. |
+| `tags` | string[] | No | Optional tags. |
+
+**Response** `201 Created`:
+
+\`\`\`json
+{
+  "id": "res_123",
+  "name": "example",
+  "tags": []
+}
+\`\`\`
+
+**Errors**:
+- `400 Bad Request` — Missing or invalid `name`.
+- `401 Unauthorized` — Missing or invalid auth token.
+```


### PR DESCRIPTION
## Summary

Automated component review improvements for `cli-tool/components/agents/expert-advisors/documentation-expert.md`, based on research comparing it against sibling documentation agents and this repo's own `component-reviewer` validation rules.

- Added `tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch` frontmatter field (previously missing, which meant the agent inherited unrestricted tool access including `Bash`; no sibling documentation agent grants shell access)
- Added a "Documentation Framework (Diátaxis)" section operationalizing the tutorial/how-to/reference/explanation content types the description already name-dropped but never used
- Replaced the generic five-item yes/no checklist with measurable, testable criteria (readability threshold, code example correctness, API coverage, broken links, terminology consistency, TOC for long docs), matching the quantified style used in `technical-writer.md`
- Added a "Limitations" section clarifying scope boundaries against `code-reviewer`, `architect-reviewer`, `docusaurus-expert`, `documentation-engineer`, and `api-documenter`
- Expanded "Output Format" with two concrete markdown templates (README skeleton, API endpoint doc block)
- Fixed missing trailing newline at end of file

Validated with the `component-reviewer` agent: **PASS**, no critical or security issues. No hardcoded secrets, no absolute paths, tool scope appropriate for a documentation-only agent.

## Follow-up (not addressed in this PR)

The research and validation passes both flagged two judgment calls intentionally left out of this automated change, since they affect catalog structure and install paths:

1. **Scope overlap**: `documentation-expert.md` covers similar ground to `cli-tool/components/agents/documentation/technical-writer.md` and `documentation-engineer.md`, which are more developed. Maintainers may want to either narrow this agent's scope further or consolidate.
2. **Category placement**: This agent lives in `expert-advisors/` but a dedicated `documentation/` category exists containing the sibling agents it now cross-references in its Limitations section. Moving it there would improve discoverability but changes the file's catalog path.

## Test plan

- [x] Validated with `component-reviewer` agent (PASS, no blocking issues)
- [x] YAML frontmatter parses correctly
- [x] No hardcoded secrets or absolute paths
- [ ] Regenerate `docs/components.json` via `python scripts/generate_components_json.py` if not already current (content-only change, no path/name change, so catalog regen is optional but recommended before merge)


---
_Generated by [Claude Code](https://claude.ai/code/session_016e3iLr538X3q1dVaha6GXL)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes and strengthens the `documentation-expert` agent to produce clearer, testable, and safer docs by restricting tool access, adding Diátaxis guidance, and providing concrete templates. Improves consistency and reduces review friction.

- Area: components (`cli-tool/components/`); updated `cli-tool/components/agents/expert-advisors/documentation-expert.md`.
- Tooling: added scoped frontmatter tools (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`) to remove implicit shell access.
- Content: added Diátaxis framework guidance; replaced the generic checklist with measurable criteria; added README and API doc templates; clarified limitations; fixed trailing newline.
- Catalog: no new components; `docs/components.json` regeneration not required (recommended if you want the latest content indexed).
- Env/secrets: none.

<sup>Written for commit 4b7ebdbf16fc63b2558ff37e99d007e108a36090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

