### PR TITLE
Improve literature review skill

### DIFF
--- a/cli-tool/components/skills/scientific/literature-review/SKILL.md
+++ b/cli-tool/components/skills/scientific/literature-review/SKILL.md
@@ -219,6 +219,24 @@ Literature reviews follow a structured, multi-phase workflow:
    efficiency (40-60%) but improved safety profiles^16-23^.
    ```
 
+#### Mathematical Notation in Markdown
+
+When writing mathematical content, **always use LaTeX math delimiters** — never Unicode math symbols. Pandoc's PDF conversion requires LaTeX syntax:
+
+- **Inline math**: wrap with `$...$`
+  - Correct: `$\alpha$`, `$\int_0^\infty f(x)\,dx$`, `$p \leq 0.05$`
+  - Wrong: `α`, `∫₀^∞ f(x)dx`, `p ≤ 0.05`
+- **Block/display math**: wrap with `$$...$$` on its own line
+  - Correct:
+    ```
+    $$
+    \sum_{i=1}^{n} x_i = \bar{x} \cdot n
+    $$
+    ```
+  - Wrong: `Σᵢ xᵢ = x̄ · n`
+
+Unicode math characters (∫ ∑ α β π ≤ ≥ ≠ ∞ √ etc.) look fine in a text editor but cause pandoc PDF generation to fail or produce garbled output. Use LaTeX equivalents every time.
+
 3. **Critical Analysis**:
    - Evaluate methodological strengths and limitations across studies
    - Assess quality and consistency of evidence
@@ -293,6 +311,7 @@ Literature reviews follow a structured, multi-phase workflow:
    - [ ] Limitations acknowledged
    - [ ] References complete and accurate
    - [ ] PDF generates without errors
+   - [ ] Mathematical expressions use `$...$` / `$$...$$` LaTeX delimiters (no raw Unicode math symbols)
 
 ## Database-Specific Search Guidance
 
@@ -437,6 +456,7 @@ Detailed formatting guidelines are in `references/citation_styles.md`. Quick ref
 8. **No quality assessment**: Treats all evidence equally; assess and report quality
 9. **Publication bias**: Only positive results published; note potential bias
 10. **Outdated search**: Field evolves rapidly; clearly state search date
+11. **Unicode math symbols in markdown**: Symbols like ∫, Σ, α, ≤ break pandoc PDF conversion; use `$...$` and `$$...$$` LaTeX delimiters instead
 
 ## Example Workflow
 


### PR DESCRIPTION
The repository contains a skill `literature-review` which is used to automatically conduct a scientific literature review and create a useful summary in both markdown and PDF. However, currently, especially in math-heavy fields, the markdown may be generated with Unicode mathematical symbols instead of LaTeX expressions enclosed in `$...$` or `$$...$$` which causes downstream failures during the conversion to PDF. This PR alleviates this problem by adding relevant instructions to the skill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LaTeX math rules to the `literature-review` skill to prevent Pandoc PDF failures caused by Unicode math in generated Markdown. This makes math-heavy reviews render reliably.

- **Bug Fixes**
  - Updated `cli-tool/components/skills/scientific/literature-review/SKILL.md` with rules, examples, and a checklist item to require `$...$`/`$$...$$` LaTeX math and avoid Pandoc errors.
  - Area: components (`cli-tool/components/`).
  - No new components; catalog `docs/components.json` does not need regeneration.
  - No new environment variables or secrets.

<sup>Written for commit 4cc6bb4c5b02c1314a357d2f4c47cd1a64b1d59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

