### PR TITLE
feat: add AlphaAI financial news MCP component

### DIFF
--- a/cli-tool/components/mcps/integration/alphai.json
+++ b/cli-tool/components/mcps/integration/alphai.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "alphai": {
+      "description": "Pre-analyzed financial news via REST API and MCP. Per-ticker impact, category, and a 1-10 relevance score on every story, plus SEC Form 4 insider data. Free tier, no card.",
+      "type": "http",
+      "url": "https://mcp.alphai.io/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds AlphaAI as a remote MCP component: `cli-tool/components/mcps/integration/alphai.json`.

AlphaAI serves pre-analyzed financial news for AI agents and trading bots. Every story carries per-ticker impact analysis, a category, and a 1-10 relevance score, plus SEC Form 4 insider data as structured events.

## Component details

- Endpoint: `https://mcp.alphai.io/mcp` (streamable HTTP)
- Auth: OAuth 2.1 with dynamic client registration, so there is no API key or header to configure; the client opens a browser on connect
- Free tier: 20 req/min, 100 req/day, no card
- Same `type: http` + `url` shape as existing remote components (zread.json, web-reader.json)
- Docs: https://alphai.io/developers

AlphaAI output is AI-generated financial information for research, not investment advice (https://alphai.io/terms).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added AlphaAI as a remote MCP component to surface pre-analyzed financial news and SEC Form 4 data. This lets agents access per-ticker impact, categories, and relevance scores through the components catalog.

- **New Features**
  - Area: components (`cli-tool/components/`); added `cli-tool/components/mcps/integration/alphai.json`.
  - Endpoint/type/auth: `https://mcp.alphai.io/mcp` (`http`); OAuth 2.1 with dynamic client registration; no API keys.
  - New component added; regenerate `docs/components.json` if the catalog is built from source.
  - No new environment variables or secrets required.

<sup>Written for commit 2008065bdddf9a7595bed32b1aa9124afc2e276d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

