### PR TITLE
chore: sync remaining Anthropic skills LICENSE attribution

### DIFF
--- a/cli-tool/components/skills/business-marketing/brand-guidelines-anthropic/LICENSE.txt
+++ b/cli-tool/components/skills/business-marketing/brand-guidelines-anthropic/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/development/web-artifacts-builder/LICENSE.txt
+++ b/cli-tool/components/skills/development/web-artifacts-builder/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cli-tool/components/skills/enterprise-communication/internal-comms-anthropic/LICENSE.txt
+++ b/cli-tool/components/skills/enterprise-communication/internal-comms-anthropic/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Anthropic, PBC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Continuation of the LICENSE audit from #670, which compared skills against [anthropics/skills](https://github.com/anthropics/skills) and filled in the unfilled Apache-2.0 copyright placeholder for `artifacts-builder` and `webapp-testing`, but missed three other skills carrying the same drift:

- `cli-tool/components/skills/business-marketing/brand-guidelines-anthropic/LICENSE.txt`
- `cli-tool/components/skills/enterprise-communication/internal-comms-anthropic/LICENSE.txt`
- `cli-tool/components/skills/development/web-artifacts-builder/LICENSE.txt`

Each had `Copyright [yyyy] [name of copyright owner]` on line 190; changed to `Copyright 2026 Anthropic, PBC.` to match upstream and the sibling skills already fixed in #670.

This PR was produced by a scheduled routine that did a full recursive diff of all 17 skills in `anthropics/skills` against their counterparts in this repo. This was the only drift found — everything else (docx, pdf-anthropic, pptx, xlsx, algorithmic-art, canvas-design, theme-factory, mcp-builder, skill-creator, slack-gif-creator, webapp-testing, and the various duplicate/official/community variants) is already byte-for-byte in sync with upstream, or only has local-only extra files with nothing missing.

The `-community` suffixed variants of `brand-guidelines` and `internal-comms` deliberately keep the placeholder unfilled by design (generic/reusable) and were intentionally left untouched, as were `claude-api`, `doc-coauthoring`, and `frontend-design`, which were migrated from a different marketplace source per #670 and coincidentally share names with upstream skills that have different content.

## Test plan

- [x] `git diff` confirms exactly one line changed per file, nothing else touched
- [x] Validated with the `component-reviewer` agent — approved, no critical issues
- [x] Regenerated `docs/components.json` locally to sanity-check: skill/category counts matched HEAD exactly and no skills disappeared, but the generator reset all download counts to zero in this environment (same known issue noted in #670) — since `LICENSE.txt` isn't part of the generated catalog, the regenerated artifacts were reverted and are **not** included in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01VmEZQfzw34oPEAVEYhqCgj)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs LICENSE attribution in three Anthropic skills to match the upstream `anthropics/skills`. Replaces the Apache-2.0 placeholder with "Copyright 2026 Anthropic, PBC."; no runtime or build impact.

- **Details**
  - Area: components (`cli-tool/components/`)
  - Updated LICENSE.txt in: business-marketing/brand-guidelines-anthropic, enterprise-communication/internal-comms-anthropic, development/web-artifacts-builder
  - No new components; `docs/components.json` regeneration not needed
  - No new environment variables or secrets

<sup>Written for commit 1b9fe71e0ce909a51e7ad9d1059fd0bde673f224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

