### PR TITLE
fix: improve mobile flexbox layout in dashboard

### DIFF
--- a/dashboard/src/components/ComponentGrid.tsx
+++ b/dashboard/src/components/ComponentGrid.tsx
@@ -243,9 +243,9 @@ export default function ComponentGrid({ initialType }: Props) {
     <div>
       {/* Enhanced Filter bar with view modes */}
       <div className="border-b border-[var(--color-border)] bg-[var(--color-surface-0)] backdrop-blur-sm sticky top-14 z-10">
-        <div className="flex flex-wrap items-center gap-2.5 px-6 py-4">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2.5 px-6 py-4">
           {/* Search */}
-          <div className="relative flex-1 min-w-[140px] max-w-md">
+          <div className="relative w-full sm:w-auto sm:flex-1 sm:min-w-[140px] sm:max-w-md">
             <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-text-tertiary)] pointer-events-none transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
               <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
@@ -269,35 +269,39 @@ export default function ComponentGrid({ initialType }: Props) {
             )}
           </div>
 
-          {/* Category select */}
-          <select
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            className="bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded-lg text-[13px] text-[var(--color-text-secondary)] font-medium px-3.5 py-2.5 pr-9 outline-none focus:bg-[var(--color-surface-3)] focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-500)]/20 cursor-pointer transition-all appearance-none hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2020%2020%22%3E%3Cpath%20stroke%3D%22%23737373%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%221.5%22%20d%3D%22m6%208%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat"
-          >
-            <option value="all">All categories</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>{cat}</option>
-            ))}
-          </select>
+          {/* Category select + advanced filters toggle: share a row on mobile,
+              flow individually as flex items from sm: up (display:contents
+              unwraps this grouping div so it doesn't affect desktop layout) */}
+          <div className="flex items-center gap-2.5 sm:contents">
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="flex-1 sm:flex-none min-w-0 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded-lg text-[13px] text-[var(--color-text-secondary)] font-medium px-3.5 py-2.5 pr-9 outline-none focus:bg-[var(--color-surface-3)] focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-500)]/20 cursor-pointer transition-all appearance-none hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2020%2020%22%3E%3Cpath%20stroke%3D%22%23737373%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%221.5%22%20d%3D%22m6%208%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat"
+            >
+              <option value="all">All categories</option>
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
 
