### PR TITLE
Add internet-court skill (agent-to-agent commerce)

### DIFF
--- a/cli-tool/components/skills/development/internet-court/SKILL.md
+++ b/cli-tool/components/skills/development/internet-court/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: internet-court
+description: "The trust layer for agent-to-agent commerce — natural-language mandates, delegated permissions (ERC-7710), x402 payments, escrow, and dispute resolution as one open, catch-all skill. Use for agent mandates, delegated permissions, GenLayer supervision, revocation, x402 payments, escrow, verification, dispute resolution, and agent-to-agent commerce."
+license: MIT
+author: Internet Court Consortium
+repo: https://github.com/internet-court/internet-court-skill
+tags: [agent-payments, x402, erc-7710, erc-8004, escrow, genlayer, dispute-resolution, a2a, agentic-commerce]
+---
+
+# Internet Court
+
+The trust layer for agent-to-agent commerce. It turns "I want my agent to
+transact, but I don't trust it with money" into an enforceable workflow: a
+natural-language mandate becomes bounded authority, payments, escrow, signed
+evidence, independent review, and revocation or dispute resolution when
+something goes wrong.
+
+This is a condensed entry point. The full package — a master router plus ~70
+vendored protocol and connector skills — lives at
+**https://github.com/internet-court/internet-court-skill** (homepage:
+https://internetcourt.org). Install the whole package for the sub-skills, or
+let this router fetch them on demand from the repo.
+
+## When to use
+
+Trigger whenever an agent needs to transact with another agent or a paid
+service, or a user mentions: agent payments, paid APIs (HTTP 402 / x402),
+wallet custody or trust, spending mandates, delegated permissions (ERC-7710 /
+7715), escrow, agent identity or reputation (ERC-8004), negotiation between
+agents (A2A), machine payments (MPP), supervision, revocation, verification, or
+dispute resolution (GenLayer, Kleros) — even if they never say "Internet Court".
+
+## The stack it routes to
+
+| Layer | Concern | Examples in the full package |
+|---|---|---|
+| 1 | Identity & reputation | ERC-8004 registries, Starknet identity |
+| 2 | Negotiation | A2A protocol |
+| 3 | Contracts & obligations | Arkhai/Alkahest escrow, ERC-7710 delegations |
+| 4 | Payment & escrow | x402, MPP, ERC-7710/7715 delegated wallets |
+| 5 | Execution | compute, data & value rails |
+| 6 | Verification & disputes | GenLayer, Kleros, Intelligent Oracle |
+
+## How to use
+
+1. Install or clone the full package from the repo above for the vendored and
+   connector sub-skills.
+2. Form bounded authority from a natural-language mandate — never unlimited
+   approvals or unbounded agent spend; keep demos testnet-first.
+3. Route the task to the right layer above; load the specific sub-skill's
+   `SKILL.md` from the package (on disk, or from the repo's raw URL) before
+   relying on its mechanics — never invent a protocol's behavior.
+4. Produce checkable evidence (tx hashes, signed receipts); on disputes, route
+   to the verification layer and disclose the decision-vs-enforcement boundary.
+
+MIT licensed. See the canonical repository for full routing, connectors, and
+`skills-lock.json`.


### PR DESCRIPTION
Adds `cli-tool/components/skills/development/internet-court/SKILL.md` under **skills → development**. A condensed router skill for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and GenLayer dispute resolution — pointing to the full package at https://github.com/internet-court/internet-court-skill (MIT). Single-line `description`, inline `tags`, clean body (no tool invocations). Left the auto-generated `components.json`/`search-index.json` untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `internet-court` skill for agent-to-agent commerce, routing mandates, delegated permissions (ERC-7710), x402 payments, escrow, and GenLayer dispute resolution. Provides a clean, single-skill entry that links to the full router package.

- Area: components (`cli-tool/components/`)
- New component added: `cli-tool/components/skills/development/internet-court/SKILL.md`
- Catalog: regenerate `docs/components.json` (and search index) to include the new skill
- Env vars/secrets: none

<sup>Written for commit 2ff9e88199231f71b595868786b4bfad6c305d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

