### PR TITLE
feat: add nika MCP (read-only AI workflow oracle) to devtools

### DIFF
--- a/cli-tool/components/mcps/devtools/nika.json
+++ b/cli-tool/components/mcps/devtools/nika.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "nika": {
+      "description": "Read-only oracle for Nika AI workflows (.nika.yaml): validate a workflow, get findings explained with fix guidance, browse schema and examples, and see an honest cost estimate — all before a single token is spent. No execution and no mutation over MCP by design. Requires the nika binary (brew install supernovae-st/tap/nika).",
+      "command": "nika",
+      "args": ["mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Adds the **nika** MCP server component (devtools): a read-only oracle over the Nika workflow engine — agents validate `.nika.yaml` workflow DAGs, get findings explained, browse schema/examples, and see an honest cost estimate before anything runs. No execution/mutation over MCP by design (threat model documented in-repo). Binary install (brew or SHA256SUMS-verified tarball) — no env vars needed.

Format mirrors `mcps/audio/elevenlabs.json`. Disclosure: I'm the author (engine AGPL-3.0, Rust).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `nika` MCP server to devtools to validate `.nika.yaml` workflows and estimate cost without running them. Gives agents a read-only oracle with schema/examples browsing and clear findings.

- Area: components (`cli-tool/components/`)
- New component: `cli-tool/components/mcps/devtools/nika.json`; regenerate `docs/components.json`
- Capabilities: validation with explanations, schema/examples browsing, cost estimate; no execution or mutation over MCP
- Requires `nika` binary (`brew install supernovae-st/tap/nika`); no new env vars or secrets

<sup>Written for commit 67ac199dc48fb6e8a60d2696ee06be3df857ad0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

