### PR TITLE
chore: sync Anthropic skills LICENSE attribution with upstream

### DIFF
--- a/cli-tool/components/skills/ANTHROPIC_ATTRIBUTION.md
+++ b/cli-tool/components/skills/ANTHROPIC_ATTRIBUTION.md
@@ -78,4 +78,4 @@ For more information about skills, visit:
 
 ---
 
-**Last Updated**: April 18, 2026
+**Last Updated**: July 3, 2026

--- a/cli-tool/components/skills/development/artifacts-builder/LICENSE.txt
+++ b/cli-tool/components/skills/development/artifacts-builder/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/development/webapp-testing/LICENSE.txt
+++ b/cli-tool/components/skills/development/webapp-testing/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Compared every skill tracked in `cli-tool/components/skills/ANTHROPIC_ATTRIBUTION.md` against the current [anthropics/skills](https://github.com/anthropics/skills) repo.
- Content is already in sync: `docx`, `pptx`, `xlsx`, `pdf` (as `pdf-anthropic`), `algorithmic-art`, `brand-guidelines`, `canvas-design`, `internal-comms`, `mcp-builder`, `skill-creator`, `slack-gif-creator`, `theme-factory` all match upstream (local `docx`/`pptx`/`xlsx` even carry a few extra legacy files upstream has since pruned — left in place, nothing to sync).
- The only drift found: `development/artifacts-builder/LICENSE.txt` and `development/webapp-testing/LICENSE.txt` still had the unfilled Apache-2.0 placeholder (`Copyright [yyyy] [name of copyright owner]`). Every other tracked skill's LICENSE.txt already reads `Copyright 2026 Anthropic, PBC.` upstream — filled in the same way here.
- Bumped the "Last Updated" date in `ANTHROPIC_ATTRIBUTION.md`.
- `claude-api`, `doc-coauthoring`, and `frontend-design` also exist locally under the same names as skills now published upstream, but `git log` shows they were originally migrated from a different marketplace source (AugmentClaude best-claude-skills), not from `anthropics/skills`. Left untouched per "never overwrite locally customized skills" — overwriting would destroy differently-sourced content under a name collision, not sync an Anthropic skill.

## Notes
- Both updated skills were validated with the `component-reviewer` agent — no critical issues or warnings.
- Catalog regeneration (`python scripts/generate_components_json.py`) was run but **not committed**: LICENSE.txt isn't part of the generated index (confirmed no diff in `dashboard/public/component-content/`), and running the generator in this environment reset all download counts to much lower values and dropped an unrelated skill (`database/postgres-schema-design`) from the index — both regressions unrelated to this change, so the generated JSON was reverted to avoid corrupting production catalog data.

## Test plan
- [x] `component-reviewer` agent validated both updated skills (PASS, no issues)
- [x] Verified diff is limited to the two LICENSE.txt copyright lines + attribution doc date
- [x] Confirmed no other tracked Anthropic skill has drifted from upstream content

https://claude.ai/code/session_019nn9iHjwpu6g5Fc6HM8hJR


---
_Generated by [Claude Code](https://claude.ai/code/session_019nn9iHjwpu6g5Fc6HM8hJR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync Anthropic skills license attribution with upstream by filling two Apache-2.0 placeholders and updating the attribution date. No feature or runtime changes.

- Area: components (`cli-tool/components/`)
- Updated `development/artifacts-builder/LICENSE.txt`, `development/webapp-testing/LICENSE.txt` to "Copyright 2026 Anthropic, PBC."; bumped date in `skills/ANTHROPIC_ATTRIBUTION.md`
- Left locally sourced skills with name collisions (`claude-api`, `doc-coauthoring`, `frontend-design`) unchanged
- No new components; no catalog regeneration (`docs/components.json`) needed
- No new environment variables or secrets

<sup>Written for commit ce330cf030eae8fa4257ecf06c1732e7f50ca03b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