-          {/* Advanced Filters Toggle */}
-          <button
-            onClick={() => setShowFilters(!showFilters)}
-            className={`flex items-center gap-2 px-3 py-2 text-[13px] font-mono font-semibold rounded border transition-all ${
-              showFilters || hasActiveFilters
-                ? 'bg-[var(--color-accent)] text-white border-[var(--color-accent)]'
-                : 'bg-[var(--color-surface-2)] text-[var(--color-text-secondary)] border-[var(--color-border)] hover:border-[var(--color-accent)] hover:text-[var(--color-text-primary)]'
-            }`}
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-            </svg>
-            <span className="hidden sm:inline">Filters</span>
-            {hasActiveFilters && (
-              <span className="w-2 h-2 rounded-full bg-white animate-pulse"></span>
-            )}
-          </button>
+            {/* Advanced Filters Toggle */}
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className={`shrink-0 flex items-center gap-2 px-3 py-2 text-[13px] font-mono font-semibold rounded border transition-all ${
+                showFilters || hasActiveFilters
+                  ? 'bg-[var(--color-accent)] text-white border-[var(--color-accent)]'
+                  : 'bg-[var(--color-surface-2)] text-[var(--color-text-secondary)] border-[var(--color-border)] hover:border-[var(--color-accent)] hover:text-[var(--color-text-primary)]'
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+              </svg>
+              <span className="hidden sm:inline">Filters</span>
+              {hasActiveFilters && (
+                <span className="w-2 h-2 rounded-full bg-white animate-pulse"></span>
+              )}
+            </button>
+          </div>
 
           {/* View Mode Toggle */}
           <div className="hidden md:flex items-center gap-1 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded-lg p-1">
@@ -330,12 +334,12 @@ export default function ComponentGrid({ initialType }: Props) {
           </div>
 
           {/* Sort */}
-          <div className="flex items-center gap-2 ml-auto">
+          <div className="flex items-center gap-2 w-full sm:w-auto sm:ml-auto">
             <span className="text-[11px] text-[var(--color-text-tertiary)] font-medium hidden sm:inline">Sort by</span>
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as 'downloads' | 'name')}
-              className="font-mono bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded text-[13px] text-[var(--color-text-secondary)] font-medium px-3 py-2 pr-9 outline-none focus:border-[var(--color-accent)] cursor-pointer transition-all appearance-none hover:border-[var(--color-accent)] hover:text-[var(--color-text-primary)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2020%2020%22%3E%3Cpath%20stroke%3D%22%237d8590%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%221.5%22%20d%3D%22m6%208%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat"
+              className="flex-1 sm:flex-none font-mono bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded text-[13px] text-[var(--color-text-secondary)] font-medium px-3 py-2 pr-9 outline-none focus:border-[var(--color-accent)] cursor-pointer transition-all appearance-none hover:border-[var(--color-accent)] hover:text-[var(--color-text-primary)] bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20fill%3D%22none%22%20viewBox%3D%220%200%2020%2020%22%3E%3Cpath%20stroke%3D%22%237d8590%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%221.5%22%20d%3D%22m6%208%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat"
             >
               <option value="downloads">Most Popular</option>
               <option value="name">Alphabetical</option>

--- a/dashboard/src/components/FeaturedSection.astro
+++ b/dashboard/src/components/FeaturedSection.astro
@@ -3,8 +3,8 @@ import FeaturedCard from './FeaturedCard.astro';
 import { FEATURED_ITEMS } from '../lib/constants';
 
 const gridColsClass = FEATURED_ITEMS.length % 2 === 0
-  ? 'md:grid-cols-2'
-  : 'md:grid-cols-3';
+  ? 'sm:grid-cols-2'
+  : 'sm:grid-cols-2 lg:grid-cols-3';
 ---
 
 <section class="px-6 py-4 mb-2">

--- a/dashboard/src/components/TopBar.astro
+++ b/dashboard/src/components/TopBar.astro
@@ -3,10 +3,10 @@ import ThemeToggle from './ThemeToggle.tsx';
 ---
 
 <header class="sticky top-0 z-20 bg-[var(--color-surface-0)] border-b border-[var(--color-border)] transition-all duration-200">
-  <div class="flex items-center justify-between px-6 h-14">
+  <div class="flex items-center gap-3 justify-between px-6 h-14">
     <!-- Mobile menu button -->
     <button
-      class="md:hidden p-2 rounded border border-[var(--color-border)] hover:bg-[var(--color-surface-2)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] transition-all duration-150 flex items-center justify-center"
+      class="md:hidden shrink-0 p-2 rounded border border-[var(--color-border)] hover:bg-[var(--color-surface-2)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] transition-all duration-150 flex items-center justify-center"
       onclick="toggleSidebar()"
       aria-label="Toggle menu"
     >
@@ -18,7 +18,7 @@ import ThemeToggle from './ThemeToggle.tsx';
     <!-- Search trigger — terminal style -->
     <button
       id="searchTrigger"
-      class="flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] rounded text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-1)] transition-all duration-150 w-full max-w-md group font-ui-mono"
+      class="flex items-center gap-2 px-4 py-2 border border-[var(--color-border)] rounded text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-1)] transition-all duration-150 flex-1 min-w-0 max-w-md group font-ui-mono"
     >
       <span class="terminal-prompt text-[13px]">&gt;</span>
       <span class="text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)]">Search components...</span>


### PR DESCRIPTION
## Summary
- Filter toolbar (search/category/filters/sort) in `ComponentGrid.tsx` now stacks cleanly on mobile instead of leaving the sort dropdown orphaned right-aligned via `ml-auto` when flex-wrap kicked in.
- `FeaturedSection.astro` grid now steps through `sm:grid-cols-2` before `lg:grid-cols-3`, avoiding cramped 3-column cards right at the `md` (768px) breakpoint.
- `TopBar.astro` mobile header now has a `gap-3` between the hamburger menu button and the search input, which previously sat flush against each other.

## Test plan
- [x] Verified filter toolbar stacks full-width on mobile (375px) and matches original layout on desktop (1280px)
- [x] Verified featured cards grid at tablet (768px) now shows 2 columns instead of cramped 3
- [x] Verified 12px gap between hamburger and search input on mobile, no change on desktop
- [x] No console errors in preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the dashboard’s mobile layout by fixing toolbar wrapping and header spacing, and adjusts featured grid breakpoints for better tablet readability.

- **Bug Fixes**
  - Area: components (dashboard/)
  - Filter toolbar now stacks on mobile; category + Filters toggle share a row; sort expands full-width on small screens to avoid right-aligned orphaning.
  - Featured grid now uses `sm:grid-cols-2` and `lg:grid-cols-3` to prevent cramped 3-column cards at `md`.
  - Top bar adds a small gap; hamburger is `shrink-0` and search is `flex-1` to avoid crowding.
  - No new components; no `docs/components.json` regen needed. No new env vars or secrets.

<sup>Written for commit 6ca24efbbc421506462fa9bb89ece576f3f0ba30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

