### PR TITLE
fix: Turkey flag, mobile CTA overflow, and OSS icons in dark mode

### DIFF
--- a/dashboard/src/components/CountryFlag.tsx
+++ b/dashboard/src/components/CountryFlag.tsx
@@ -144,6 +144,16 @@ const FLAG_DATA: Record<string, (maskId: string) => React.ReactNode> = {
       </g>
     </>
   ),
+  TR: (m) => (
+    <>
+      <mask id={m}><circle cx="256" cy="256" r="256" fill="#fff"/></mask>
+      <g mask={`url(#${m})`}>
+        <path fill="#d80027" d="M0 0h512v512H0z"/>
+        <path fill="#eee" d="M199.2 155.4a100.6 100.6 0 1 0 21.6 198.3 122.8 122.8 0 1 1 0-197 100.3 100.3 0 0 0-21.6-1.3z"/>
+        <path fill="#eee" d="m294.3 202.5 8 34.7 34.8-3.9-27.9 21.8 17.9 29.8-32.2-13.9-13 33 -4.9-35-34.8 4.9 27.9-22.7-17.9-28.8 32.2 12.9z"/>
+      </g>
+    </>
+  ),
   MX: (m) => (
     <>
       <mask id={m}><circle cx="256" cy="256" r="256" fill="#fff"/></mask>

--- a/dashboard/src/components/FeaturedSection.astro
+++ b/dashboard/src/components/FeaturedSection.astro
@@ -9,7 +9,7 @@ const gridColsClass = FEATURED_ITEMS.length % 2 === 0
 
 <section class="px-6 py-4 mb-2">
   <div class="bg-[var(--color-surface-1)] rounded-md p-5 border border-[var(--color-border)]">
-    <div class="flex items-center justify-between gap-2 mb-4">
+    <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
       <div class="flex items-center gap-2">
         <span class="terminal-prompt text-[13px]">★</span>
         <h2 class="font-ui-mono text-[13px] font-bold text-[var(--color-text-primary)] tracking-wide uppercase">Featured Integrations</h2>
@@ -18,7 +18,7 @@ const gridColsClass = FEATURED_ITEMS.length % 2 === 0
         href="https://docs.google.com/forms/d/e/1FAIpQLSd7uyNot_YG4vMrt8jJuWiCfb2HNHjGcCZEoVS07SU8OCc-yA/viewform"
         target="_blank"
         rel="noopener noreferrer"
-        class="shrink-0 font-ui-mono text-[12px] font-bold text-[var(--color-accent)] border border-[var(--color-accent)] rounded-md px-3 py-1.5 hover:bg-[var(--color-accent)] hover:text-[var(--color-surface-1)] transition-colors"
+        class="w-full sm:w-auto text-center shrink-0 font-ui-mono text-[12px] font-bold text-[var(--color-accent)] border border-[var(--color-accent)] rounded-md px-3 py-1.5 hover:bg-[var(--color-accent)] hover:text-[var(--color-surface-1)] transition-colors"
       >
         Promote your component →
       </a>

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -118,7 +118,7 @@ const schemaData = JSON.stringify({
           <p class="mb-3">Supported by the open source programs of</p>
           <div class="flex items-center justify-center gap-6 flex-wrap">
             <a href="https://vercel.com/open-source-program" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 hover:text-[var(--color-text-primary)] transition-colors">
-              <img src="https://cdn.simpleicons.org/vercel/currentColor" alt="Vercel" class="h-5 w-5" />
+              <img src="https://cdn.simpleicons.org/vercel/ffffff" alt="Vercel" class="h-5 w-5 oss-icon" />
               <span>Vercel</span>
             </a>
             <a href="https://neon.tech/open-source" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 hover:text-[var(--color-text-primary)] transition-colors">
@@ -126,7 +126,7 @@ const schemaData = JSON.stringify({
               <span>Neon</span>
             </a>
             <a href="https://claude.com/contact-sales/claude-for-oss" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 hover:text-[var(--color-text-primary)] transition-colors">
-              <img src="https://cdn.simpleicons.org/anthropic/currentColor" alt="Claude" class="h-5 w-5" />
+              <img src="https://cdn.simpleicons.org/anthropic/ffffff" alt="Claude" class="h-5 w-5 oss-icon" />
               <span>Claude</span>
             </a>
           </div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -65,6 +65,10 @@ html.dark {
   --shadow-card-hover: 0 0 0 1px #d57455, 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
+html.dark .oss-icon {
+  filter: invert(0);
+}
+
 /* Light mode */
 html.light {
   /* Backgrounds - Clean whites */
@@ -96,6 +100,10 @@ html.light {
   /* Card shadows */
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-card-hover: 0 4px 12px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+html.light .oss-icon {
+  filter: invert(1);
 }
 
 html {


### PR DESCRIPTION
## Summary
- Add the missing `TR` (Turkey) flag entry to `CountryFlag.tsx` — it was falling back to the generic placeholder icon in the Trending "Top Countries" list.
- Fix the "Promote your component →" button overflowing the Featured Integrations card on mobile by allowing the header to wrap and making the button full-width below `sm`.
- Fix the Vercel and Anthropic footer icons being invisible in dark mode. They were requested with `currentColor` (which doesn't resolve for `<img>` sources) and relied on Tailwind's `dark:` variant, which is OS `prefers-color-scheme`-based by default — but this site's theme is toggled via a `.dark`/`.light` class on `<html>`, so the variant never matched. Now the icons load as fixed white and get inverted under `html.light` via a new `.oss-icon` class, consistent with the theme pattern already used elsewhere in `global.css`.

## Test plan
- [x] Verified Turkey's flag renders on `/trending` (Top Countries #5)
- [x] Verified the Featured Integrations CTA no longer overflows at mobile viewport (375px)
- [x] Verified Vercel/Neon/Claude footer icons are visible in both dark and light mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Turkey flag rendering, prevents the mobile CTA from overflowing, and makes OSS footer icons visible in both themes. Updates CountryFlag, FeaturedSection layout, and theme-aware icon styling.

- **Bug Fixes**
  - Added TR flag to render Turkey correctly in Trending.
  - Allowed Featured Integrations header to wrap; CTA is full-width on mobile to avoid overflow.
  - Switched Vercel/Claude icons to white with theme inversion via `oss-icon`, ensuring visibility in dark/light.

- **Notes**
  - Area: components (dashboard/). No new components; no docs/components.json regeneration. No new env vars or secrets.

<sup>Written for commit 59d96f5bb0c4d6115e76e4f2defd3ae8fb41d77b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

