### PR TITLE
Add posthell MCP component (marketing)

### DIFF
--- a/cli-tool/components/mcps/marketing/posthell.json
+++ b/cli-tool/components/mcps/marketing/posthell.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "posthell": {
+      "description": "posthell - social media scheduler for AI agents. Shape rough notes into posts in your voice, queue drafts for human approval, read growth analytics, and (per-key opt-in) publish to 15 networks (X, LinkedIn, Instagram, TikTok, and more). Hosted remote server; create your API key in the posthell dashboard (https://www.posthell.com/mcp).",
+      "type": "http",
+      "url": "https://www.posthell.com/api/mcp",
+      "headers": {
+        "Authorization": "Bearer your_api_key"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds posthell, a hosted social media scheduler built for AI agents, as an HTTP MCP component in the marketing category (same shape as web/zread.json).

- Remote Streamable HTTP server: `https://www.posthell.com/api/mcp`, per-user API key from the posthell dashboard
- Tools: shape_post (grounded drafting in the user's voice), create_draft (human-approval queue), list_posts (with engagement metrics), get_growth, publish_post (per-key opt-in, spend-capped)
- 15 networks; docs at https://www.posthell.com/mcp; also in the official MCP registry (io.github.Rohan27s/posthell)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `posthell` as a marketing MCP component for drafting, scheduling, analytics, and optional publishing via a hosted HTTP server.

- Area: components (`cli-tool/components/`); added `cli-tool/components/mcps/marketing/posthell.json`.
- Remote server `https://www.posthell.com/api/mcp` with `Authorization: Bearer <API_KEY>`.
- Tools: shape_post, create_draft, list_posts, get_growth, publish_post.
- New component: yes; regenerate catalog `docs/components.json`.
- Secrets: requires `posthell` API key; no new env var added.

<sup>Written for commit 6a0a4d16cb87e992da837d9beebb48f60d099a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

