### PR TITLE
Add plugin details modal and search to marketplace pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,6 +476,13 @@ All of the above are served as static Cloudflare Pages assets with
 3. Dashboard islands (`ComponentGrid.tsx`, `SearchModal.tsx`, `Sidebar.astro`, `SendToRepoModal.tsx`) load the split artifacts instead of the full catalog
 4. Download tracking via `/api/track-download-supabase`
 
+### Plugins & Marketplaces Catalog
+
+- `scripts/generate_plugins_json.py` — scans the repos listed in `REPOS` via the `gh` CLI (needs `gh auth login`) and writes `dashboard/public/plugins.json`. This is a **manual, offline step** — it does not run during `npm run build` or CI/CD, so re-running it never affects deploy time.
+- For each marketplace it records `plugins_list[].components` (counts per type) and `plugins_list[].components_items` (`{name, description}` per command/agent/skill/hook/mcp/lsp, description parsed from the item's frontmatter). The dashboard's `/plugins/[slug].astro` page renders this through `MarketplacePluginsList.tsx`, which shows a search box and a "view details" modal per plugin.
+- **`max_local_scans = 50`** in `extract_marketplace_plugins_detail()` caps how many *locally-sourced* plugins (i.e. `source: "./plugins/..."` within the marketplace's own repo) get scanned for real component names/descriptions, per marketplace, to bound GitHub API calls. Plugins beyond that cap (or plugins hosted in an external repo, which are never scanned) fall back to showing only tag badges in the modal, with no itemized breakdown — this is a graceful degradation, not an error.
+  - As of 2026-07-11, `anthropics/claude-plugins-official` alone has 51 locally-sourced plugins (out of 255 total), i.e. already at the edge of this cap. Bump `max_local_scans` if more complete coverage is needed — GitHub's rate limit (5000 req/hour authenticated) is not the constraint, wall-clock run time is (each item now costs 1 extra API call to fetch its file content for the description).
+
 ### Legacy Static Site (docs/)
 
 The `docs/` directory contains the old static HTML site (no longer deployed to www). Blog articles in `docs/blog/` are still referenced externally.

--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -1,61 +1,11 @@
 [
   {
-    "slug": "ml-plugins",
-    "name": "ml-research",
-    "author": "krasserm",
-    "description": "Native Claude Code port of Hugging Face's ml-intern: research-first autonomous ML engineering and fine-tuning (SFT/DPO/GRPO/LoRA) on HF Jobs, with dataset/repo/paper tooling and an optional budget-bounded autonomous experiment loop.",
-    "github": "https://github.com/krasserm/ml-plugins",
-    "stars": 1,
-    "type": "plugin",
-    "tags": [
-      "skills",
-      "agents",
-      "hooks"
-    ],
-    "contains": {
-      "skills": 2,
-      "agents": 2,
-      "hooks": 1
-    },
-    "highlights": [
-      "No LLM API key: every model call runs on your Claude Code subscription",
-      "Research-first fine-tuning (SFT/DPO/GRPO/LoRA) on Hugging Face Jobs",
-      "Optional budget-bounded autonomous experiment sweep"
-    ]
-  },
-  {
-    "slug": "mercadopago-claude-marketplace",
-    "name": "Mercado Pago",
-    "author": "mercadopago",
-    "description": "Official Claude Code plugin from the Mercado Pago Developer Experience team. Scaffold, review, and maintain payment integrations across 7 countries and 13 products — Checkout Pro, Bricks, Subscriptions, QR, Marketplace, and more.",
-    "github": "https://github.com/mercadopago/mercadopago-claude-marketplace",
-    "stars": 0,
-    "type": "plugin",
-    "tags": [
-      "agents",
-      "commands",
-      "skills",
-      "hooks"
-    ],
-    "contains": {
-      "agents": 1,
-      "commands": 3,
-      "skills": 13,
-      "hooks": 1
-    },
-    "highlights": [
-      "7 countries: AR, BR, MX, CL, CO, PE, UY",
-      "13 products: Checkout Pro, Bricks, QR, Subscriptions, Marketplace, and more"
-    ],
-    "website": "https://www.mercadopago.com/developers"
-  },
-  {
     "slug": "everything-claude-code",
-    "name": "Everything Claude Code",
+    "name": "Ecc",
     "author": "affaan-m",
     "description": "The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.",
     "github": "https://github.com/affaan-m/everything-claude-code",
-    "stars": 112647,
+    "stars": 228605,
     "type": "plugin",
     "tags": [
       "skills",
@@ -63,19 +13,31 @@
       "commands",
       "hooks"
     ],
-    "contains": {},
+    "contains": {
+      "skills": 1,
+      "commands": 1
+    },
     "highlights": [
+      "Plugin declares: 1 skills, 1 commands",
       "Web UI: https://ecc.tools"
     ],
-    "website": "https://ecc.tools"
+    "website": "https://ecc.tools",
+    "plugin_manifest": {
+      "skills": [
+        "./skills/"
+      ],
+      "commands": [
+        "./commands/"
+      ]
+    }
   },
   {
     "slug": "claude-mem",
     "name": "Claude Mem",
     "author": "thedotmack",
-    "description": "A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude's agent-sdk), and injects relevant context back into future sessions.",
+    "description": "Persistent Context Across Sessions for Every Agent –  Captures everything your agent does during sessions, compresses it with AI, and injects relevant context back into future sessions. Works with Claude Code, OpenClaw, Codex, Gemini, Hermes, Copilot, OpenCode + More",
     "github": "https://github.com/thedotmack/claude-mem",
-    "stars": 41624,
+    "stars": 86873,
     "type": "plugin",
     "tags": [
       "skills",
@@ -93,7 +55,7 @@
     "author": "anthropics",
     "description": "Official, Anthropic-managed directory of high quality Claude Code Plugins.",
     "github": "https://github.com/anthropics/claude-plugins-official",
-    "stars": 15048,
+    "stars": 31988,
     "type": "marketplace",
     "tags": [
       "skills",
@@ -103,26 +65,35 @@
       "lsps"
     ],
     "contains": {
-      "plugins": 119,
+      "plugins": 255,
       "components": {
-        "agents": 16,
-        "commands": 16,
+        "agents": 23,
+        "commands": 28,
+        "skills": 40,
         "lsps": 12,
-        "skills": 23,
-        "hooks": 11
+        "hooks": 20
       }
     },
     "highlights": [
       "Official Anthropic repository",
-      "119 plugins in marketplace",
+      "255 plugins in marketplace",
       "Web UI: https://code.claude.com/docs/en/plugins"
     ],
     "website": "https://code.claude.com/docs/en/plugins",
     "plugins_list": [
       {
-        "name": "adspirer-ads-agent",
-        "description": "Cross-platform ad management for Google Ads, Meta Ads, TikTok Ads, and LinkedIn Ads. 91 tools for keyword research, campaign creation, performance analysis, and budget optimization.",
-        "source": "https://github.com/amekala/adspirer-mcp-plugin.git"
+        "name": "42crunch-api-security-testing",
+        "description": "Automate API security directly in Claude Code with 42Crunch - automatically audit OpenAPI specs, detect vulnerabilities aligned with OWASP API Security risks (including BOLA/BFLA), and apply AI-powered fixes. Designed for AI-assisted development workflows, it provides continuous guardrails through an audit->scan->remediate->validate loop, ensuring APIs meet enterprise security standards before deployment.",
+        "source": "https://github.com/42Crunch-AI/claude-plugins.git",
+        "source_path": "plugins/api-security-testing",
+        "author": "42Crunch"
+      },
+      {
+        "name": "adobe-for-creativity",
+        "description": "Harness Adobe's creative AI-powered tools to edit images, automate design workflows, and bring creative visions to life — from background removal to vectorization and professional retouching.",
+        "source": "https://github.com/adobe/skills.git",
+        "source_path": "plugins/creative-cloud/adobe-for-creativity",
+        "author": "Adobe"
       },
       {
         "name": "agent-sdk-dev",
@@ -132,13 +103,30 @@
         "components": {
           "agents": 2,
           "commands": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "agent-sdk-verifier-py",
+              "description": "Use this agent to verify that a Python Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a Python Agent SDK app has been created or modified."
+            },
+            {
+              "name": "agent-sdk-verifier-ts",
+              "description": "Use this agent to verify that a TypeScript Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a TypeScript Agent SDK app has been created or modified."
+            }
+          ],
+          "commands": [
+            {
+              "name": "new-sdk-app",
+              "description": "Create and setup a new Claude Agent SDK application"
+            }
+          ]
         }
       },
       {
-        "name": "ai-firstify",
-        "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp",
-        "source": "techwolf-ai/ai-first-toolkit",
-        "source_path": "plugins/ai-firstify"
+        "name": "agentforce-adlc",
+        "description": "Agentforce Agent Development Life Cycle — author, discover, scaffold, deploy, test, and optimize .agent files",
+        "source": "https://github.com/SalesforceAIResearch/agentforce-adlc.git"
       },
       {
         "name": "ai-plugins",
@@ -151,10 +139,60 @@
         "source": "https://github.com/AikidoSec/aikido-claude-plugin.git"
       },
       {
+        "name": "airtable",
+        "description": "Airtable is the database and operations layer for your agents — whether running product, marketing, sales, ops, HR, or a custom business app. It combines structured data with multiplayer visual surfaces (grid, kanban, calendar, gallery, timeline) humans and agents share — plus sync integrations to Jira, Salesforce, Zendesk, Google Drive, Databricks, and the rest of your stack, all backed by enterprise governance. This plugin makes Claude fluent in Airtable: creating bases and schema, working with records, and sharing UI for collaboration. Bundles the official Airtable MCP server.",
+        "source": "https://github.com/Airtable/skills.git",
+        "source_path": "plugins/airtable",
+        "author": "Airtable"
+      },
+      {
+        "name": "airwallex-agentos",
+        "description": "Bring Airwallex's global financial infrastructure to Claude. Orchestrate actions across your account in plain language, e.g., set up invoices from a PO, onboard suppliers from invoices, and check current cash position across currencies. AgentOS bundles pre-built finance Skills with MCP servers. A public CLI connects your agent to Airwallex's capabilities.",
+        "source": "https://github.com/airwallex/airwallex-marketplace.git",
+        "source_path": "plugins/airwallex-agentos",
+        "author": "Airwallex"
+      },
+      {
+        "name": "alloydb",
+        "description": "Create, connect, and interact with an AlloyDB for PostgreSQL database and data.",
+        "source": "https://github.com/gemini-cli-extensions/alloydb.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "alloydb-omni",
+        "description": "Create, connect, and interact with an AlloyDB Omni database and data.",
+        "source": "https://github.com/gemini-cli-extensions/alloydb-omni.git",
+        "author": "Google LLC"
+      },
+      {
         "name": "amazon-location-service",
         "description": "Guide developers through adding maps, places search, geocoding, routing, and other geospatial features with Amazon Location Service, including authentication setup, SDK integration, and best practices.",
         "source": "https://github.com/awslabs/agent-plugins.git",
         "source_path": "plugins/amazon-location-service"
+      },
+      {
+        "name": "amplitude",
+        "description": "Use Amplitude as an expert analyst — instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts.",
+        "source": "https://github.com/amplitude/mcp-marketplace.git",
+        "source_path": "plugins/amplitude"
+      },
+      {
+        "name": "apollo",
+        "description": "Prospect, enrich leads, load outreach sequences, and query sales analytics with Apollo.io — one-click MCP server integration for Claude Code and Cowork.",
+        "source": "https://github.com/apolloio/apollo-mcp-plugin.git",
+        "author": "Apollo.io"
+      },
+      {
+        "name": "apollo-skills",
+        "description": "Apollo GraphQL agent skills for Claude Code — Apollo Client, Server, Federation, Connectors, Router, Rover CLI, iOS, Kotlin, and the Apollo MCP server. Covers schema design, query optimization, and GraphQL best practices.",
+        "source": "https://github.com/apollographql/skills.git",
+        "author": "Apollo GraphQL"
+      },
+      {
+        "name": "appwrite",
+        "description": "Appwrite tools for Claude Code, including SDK skills, Appwrite MCP servers, and deployment commands.",
+        "source": "https://github.com/appwrite/claude-plugin.git",
+        "author": "Appwrite"
       },
       {
         "name": "asana",
@@ -186,10 +224,52 @@
         ]
       },
       {
-        "name": "autofix-bot",
-        "description": "Code review agent that detects security vulnerabilities, code quality issues, and hardcoded secrets. Combines 5,000+ static analyzers to scan your code and dependencies for CVEs.",
-        "source": "./external_plugins/autofix-bot",
-        "author": "DeepSource Corp"
+        "name": "auth0",
+        "description": "Enterprise-grade auth, easy to implement. Add login, SSO, MFA, and access control to any app with framework-aware guidance.",
+        "source": "https://github.com/auth0/agent-skills.git",
+        "source_path": "plugins/auth0",
+        "author": "Auth0"
+      },
+      {
+        "name": "aws-agents",
+        "description": "Build, deploy, and operate AI agents on AWS. Skills for scaffolding agents with Amazon Bedrock AgentCore, connecting tools, memory, policies, evaluation, debugging, and production hardening.",
+        "source": "https://github.com/aws/agent-toolkit-for-aws.git",
+        "source_path": "plugins/aws-agents",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "aws-agents-for-devsecops",
+        "description": "Investigate incidents, review code and execute UAT for release readiness, scan code for vulnerabilities, and run penetration tests with AWS DevOps Agent and AWS Security Agent.",
+        "source": "https://github.com/aws/agent-toolkit-for-aws.git",
+        "source_path": "plugins/aws-agents-for-devsecops",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "aws-amplify",
+        "description": "Build full-stack apps with AWS Amplify Gen 2 using guided workflows for authentication, data models, storage, GraphQL APIs, and Lambda functions.",
+        "source": "https://github.com/awslabs/agent-plugins.git",
+        "source_path": "plugins/aws-amplify"
+      },
+      {
+        "name": "aws-core",
+        "description": "Build, deploy, and operate applications on AWS. Skills to author infrastructure-as-code, use core services, and complete common tasks.",
+        "source": "https://github.com/aws/agent-toolkit-for-aws.git",
+        "source_path": "plugins/aws-core",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "aws-data-analytics",
+        "description": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena.",
+        "source": "https://github.com/aws/agent-toolkit-for-aws.git",
+        "source_path": "plugins/aws-data-analytics",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "aws-dev-toolkit",
+        "description": "AWS development toolkit — 34 skills, 11 agents, and 3 MCP servers for building, migrating, and performing architecture reviews on AWS.",
+        "source": "https://github.com/aws-samples/sample-claude-code-plugins-for-startups.git",
+        "source_path": "plugins/aws-dev-toolkit",
+        "author": "aws-samples"
       },
       {
         "name": "aws-serverless",
@@ -198,14 +278,142 @@
         "source_path": "plugins/aws-serverless"
       },
       {
+        "name": "aws-startup-advisor",
+        "description": "Personalized architecture, cost, security, and migration guidance for startups. From day-one account setup and security baselines to production-ready infrastructure, cost optimization, and beyond. Includes AWS Activate Credits eligibility, 60+ exclusive startup offers, and multi-account multi-region support. Built on expertise from AWS Startup Solutions Architects and patterns from 350,000+ startups.",
+        "source": "https://github.com/awslabs/startups.git",
+        "source_path": "advisor/plugins/aws-startup-advisor",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "aws-transform",
+        "description": "Migrate, modernize, and upgrade codebases to AWS. Transforms .NET Framework to .NET 8/10, mainframe COBOL to Java, VMware VMs to EC2, SQL Server to Aurora, and upgrades Java/Python/Node.js versions and AWS SDKs. AWS Transform - continuous modernization analyzes codebases for tech debt, security issues, and upgrade opportunities, then remediates them.",
+        "source": "https://github.com/awslabs/agent-plugins.git",
+        "source_path": "plugins/aws-transform",
+        "author": "Amazon Web Services"
+      },
+      {
+        "name": "azure",
+        "description": "Transform Claude into an Azure expert. This plugin integrates the Azure MCP server and specialized Azure skills to move beyond generic advice. It enables Claude to perform real-world tasks: listing resources, validating deployments, diagnosing infrastructure issues, and optimizing costs across 50+ Azure services.",
+        "source": "https://github.com/microsoft/azure-skills.git"
+      },
+      {
+        "name": "azure-cosmos-db-assistant",
+        "description": "Expert assistant for Azure Cosmos DB — data modeling, query optimization, performance tuning, and best practices.",
+        "source": "https://github.com/AzureCosmosDB/cosmosdb-claude-code-plugin.git"
+      },
+      {
+        "name": "base44",
+        "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills",
+        "source": "https://github.com/base44/skills.git"
+      },
+      {
+        "name": "bigdata-com",
+        "description": "Official Bigdata.com plugin providing financial research, analytics, and intelligence tools powered by Bigdata MCP.",
+        "source": "https://github.com/Bigdata-com/bigdata-plugins-marketplace.git",
+        "source_path": "plugins/bigdata-com",
+        "author": "RavenPack"
+      },
+      {
+        "name": "bigquery-data-analytics",
+        "description": "Connect, query, and generate data insights for BigQuery datasets and data.",
+        "source": "https://github.com/gemini-cli-extensions/bigquery-data-analytics.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "boltz",
+        "description": "Predict structures, screen molecules and proteins, and design binders with Boltz from Claude Code.",
+        "source": "https://github.com/boltz-bio/boltz-api-skills.git",
+        "source_path": "plugins/boltz",
+        "author": "Boltz"
+      },
+      {
+        "name": "box",
+        "description": "Work with your Box content directly from Claude Code — search files, organize folders, collaborate with your team, and use Box AI to answer questions, summarize documents, and extract data without leaving your workflow.",
+        "source": "https://github.com/box/box-for-ai.git",
+        "components": {
+          "skills": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "box",
+              "description": ""
+            },
+            {
+              "name": "box-legal-workflows",
+              "description": ""
+            },
+            {
+              "name": "box-legal-workflows-contract",
+              "description": ""
+            },
+            {
+              "name": "box-legal-workflows-intake",
+              "description": ""
+            },
+            {
+              "name": "box-legal-workflows-ma",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
         "name": "brightdata-plugin",
         "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 7 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, Python SDK best practices for the brightda...",
         "source": "https://github.com/brightdata/skills.git"
       },
       {
+        "name": "buildkite",
+        "description": "Official Buildkite skills for Claude Code, Cursor, and other AI coding agents — pipelines, migration, preflight, agent runtime, CLI, and API",
+        "source": "https://github.com/buildkite/skills.git",
+        "author": "Buildkite"
+      },
+      {
+        "name": "canva",
+        "description": "Create, edit, review, resize, and brand-check Canva designs with the Canva MCP server.",
+        "source": "https://github.com/canva-sdks/canva-skills.git",
+        "source_path": "plugins/canva",
+        "author": "Canva"
+      },
+      {
+        "name": "carta-cap-table",
+        "description": "Carta Cap Table plugin — skills and hooks for querying cap tables, grants, SAFEs, 409A valuations, waterfall scenarios, and more",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-cap-table",
+        "author": "Carta Engineering"
+      },
+      {
+        "name": "carta-crm",
+        "description": "Manage the Carta CRM conversationally — search, add, update, and enrich investors, companies, contacts, deals, notes, and fundraisings via the Carta CRM MCP Server.",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-crm",
+        "author": "Carta Engineering"
+      },
+      {
+        "name": "carta-investors",
+        "description": "Carta Investors plugin — skills for querying investor data, performance benchmarks, regulatory reporting, AGM deck generation, brand extraction, and more via the Carta MCP Server.",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-investors",
+        "author": "Carta Engineering"
+      },
+      {
+        "name": "cds-mcp",
+        "description": "AI-assisted development of SAP Cloud Application Programming Model (CAP) projects. Search CDS models and CAP documentation.",
+        "source": "https://github.com/cap-js/mcp-server.git",
+        "author": "SAP SE"
+      },
+      {
         "name": "chrome-devtools-mcp",
         "description": "Control and inspect a live Chrome browser from your coding agent. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions with Puppeteer.",
         "source": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git"
+      },
+      {
+        "name": "circle-skills",
+        "description": "Ship stablecoin apps faster. Best-practice skills for USDC payments, cross-chain transfers, wallets, and smart contracts — plus Circle's MCP server for real-time SDK and documentation guidance.",
+        "source": "https://github.com/circlefin/skills.git",
+        "source_path": "plugins/circle",
+        "author": "Circle"
       },
       {
         "name": "circleback",
@@ -219,6 +427,14 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "clangd",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -228,6 +444,14 @@
         "author": "Anthropic",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "claude-automation-recommender",
+              "description": "Analyze a codebase and recommend Claude Code automations (hooks, subagents, skills, plugins, MCP servers). Use when user asks for automation recommendations, wants to optimize their Claude Code setup, mentions improving Claude Code workflows, asks how to first set up Claude Code for a project, or wants to know what Claude Code features they should use."
+            }
+          ]
         }
       },
       {
@@ -238,7 +462,56 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "claude-md-improver",
+              "description": "Audit and improve CLAUDE.md files in repositories. Use when user asks to check, audit, update, improve, or fix CLAUDE.md files. Scans for all CLAUDE.md files, evaluates quality against templates, outputs quality report, then makes targeted updates. Also use when the user mentions \"CLAUDE.md maintenance\" or \"project memory optimization\"."
+            }
+          ],
+          "commands": [
+            {
+              "name": "revise-claude-md",
+              "description": "Update CLAUDE.md with learnings from this session"
+            }
+          ]
         }
+      },
+      {
+        "name": "clickhouse",
+        "description": "Connect Claude to your ClickHouse Cloud databases. Browse organizations, services, databases, and table schemas. Run read-only SQL queries against your data and get instant analytical answers. Monitor service backups, review billing costs, and inspect ClickPipe configurations - all through natural conversation.",
+        "source": "https://github.com/ClickHouse/clickhouse-claude-code-plugin.git",
+        "author": "ClickHouse"
+      },
+      {
+        "name": "clickhouse-best-practices",
+        "description": "28 best practice rules for ClickHouse schema design, query optimization, and data ingestion — prioritized by impact",
+        "source": "https://github.com/ClickHouse/agent-skills.git",
+        "author": "ClickHouse Inc"
+      },
+      {
+        "name": "cloud-sql-mysql",
+        "description": "Connect and interact with a Cloud SQL for MySQL database and data.",
+        "source": "https://github.com/gemini-cli-extensions/cloud-sql-mysql.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "cloud-sql-postgresql",
+        "description": "Create, connect, and interact with a Cloud SQL for PostgreSQL database and data.",
+        "source": "https://github.com/gemini-cli-extensions/cloud-sql-postgresql.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "cloud-sql-sqlserver",
+        "description": "Connect to Cloud SQL for SQL Server",
+        "source": "https://github.com/gemini-cli-extensions/cloud-sql-sqlserver.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "cloudflare",
+        "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
+        "source": "https://github.com/cloudflare/skills.git"
       },
       {
         "name": "cloudinary",
@@ -247,8 +520,93 @@
       },
       {
         "name": "cockroachdb",
-        "description": "CockroachDB plugin for Claude Code — explore schemas, write optimized SQL, debug queries, and manage distributed database clusters directly from your AI coding agent.",
-        "source": "https://github.com/cockroachdb/claude-plugin.git"
+        "description": "Connect Claude Code directly to your CockroachDB clusters for hands-on database work — explore schemas, write optimized SQL, debug queries, and manage distributed database clusters. This plugin provides 14 tools across two active MCP backends (self-hosted MCP Toolbox and managed CockroachDB Cloud MCP Server), three specialized agents (DBA, Developer, Operator), 32 skills across 6 operational domains, and built-in safety hooks.",
+        "source": "https://github.com/cockroachdb/claude-plugin.git",
+        "author": "Cockroach Labs"
+      },
+      {
+        "name": "code-modernization",
+        "description": "Modernize legacy codebases (COBOL, legacy Java/C++, monolith web apps) with a structured preflight / assess / map / extract-rules / brief / reimagine / transform / harden workflow, an interactive topology viewer, and specialist review agents",
+        "source": "./plugins/code-modernization",
+        "author": "Anthropic",
+        "components": {
+          "agents": 7,
+          "commands": 10
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "architecture-critic",
+              "description": "Reviews proposed target architectures and transformed code against modern best practice. Adversarial — looks for over-engineering, missed requirements, and simpler alternatives."
+            },
+            {
+              "name": "business-rules-extractor",
+              "description": "Mines domain logic, calculations, validations, and policies from legacy code into testable Given/When/Then specifications. Use when you need to separate \"what the business requires\" from \"how the old code happened to implement it.\""
+            },
+            {
+              "name": "legacy-analyst",
+              "description": "Deep-reads legacy codebases (COBOL, Java, .NET, Node, anything) to build structural and behavioral understanding. Use for discovery, dependency mapping, dead-code detection, and \"what does this system actually do\" questions."
+            },
+            {
+              "name": "scaffolder",
+              "description": "Scaffolds one service of a reimagined system from the approved architecture and spec — project skeleton, domain model, API stubs, executable acceptance tests. Write access is scoped to its own service directory under modernized/."
+            },
+            {
+              "name": "security-auditor",
+              "description": "Adversarial security reviewer — OWASP Top 10, CWE, dependency CVEs, secrets, injection. Use for security debt scanning and pre-modernization hardening."
+            },
+            {
+              "name": "test-engineer",
+              "description": "Writes characterization, contract, and equivalence tests that pin down legacy behavior so transformation can be proven correct. Use before any rewrite."
+            },
+            {
+              "name": "version-delta-analyst",
+              "description": "Identifies the breaking changes between two versions of the SAME stack (e.g. .NET Framework 4.8 → .NET 8, Java 8 → 17/21, Spring Boot 2 → 3) that actually bite a given codebase, and drives the ecosystem's migration tooling. Use for same-stack uplifts, where code is preserved and tweaked — not rewritten from intent. (Note: some \"same-stack\" bumps are really rewrites — Python 2 → 3 with pervasive str/bytes, AngularJS → Angular — where minimal-diff fails; flag those for /modernize-transform.)"
+            }
+          ],
+          "commands": [
+            {
+              "name": "modernize-assess",
+              "description": "Full discovery & portfolio analysis of a legacy system — inventory, complexity, debt, relative scale"
+            },
+            {
+              "name": "modernize-brief",
+              "description": "Generate a phased Modernization Brief — the approved plan that transformation agents will execute against"
+            },
+            {
+              "name": "modernize-extract-rules",
+              "description": "Mine business logic from legacy code into testable, human-readable rule specifications"
+            },
+            {
+              "name": "modernize-harden",
+              "description": "Security vulnerability scan with a reviewable remediation patch — OWASP, CWE, CVE, secrets, injection"
+            },
+            {
+              "name": "modernize-map",
+              "description": "Dependency & topology mapping — call graphs, data lineage, batch flows, rendered as navigable diagrams"
+            },
+            {
+              "name": "modernize-preflight",
+              "description": "Environment readiness check — analysis tools, build toolchain, source completeness, telemetry access"
+            },
+            {
+              "name": "modernize-reimagine",
+              "description": "Multi-agent greenfield rebuild — extract specs from legacy, design AI-native, scaffold & validate with HITL"
+            },
+            {
+              "name": "modernize-status",
+              "description": "Where am I in the modernization workflow — artifact inventory, staleness, secrets hygiene, next step"
+            },
+            {
+              "name": "modernize-transform",
+              "description": "Transform one legacy module to the target stack — idiomatic rewrite with behavior-equivalence tests"
+            },
+            {
+              "name": "modernize-uplift",
+              "description": "Same-stack version uplift (e.g. .NET Framework 4.8 → .NET 8) — preserve the code, fix the version deltas, prove equivalence by running one test suite on both runtimes"
+            }
+          ]
+        }
       },
       {
         "name": "code-review",
@@ -257,6 +615,14 @@
         "author": "Anthropic",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "code-review",
+              "description": "Code review a pull request"
+            }
+          ]
         }
       },
       {
@@ -266,12 +632,26 @@
         "author": "Anthropic",
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-simplifier",
+              "description": "Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise."
+            }
+          ]
         }
       },
       {
         "name": "coderabbit",
         "description": "Your code review partner. CodeRabbit provides external validation using a specialized AI architecture and 40+ integrated static analyzers—offering a different perspective that catches bugs, security vulnerabilities, logic errors, and edge cases. Context-aware analysis via AST parsing and codegraph relationships. Automatically incorporates CLAUDE.md and project coding guidelines into reviews. Useful after writing or modifying code, before commits, when implementing complex or security-sensitive logic, or when a second opinion would increase confidence in the changes. Returns specific findings with suggested fixes that can be applied immediately. Free to use.",
-        "source": "https://github.com/coderabbitai/claude-plugin.git"
+        "source": "https://github.com/coderabbitai/skills.git"
+      },
+      {
+        "name": "codspeed",
+        "description": "CodSpeed is the all-in-one performance testing toolkit. Dive into benchmarking results, flamegraphs, and performance comparisons — give Claude granular profiling context to pinpoint bottlenecks and autonomously iterate on performance via the CodSpeed MCP server.",
+        "source": "https://github.com/CodSpeedHQ/codspeed.git",
+        "author": "CodSpeed"
       },
       {
         "name": "commit-commands",
@@ -280,7 +660,29 @@
         "author": "Anthropic",
         "components": {
           "commands": 3
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "clean_gone",
+              "description": "Cleans up all git branches marked as [gone] (branches that have been deleted on the remote but still exist locally), including removing associated worktrees."
+            },
+            {
+              "name": "commit-push-pr",
+              "description": "Commit, push, and open a PR"
+            },
+            {
+              "name": "commit",
+              "description": "Create a git commit"
+            }
+          ]
         }
+      },
+      {
+        "name": "confidence",
+        "description": "Access Confidence feature flags, experiments, and migration tools directly from Claude Code.",
+        "source": "https://github.com/spotify/confidence-ai-plugins.git",
+        "author": "Spotify Confidence"
       },
       {
         "name": "context7",
@@ -291,13 +693,84 @@
         ]
       },
       {
+        "name": "convex",
+        "description": "Official Convex plugin for Claude Code with bundled Convex skills, the convex-expert subagent for code-writing, a runtime-error monitor, and MCP access for backend development, schema design, real-time features, auth, file storage, scheduled jobs, and AI agents.",
+        "source": "https://github.com/get-convex/convex-backend-skill.git",
+        "author": "Convex",
+        "tags": [
+          "convex",
+          "backend",
+          "database",
+          "realtime",
+          "reactive",
+          "websocket",
+          "auth",
+          "storage",
+          "scheduler",
+          "cron",
+          "agent",
+          "rag",
+          "mobile",
+          "typescript",
+          "mcp"
+        ]
+      },
+      {
+        "name": "crowdstrike-falcon-foundry",
+        "description": "CrowdStrike Falcon Foundry development skills for building cybersecurity applications on the Falcon platform. Includes UI development, collections, functions, workflows, API integration, security patterns, and debugging workflows.",
+        "source": "https://github.com/CrowdStrike/foundry-skills.git",
+        "author": "CrowdStrike"
+      },
+      {
         "name": "csharp-lsp",
         "description": "C# language server for code intelligence",
         "source": "./plugins/csharp-lsp",
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "csharp-ls",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "cwc-makers",
+        "description": "Onboard a Code-with-Claude Makers Cardputer with one /maker-setup command — clones the build-with-claude repo, flashes UIFlow firmware, and installs the Claude Buddy app bundle.",
+        "source": "./plugins/cwc-makers",
+        "author": "Anthropic",
+        "components": {
+          "skills": 2,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "cardputer-buddy",
+              "description": "Iterate on the Cardputer-Adv MicroPython app bundle (Claude Buddy, Snake, Hello) after the device is already provisioned via m5-onboard. Use when the user wants to add a new app, push a single changed .py without re-flashing, watch device serial logs, or run a one-shot REPL command. Trigger on \"add an app\", \"push to the cardputer\", \"tail the device\", \"run on the device\", or follow-up work after /maker-setup."
+            },
+            {
+              "name": "m5-onboard",
+              "description": "End-to-end onboarding for a freshly-plugged-in M5Stack ESP32 device (Cardputer, Cardputer-Adv, Core, CoreS3, Stick) — detect on USB, flash UIFlow 2.0 firmware, and install the Claude Buddy MicroPython app bundle. Use whenever the user plugs in or wants to flash/provision/reset an M5Stack or ESP32 board, or says \"m5-onboard go\"."
+            }
+          ],
+          "commands": [
+            {
+              "name": "maker-setup",
+              "description": "Onboard a Code-with-Claude Makers Cardputer — fetch the build-with-claude repo, flash firmware, and install the Claude Buddy apps."
+            }
+          ]
+        }
+      },
+      {
+        "name": "dash0",
+        "description": "OpenTelemetry observability for Claude Code sessions. Captures tool calls, LLM invocations, token usage, and errors as OTel traces. Send telemetry to Dash0 or any OpenTelemetry-compatible backend.",
+        "source": "https://github.com/dash0hq/dash0-agent-plugin.git",
+        "author": "Dash0"
       },
       {
         "name": "data",
@@ -305,9 +778,58 @@
         "source": "https://github.com/astronomer/agents.git"
       },
       {
+        "name": "data-agent-kit-starter-pack",
+        "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
+        "source": "https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack.git",
+        "author": "Google LLC"
+      },
+      {
         "name": "data-engineering",
         "description": "Data engineering plugin - warehouse exploration, pipeline authoring, Airflow integration",
         "source": "https://github.com/astronomer/agents.git"
+      },
+      {
+        "name": "databases-on-aws",
+        "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
+        "source": "https://github.com/awslabs/agent-plugins.git",
+        "source_path": "plugins/databases-on-aws"
+      },
+      {
+        "name": "databricks",
+        "description": "Databricks skills for the CLI, Apps, Lakebase, Model Serving, Lakeflow Jobs, Spark Declarative Pipelines, Declarative Automation Bundles (DABs), and classic-to-serverless migration.",
+        "source": "https://github.com/databricks/databricks-agent-skills.git",
+        "source_path": "plugins/databricks/claude",
+        "author": "Databricks"
+      },
+      {
+        "name": "datadog",
+        "description": "Use Datadog directly in Claude Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation. This plugin is in preview.",
+        "source": "https://github.com/datadog-labs/claude-code-plugin.git",
+        "author": "Datadog"
+      },
+      {
+        "name": "datahub-skills",
+        "description": "DataHub development and interaction toolkit with connector planning, PR review, catalog search, metadata enrichment, lineage tracing, data quality management, and connection setup skills",
+        "source": "https://github.com/datahub-project/datahub-skills.git",
+        "author": "DataHub"
+      },
+      {
+        "name": "dataproc",
+        "description": "Manage Dataproc clusters and jobs.",
+        "source": "https://github.com/gemini-cli-extensions/dataproc.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "datarobot-agent-skills",
+        "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
+        "source": "https://github.com/datarobot-oss/datarobot-agent-skills.git",
+        "author": "DataRobot"
+      },
+      {
+        "name": "dataverse",
+        "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+        "source": "https://github.com/microsoft/Dataverse-skills.git",
+        "source_path": ".github/plugins/dataverse"
       },
       {
         "name": "deploy-on-aws",
@@ -316,17 +838,62 @@
         "source_path": "plugins/deploy-on-aws"
       },
       {
+        "name": "desktop-commander",
+        "description": "MCP server for terminal commands, process management, and file operations across text, code, PDF, DOCX, Excel, images, and structured data.",
+        "source": "https://github.com/wonderwhy-er/DesktopCommanderMCP.git",
+        "source_path": "plugins/claude",
+        "author": "Desktop Commander"
+      },
+      {
         "name": "discord",
         "description": "Discord messaging bridge with built-in access control. Manage pairing, allowlists, and policy via /discord:access.",
         "source": "./external_plugins/discord",
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "access",
+              "description": "Manage Discord channel access — approve pairings, edit allowlists, set DM/group policy. Use when the user asks to pair, approve someone, check who's allowed, or change policy for the Discord channel."
+            },
+            {
+              "name": "configure",
+              "description": "Set up the Discord channel — save the bot token and review access policy. Use when the user pastes a Discord bot token, asks to configure Discord, asks \"how do I set this up\" or \"who can reach me,\" or wants to check channel status."
+            }
+          ]
         }
       },
       {
-        "name": "elixir-ls-lsp",
-        "description": "Elixir language server (ElixirLS) for Claude Code — provides code intelligence and diagnostics for .ex, .exs, and .heex files.",
-        "source": "https://github.com/MikaelFangel/claude-elixir-ls-lsp.git"
+        "name": "dominodatalab",
+        "description": "Full Domino Data Lab platform support — workspaces, jobs, model deployment, experiment tracking, GenAI tracing, Spark/Ray/Dask, and app deployment for data science teams",
+        "source": "https://github.com/dominodatalab/domino-claude-plugin.git",
+        "author": "Domino Data Lab"
+      },
+      {
+        "name": "dropbox",
+        "description": "The Dropbox plugin for Claude connects your Dropbox files directly to Claude, so you can search, organize, save generated content, and create sharing links without switching tools. It respects your existing Dropbox permissions, and Claude only works with files you already have access to.",
+        "source": "https://github.com/dropbox/dropbox-ai-plugins.git",
+        "source_path": "claude",
+        "author": "Dropbox"
+      },
+      {
+        "name": "duckdb-skills",
+        "description": "DuckDB-powered skills for Claude Code: read any data file, attach and query DuckDB databases, search DuckDB/DuckLake docs, search past session logs, and install/update DuckDB extensions.",
+        "source": "https://github.com/duckdb/duckdb-skills.git",
+        "author": "DuckDB Foundation"
+      },
+      {
+        "name": "duende-skills",
+        "description": "Duende development skills and agents for Claude Code — covering OAuth/OIDC protocols, IdentityServer, token management, ASP.NET Core authentication/authorization, BFF patterns, and secure identity architecture",
+        "source": "https://github.com/DuendeSoftware/duende-skills.git",
+        "author": "Duende Software"
+      },
+      {
+        "name": "exa",
+        "description": "Exa AI web search, deep research, and content extraction. Provides MCP tools and research skills for comprehensive web search, people discovery, company research, academic papers, and more.",
+        "source": "https://github.com/exa-labs/exa-mcp-server.git",
+        "author": "Exa"
       },
       {
         "name": "explanatory-output-style",
@@ -335,7 +902,21 @@
         "author": "Anthropic",
         "components": {
           "hooks": 1
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "expo",
+        "description": "Official Expo skills for building, deploying, upgrading, and debugging React Native apps with Expo. Covers UI development with Expo Router, SwiftUI and Jetpack Compose components, Tailwind CSS setup, API routes, data fetching, CI/CD workflows, App Store and Play Store deployment, SDK upgrades, DOM components, and dev client distribution.",
+        "source": "https://github.com/expo/skills.git",
+        "source_path": "plugins/expo"
       },
       {
         "name": "fakechat",
@@ -355,6 +936,28 @@
         "components": {
           "agents": 3,
           "commands": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-architect",
+              "description": "Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences"
+            },
+            {
+              "name": "code-explorer",
+              "description": "Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development"
+            },
+            {
+              "name": "code-reviewer",
+              "description": "Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter"
+            }
+          ],
+          "commands": [
+            {
+              "name": "feature-dev",
+              "description": "Guided feature development with codebase understanding and architecture focus"
+            }
+          ]
         }
       },
       {
@@ -378,19 +981,16 @@
         "source": "https://github.com/firecrawl/firecrawl-claude-plugin.git"
       },
       {
-        "name": "firetiger",
-        "description": "Claude Code plugin for Firetiger observability workflows and MCP-powered investigations.",
-        "source": "https://github.com/firetiger-oss/claude-plugin.git"
+        "name": "firestore-native",
+        "description": "Connect and interact with Firestore databases, collections, and documents.",
+        "source": "https://github.com/gemini-cli-extensions/firestore-native.git",
+        "author": "Google LLC"
       },
       {
-        "name": "flint",
-        "description": "Build and manage websites with Flint's AI website builder through natural conversation.",
-        "source": "https://github.com/tryflint/claude-code-plugin.git"
-      },
-      {
-        "name": "followrabbit",
-        "description": "Cloud cost optimization for GCP infrastructure. Review changes for cost impact and auto-apply savings recommendations using the followrabbit CLI.",
-        "source": "https://github.com/followrabbit-ai/awesome-rabbit.git"
+        "name": "forge-skills",
+        "description": "Forge-focused skills and MCP configuration for Atlassian Forge: scaffold and deploy apps (forge create, templates, dev spaces), build Teamwork Graph connectors for Rovo Search/Rovo Chat, pre-deploy review, systematic debugging, plus Forge docs and Atlassian Design System lookups via MCP.",
+        "source": "https://github.com/atlassian/forge-skills.git",
+        "author": "Atlassian"
       },
       {
         "name": "frontend-design",
@@ -399,7 +999,21 @@
         "author": "Anthropic",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "frontend-design",
+              "description": "Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults."
+            }
+          ]
         }
+      },
+      {
+        "name": "fullstory",
+        "description": "Connect Claude to Fullstory to query behavioral analytics, session replays, and customer experience insights.",
+        "source": "fullstorydev/fullstory-skills",
+        "author": "Fullstory"
       },
       {
         "name": "github",
@@ -412,18 +1026,42 @@
         "source": "./external_plugins/gitlab"
       },
       {
-        "name": "goodmem",
-        "description": "GoodMem memory infrastructure for AI agents. Use Python SDK skills to write code that manages embedders, spaces, and memories, or use MCP tools to perform GoodMem operations directly via natural language.",
-        "source": "https://github.com/PAIR-Systems-Inc/goodmem-claude-code-plugin.git"
-      },
-      {
         "name": "gopls-lsp",
         "description": "Go language server for code intelligence and refactoring",
         "source": "./plugins/gopls-lsp",
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "gopls",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "grafana-assistant",
+        "description": "Skills and rules for developing and using the Grafana Assistant app and CLI.",
+        "source": "https://github.com/grafana/ai-marketplace.git",
+        "source_path": "plugins/grafana-assistant",
+        "author": "Grafana"
+      },
+      {
+        "name": "grafana-cloud-mcp",
+        "description": "Hosted MCP server for AI-assisted Grafana Cloud observability — no local installation required.",
+        "source": "https://github.com/grafana/ai-marketplace.git",
+        "source_path": "plugins/grafana-cloud-mcp",
+        "author": "Grafana"
+      },
+      {
+        "name": "grafana-mcp",
+        "description": "MCP server for AI-assisted Grafana dashboard, datasource, alerting, and incident management.",
+        "source": "https://github.com/grafana/ai-marketplace.git",
+        "source_path": "plugins/grafana-mcp",
+        "author": "Grafana"
       },
       {
         "name": "greptile",
@@ -431,10 +1069,11 @@
         "source": "./external_plugins/greptile"
       },
       {
-        "name": "helius",
-        "description": "Build on Solana with Helius — live blockchain tools, expert coding patterns, and autonomous account signup",
-        "source": "helius-labs/core-ai",
-        "source_path": "helius-plugin"
+        "name": "honeycomb",
+        "description": "Skills, agents, and workflows for Honeycomb observability — query patterns, production investigations, SLOs, OpenTelemetry instrumentation, and Beeline migration. Designed to complement the Honeycomb MCP server.",
+        "source": "https://github.com/honeycombio/agent-skill.git",
+        "source_path": "honeycomb",
+        "author": "Honeycomb"
       },
       {
         "name": "hookify",
@@ -446,7 +1085,71 @@
           "agents": 1,
           "commands": 4,
           "hooks": 6
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "writing-rules",
+              "description": "This skill should be used when the user asks to \"create a hookify rule\", \"write a hook rule\", \"configure hookify\", \"add a hookify rule\", or needs guidance on hookify rule syntax and patterns."
+            }
+          ],
+          "agents": [
+            {
+              "name": "conversation-analyzer",
+              "description": "Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Typical triggers include the /hookify command being invoked without arguments, or the user explicitly asking to look back at the current conversation and surface mistakes that should be prevented in the future. See \"When to invoke\" in the agent body for worked scenarios."
+            }
+          ],
+          "commands": [
+            {
+              "name": "configure",
+              "description": "Enable or disable hookify rules interactively"
+            },
+            {
+              "name": "help",
+              "description": "Get help with the hookify plugin"
+            },
+            {
+              "name": "hookify",
+              "description": "Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions"
+            },
+            {
+              "name": "list",
+              "description": "List all configured hookify rules"
+            }
+          ],
+          "hooks": [
+            {
+              "name": "__init__",
+              "description": ""
+            },
+            {
+              "name": "hooks",
+              "description": ""
+            },
+            {
+              "name": "posttooluse",
+              "description": ""
+            },
+            {
+              "name": "pretooluse",
+              "description": ""
+            },
+            {
+              "name": "stop",
+              "description": ""
+            },
+            {
+              "name": "userpromptsubmit",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "hostinger",
+        "description": "Deploy, manage and monitor Hostinger services — Websites, Domains, Ecommerce, Email Marketing, Subscriptions & Payments, and VPS. Authenticate via browser (OAuth) or API token.",
+        "source": "https://github.com/hostinger/claude-plugin.git",
+        "author": "Hostinger"
       },
       {
         "name": "huggingface-skills",
@@ -454,11 +1157,42 @@
         "source": "https://github.com/huggingface/skills.git"
       },
       {
+        "name": "hunter",
+        "description": "Find and verify professional email addresses, search contacts by domain, and enrich company data -- directly in Claude.",
+        "source": "https://github.com/hunter-io/claude-plugin.git",
+        "author": "Hunter.io"
+      },
+      {
+        "name": "hyperframes",
+        "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website-to-video capture for HyperFrames.",
+        "source": "https://github.com/heygen-com/hyperframes.git",
+        "author": "HeyGen"
+      },
+      {
+        "name": "idmp-plugin",
+        "description": "TDengine IDMP plugin with packaged skills for discovery, schema inspection, and safe operational workflows.",
+        "source": "https://github.com/taosdata/agent-skills.git",
+        "source_path": "plugins/idmp-plugin",
+        "author": "TaosData"
+      },
+      {
         "name": "imessage",
         "description": "iMessage messaging bridge with built-in access control. Reads chat.db directly, sends via AppleScript. Manage pairing, allowlists, and policy via /imessage:access.",
         "source": "./external_plugins/imessage",
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "access",
+              "description": "Manage iMessage channel access — approve pairings, edit allowlists, set DM/group policy. Use when the user asks to pair, approve someone, check who's allowed, or change policy for the iMessage channel."
+            },
+            {
+              "name": "configure",
+              "description": "Check iMessage channel setup and review access policy. Use when the user asks to configure iMessage, asks \"how do I set this up\" or \"who can reach me,\" or wants to know why texts aren't reaching the assistant."
+            }
+          ]
         }
       },
       {
@@ -473,7 +1207,27 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "jdtls",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "jfrog",
+        "description": "Use the JFrog Platform from Claude Code: Artifactory repos and artifacts, security findings and exposures, Catalog package safety and downloads, workflows across the SDLC, and platform administration.",
+        "source": "jfrog/claude-plugin",
+        "author": "JFrog Ltd."
+      },
+      {
+        "name": "knowledge-catalog",
+        "description": "Connect to Knowledge Catalog to discover, manage, monitor, and govern data and AI artifacts across your data platform",
+        "source": "https://github.com/gemini-cli-extensions/knowledge-catalog.git",
+        "author": "Google LLC"
       },
       {
         "name": "kotlin-lsp",
@@ -482,12 +1236,44 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "kotlin-lsp",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "langfuse-observability",
+        "description": "Langfuse observability plugin for Claude Code — captures and exports traces, spans, and session telemetry from Claude Code to Langfuse for LLM monitoring, debugging, and evaluation",
+        "source": "https://github.com/langfuse/claude-observability-plugin.git",
+        "author": "Langfuse"
       },
       {
         "name": "laravel-boost",
         "description": "Laravel development toolkit MCP server. Provides intelligent assistance for Laravel applications including Artisan commands, Eloquent queries, routing, migrations, and framework-specific code generation.",
         "source": "./external_plugins/laravel-boost"
+      },
+      {
+        "name": "learn-with-coursera",
+        "description": "Turn any learning intent into a personalized Coursera experience. Asks three quick questions (topic, familiarity, preferred format), searches Coursera's catalog, and delivers the right next step — a course, hands-on project, short video, or live roleplay — then maps a path forward. Requires the Coursera connector for catalog tools.",
+        "source": "https://github.com/coursera/skills.git",
+        "source_path": "skills",
+        "author": "Coursera",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "learn-with-coursera",
+              "description": ""
+            }
+          ]
+        }
       },
       {
         "name": "learning-output-style",
@@ -496,12 +1282,20 @@
         "author": "Anthropic",
         "components": {
           "hooks": 1
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
         "name": "legalzoom",
         "description": "Attorney guidance and legal tools for business and personal needs. AI-powered document review identifies critical risks and important clauses, advises when to engage an attorney, and routes to LegalZoom's network when professional expertise is needed.",
-        "source": "legalzoom/claude-plugins",
+        "source": "https://github.com/legalzoom/claude-plugins.git",
         "source_path": "plugins/legalzoom"
       },
       {
@@ -510,13 +1304,103 @@
         "source": "./external_plugins/linear"
       },
       {
+        "name": "liquid-lsp",
+        "description": "LSP integration for Shopify Liquid templates via the Shopify CLI theme language server.",
+        "source": "https://github.com/Shopify/liquid-skills.git",
+        "source_path": "plugins/liquid-lsp",
+        "author": "Shopify"
+      },
+      {
+        "name": "liquid-skills",
+        "description": "Liquid language fundamentals, CSS/JS/HTML coding standards, and WCAG accessibility patterns for Shopify themes",
+        "source": "https://github.com/Shopify/liquid-skills.git",
+        "source_path": "plugins/liquid-skills",
+        "author": "Shopify"
+      },
+      {
+        "name": "logfire",
+        "description": "Add Logfire observability to Python applications with auto-instrumentation for FastAPI, httpx, asyncpg, SQLAlchemy, and more",
+        "source": "https://github.com/pydantic/skills.git",
+        "source_path": "plugins/logfire",
+        "author": "Pydantic"
+      },
+      {
+        "name": "logrocket",
+        "description": "Connect Claude Code to LogRocket to query session replays, metrics, issues, and user behavior using natural language.",
+        "source": "https://github.com/LogRocket/logrocket-claude-plugin.git",
+        "source_path": "plugins/logrocket",
+        "author": "LogRocket"
+      },
+      {
+        "name": "looker",
+        "description": "Connect to Looker and interact with your data using LookML.",
+        "source": "https://github.com/gemini-cli-extensions/looker.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "lovable",
+        "description": "Build, iterate on, deploy, and manage Lovable apps from Claude Code. Bundles the official Lovable MCP server (remote, OAuth 2.1) and adds focused commands for the common build/iterate/database workflows, with credit- and publish-safety prompts.",
+        "source": "https://github.com/lovablelabs/mcp.git",
+        "author": "Lovable"
+      },
+      {
         "name": "lua-lsp",
         "description": "Lua language server for code intelligence",
         "source": "./plugins/lua-lsp",
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "lua",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "lumen",
+        "description": "Precise local semantic code search via MCP. Indexes your codebase with Go AST parsing, embeds with Ollama or LM Studio, and exposes vector search to Claude through an MCP server — no cloud, no npm.",
+        "source": "https://github.com/ory/lumen.git",
+        "author": "Ory Corp"
+      },
+      {
+        "name": "lusha",
+        "description": "Prospect, enrich, and build call-ready lead lists using Lusha's B2B intelligence platform — verified phone numbers, company signals, and lookalike targeting.",
+        "source": "https://github.com/lusha-oss/lusha-mcp-plugin.git",
+        "author": "Lusha"
+      },
+      {
+        "name": "mapbox",
+        "description": "Mapbox skills and MCP servers for building location-aware applications with AI. Includes geospatial tools, style management, and patterns for web, iOS, Android, and AI agent frameworks.",
+        "source": "https://github.com/mapbox/mapbox-agent-skills.git",
+        "author": "Mapbox"
+      },
+      {
+        "name": "math-olympiad",
+        "description": "Solve competition math (IMO, Putnam, USAMO) with adversarial verification that catches what self-verification misses. Fresh-context verifiers attack proofs with specific failure patterns. Calibrated abstention over bluffing.",
+        "source": "./plugins/math-olympiad",
+        "author": "Anthropic",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "math-olympiad",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "mcp-apps",
+        "description": "Skills for creating MCP Apps with the MCP Apps SDK",
+        "source": "https://github.com/modelcontextprotocol/ext-apps.git",
+        "source_path": "plugins/mcp-apps",
+        "author": "Anthropic / Model Context Protocol"
       },
       {
         "name": "mcp-server-dev",
@@ -525,7 +1409,53 @@
         "author": "Anthropic",
         "components": {
           "skills": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "build-mcp-app",
+              "description": "This skill should be used when the user wants to build an \"MCP app\", add \"interactive UI\" or \"widgets\" to an MCP server, \"render components in chat\", build \"MCP UI resources\", make a tool that shows a \"form\", \"picker\", \"dashboard\" or \"confirmation dialog\" inline in the conversation, or mentions \"apps SDK\" in the context of MCP. Use AFTER the build-mcp-server skill has settled the deployment model, or when the user already knows they want UI widgets."
+            },
+            {
+              "name": "build-mcp-server",
+              "description": "This skill should be used when the user asks to \"build an MCP server\", \"create an MCP\", \"make an MCP integration\", \"wrap an API for Claude\", \"expose tools to Claude\", \"make an MCP app\", or discusses building something with the Model Context Protocol. It is the entry point for MCP server development — it interrogates the user about their use case, determines the right deployment model (remote HTTP, MCPB, local stdio), picks a tool-design pattern, and hands off to specialized skills."
+            },
+            {
+              "name": "build-mcpb",
+              "description": "This skill should be used when the user wants to \"package an MCP server\", \"bundle an MCP\", \"make an MCPB\", \"ship a local MCP server\", \"distribute a local MCP\", discusses \".mcpb files\", mentions bundling a Node or Python runtime with their MCP server, or needs an MCP server that interacts with the local filesystem, desktop apps, or OS and must be installable without the user having Node/Python set up."
+            }
+          ]
         }
+      },
+      {
+        "name": "mcp-tunnels",
+        "description": "Connect Claude to a private MCP server through an Anthropic MCP tunnel. The /create-docker-mcp-tunnel command drives the Docker Compose quickstart end to end: certificates, proxy config, cloudflared, and a verifiable sample server.",
+        "source": "./plugins/mcp-tunnels",
+        "author": "Anthropic",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-docker-mcp-tunnel",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "mercadopago",
+        "description": "Mercado Pago full-product integration toolkit. One agent routes to four orchestration skills (mp-integrate wizard, mp-webhooks, mp-test-setup, mp-review) that pull every endpoint, payload, and snippet live from the official Mercado Pago MCP server. The MCP must always be connected — there is no offline mode.",
+        "source": "https://github.com/mercadopago/mercadopago-claude-marketplace.git",
+        "source_path": "plugins/mercadopago",
+        "author": "Mercado Pago Developer Experience"
+      },
+      {
+        "name": "mergify",
+        "description": "Skills for the Mergify CLI: manage merge queues, stacked pull requests, Test Insights (flaky tests, quarantine), merge protections, and Mergify configuration directly from the terminal.",
+        "source": "https://github.com/mergifyio/mergify-cli.git",
+        "author": "Mergify"
       },
       {
         "name": "microsoft-docs",
@@ -534,9 +1464,10 @@
       },
       {
         "name": "migration-to-aws",
-        "description": "Assess current cloud provider usage and billing to estimate and compare AWS services and pricing, with recommendations for migration or continued use of current provider.",
-        "source": "https://github.com/awslabs/agent-plugins.git",
-        "source_path": "plugins/migration-to-aws"
+        "description": "Plan a migration from Google Cloud Platform (and OpenAI/Gemini AI workloads) to AWS. Analyzes your Infrastructure-as-Code files, app code, and GCP billing data to discover resources, design an AWS architecture, estimate costs, and generate migration artifacts — including AI-provider mapping to Amazon Bedrock. Processing is local; your data stays in your environment.",
+        "source": "https://github.com/awslabs/startups.git",
+        "source_path": "migrate/plugins/migration-to-aws",
+        "author": "Amazon Web Services"
       },
       {
         "name": "mintlify",
@@ -544,15 +1475,76 @@
         "source": "https://github.com/mintlify/mintlify-claude-plugin.git"
       },
       {
+        "name": "miro",
+        "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
+        "source": "https://github.com/miroapp/miro-ai.git",
+        "source_path": "claude-plugins/miro",
+        "author": "Miro"
+      },
+      {
+        "name": "monday-crm",
+        "description": "Run your monday CRM in plain language. Build a pipeline from scratch, start the day with a ranked deal briefing, spin up a forecast dashboard, audit board health, clean up messy data in bulk, and turn meeting notes into deal updates. Every skill writes back into monday as a real update, doc, or dashboard. Built on the official monday MCP connector.",
+        "source": "https://github.com/mondaycom/mcp.git",
+        "source_path": "plugins/monday-crm",
+        "author": "monday.com"
+      },
+      {
+        "name": "mongodb",
+        "description": "Official Claude plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
+        "source": "https://github.com/mongodb/agent-skills.git"
+      },
+      {
         "name": "neon",
         "description": "Manage your Neon projects and databases with the neon-postgres agent skill and the Neon MCP Server.",
-        "source": "neondatabase/agent-skills",
+        "source": "https://github.com/neondatabase/agent-skills.git",
         "source_path": "plugins/neon-postgres"
       },
       {
         "name": "netlify-skills",
         "description": "Netlify platform skills for Claude Code — functions, edge functions, blobs, database, image CDN, forms, config, CLI, frameworks, caching, AI gateway, and deployment.",
         "source": "https://github.com/netlify/context-and-tools.git"
+      },
+      {
+        "name": "netsuite-suitecloud",
+        "description": "NetSuite agent skills from Oracle — authoring guidance for SuiteCloud Development Framework (SDF) objects and UIF single-page-app components, plus runtime guidance for the NetSuite AI Service Connector.",
+        "source": "https://github.com/oracle/netsuite-suitecloud-sdk.git",
+        "source_path": "packages/agent-skills",
+        "author": "Oracle NetSuite",
+        "components": {
+          "skills": 7
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "netsuite-ai-connector-instructions",
+              "description": ""
+            },
+            {
+              "name": "netsuite-sdf-roles-and-permissions",
+              "description": ""
+            },
+            {
+              "name": "netsuite-uif-spa-reference",
+              "description": ""
+            },
+            {
+              "name": "netsuite-owasp-secure-coding",
+              "description": ""
+            },
+            {
+              "name": "netsuite-sdf-project-documentation",
+              "description": ""
+            },
+            {
+              "name": "netsuite-suitescript-records-reference",
+              "description": ""
+            },
+            {
+              "name": "netsuite-suitescript-upgrade",
+              "description": ""
+            }
+          ]
+        }
       },
       {
         "name": "nightvision",
@@ -570,14 +1562,45 @@
         "source": "https://github.com/makenotion/claude-code-notion-plugin.git"
       },
       {
-        "name": "opsera-devsecops",
-        "description": "Opsera DevSecOps Agent — AI-powered architecture analysis, security scanning, compliance auditing, and SQL security for your codebase. Free trial included.",
-        "source": "https://github.com/opsera-agents/opsera-devsecops.git"
+        "name": "nvidia-skills",
+        "description": "NVIDIA agent skills for accelerated-computing workflows — starting with cuOpt vehicle-routing optimization (VRP, TSP, PDP) via the cuOpt Python API.",
+        "source": "https://github.com/NVIDIA/skills.git",
+        "source_path": "plugins/nvidia-skills",
+        "author": "NVIDIA"
       },
       {
-        "name": "optibot",
-        "description": "AI code review that catches production-breaking bugs, business logic issues, and security vulnerabilities — directly in Claude Code.",
-        "source": "https://github.com/Optimal-AI/optibot-skill.git"
+        "name": "oracle-ai-data-platform-workbench-databricks-migrator",
+        "description": "Drive the Oracle AI Data Platform (AIDP) Databricks Migration Toolkit in natural language. Plans and executes automated Databricks → AIDP migrations of notebooks, jobs, schedules, and catalog DDL — Pass-1 dependency rewrite + Pass-2 cell-by-cell execute/verify/fix on a live AIDP cluster with Claude.",
+        "source": "https://github.com/oracle-samples/oracle-aidp-samples.git",
+        "source_path": "ai/claude-code-plugins/oracle-ai-data-platform-workbench-databricks-migrator",
+        "author": "Oracle"
+      },
+      {
+        "name": "oracle-ai-data-platform-workbench-engineer-agent",
+        "description": "Oracle AI Data Platform (AIDP) Workbench engineer agent for Claude Code — a 37-skill agent that operates the full Spark/Delta lakehouse in natural language. Discovers your catalog into a grounding cache, turns plain English into accurate Spark SQL, and runs the lifecycle (CREATE/INSERT/UPDATE/DELETE/MERGE, OPTIMIZE/VACUUM, time-travel). Ingests files, profiles data and sets quality rules, authors and repairs pipelines, provisions clusters, and debugs via the Spark UI. Governs the platform (roles, credential store, Delta Sharing, audit logs), plus native Git, bundles, and MLOps/MLflow. Runs via the official Oracle aidp CLI.",
+        "source": "https://github.com/oracle-samples/oracle-aidp-samples.git",
+        "source_path": "ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent",
+        "author": "Oracle"
+      },
+      {
+        "name": "oracle-ai-data-platform-workbench-spark-connectors",
+        "description": "Oracle AI Data Platform Workbench Spark connectors for Claude Code. 18 connector skills covering every data source workbench customers commonly need: Oracle Autonomous DB family (ALH/ADW/ATP) via wallet/IAM-DB-Token/API-key, ExaCS, Fusion ERP REST, Fusion BICC, EPM Cloud Planning, Essbase 21c, OCI Streaming (Kafka), OCI Object Storage, Apache Iceberg, plus external systems (PostgreSQL, MySQL/HeatWave, SQL Server, Snowflake, Azure ADLS Gen2, AWS S3, generic REST, custom JDBC, Excel). Live-validated on the workbench `tpcds` cluster (Spark 3.5.0): 17 PASS / 4 ship-as-is out of 21 test rows.",
+        "source": "https://github.com/oracle-samples/oracle-aidp-samples.git",
+        "source_path": "ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors",
+        "author": "Oracle"
+      },
+      {
+        "name": "oracledb",
+        "description": "Connect, query, and interact with Oracle Databases and their data.",
+        "source": "https://github.com/gemini-cli-extensions/oracledb.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "outputai",
+        "description": "Output.ai workflow development toolkit for Claude Code. Adds 5 specialist agents (planner, builder, debugger, prompt writer, quality reviewer), 40+ slash-command skills covering scaffolding, debugging, evaluation, and credential management, plus a SessionStart hook that auto-loads Output SDK conventions so Claude understands the framework before the first prompt.",
+        "source": "https://github.com/growthxai/output.git",
+        "source_path": "coding_assistants/claude/plugins/outputai",
+        "author": "Output.ai"
       },
       {
         "name": "pagerduty",
@@ -591,12 +1614,32 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "intelephense",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "pigment",
+        "description": "Analyze business data and build custom Pigment models, metrics, and boards through natural language.",
+        "source": "https://github.com/gopigment/ai-plugins.git",
+        "author": "Pigment"
       },
       {
         "name": "pinecone",
         "description": "Pinecone vector database integration. Streamline your Pinecone development with powerful tools for managing vector indexes, querying data, and rapid prototyping. Use slash commands like /quickstart to generate AGENTS.md files and initialize Python projects and /query to quickly explore indexes. Access the Pinecone MCP server for creating, describing, upserting and querying indexes with Claude. Perfect for developers building semantic search, RAG applications, recommendation systems, and other vector-based applications with Pinecone.",
         "source": "https://github.com/pinecone-io/pinecone-claude-code-plugin.git"
+      },
+      {
+        "name": "pixeltable",
+        "description": "Build multimodal AI applications with Pixeltable -- tables, computed columns, embedding search, UDFs, tool-calling agents, and 25+ AI provider integrations.",
+        "source": "https://github.com/pixeltable/pixeltable-skill.git",
+        "author": "Pixeltable"
       },
       {
         "name": "planetscale",
@@ -610,6 +1653,14 @@
         "author": "Anthropic",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "playground",
+              "description": "Creates interactive HTML playgrounds — self-contained single-file explorers that let users configure something visually through controls, see a live preview, and copy out a prompt. Use when the user asks to make a playground, explorer, or interactive tool for a topic."
+            }
+          ]
         }
       },
       {
@@ -626,6 +1677,58 @@
           "skills": 7,
           "agents": 3,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-development",
+              "description": "This skill should be used when the user asks to \"create an agent\", \"add an agent\", \"write a subagent\", \"agent frontmatter\", \"when to use description\", \"agent examples\", \"agent tools\", \"agent colors\", \"autonomous agent\", or needs guidance on agent structure, system prompts, triggering conditions, or agent development best practices for Claude Code plugins."
+            },
+            {
+              "name": "command-development",
+              "description": "This skill should be used when the user asks to \"create a slash command\", \"add a command\", \"write a custom command\", \"define command arguments\", \"use command frontmatter\", \"organize commands\", \"create command with file references\", \"interactive command\", \"use AskUserQuestion in command\", or needs guidance on slash command structure, YAML frontmatter fields, dynamic arguments, bash execution in commands, user interaction patterns, or command development best practices for Claude Code."
+            },
+            {
+              "name": "hook-development",
+              "description": ""
+            },
+            {
+              "name": "mcp-integration",
+              "description": "This skill should be used when the user asks to \"add MCP server\", \"integrate MCP\", \"configure MCP in plugin\", \"use .mcp.json\", \"set up Model Context Protocol\", \"connect external service\", mentions \"${CLAUDE_PLUGIN_ROOT} with MCP\", or discusses MCP server types (SSE, stdio, HTTP, WebSocket). Provides comprehensive guidance for integrating Model Context Protocol servers into Claude Code plugins for external tool and service integration."
+            },
+            {
+              "name": "plugin-settings",
+              "description": "This skill should be used when the user asks about \"plugin settings\", \"store plugin configuration\", \"user-configurable plugin\", \".local.md files\", \"plugin state files\", \"read YAML frontmatter\", \"per-project plugin settings\", or wants to make plugin behavior configurable. Documents the .claude/plugin-name.local.md pattern for storing plugin-specific configuration with YAML frontmatter and markdown content."
+            },
+            {
+              "name": "plugin-structure",
+              "description": "This skill should be used when the user asks to \"create a plugin\", \"scaffold a plugin\", \"understand plugin structure\", \"organize plugin components\", \"set up plugin.json\", \"use ${CLAUDE_PLUGIN_ROOT}\", \"add commands/agents/skills/hooks\", \"configure auto-discovery\", or needs guidance on plugin directory layout, manifest configuration, component organization, file naming conventions, or Claude Code plugin architecture best practices."
+            },
+            {
+              "name": "skill-development",
+              "description": "This skill should be used when the user wants to \"create a skill\", \"add a skill to plugin\", \"write a new skill\", \"improve skill description\", \"organize skill content\", or needs guidance on skill structure, progressive disclosure, or skill development best practices for Claude Code plugins."
+            }
+          ],
+          "agents": [
+            {
+              "name": "agent-creator",
+              "description": "|"
+            },
+            {
+              "name": "plugin-validator",
+              "description": "|"
+            },
+            {
+              "name": "skill-reviewer",
+              "description": "|"
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-plugin",
+              "description": "Guided end-to-end plugin creation workflow with component design, implementation, and validation"
+            }
+          ]
         }
       },
       {
@@ -651,7 +1754,48 @@
         "components": {
           "agents": 6,
           "commands": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-reviewer",
+              "description": "Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will be recently completed work which is unstaged in git (can be retrieved by running git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. Typical triggers include the user asking for a review of a feature they just implemented, the assistant proactively reviewing its own newly-written code before declaring a task done, and a final pre-PR check before opening a pull request. See \"When to invoke\" in the agent body for worked scenarios."
+            },
+            {
+              "name": "code-simplifier",
+              "description": "|"
+            },
+            {
+              "name": "comment-analyzer",
+              "description": "Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes (1) after generating large documentation comments or docstrings, (2) before finalizing a pull request that adds or modifies comments, (3) when reviewing existing comments for potential technical debt or comment rot, and (4) when you need to verify that comments accurately reflect the code they describe. See \"When to invoke\" in the agent body for worked scenarios."
+            },
+            {
+              "name": "pr-test-analyzer",
+              "description": "Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Typical triggers include the user asking whether tests on a freshly-created PR are thorough, an updated PR adding new logic that needs coverage analysis, and a final pre-merge double-check before marking a PR ready. See \"When to invoke\" in the agent body for worked scenarios."
+            },
+            {
+              "name": "silent-failure-hunter",
+              "description": "Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors. Examples:\\n\\n<example>\\nContext: Daisy has just finished implementing a new feature that fetches data from an API with fallback behavior.\\nDaisy: \"I've added error handling to the API client. Can you review it?\"\\nAssistant: \"Let me use the silent-failure-hunter agent to thoroughly examine the error handling in your changes.\"\\n<Task tool invocation to launch silent-failure-hunter agent>\\n</example>\\n\\n<example>\\nContext: Daisy has created a PR with changes that include try-catch blocks.\\nDaisy: \"Please review PR #1234\"\\nAssistant: \"I'll use the silent-failure-hunter agent to check for any silent failures or inadequate error handling in this PR.\"\\n<Task tool invocation to launch silent-failure-hunter agent>\\n</example>\\n\\n<example>\\nContext: Daisy has just refactored error handling code.\\nDaisy: \"I've updated the error handling in the authentication module\"\\nAssistant: \"Let me proactively use the silent-failure-hunter agent to ensure the error handling changes don't introduce silent failures.\"\\n<Task tool invocation to launch silent-failure-hunter agent>\\n</example>"
+            },
+            {
+              "name": "type-design-analyzer",
+              "description": "Use this agent when you need expert analysis of type design in your codebase. Specifically use it (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, and (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement. See \"When to invoke\" in the agent body for worked scenarios."
+            }
+          ],
+          "commands": [
+            {
+              "name": "review-pr",
+              "description": "Comprehensive PR review using specialized agents"
+            }
+          ]
         }
+      },
+      {
+        "name": "preset-cli-skills",
+        "description": "Preset CLI skills for explicit shell, scripting, and CI/CD workflows driven by the `sup` CLI (PyPI package `superset-sup`). Use only for CLI workflows; do not use for MCP-only work or as a substitute for direct API calls when the user wants HTTP/SDK code.",
+        "source": "https://github.com/preset-io/agent-skills.git",
+        "source_path": "plugins/preset-cli-skills",
+        "author": "Preset"
       },
       {
         "name": "prisma",
@@ -659,9 +1803,27 @@
         "source": "https://github.com/prisma/claude-plugin.git"
       },
       {
-        "name": "product-tracking-skills",
-        "description": "AI agent skills that make SaaS products data-ready for product analytics — from codebase scan to tracking plan to working instrumentation code.",
-        "source": "https://github.com/Accoil/product-tracking-skills.git"
+        "name": "project-artifact",
+        "description": "Generate and publish a living project status page — overview & success criteria, the workstream sequence, and next steps — as a shareable claude.ai artifact backed by a per-project config, so refreshes re-gather live state, redeploy the same URL, and report only the delta.",
+        "source": "./plugins/project-artifact",
+        "author": "Anthropic",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "project-artifact",
+              "description": "Generate and publish a project status artifact — an opinionated, tabbed status page for a project too big for one update (overview & success criteria, the workstream sequence, next steps, plus background, plan, risks & open questions, and decisions/FAQ when they earn a tab) — published with the built-in Artifact tool to a default-private claude.ai page the user can share with teammates. Use when a piece of work spans several workstreams and you want a shareable overview kept current. Each artifact is backed by a small per-project config in the plugin data dir, so refreshing it re-gathers live state, redeploys the same URL, and reports only the delta. For software projects whose workstreams are PRs, also read swe.md (the X.Y PR-numbering convention; pulling PR state with gh/git; a per-PR detail block). Needs the built-in Artifact tool (claude.ai login). Not for single-PR changes or public docs."
+            }
+          ]
+        }
+      },
+      {
+        "name": "pydantic-ai",
+        "description": "Write accurate Pydantic AI code from the start. Up-to-date patterns, decision trees, and common gotchas for agents, tools, structured output, streaming, and multi-agent apps.",
+        "source": "https://github.com/pydantic/skills.git",
+        "source_path": "plugins/ai"
       },
       {
         "name": "pyright-lsp",
@@ -670,7 +1832,21 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "pyright",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "qdrant-skills",
+        "description": "Agent skills for Qdrant vector search covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java.",
+        "source": "https://github.com/qdrant/skills.git",
+        "author": "Qdrant"
       },
       {
         "name": "qodo-skills",
@@ -678,9 +1854,21 @@
         "source": "https://github.com/qodo-ai/qodo-skills.git"
       },
       {
+        "name": "qt-development-skills",
+        "description": "Agentic engineering skills for Qt software development — Qt C++/QML code review, QML coding, and Qt C++/QML code documentation.",
+        "source": "https://github.com/TheQtCompanyRnD/agent-skills.git",
+        "author": "Qt Group"
+      },
+      {
+        "name": "quarkus-agent",
+        "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
+        "source": "https://github.com/quarkusio/quarkus-agent-mcp.git",
+        "author": "Quarkus"
+      },
+      {
         "name": "railway",
         "description": "Deploy and manage apps, databases, and infrastructure on Railway. Covers project setup, deploys, environment configuration, networking, troubleshooting, and monitoring.",
-        "source": "railwayapp/railway-skills",
+        "source": "https://github.com/railwayapp/railway-skills.git",
         "source_path": "plugins/railway"
       },
       {
@@ -691,12 +1879,42 @@
         "components": {
           "commands": 3,
           "hooks": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "cancel-ralph",
+              "description": "Cancel active Ralph Loop"
+            },
+            {
+              "name": "help",
+              "description": "Explain Ralph Loop plugin and available commands"
+            },
+            {
+              "name": "ralph-loop",
+              "description": "Start Ralph Loop in current session"
+            }
+          ],
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
         "name": "rc",
         "description": "Configure RevenueCat projects, apps, products, entitlements, and offerings directly from Claude Code. Manage your in-app purchase backend without leaving your development workflow.",
-        "source": "https://github.com/RevenueCat/rc-claude-code-plugin.git"
+        "source": "https://github.com/RevenueCat/rc-claude-code-plugin.git",
+        "source_path": "revenuecat"
+      },
+      {
+        "name": "redis-development",
+        "description": "Redis development best practices — data structures, query engine, vector search, caching, and performance optimization",
+        "source": "https://github.com/redis/agent-skills.git",
+        "source_path": "plugins/redis-development",
+        "author": "Redis"
       },
       {
         "name": "remember",
@@ -704,9 +1922,34 @@
         "source": "https://github.com/Digital-Process-Tools/claude-remember.git"
       },
       {
+        "name": "render",
+        "description": "Deploy, debug, and monitor applications on Render. Includes skills, an agent, slash commands, and a render.yaml validation hook.",
+        "source": "https://github.com/render-oss/render-plugin-claude-code.git",
+        "author": "Render"
+      },
+      {
+        "name": "resend",
+        "description": "Agent skills for working with Resend to send and receive emails — email API integration, agent inbox, CLI, React Email components, and deliverability best practices. Includes the Resend MCP server.",
+        "source": "https://github.com/resend/resend-skills.git",
+        "author": "Resend"
+      },
+      {
         "name": "revenuecat",
         "description": "Configure RevenueCat projects, apps, products, entitlements, and offerings directly from Claude Code. Manage your in-app purchase backend without leaving your development workflow.",
-        "source": "https://github.com/RevenueCat/rc-claude-code-plugin.git"
+        "source": "https://github.com/RevenueCat/rc-claude-code-plugin.git",
+        "source_path": "revenuecat"
+      },
+      {
+        "name": "rill",
+        "description": "Skills for developing and querying projects in the Rill business intelligence platform",
+        "source": "https://github.com/rilldata/agent-skills.git",
+        "author": "Rill Data"
+      },
+      {
+        "name": "rootly",
+        "description": "Full-lifecycle incident management: deploy safety, incident response, on-call management, and retrospectives.",
+        "source": "https://github.com/Rootly-AI-Labs/rootly-claude-plugin.git",
+        "author": "Rootly"
       },
       {
         "name": "ruby-lsp",
@@ -715,7 +1958,21 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "ruby-lsp",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "runway-api",
+        "description": "Video generation at scale. Generate videos, images, and audio with Runway's API — batch ad campaigns, product videos, multishot stories, and creative iteration. Supports seedance2, gen4.5, veo3, Nano, Banana Pro, and more.",
+        "source": "https://github.com/runwayml/skills.git",
+        "author": "Runway"
       },
       {
         "name": "rust-analyzer-lsp",
@@ -724,26 +1981,115 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "rust-analyzer",
+              "description": ""
+            }
+          ]
         }
       },
       {
-        "name": "sanity-plugin",
+        "name": "sagemaker-ai",
+        "description": "Build, train, and deploy AI models with deep AWS AI/ML expertise brought directly into your coding assistants, covering the surface area of Amazon SageMaker AI.",
+        "source": "https://github.com/awslabs/agent-plugins.git",
+        "source_path": "plugins/sagemaker-ai"
+      },
+      {
+        "name": "sanity",
         "description": "Sanity content platform integration with MCP server, agent skills, and slash commands. Query and author content, build and optimize GROQ queries, design schemas, and set up Visual Editing.",
         "source": "https://github.com/sanity-io/agent-toolkit.git",
         "author": "Sanity"
       },
       {
-        "name": "searchfit-seo",
-        "description": "Free AI-powered SEO toolkit — audit websites, plan content strategy, optimize pages, generate schema markup, cluster keywords, and track AI visibility. Works with any website or codebase.",
-        "source": "https://github.com/searchfit/searchfit-seo.git"
+        "name": "sap-cds-mcp",
+        "description": "AI-assisted development of SAP Cloud Application Programming Model (CAP) projects. Search CDS models and CAP documentation.",
+        "source": "https://github.com/cap-js/mcp-server.git",
+        "author": "SAP SE"
+      },
+      {
+        "name": "sap-fiori-mcp-server",
+        "description": "MCP server for SAP Fiori development tools for Claude Code. Build and modify SAP Fiori applications with AI assistance.",
+        "source": "https://github.com/SAP/open-ux-tools.git",
+        "source_path": "packages/fiori-mcp-server",
+        "author": "SAP SE"
+      },
+      {
+        "name": "sap-hana-cli",
+        "description": "150+ SAP HANA database tools for AI assistants. Query tables, import/export data, profile data quality, compare schemas, manage backups, monitor performance, and more. Connects to SAP HANA Cloud and on-premise databases.",
+        "source": "https://github.com/SAP-samples/hana-cli-claude-plugin.git",
+        "author": "SAP SE"
+      },
+      {
+        "name": "sap-mdk-server",
+        "description": "MCP server for SAP Mobile Development Kit (MDK). Build and modify MDK applications with AI assistance — schema lookups, action validation, rule editing, and project scaffolding.",
+        "source": "https://github.com/SAP/mdk-mcp-server.git",
+        "author": "SAP SE"
+      },
+      {
+        "name": "save-to-spotify",
+        "description": "Create polished audio episodes with TTS narration, rich timelines, cover images, and save them to Spotify via the save-to-spotify CLI.",
+        "source": "https://github.com/spotify/save-to-spotify.git",
+        "source_path": "plugin",
+        "author": "Spotify"
       },
       {
         "name": "security-guidance",
-        "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
+        "description": "Security review for Claude-generated code. Pattern-based warnings on edits, LLM-powered diff review on Stop, and an agentic commit reviewer that catches injection, XSS, SSRF, hardcoded secrets, and 25+ other vulnerability classes.",
         "source": "./plugins/security-guidance",
         "author": "Anthropic",
         "components": {
-          "hooks": 2
+          "hooks": 11
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "_base",
+              "description": ""
+            },
+            {
+              "name": "diffstate",
+              "description": ""
+            },
+            {
+              "name": "ensure_agent_sdk",
+              "description": ""
+            },
+            {
+              "name": "extensibility",
+              "description": ""
+            },
+            {
+              "name": "gitutil",
+              "description": ""
+            },
+            {
+              "name": "hooks",
+              "description": ""
+            },
+            {
+              "name": "llm",
+              "description": ""
+            },
+            {
+              "name": "patterns",
+              "description": ""
+            },
+            {
+              "name": "review_api",
+              "description": ""
+            },
+            {
+              "name": "security_reminder_hook",
+              "description": ""
+            },
+            {
+              "name": "session_state",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -755,7 +2101,14 @@
       {
         "name": "sentry",
         "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
-        "source": "https://github.com/getsentry/sentry-for-claude.git"
+        "source": "https://github.com/getsentry/plugin-claude.git"
+      },
+      {
+        "name": "sentry-cli",
+        "description": "Skills for using the Sentry CLI to interact with Sentry from the command line",
+        "source": "https://github.com/getsentry/cli.git",
+        "source_path": "plugins/sentry-cli",
+        "author": "Sentry"
       },
       {
         "name": "serena",
@@ -766,18 +2119,75 @@
         ]
       },
       {
+        "name": "servicenow-sdk",
+        "description": "Create, edit, and deploy ServiceNow applications with the Fluent SDK effortlessly through Claude AI.",
+        "source": "https://github.com/ServiceNow/sdk.git",
+        "source_path": "providers/claude/plugin",
+        "author": "ServiceNow"
+      },
+      {
+        "name": "session-report",
+        "description": "Generate an explorable HTML report of Claude Code session usage — tokens, cache efficiency, subagents, skills, and the most expensive prompts — from local ~/.claude/projects transcripts.",
+        "source": "./plugins/session-report",
+        "author": "Anthropic",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "session-report",
+              "description": "Generate an explorable HTML report of Claude Code session usage (tokens, cache, subagents, skills, expensive prompts) from ~/.claude/projects transcripts."
+            }
+          ]
+        }
+      },
+      {
+        "name": "shopify",
+        "description": "Shopify developer tools for Claude Code — search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code",
+        "source": "https://github.com/Shopify/shopify-plugins.git",
+        "author": "Shopify"
+      },
+      {
+        "name": "shopify-ai-toolkit",
+        "description": "Shopify's AI Toolkit provides 18 development skills for building on the Shopify platform, covering documentation search, API schema access, GraphQL and Liquid code validation, Hydrogen storefronts, Polaris UI extensions, store management via CLI, and onboarding guidance for both developers and merchants.",
+        "source": "https://github.com/Shopify/Shopify-AI-Toolkit.git",
+        "author": "Shopify"
+      },
+      {
         "name": "skill-creator",
         "description": "Create new skills, improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, update or optimize an existing skill, run evals to test a skill, or benchmark skill performance with variance analysis.",
         "source": "./plugins/skill-creator",
         "author": "Anthropic",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-creator",
+              "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy."
+            }
+          ]
         }
       },
       {
         "name": "slack",
         "description": "Slack workspace integration. Search messages, access channels, read threads, and stay connected with your team's communications while coding. Find relevant discussions and context quickly.",
         "source": "https://github.com/slackapi/slack-mcp-plugin.git"
+      },
+      {
+        "name": "snowflake-cortex-code",
+        "description": "Automatically route Snowflake prompts from Claude Code to Cortex Code for execution. Provides slash commands for code review and task delegation, plus skills for routing, run, and setup.",
+        "source": "https://github.com/Snowflake-Labs/snowflake-ai-kit.git",
+        "source_path": "plugins/cortex-code",
+        "author": "Snowflake"
+      },
+      {
+        "name": "sonarqube",
+        "description": "Automatically enforce SonarQube code quality and security in the agent coding loop — 7,000+ rules, secrets scanning, agentic analysis, and quality gates across 40+ languages. PostToolUse hooks run analysis after every file edit. Pre-tool secrets scanning prevents 450+ patterns from reaching the LLM. Slash commands give on-demand access to quality gate status, coverage, duplication, and dependency risks. Includes SonarQube CLI, MCP Server, skills, hooks, and slash commands.",
+        "source": "https://github.com/SonarSource/sonarqube-agent-plugins.git",
+        "author": "SonarSource"
       },
       {
         "name": "sonatype-guide",
@@ -790,35 +2200,32 @@
         "source": "https://github.com/sourcegraph-community/sourcegraph-claudecode-plugin.git"
       },
       {
-        "name": "stagehand",
-        "description": "Browser automation skill for Claude Code using Stagehand. Automate web interactions, extract data, and navigate websites using natural language.",
-        "source": "browserbase/agent-browse",
-        "author": "Browserbase",
-        "tags": [
-          "browser",
-          "automation",
-          "stagehand",
-          "web-scraping"
-        ],
-        "components": {
-          "skills": 1
-        }
+        "name": "spanner",
+        "description": "Connect and interact with Spanner data using natural language.",
+        "source": "https://github.com/gemini-cli-extensions/spanner.git",
+        "author": "Google LLC"
+      },
+      {
+        "name": "spotify-ads-api",
+        "description": "Manage Spotify ad campaigns with natural language. Create campaigns, ad sets, ads, pull reports, and handle OAuth — all through conversation.",
+        "source": "https://github.com/spotify/ads-claude-plugin.git"
       },
       {
         "name": "stripe",
         "description": "Stripe development plugin for Claude",
-        "source": "stripe/ai",
+        "source": "https://github.com/stripe/ai.git",
         "source_path": "providers/claude/plugin"
       },
       {
         "name": "sumup",
         "description": "SumUp payment integrations across terminal and online checkout flows. Build Android and iOS POS apps with SumUp card readers, online checkout with server SDKs and the checkout widget, and control card readers remotely via Cloud API.",
-        "source": "https://github.com/sumup/sumup-skills.git"
+        "source": "https://github.com/sumup/sumup-skills.git",
+        "source_path": "providers/claude/plugin"
       },
       {
         "name": "supabase",
         "description": "Supabase MCP integration for database operations, authentication, storage, and real-time subscriptions. Manage your Supabase projects, run SQL queries, and interact with your backend directly.",
-        "source": "./external_plugins/supabase"
+        "source": "https://github.com/supabase-community/supabase-plugin.git"
       },
       {
         "name": "superpowers",
@@ -832,7 +2239,27 @@
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "sourcekit-lsp",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "tavily",
+        "description": "Build AI applications with real-time web data using Tavily's search, extract, crawl, and research APIs.",
+        "source": "https://github.com/tavily-ai/skills.git",
+        "author": "Tavily Team"
+      },
+      {
+        "name": "teamcity-cli",
+        "description": "Agent skill for interacting with TeamCity CI/CD using the teamcity CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
+        "source": "https://github.com/JetBrains/teamcity-cli.git",
+        "author": "JetBrains"
       },
       {
         "name": "telegram",
@@ -840,6 +2267,18 @@
         "source": "./external_plugins/telegram",
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "access",
+              "description": "Manage Telegram channel access — approve pairings, edit allowlists, set DM/group policy. Use when the user asks to pair, approve someone, check who's allowed, or change policy for the Telegram channel."
+            },
+            {
+              "name": "configure",
+              "description": "Set up the Telegram channel — save the bot token and review access policy. Use when the user pastes a Telegram bot token, asks to configure Telegram, asks \"how do I set this up\" or \"who can reach me,\" or wants to check channel status."
+            }
+          ]
         }
       },
       {
@@ -849,13 +2288,79 @@
         "author": "HashiCorp"
       },
       {
+        "name": "togetherai-skills",
+        "description": "Agent Skills for Together AI platform — inference, training, embeddings, audio, video, images, function calling, and infrastructure. Covers serverless chat completions, image/video generation, fine-tuning, batch inference, evaluations, sandboxes, dedicated endpoints, and GPU clusters.",
+        "source": "https://github.com/togethercomputer/skills.git",
+        "author": "Together AI"
+      },
+      {
+        "name": "twilio-developer-kit",
+        "description": "Twilio Skills provide procedural knowledge for AI coding agents — which APIs to use, in what order, and what to avoid. Covers SMS, Voice, WhatsApp, Verify, SendGrid, Compliance, and 30+ products.",
+        "source": "https://github.com/twilio/ai.git",
+        "author": "Twilio"
+      },
+      {
         "name": "typescript-lsp",
         "description": "TypeScript/JavaScript language server for enhanced code intelligence",
         "source": "./plugins/typescript-lsp",
         "author": "Anthropic",
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "typescript",
+              "description": ""
+            }
+          ]
         }
+      },
+      {
+        "name": "ui5",
+        "description": "SAPUI5 / OpenUI5 plugin for coding agents. Create and validate UI5 projects, access API documentation, run UI5 linter, get development guidelines and best practices for UI5 development.",
+        "source": "https://github.com/UI5/plugins-coding-agents.git",
+        "source_path": "plugins/ui5",
+        "author": "SAP SE"
+      },
+      {
+        "name": "ui5-modernization",
+        "description": "Complete UI5 modernization toolkit with workflow and specialized fix patterns for modernizing SAPUI5/OpenUI5 applications.",
+        "source": "https://github.com/UI5/plugins-coding-agents.git",
+        "source_path": "plugins/ui5-modernization",
+        "author": "SAP SE"
+      },
+      {
+        "name": "ui5-typescript-conversion",
+        "description": "SAPUI5 / OpenUI5 plugin for coding agents. Convert JavaScript based UI5 projects to TypeScript.",
+        "source": "https://github.com/UI5/plugins-coding-agents.git",
+        "source_path": "plugins/ui5-typescript-conversion",
+        "author": "SAP SE"
+      },
+      {
+        "name": "unreal-engine-skills-for-claude-code",
+        "description": "Control Unreal Editor directly from Claude Code via MCP. Hundreds of tools exposed via Unreal's ToolsetRegistry across 30+ toolsets: actors, blueprints, materials, Niagara, Control Rigs, Sequencer, State Trees, widgets, Gameplay Ability System, automation testing, and more.",
+        "source": "https://github.com/EpicGames/unreal-engine-skills-for-claude-code-plugin.git",
+        "author": "Epic Games"
+      },
+      {
+        "name": "valtown",
+        "description": "Build and deploy on Val Town. Bundles the Val Town MCP server and platform skills (HTTP vals, cron/intervals, SQLite, email, OAuth, React UI, third-party integrations, templates).",
+        "source": "https://github.com/val-town/plugins.git",
+        "source_path": "plugin",
+        "author": "Val Town"
+      },
+      {
+        "name": "vanta",
+        "description": "The Vanta plugin connects Claude Code to Vanta's security and compliance platform through the Vanta MCP server. It combines Vanta's test-specific remediation intelligence with your local repository context to help you fix compliance failures faster.",
+        "source": "https://github.com/VantaInc/vanta-mcp-plugin.git",
+        "author": "Vanta"
+      },
+      {
+        "name": "vanta-mcp-plugin",
+        "description": "The Vanta plugin connects Claude Code to Vanta's security and compliance platform through the Vanta MCP server. It combines Vanta's test-specific remediation intelligence with your local repository context to help you fix compliance failures faster.",
+        "source": "https://github.com/VantaInc/vanta-mcp-plugin.git",
+        "author": "Vanta"
       },
       {
         "name": "vercel",
@@ -863,9 +2368,22 @@
         "source": "https://github.com/vercel/vercel-plugin.git"
       },
       {
-        "name": "voila-api",
-        "description": "Definitive guide for the Voila API. Covers shipment creation (Manual/Smart Shipping), real-time tracking, detailed history, manifesting, collections, webhooks, and third-party integrations (Sorted, Peoplevox, Mintsoft, Veeqo, JD).",
-        "source": "https://github.com/TSedmanDC/Voila-API-Skill.git"
+        "name": "vibe-prospecting",
+        "description": "Vibe Prospecting connects Claude to live B2B company and contact data so users can search, match, enrich, filter, and export prospects at scale. It turns natural-language requests into structured GTM workflows for lead generation, CRM enrichment, company research, executive discovery, and multi-step prospecting automation inside Claude Cowork and Claude Code.",
+        "source": "https://github.com/explorium-ai/vibeprospecting-plugin.git",
+        "author": "vibeprospecting.ai"
+      },
+      {
+        "name": "vsql-extension-builder",
+        "description": "Builds a VillageSQL extension for MySQL end-to-end through a 7-phase persona-driven workflow. Commonly used to port PostgreSQL extensions to MySQL.",
+        "source": "https://github.com/villagesql/villagesql-skills.git",
+        "author": "VillageSQL"
+      },
+      {
+        "name": "windsor-ai",
+        "description": "Connect Claude Code to 325+ business data sources via Windsor.ai. Query marketing, sales, CRM, ecommerce, finance, and analytics data from Google Ads, Meta, HubSpot, Salesforce, Shopify, Stripe, and hundreds more — directly from your terminal.",
+        "source": "https://github.com/windsor-ai/claude-windsor-ai-plugin.git",
+        "author": "Windsor.ai"
       },
       {
         "name": "wix",
@@ -873,20 +2391,64 @@
         "source": "https://github.com/wix/skills.git"
       },
       {
-        "name": "wordpress.com",
-        "description": "Uses Claude Code to create and edit WordPress sites with WordPress Studio before deploying changes to your WordPress.com site.",
+        "name": "build-with-wordpress",
+        "description": "Craft production-grade WordPress sites and applications. Everything from themes and plugins to commerce and deployment.",
         "source": "https://github.com/Automattic/claude-code-wordpress.com.git"
+      },
+      {
+        "name": "workos",
+        "description": "WorkOS integration skills for AuthKit, SSO, Directory Sync, RBAC, Vault, Audit Logs, migrations, and API references.",
+        "source": "https://github.com/workos/skills.git",
+        "source_path": "plugins/workos",
+        "author": "WorkOS"
+      },
+      {
+        "name": "youdotcom-agent-skills",
+        "description": "You.com agent skills for web search, research with citations, and content extraction. Guided integrations for Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, crewAI, LangChain, Microsoft Teams.ai, direct REST API, and bash CLI.",
+        "source": "https://github.com/youdotcom-oss/agent-skills.git",
+        "author": "You.com"
       },
       {
         "name": "zapier",
         "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
-        "source": "zapier/zapier-mcp",
+        "source": "https://github.com/zapier/zapier-mcp.git",
         "source_path": "plugins/zapier"
+      },
+      {
+        "name": "zilliz",
+        "description": "Zilliz Cloud management plugin with 14 skills covering cluster lifecycle, collection schema, vector search, index tuning, bulk import, RBAC, backups, and monitoring.",
+        "source": "https://github.com/zilliztech/zilliz-plugin.git",
+        "source_path": "plugins/zilliz",
+        "author": "Zilliz"
+      },
+      {
+        "name": "zoom-plugin",
+        "description": "Claude plugin for planning, building, and debugging Zoom integrations across REST APIs, SDKs, webhooks, bots, and MCP workflows.",
+        "source": "https://github.com/zoom/zoom-plugin.git"
       },
       {
         "name": "zoominfo",
         "description": "Search companies and contacts, enrich leads, find lookalikes, and get AI-ranked contact recommendations. Pre-built skills chain multiple ZoomInfo tools into complete B2B sales workflows.",
-        "source": "https://github.com/Zoominfo/zoominfo-mcp-plugin.git"
+        "source": "https://github.com/Zoominfo/zoominfo-mcp-plugin.git",
+        "author": "ZoomInfo"
+      },
+      {
+        "name": "zscaler",
+        "description": "Manage Zscaler cloud security platform including ZPA (private access), ZIA (internet access), ZDX (digital experience), ZCC (client connector), EASM (attack surface), and Z-Insights (analytics). Create and manage policies, troubleshoot connectivity, audit security configurations, and investigate incidents across the full Zscaler ecosystem.",
+        "source": "https://github.com/zscaler/zscaler-mcp-server.git",
+        "author": "Zscaler"
+      },
+      {
+        "name": "langfuse",
+        "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
+        "source": "https://github.com/langfuse/skills.git",
+        "author": "Langfuse"
+      },
+      {
+        "name": "zyte-web-data",
+        "description": "Web scraping skills for Claude Code powered by the Zyte API — scrape sites, generate and run Scrapy spiders, define extraction schemas, and ship to Scrapy Cloud.",
+        "source": "https://github.com/zytedata/claude-skills.git",
+        "author": "Zyte"
       }
     ]
   },
@@ -896,7 +2458,7 @@
     "author": "jarrodwatts",
     "description": "A Claude Code plugin that shows what's happening - context usage, active tools, running agents, and todo progress",
     "github": "https://github.com/jarrodwatts/claude-hud",
-    "stars": 14334,
+    "stars": 26330,
     "type": "plugin",
     "tags": [
       "commands"
@@ -918,70 +2480,18 @@
     "slug": "compound-engineering-plugin",
     "name": "Compound Engineering Plugin",
     "author": "EveryInc",
-    "description": "Office Compound Engineering plugin for Claude Code, Codex, and more",
+    "description": "Official Compound Engineering plugin for Claude Code, Codex, Cursor, and more",
     "github": "https://github.com/EveryInc/compound-engineering-plugin",
-    "stars": 11291,
-    "type": "marketplace",
+    "stars": 23054,
+    "type": "plugin",
     "tags": [
-      "skills",
-      "agents",
-      "commands",
-      "mcps"
+      "skills"
     ],
-    "contains": {
-      "plugins": 2,
-      "components": {
-        "skills": 42,
-        "agents": 6,
-        "mcps": 1,
-        "commands": 3
-      }
-    },
+    "contains": {},
     "highlights": [
-      "2 plugins in marketplace",
       "Web UI: https://every.to/guides/compound-engineering"
     ],
-    "website": "https://every.to/guides/compound-engineering",
-    "plugins_list": [
-      {
-        "name": "compound-engineering",
-        "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.",
-        "source": "./plugins/compound-engineering",
-        "author": "Kieran Klaassen",
-        "tags": [
-          "ai-powered",
-          "compound-engineering",
-          "workflow-automation",
-          "code-review",
-          "quality",
-          "knowledge-management",
-          "image-generation"
-        ],
-        "components": {
-          "skills": 41,
-          "agents": 6,
-          "mcps": 1
-        }
-      },
-      {
-        "name": "coding-tutor",
-        "description": "Personalized coding tutorials that build on your existing knowledge and use your actual codebase for examples. Includes spaced repetition quizzes to reinforce learning. Includes 3 commands and 1 skill.",
-        "source": "./plugins/coding-tutor",
-        "author": "Nityesh Agarwal",
-        "tags": [
-          "coding",
-          "programming",
-          "tutorial",
-          "learning",
-          "spaced-repetition",
-          "education"
-        ],
-        "components": {
-          "skills": 1,
-          "commands": 3
-        }
-      }
-    ]
+    "website": "https://every.to/guides/compound-engineering"
   },
   {
     "slug": "knowledge-work-plugins",
@@ -989,7 +2499,7 @@
     "author": "anthropics",
     "description": "Open source repository of plugins primarily intended for knowledge workers to use in Claude Cowork",
     "github": "https://github.com/anthropics/knowledge-work-plugins",
-    "stars": 10538,
+    "stars": 22535,
     "type": "marketplace",
     "tags": [
       "skills",
@@ -997,16 +2507,16 @@
       "commands"
     ],
     "contains": {
-      "plugins": 39,
+      "plugins": 85,
       "components": {
-        "skills": 118,
+        "skills": 186,
         "commands": 15,
         "agents": 5
       }
     },
     "highlights": [
       "Official Anthropic repository",
-      "39 plugins in marketplace"
+      "85 plugins in marketplace"
     ],
     "plugins_list": [
       {
@@ -1015,6 +2525,26 @@
         "source": "./productivity",
         "components": {
           "skills": 4
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "memory-management",
+              "description": "Two-tier memory system that makes Claude a true workplace collaborator. Decodes shorthand, acronyms, nicknames, and internal language so Claude understands requests like a colleague would. CLAUDE.md for working memory, memory/ directory for the full knowledge base."
+            },
+            {
+              "name": "start",
+              "description": "Initialize the productivity system and open the dashboard. Use when setting up the plugin for the first time, bootstrapping working memory from your existing task list, or decoding the shorthand (nicknames, acronyms, project codenames) you use in your todos."
+            },
+            {
+              "name": "task-management",
+              "description": "Simple task management using a shared TASKS.md file. Reference this when the user asks about their tasks, wants to add/complete tasks, or needs help tracking commitments."
+            },
+            {
+              "name": "update",
+              "description": "Sync tasks and refresh memory from your current activity. Use when pulling new assignments from your project tracker into TASKS.md, triaging stale or overdue tasks, filling memory gaps for unknown people or projects, or running a comprehensive scan to catch todos buried in chat and email."
+            }
+          ]
         }
       },
       {
@@ -1023,6 +2553,30 @@
         "source": "./enterprise-search",
         "components": {
           "skills": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "digest",
+              "description": "Generate a daily or weekly digest of activity across all connected sources. Use when catching up after time away, starting the day and wanting a summary of mentions and action items, or reviewing a week's decisions and document updates grouped by project."
+            },
+            {
+              "name": "knowledge-synthesis",
+              "description": "Combines search results from multiple sources into coherent, deduplicated answers with source attribution. Handles confidence scoring based on freshness and authority, and summarizes large result sets effectively."
+            },
+            {
+              "name": "search-strategy",
+              "description": "Query decomposition and multi-source search orchestration. Breaks natural language questions into targeted searches per source, translates queries into source-specific syntax, ranks results by relevance, and handles ambiguity and fallback strategies."
+            },
+            {
+              "name": "search",
+              "description": "Search across all connected sources in one query. Trigger with \"find that doc about...\", \"what did we decide on...\", \"where was the conversation about...\", or when looking for a decision, document, or discussion that could live in chat, email, cloud storage, or a project tracker."
+            },
+            {
+              "name": "source-management",
+              "description": "Manages connected MCP sources for enterprise search. Detects available sources, guides users to connect new ones, handles source priority ordering, and manages rate limiting awareness."
+            }
+          ]
         }
       },
       {
@@ -1031,6 +2585,18 @@
         "source": "./cowork-plugin-management",
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "cowork-plugin-customizer",
+              "description": ">"
+            },
+            {
+              "name": "create-cowork-plugin",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -1039,6 +2605,46 @@
         "source": "./sales",
         "components": {
           "skills": 9
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "account-research",
+              "description": "Research a company or person and get actionable sales intel. Works standalone with web search, supercharged when you connect enrichment tools or your CRM. Trigger with \"research [company]\", \"look up [person]\", \"intel on [prospect]\", \"who is [name] at [company]\", or \"tell me about [company]\"."
+            },
+            {
+              "name": "call-prep",
+              "description": "Prepare for a sales call with account context, attendee research, and suggested agenda. Works standalone with user input and web research, supercharged when you connect your CRM, email, chat, or transcripts. Trigger with \"prep me for my call with [company]\", \"I'm meeting with [company] prep me\", \"call prep [company]\", or \"get me ready for [meeting]\"."
+            },
+            {
+              "name": "call-summary",
+              "description": "Process call notes or a transcript — extract action items, draft follow-up email, generate internal summary. Use when pasting rough notes or a transcript after a discovery, demo, or negotiation call, drafting a customer follow-up, logging the activity for your CRM, or capturing objections and next steps for your team."
+            },
+            {
+              "name": "competitive-intelligence",
+              "description": "Research your competitors and build an interactive battlecard. Outputs an HTML artifact with clickable competitor cards and a comparison matrix. Trigger with \"competitive intel\", \"research competitors\", \"how do we compare to [competitor]\", \"battlecard for [competitor]\", or \"what's new with [competitor]\"."
+            },
+            {
+              "name": "create-an-asset",
+              "description": "Generate tailored sales assets (landing pages, decks, one-pagers, workflow demos) from your deal context. Describe your prospect, audience, and goal — get a polished, branded asset ready to share with customers."
+            },
+            {
+              "name": "daily-briefing",
+              "description": "Start your day with a prioritized sales briefing. Works standalone when you tell me your meetings and priorities, supercharged when you connect your calendar, CRM, and email. Trigger with \"morning briefing\", \"daily brief\", \"what's on my plate today\", \"prep my day\", or \"start my day\"."
+            },
+            {
+              "name": "draft-outreach",
+              "description": "Research a prospect then draft personalized outreach. Uses web research by default, supercharged with enrichment and CRM. Trigger with \"draft outreach to [person/company]\", \"write cold email to [prospect]\", \"reach out to [name]\"."
+            },
+            {
+              "name": "forecast",
+              "description": "Generate a weighted sales forecast with best/likely/worst scenarios, commit vs. upside breakdown, and gap analysis. Use when preparing a quarterly forecast call, assessing gap-to-quota from a pipeline CSV, deciding which deals to commit vs. call upside, or checking pipeline coverage against your number."
+            },
+            {
+              "name": "pipeline-review",
+              "description": "Analyze pipeline health — prioritize deals, flag risks, get a weekly action plan. Use when running a weekly pipeline review, deciding which deals to focus on this week, spotting stale or stuck opportunities, auditing for hygiene issues like bad close dates, or identifying single-threaded deals."
+            }
+          ]
         }
       },
       {
@@ -1047,6 +2653,42 @@
         "source": "./finance",
         "components": {
           "skills": 8
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "audit-support",
+              "description": "Support SOX 404 compliance with control testing methodology, sample selection, and documentation standards. Use when generating testing workpapers, selecting audit samples, classifying control deficiencies, or preparing for internal or external audits."
+            },
+            {
+              "name": "close-management",
+              "description": "Manage the month-end close process with task sequencing, dependencies, and status tracking. Use when planning the close calendar, tracking close progress, identifying blockers, or sequencing close activities by day."
+            },
+            {
+              "name": "financial-statements",
+              "description": "Generate financial statements (income statement, balance sheet, cash flow) with period-over-period comparison and variance analysis. Use when preparing a monthly or quarterly P&L, closing the books and need to flag material variances, comparing actuals to budget, building a financial summary for leadership review, or looking up GAAP presentation requirements and period-end adjustments."
+            },
+            {
+              "name": "journal-entry-prep",
+              "description": "Prepare journal entries with proper debits, credits, and supporting documentation for month-end close. Use when booking accruals, prepaid amortization, fixed asset depreciation, payroll entries, revenue recognition, or any manual journal entry."
+            },
+            {
+              "name": "journal-entry",
+              "description": "Prepare journal entries with proper debits, credits, and supporting detail. Use when booking month-end accruals (AP, payroll, prepaid), recording depreciation or amortization, posting revenue recognition or deferred revenue adjustments, or documenting an entry for audit review."
+            },
+            {
+              "name": "reconciliation",
+              "description": "Reconcile accounts by comparing GL balances to subledgers, bank statements, or third-party data. Use when performing bank reconciliations, GL-to-subledger recs, intercompany reconciliations, or identifying and categorizing reconciling items."
+            },
+            {
+              "name": "sox-testing",
+              "description": "Generate SOX sample selections, testing workpapers, and control assessments. Use when planning quarterly or annual SOX 404 testing, pulling a sample for a control (revenue, P2P, ITGC, close), building a testing workpaper template, or evaluating and classifying a control deficiency."
+            },
+            {
+              "name": "variance-analysis",
+              "description": "Decompose financial variances into drivers with narrative explanations and waterfall analysis. Use when analyzing budget vs. actual, period-over-period changes, revenue or expense variances, or preparing variance commentary for leadership."
+            }
+          ]
         }
       },
       {
@@ -1055,6 +2697,50 @@
         "source": "./data",
         "components": {
           "skills": 10
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "analyze",
+              "description": "Answer data questions -- from quick lookups to full analyses. Use when looking up a single metric, investigating what's driving a trend or drop, comparing segments over time, or preparing a formal data report for stakeholders."
+            },
+            {
+              "name": "build-dashboard",
+              "description": "Build an interactive HTML dashboard with charts, filters, and tables. Use when creating an executive overview with KPI cards, turning query results into a shareable self-contained report, building a team monitoring snapshot, or needing multiple charts with filters in one browser-openable file."
+            },
+            {
+              "name": "create-viz",
+              "description": "Create publication-quality visualizations with Python. Use when turning query results or a DataFrame into a chart, selecting the right chart type for a trend or comparison, generating a plot for a report or presentation, or needing an interactive chart with hover and zoom."
+            },
+            {
+              "name": "data-context-extractor",
+              "description": ">"
+            },
+            {
+              "name": "data-visualization",
+              "description": "Create effective data visualizations with Python (matplotlib, seaborn, plotly). Use when building charts, choosing the right chart type for a dataset, creating publication-quality figures, or applying design principles like accessibility and color theory."
+            },
+            {
+              "name": "explore-data",
+              "description": "Profile and explore a dataset to understand its shape, quality, and patterns. Use when encountering a new table or file, checking null rates and column distributions, spotting data quality issues like duplicates or suspicious values, or deciding which dimensions and metrics to analyze."
+            },
+            {
+              "name": "sql-queries",
+              "description": "Write correct, performant SQL across all major data warehouse dialects (Snowflake, BigQuery, Databricks, PostgreSQL, etc.). Use when writing queries, optimizing slow SQL, translating between dialects, or building complex analytical queries with CTEs, window functions, or aggregations."
+            },
+            {
+              "name": "statistical-analysis",
+              "description": "Apply statistical methods including descriptive stats, trend analysis, outlier detection, and hypothesis testing. Use when analyzing distributions, testing for significance, detecting anomalies, computing correlations, or interpreting statistical results."
+            },
+            {
+              "name": "validate-data",
+              "description": "QA an analysis before sharing -- methodology, accuracy, and bias checks. Use when reviewing an analysis before a stakeholder presentation, spot-checking calculations and aggregation logic, verifying a SQL query's results look right, or assessing whether conclusions are actually supported by the data."
+            },
+            {
+              "name": "write-query",
+              "description": "Write optimized SQL for your dialect with best practices. Use when translating a natural-language data need into SQL, building a multi-CTE query with joins and aggregations, optimizing a query against a large partitioned table, or getting dialect-specific syntax for Snowflake, BigQuery, Postgres, etc."
+            }
+          ]
         }
       },
       {
@@ -1063,6 +2749,46 @@
         "source": "./legal",
         "components": {
           "skills": 9
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "brief",
+              "description": "Generate contextual briefings for legal work — daily summary, topic research, or incident response. Use when starting your day and need a scan of legal-relevant items across email, calendar, and contracts, when researching a specific legal question across internal sources, or when a developing situation (data breach, litigation threat, regulatory inquiry) needs rapid context."
+            },
+            {
+              "name": "compliance-check",
+              "description": "Run a compliance check on a proposed action, product feature, or business initiative, surfacing applicable regulations, required approvals, and risk areas. Use when launching a feature that touches personal data, when marketing or product proposes something with regulatory implications, or when you need to know which approvals and jurisdictional requirements apply before proceeding."
+            },
+            {
+              "name": "legal-response",
+              "description": "Generate a response to a common legal inquiry using configured templates, with built-in escalation checks for situations that shouldn't use a templated reply. Use when responding to data subject requests, litigation hold notices, vendor legal questions, NDA requests from business teams, or subpoenas."
+            },
+            {
+              "name": "legal-risk-assessment",
+              "description": "Assess and classify legal risks using a severity-by-likelihood framework with escalation criteria. Use when evaluating contract risk, assessing deal exposure, classifying issues by severity, or determining whether a matter needs senior counsel or outside legal review."
+            },
+            {
+              "name": "meeting-briefing",
+              "description": "Prepare structured briefings for meetings with legal relevance and track resulting action items. Use when preparing for contract negotiations, board meetings, compliance reviews, or any meeting where legal context, background research, or action tracking is needed."
+            },
+            {
+              "name": "review-contract",
+              "description": "Review a contract against your organization's negotiation playbook — flag deviations, generate redlines, provide business impact analysis. Use when reviewing vendor or customer agreements, when you need clause-by-clause analysis against standard positions, or when preparing a negotiation strategy with prioritized redlines and fallback positions."
+            },
+            {
+              "name": "signature-request",
+              "description": "Prepare and route a document for e-signature — run a pre-signature checklist, configure signing order, and send for execution. Use when a contract is finalized and ready to sign, when verifying entity names, exhibits, and signature blocks before sending, or when setting up an envelope with sequential or parallel signers."
+            },
+            {
+              "name": "triage-nda",
+              "description": "Rapidly triage an incoming NDA and classify it as GREEN (standard approval), YELLOW (counsel review), or RED (full legal review). Use when a new NDA arrives from sales or business development, when screening for embedded non-solicits, non-competes, or missing carveouts, or when deciding whether an NDA can be signed under standard delegation."
+            },
+            {
+              "name": "vendor-check",
+              "description": "Check the status of existing agreements with a vendor across all connected systems — CLM, CRM, email, and document storage — with gap analysis and upcoming deadlines. Use when onboarding or renewing a vendor, when you need a consolidated view of what's signed and what's missing (MSA, DPA, SOW), or when checking for approaching expirations and surviving obligations."
+            }
+          ]
         }
       },
       {
@@ -1071,6 +2797,42 @@
         "source": "./marketing",
         "components": {
           "skills": 8
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "brand-review",
+              "description": "Review content against your brand voice, style guide, and messaging pillars, flagging deviations by severity with specific before/after fixes. Use when checking a draft before it ships, when auditing copy for voice consistency and terminology, or when screening for unsubstantiated claims, missing disclaimers, and other legal flags."
+            },
+            {
+              "name": "campaign-plan",
+              "description": "Generate a full campaign brief with objectives, audience, messaging, channel strategy, content calendar, and success metrics. Use when planning a product launch, lead-gen push, or awareness campaign, when you need a week-by-week content calendar with dependencies, or when translating a marketing goal into a structured, executable plan."
+            },
+            {
+              "name": "competitive-brief",
+              "description": "Research competitors and generate a positioning and messaging comparison with content gaps, opportunities, and threats. Use when building sales battlecards, when finding positioning gaps and messaging angles competitors haven't claimed, or when a competitor makes a move and you need to assess the impact."
+            },
+            {
+              "name": "content-creation",
+              "description": "Draft marketing content across channels — blog posts, social media, email newsletters, landing pages, press releases, and case studies. Use when writing any marketing content, when you need channel-specific formatting, SEO-optimized copy, headline options, or calls to action."
+            },
+            {
+              "name": "draft-content",
+              "description": "Draft blog posts, social media, email newsletters, landing pages, press releases, and case studies with channel-specific formatting and SEO recommendations. Use when writing any marketing content, when you need headline or subject line options, or when adapting a message for a specific platform, audience, and brand voice."
+            },
+            {
+              "name": "email-sequence",
+              "description": "Design and draft multi-email sequences with full copy, timing, branching logic, exit conditions, and performance benchmarks. Use when building onboarding, lead nurture, re-engagement, win-back, or product launch flows, when you need a complete drip campaign with A/B test suggestions, or when mapping a sequence end-to-end with a flow diagram."
+            },
+            {
+              "name": "performance-report",
+              "description": "Build a marketing performance report with key metrics, trend analysis, wins and misses, and prioritized optimization recommendations. Use when wrapping a campaign, when preparing weekly, monthly, or quarterly channel summaries for stakeholders, or when you need data translated into an executive summary with next-period priorities."
+            },
+            {
+              "name": "seo-audit",
+              "description": "Run a comprehensive SEO audit — keyword research, on-page analysis, content gaps, technical checks, and competitor comparison. Use when assessing a site's SEO health, when finding keyword opportunities and content gaps competitors own, or when you need a prioritized action plan split into quick wins and strategic investments."
+            }
+          ]
         }
       },
       {
@@ -1079,6 +2841,30 @@
         "source": "./customer-support",
         "components": {
           "skills": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "customer-escalation",
+              "description": "Package an escalation for engineering, product, or leadership with full context. Use when a bug needs engineering attention beyond normal support, multiple customers report the same issue, a customer is threatening to churn, or an issue has sat unresolved past its SLA."
+            },
+            {
+              "name": "customer-research",
+              "description": "Multi-source research on a customer question or topic with source attribution. Use when a customer asks something you need to look up, investigating whether a bug has been reported before, checking what was previously told to a specific account, or gathering background before drafting a response."
+            },
+            {
+              "name": "draft-response",
+              "description": "Draft a professional customer-facing response tailored to the situation and relationship. Use when answering a product question, responding to an escalation or outage, delivering bad news like a delay or won't-fix, declining a feature request, or replying to a billing issue."
+            },
+            {
+              "name": "kb-article",
+              "description": "Draft a knowledge base article from a resolved issue or common question. Use when a ticket resolution is worth documenting for self-service, the same question keeps coming up, a workaround needs to be published, or a known issue should be communicated to customers."
+            },
+            {
+              "name": "ticket-triage",
+              "description": "Triage and prioritize a support ticket or customer issue. Use when a new ticket comes in and needs categorization, assigning P1-P4 priority, deciding which team should handle it, or checking whether it's a duplicate or known issue before routing."
+            }
+          ]
         }
       },
       {
@@ -1088,6 +2874,84 @@
         "components": {
           "skills": 8,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "competitive-brief",
+              "description": "Create a competitive analysis brief for one or more competitors or a feature area. Use when informing product strategy or feature prioritization, building sales battle cards, prepping board or investor materials, or deciding where to differentiate vs. achieve parity."
+            },
+            {
+              "name": "metrics-review",
+              "description": "Review and analyze product metrics with trend analysis and actionable insights. Use when running a weekly, monthly, or quarterly metrics review, investigating a sudden spike or drop, comparing performance against targets, or turning raw numbers into a scorecard with recommended actions."
+            },
+            {
+              "name": "product-brainstorming",
+              "description": "Brainstorm product ideas, explore problem spaces, and challenge assumptions as a thinking partner. Use when exploring a new opportunity, generating solutions to a product problem, stress-testing an idea, or when a PM needs to think out loud with a sharp sparring partner before converging on a direction."
+            },
+            {
+              "name": "roadmap-update",
+              "description": "Update, create, or reprioritize your product roadmap. Use when adding a new initiative and deciding what moves to make room, shifting priorities after new information comes in, moving timelines due to a dependency slip, or building a Now/Next/Later view from scratch."
+            },
+            {
+              "name": "sprint-planning",
+              "description": "Plan a sprint — scope work, estimate capacity, set goals, and draft a sprint plan. Use when kicking off a new sprint, sizing a backlog against team availability (accounting for PTO and meetings), deciding what's P0 vs. stretch, or handling carryover from the last sprint."
+            },
+            {
+              "name": "stakeholder-update",
+              "description": "Generate a stakeholder update tailored to audience and cadence. Use when writing a weekly or monthly status for leadership, announcing a launch, escalating a risk or blocker, or translating the same progress into exec-brief, engineering-detail, or customer-facing versions."
+            },
+            {
+              "name": "synthesize-research",
+              "description": "Synthesize user research from interviews, surveys, and feedback into structured insights. Use when you have a pile of interview notes, survey responses, or support tickets to make sense of, need to extract themes and rank findings by frequency and impact, or want to turn raw feedback into roadmap recommendations."
+            },
+            {
+              "name": "write-spec",
+              "description": "Write a feature spec or PRD from a problem statement or feature idea. Use when turning a vague idea or user request into a structured document, scoping a feature with goals and non-goals, defining success metrics and acceptance criteria, or breaking a big ask into a phased spec."
+            }
+          ],
+          "commands": [
+            {
+              "name": "brainstorm",
+              "description": "Brainstorm a product idea, problem space, or strategic question with a sharp thinking partner"
+            }
+          ]
+        }
+      },
+      {
+        "name": "bio-research",
+        "description": "Connect to preclinical research tools and databases (literature search, genomics analysis, target prioritization) to accelerate early-stage life sciences R&D",
+        "source": "./bio-research",
+        "components": {
+          "skills": 6
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "instrument-data-to-allotrope",
+              "description": "Convert laboratory instrument output files (PDF, CSV, Excel, TXT) to Allotrope Simple Model (ASM) JSON format or flattened 2D CSV. Use this skill when scientists need to standardize instrument data for LIMS systems, data lakes, or downstream analysis. Supports auto-detection of instrument types. Outputs include full ASM JSON, flattened CSV for easy import, and exportable Python code for data engineers. Common triggers include converting instrument files, standardizing lab data, preparing data for upload to LIMS/ELN systems, or generating parser code for production pipelines."
+            },
+            {
+              "name": "nextflow-development",
+              "description": "Run nf-core bioinformatics pipelines (rnaseq, sarek, atacseq) on sequencing data. Use when analyzing RNA-seq, WGS/WES, or ATAC-seq data—either local FASTQs or public datasets from GEO/SRA. Triggers on nf-core, Nextflow, FASTQ analysis, variant calling, gene expression, differential expression, GEO reanalysis, GSE/GSM/SRR accessions, or samplesheet creation."
+            },
+            {
+              "name": "scientific-problem-selection",
+              "description": "This skill should be used when scientists need help with research problem selection, project ideation, troubleshooting stuck projects, or strategic scientific decisions. Use this skill when users ask to pitch a new research idea, work through a project problem, evaluate project risks, plan research strategy, navigate decision trees, or get help choosing what scientific problem to work on. Typical requests include \"I have an idea for a project\", \"I'm stuck on my research\", \"help me evaluate this project\", \"what should I work on\", or \"I need strategic advice about my research\"."
+            },
+            {
+              "name": "scvi-tools",
+              "description": "Deep learning for single-cell analysis using scvi-tools. This skill should be used when users need (1) data integration and batch correction with scVI/scANVI, (2) ATAC-seq analysis with PeakVI, (3) CITE-seq multi-modal analysis with totalVI, (4) multiome RNA+ATAC analysis with MultiVI, (5) spatial transcriptomics deconvolution with DestVI, (6) label transfer and reference mapping with scANVI/scArches, (7) RNA velocity with veloVI, or (8) any deep learning-based single-cell method. Triggers include mentions of scVI, scANVI, totalVI, PeakVI, MultiVI, DestVI, veloVI, sysVI, scArches, variational autoencoder, VAE, batch correction, data integration, multi-modal, CITE-seq, multiome, reference mapping, latent space."
+            },
+            {
+              "name": "single-cell-rna-qc",
+              "description": "Performs quality control on single-cell RNA-seq data (.h5ad or .h5 files) using scverse best practices with MAD-based filtering and comprehensive visualizations. Use when users request QC analysis, filtering low-quality cells, assessing data quality, or following scverse/scanpy best practices for single-cell analysis."
+            },
+            {
+              "name": "start",
+              "description": "Set up your bio-research environment and explore available tools. Use when first getting oriented with the plugin, checking which literature, drug-discovery, or visualization MCP servers are connected, or surveying available analysis skills before starting a new project."
+            }
+          ]
         }
       },
       {
@@ -1098,6 +2962,40 @@
         "components": {
           "skills": 2,
           "commands": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "slack-messaging",
+              "description": "Guidance for composing well-formatted, effective Slack messages using mrkdwn syntax"
+            },
+            {
+              "name": "slack-search",
+              "description": "Guidance for effectively searching Slack to find messages, files, channels, and people"
+            }
+          ],
+          "commands": [
+            {
+              "name": "channel-digest",
+              "description": "Get a digest of recent activity across multiple Slack channels"
+            },
+            {
+              "name": "draft-announcement",
+              "description": "Draft a well-formatted Slack announcement and save it as a draft"
+            },
+            {
+              "name": "find-discussions",
+              "description": "Find discussions about a specific topic across Slack channels"
+            },
+            {
+              "name": "standup",
+              "description": "Generate a standup update based on your recent Slack activity"
+            },
+            {
+              "name": "summarize-channel",
+              "description": "Summarize recent activity in a Slack channel"
+            }
+          ]
         }
       },
       {
@@ -1107,6 +3005,22 @@
         "author": "Apollo.io",
         "components": {
           "skills": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "enrich-lead",
+              "description": "Instant lead enrichment. Drop a name, company, LinkedIn URL, or email and get the full contact card with email, phone, title, company intel, and next actions."
+            },
+            {
+              "name": "prospect",
+              "description": "Full ICP-to-leads pipeline. Describe your ideal customer in plain English and get a ranked table of enriched decision-maker leads with emails and phone numbers."
+            },
+            {
+              "name": "sequence-load",
+              "description": "Find leads matching criteria and bulk-add them to an Apollo outreach sequence. Handles enrichment, contact creation, deduplication, and enrollment in one flow."
+            }
+          ]
         }
       },
       {
@@ -1117,6 +3031,44 @@
         "components": {
           "skills": 6,
           "commands": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "account-research",
+              "description": "Research a company using Common Room data. Triggers on 'research [company]', 'tell me about [domain]', 'pull up signals for [account]', 'what's going on with [company]', or any account-level question."
+            },
+            {
+              "name": "call-prep",
+              "description": "Prepare for a customer or prospect call using Common Room signals. Triggers on 'prep me for my call with [company]', 'prepare for a meeting with [company]', 'what should I know before talking to [company]', or any call preparation request."
+            },
+            {
+              "name": "compose-outreach",
+              "description": "Generate personalized outreach messages using Common Room signals. Triggers on 'draft outreach to [person]', 'write an email to [name]', 'compose a message for [contact]', or any outreach drafting request."
+            },
+            {
+              "name": "contact-research",
+              "description": "Research a specific person using Common Room data. Triggers on 'who is [name]', 'look up [email]', 'research [contact]', 'is [name] a warm lead', or any contact-level question."
+            },
+            {
+              "name": "prospect",
+              "description": "Build targeted account or contact lists using Common Room's Prospector. Triggers on 'find companies that match [criteria]', 'build a prospect list', 'find contacts at [type of company]', 'show me companies hiring [role]', or any list-building request."
+            },
+            {
+              "name": "weekly-prep-brief",
+              "description": "Generate a comprehensive weekly briefing for all external calls in the next 7 days. Triggers on 'weekly prep brief', 'prepare my week', 'what calls do I have this week', 'Monday prep', or any weekly planning request."
+            }
+          ],
+          "commands": [
+            {
+              "name": "generate-account-plan",
+              "description": "Generate a comprehensive strategic account plan"
+            },
+            {
+              "name": "weekly-brief",
+              "description": "Generate a weekly prep briefing from your calendar and Common Room"
+            }
+          ]
         }
       },
       {
@@ -1125,6 +3077,50 @@
         "source": "./engineering",
         "components": {
           "skills": 10
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "architecture",
+              "description": "Create or evaluate an architecture decision record (ADR). Use when choosing between technologies (e.g., Kafka vs SQS), documenting a design decision with trade-offs and consequences, reviewing a system design proposal, or designing a new component from requirements and constraints."
+            },
+            {
+              "name": "code-review",
+              "description": "Review code changes for security, performance, and correctness. Trigger with a PR URL or diff, \"review this before I merge\", \"is this code safe?\", or when checking a change for N+1 queries, injection risks, missing edge cases, or error handling gaps."
+            },
+            {
+              "name": "debug",
+              "description": "Structured debugging session — reproduce, isolate, diagnose, and fix. Trigger with an error message or stack trace, \"this works in staging but not prod\", \"something broke after the deploy\", or when behavior diverges from expected and the cause isn't obvious."
+            },
+            {
+              "name": "deploy-checklist",
+              "description": "Pre-deployment verification checklist. Use when about to ship a release, deploying a change with database migrations or feature flags, verifying CI status and approvals before going to production, or documenting rollback triggers ahead of time."
+            },
+            {
+              "name": "documentation",
+              "description": "Write and maintain technical documentation. Trigger with \"write docs for\", \"document this\", \"create a README\", \"write a runbook\", \"onboarding guide\", or when the user needs help with any form of technical writing — API docs, architecture docs, or operational runbooks."
+            },
+            {
+              "name": "incident-response",
+              "description": "Run an incident response workflow — triage, communicate, and write postmortem. Trigger with \"we have an incident\", \"production is down\", an alert that needs severity assessment, a status update mid-incident, or when writing a blameless postmortem after resolution."
+            },
+            {
+              "name": "standup",
+              "description": "Generate a standup update from recent activity. Use when preparing for daily standup, summarizing yesterday's commits and PRs and ticket moves, formatting work into yesterday/today/blockers, or structuring a few rough notes into a shareable update."
+            },
+            {
+              "name": "system-design",
+              "description": "Design systems, services, and architectures. Trigger with \"design a system for\", \"how should we architect\", \"system design for\", \"what's the right architecture for\", or when the user needs help with API design, data modeling, or service boundaries."
+            },
+            {
+              "name": "tech-debt",
+              "description": "Identify, categorize, and prioritize technical debt. Trigger with \"tech debt\", \"technical debt audit\", \"what should we refactor\", \"code health\", or when the user asks about code quality, refactoring priorities, or maintenance backlog."
+            },
+            {
+              "name": "testing-strategy",
+              "description": "Design test strategies and test plans. Trigger with \"how should we test\", \"test strategy for\", \"write tests for\", \"test plan\", \"what tests do we need\", or when the user needs help with testing approaches, coverage, or test architecture."
+            }
+          ]
         }
       },
       {
@@ -1133,6 +3129,46 @@
         "source": "./human-resources",
         "components": {
           "skills": 9
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "comp-analysis",
+              "description": "Analyze compensation — benchmarking, band placement, and equity modeling. Trigger with \"what should we pay a [role]\", \"is this offer competitive\", \"model this equity grant\", or when uploading comp data to find outliers and retention risks."
+            },
+            {
+              "name": "draft-offer",
+              "description": "Draft an offer letter with comp details and terms. Use when a candidate is ready for an offer, assembling a total comp package (base, equity, signing bonus), writing the offer letter text itself, or prepping negotiation guidance for the hiring manager."
+            },
+            {
+              "name": "interview-prep",
+              "description": "Create structured interview plans with competency-based questions and scorecards. Trigger with \"interview plan for\", \"interview questions for\", \"how should we interview\", \"scorecard for\", or when the user is preparing to interview candidates."
+            },
+            {
+              "name": "onboarding",
+              "description": "Generate an onboarding checklist and first-week plan for a new hire. Use when someone has a start date coming up, building the pre-start task list (accounts, equipment, buddy), scheduling Day 1 and Week 1, or setting 30/60/90-day goals for a new team member."
+            },
+            {
+              "name": "org-planning",
+              "description": "Headcount planning, org design, and team structure optimization. Trigger with \"org planning\", \"headcount plan\", \"team structure\", \"reorg\", \"who should we hire next\", or when the user is thinking about team size, reporting structure, or organizational design."
+            },
+            {
+              "name": "people-report",
+              "description": "Generate headcount, attrition, diversity, or org health reports. Use when pulling a headcount snapshot for leadership, analyzing turnover trends by team, preparing diversity representation metrics, or assessing span of control and flight risk across the org."
+            },
+            {
+              "name": "performance-review",
+              "description": "Structure a performance review with self-assessment, manager template, and calibration prep. Use when review season kicks off and you need a self-assessment template, writing a manager review for a direct report, prepping rating distributions and promotion cases for calibration, or turning vague feedback into specific behavioral examples."
+            },
+            {
+              "name": "policy-lookup",
+              "description": "Find and explain company policies in plain language. Trigger with \"what's our PTO policy\", \"can I work remotely from another country\", \"how do expenses work\", or any plain-language question about benefits, travel, leave, or handbook rules."
+            },
+            {
+              "name": "recruiting-pipeline",
+              "description": "Track and manage recruiting pipeline stages. Trigger with \"recruiting update\", \"candidate pipeline\", \"how many candidates\", \"hiring status\", or when the user discusses sourcing, screening, interviewing, or extending offers."
+            }
+          ]
         }
       },
       {
@@ -1141,6 +3177,38 @@
         "source": "./design",
         "components": {
           "skills": 7
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "accessibility-review",
+              "description": "Run a WCAG 2.1 AA accessibility audit on a design or page. Trigger with \"audit accessibility\", \"check a11y\", \"is this accessible?\", or when reviewing a design for color contrast, keyboard navigation, touch target size, or screen reader behavior before handoff."
+            },
+            {
+              "name": "design-critique",
+              "description": "Get structured design feedback on usability, hierarchy, and consistency. Trigger with \"review this design\", \"critique this mockup\", \"what do you think of this screen?\", or when sharing a Figma link or screenshot for feedback at any stage from exploration to final polish."
+            },
+            {
+              "name": "design-handoff",
+              "description": "Generate developer handoff specs from a design. Use when a design is ready for engineering and needs a spec sheet covering layout, design tokens, component props, interaction states, responsive breakpoints, edge cases, and animation details."
+            },
+            {
+              "name": "design-system",
+              "description": "Audit, document, or extend your design system. Use when checking for naming inconsistencies or hardcoded values across components, writing documentation for a component's variants, states, and accessibility notes, or designing a new pattern that fits the existing system."
+            },
+            {
+              "name": "research-synthesis",
+              "description": "Synthesize user research into themes, insights, and recommendations. Use when you have interview transcripts, survey results, usability test notes, support tickets, or NPS responses that need to be distilled into patterns, user segments, and prioritized next steps."
+            },
+            {
+              "name": "user-research",
+              "description": "Plan, conduct, and synthesize user research. Trigger with \"user research plan\", \"interview guide\", \"usability test\", \"survey design\", \"research questions\", or when the user needs help with any aspect of understanding their users through research."
+            },
+            {
+              "name": "ux-copy",
+              "description": "Write or review UX copy — microcopy, error messages, empty states, CTAs. Trigger with \"write copy for\", \"what should this button say?\", \"review this error message\", or when naming a CTA, wording a confirmation dialog, filling an empty state, or writing onboarding text."
+            }
+          ]
         }
       },
       {
@@ -1149,6 +3217,182 @@
         "source": "./operations",
         "components": {
           "skills": 9
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "capacity-plan",
+              "description": "Plan resource capacity — workload analysis and utilization forecasting. Use when heading into quarterly planning, the team feels overallocated and you need the numbers, deciding whether to hire or deprioritize, or stress-testing whether upcoming projects fit the people you have."
+            },
+            {
+              "name": "change-request",
+              "description": "Create a change management request with impact analysis and rollback plan. Use when proposing a system or process change that needs approval, preparing a change record for CAB review, documenting risk and rollback steps before a deployment, or planning stakeholder communications for a rollout."
+            },
+            {
+              "name": "compliance-tracking",
+              "description": "Track compliance requirements and audit readiness. Trigger with \"compliance\", \"audit prep\", \"SOC 2\", \"ISO 27001\", \"GDPR\", \"regulatory requirement\", or when the user needs help tracking, preparing for, or documenting compliance activities."
+            },
+            {
+              "name": "process-doc",
+              "description": "Document a business process — flowcharts, RACI, and SOPs. Use when formalizing a process that lives in someone's head, building a RACI to clarify who owns what, writing an SOP for a handoff or audit, or capturing the exceptions and edge cases of how work actually gets done."
+            },
+            {
+              "name": "process-optimization",
+              "description": "Analyze and improve business processes. Trigger with \"this process is slow\", \"how can we improve\", \"streamline this workflow\", \"too many steps\", \"bottleneck\", or when the user describes an inefficient process they want to fix."
+            },
+            {
+              "name": "risk-assessment",
+              "description": "Identify, assess, and mitigate operational risks. Trigger with \"what are the risks\", \"risk assessment\", \"risk register\", \"what could go wrong\", or when the user is evaluating risks associated with a project, vendor, process, or decision."
+            },
+            {
+              "name": "runbook",
+              "description": "Create or update an operational runbook for a recurring task or procedure. Use when documenting a task that on-call or ops needs to run repeatably, turning tribal knowledge into exact step-by-step commands, adding troubleshooting and rollback steps to an existing procedure, or writing escalation paths for when things go wrong."
+            },
+            {
+              "name": "status-report",
+              "description": "Generate a status report with KPIs, risks, and action items. Use when writing a weekly or monthly update for leadership, summarizing project health with green/yellow/red status, surfacing risks and decisions that need stakeholder attention, or turning a pile of project tracker activity into a readable narrative."
+            },
+            {
+              "name": "vendor-review",
+              "description": "Evaluate a vendor — cost analysis, risk assessment, and recommendation. Use when reviewing a new vendor proposal, deciding whether to renew or replace a contract, comparing two vendors side-by-side, or building a TCO breakdown and negotiation points before procurement sign-off."
+            }
+          ]
+        }
+      },
+      {
+        "name": "small-business",
+        "description": "Pre-built small business workflows (including payroll planning, month-end close, weekly briefs, and growth campaigns) using your QuickBooks, PayPal, HubSpot, Docusign, Gsuite, O365, Canva, and other connected tools. You approve every step that touches money or customers.",
+        "source": "./small-business",
+        "components": {
+          "skills": 31
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "business-pulse",
+              "description": ">"
+            },
+            {
+              "name": "call-list",
+              "description": "Ranks the top-5 leads most worth calling today, supplies talking points from email history, blocks time on the calendar, and drafts follow-up messages. Accepts optional count and date arguments."
+            },
+            {
+              "name": "canva-creator",
+              "description": ">"
+            },
+            {
+              "name": "cash-flow-snapshot",
+              "description": ">"
+            },
+            {
+              "name": "close-month",
+              "description": "Closes the month — reconciles QB vs payment processors, flags gaps, writes P&L narrative, exports close packet. Accepts optional month and save-to arguments."
+            },
+            {
+              "name": "content-strategy",
+              "description": ">"
+            },
+            {
+              "name": "contract-review",
+              "description": ">"
+            },
+            {
+              "name": "crm-cleanup",
+              "description": "Scans HubSpot for stale deals, duplicate contacts, and missing fields, then fixes what the owner approves. Accepts optional scope argument for deals, contacts, or all."
+            },
+            {
+              "name": "crm-maintenance",
+              "description": ">"
+            },
+            {
+              "name": "customer-pulse-check",
+              "description": "Synthesizes themes from PayPal disputes, HubSpot tickets, and review exports into a top-3 fixable issues list with drafted response templates. Accepts optional since-date argument."
+            },
+            {
+              "name": "customer-pulse",
+              "description": ">"
+            },
+            {
+              "name": "friday-brief",
+              "description": "Delivers the Friday end-of-week pulse — revenue vs prior week, top sellers, wins and watches. Accepts optional lookback window of 7 or 14 days."
+            },
+            {
+              "name": "handle-complaint",
+              "description": "Handles an incoming customer complaint end-to-end — pulls context, drafts a response, and suggests an operational fix. Accepts optional email or ticket ID argument."
+            },
+            {
+              "name": "invoice-chase",
+              "description": ">"
+            },
+            {
+              "name": "job-post-builder",
+              "description": ">"
+            },
+            {
+              "name": "lead-triage",
+              "description": ">"
+            },
+            {
+              "name": "margin-analyzer",
+              "description": ">"
+            },
+            {
+              "name": "monday-brief",
+              "description": "Generates a one-page Monday morning briefing — cash, sales, pipeline, week ahead, top three to-dos. Accepts optional post destination and save-to arguments."
+            },
+            {
+              "name": "month-end-prep",
+              "description": ">"
+            },
+            {
+              "name": "month-heads-up",
+              "description": "Runs on the 25th — shows the next 30-day cash-flow outlook and flags anything that needs attention before month-end. Accepts optional 30 or 60 day horizon."
+            },
+            {
+              "name": "plan-payroll",
+              "description": "Forecasts cash, ranks overdue invoices, and stages PayPal reminders so the owner can confidently run payroll. Accepts optional horizon and payroll-date arguments."
+            },
+            {
+              "name": "price-check",
+              "description": "Produces a margin-by-product table and three pricing-scenario data views so the owner can see the full financial picture before making a pricing decision. Accepts optional product name argument."
+            },
+            {
+              "name": "quarterly-review",
+              "description": "Generates a full QBR narrative — revenue trend, margin trend, customer health, top opportunities and risks — as a presentation-ready PDF or deck. Accepts optional quarter and save-to arguments."
+            },
+            {
+              "name": "review-contract",
+              "description": "Reviews a contract in plain English, surfaces red flags with severity ratings, and produces a marked-up docx/PDF with suggested redlines. Accepts optional file path or DocuSign envelope ID."
+            },
+            {
+              "name": "run-campaign",
+              "description": "Runs an end-to-end marketing campaign — sales analysis, content brief, Canva assets, HubSpot send. Accepts optional lookback and channel arguments."
+            },
+            {
+              "name": "sales-brief",
+              "description": "Surfaces top and bottom sellers, identifies seasonality patterns, and produces a 2-week content brief to push winners and clear slow movers. Accepts optional lookback window of 30, 60, or 90 days."
+            },
+            {
+              "name": "smb-onboard",
+              "description": ">"
+            },
+            {
+              "name": "smb-router",
+              "description": ">"
+            },
+            {
+              "name": "tax-prep",
+              "description": "Prepares tax-season materials — quarterly estimated tax calculation or year-end 1099 prep — and produces an accountant handoff packet. Accepts optional mode and year arguments."
+            },
+            {
+              "name": "tax-season-organizer",
+              "description": ">"
+            },
+            {
+              "name": "ticket-deflector",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -1160,7 +3404,216 @@
           "skills": 3,
           "agents": 5,
           "commands": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "brand-voice-enforcement",
+              "description": ">"
+            },
+            {
+              "name": "discover-brand",
+              "description": ">"
+            },
+            {
+              "name": "guideline-generation",
+              "description": ">"
+            }
+          ],
+          "agents": [
+            {
+              "name": "content-generation",
+              "description": ">"
+            },
+            {
+              "name": "conversation-analysis",
+              "description": ">"
+            },
+            {
+              "name": "discover-brand",
+              "description": ">"
+            },
+            {
+              "name": "document-analysis",
+              "description": ">"
+            },
+            {
+              "name": "quality-assurance",
+              "description": ">"
+            }
+          ],
+          "commands": [
+            {
+              "name": "discover-brand",
+              "description": "Search connected platforms for brand materials and produce a discovery report"
+            },
+            {
+              "name": "enforce-voice",
+              "description": "Apply brand guidelines to content creation"
+            },
+            {
+              "name": "generate-guidelines",
+              "description": "Generate brand voice guidelines from documents, transcripts, discovery reports, or any combination"
+            }
+          ]
         }
+      },
+      {
+        "name": "tavily",
+        "description": "Build AI applications with real-time web data using Tavily's search, extract, crawl, and research APIs.",
+        "source": "https://github.com/tavily-ai/skills.git"
+      },
+      {
+        "name": "vanta-mcp-plugin",
+        "description": "The Vanta plugin connects Claude to Vanta's security and compliance platform through the Vanta MCP server. List failing compliance tests, get test-specific remediation context, and fix failing tests with code changes — directly from your Claude session.",
+        "source": "https://github.com/VantaInc/vanta-mcp-plugin.git"
+      },
+      {
+        "name": "zoom-plugin",
+        "description": "Plan, build, and debug Zoom integrations across REST APIs, Meeting SDK, Video SDK, webhooks, bots, and MCP workflows. Search meetings, retrieve recordings, access transcripts, and design AI-powered Zoom experiences.",
+        "source": "./partner-built/zoom-plugin",
+        "author": "Zoom",
+        "components": {
+          "skills": 30
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "build-zoom-bot",
+              "description": "Build a Zoom meeting bot, recorder, or real-time media workflow. Use when joining meetings programmatically, processing live media or transcripts, or combining Meeting SDK, RTMS, and backend services."
+            },
+            {
+              "name": "build-zoom-meeting-app",
+              "description": "Build or embed a Zoom meeting flow. Use when implementing Meeting SDK joins, web or mobile meeting embeds, meeting lifecycle flows, or when deciding between Meeting SDK and Video SDK."
+            },
+            {
+              "name": "choose-zoom-approach",
+              "description": "Choose the right Zoom architecture for a use case. Use when deciding between REST API, Webhooks, WebSockets, Meeting SDK, Video SDK, Zoom Apps SDK, Zoom MCP, Phone, Contact Center, or a hybrid approach."
+            },
+            {
+              "name": "cobrowse-sdk",
+              "description": "Reference skill for Zoom Cobrowse SDK. Use after routing to a collaborative-support workflow when implementing browser co-browsing, annotation tools, privacy masking, remote assist, or PIN-based session sharing."
+            },
+            {
+              "name": "contact-center",
+              "description": "Reference skill for Zoom Contact Center. Use after routing to a contact-center workflow when implementing app, web, or native integrations; engagement context and state handling; campaigns; callbacks; or version-drift troubleshooting."
+            },
+            {
+              "name": "debug-zoom-integration",
+              "description": "Debug broken Zoom implementations quickly. Use when auth, webhooks, SDK joins, MCP transport, or real-time media workflows are failing and you need to isolate the layer before proposing a fix."
+            },
+            {
+              "name": "debug-zoom",
+              "description": "Debug a broken Zoom integration by isolating the failure point and routing into the right Zoom references. Use when auth, API, webhook, SDK, or MCP behavior is failing and you need a ranked hypothesis list plus verification steps."
+            },
+            {
+              "name": "design-mcp-workflow",
+              "description": "Design a Zoom MCP workflow for Claude. Use when deciding whether Zoom MCP fits a task, when planning tool-based AI workflows, or when separating MCP responsibilities from REST API responsibilities."
+            },
+            {
+              "name": "general",
+              "description": "Cross-product Zoom reference skill. Use after the workflow is clear when you need shared platform guidance, app-model comparisons, authentication context, scopes, marketplace considerations, or API-vs-MCP routing."
+            },
+            {
+              "name": "meeting-sdk",
+              "description": "Reference skill for Zoom Meeting SDK. Use after routing to a meeting-embed workflow when implementing real Zoom meeting joins, platform-specific SDK behavior, auth and join flows, waiting room issues, or meeting bot patterns."
+            },
+            {
+              "name": "oauth",
+              "description": "Reference skill for Zoom authentication. Use after routing to an auth workflow when choosing app credentials, grant types, scopes, token refresh behavior, or debugging Zoom OAuth failures."
+            },
+            {
+              "name": "phone",
+              "description": "Reference skill for Zoom Phone. Use after routing to a phone workflow when implementing OAuth, Phone APIs, webhooks, Smart Embed events, URI schemes, CRM or CTI dialers, or call handling automation."
+            },
+            {
+              "name": "plan-zoom-integration",
+              "description": "Turn a Zoom integration idea into an implementation plan with architecture, auth, and delivery milestones. Use when you need a practical build plan, phased delivery sequence, risk list, and next-step recommendation."
+            },
+            {
+              "name": "plan-zoom-product",
+              "description": "Choose the right Zoom building surface for a use case and explain the tradeoffs clearly. Use when deciding between REST API, Webhooks, WebSockets, Meeting SDK, Video SDK, Zoom Apps SDK, Phone, Contact Center, or MCP for a specific product idea or integration goal."
+            },
+            {
+              "name": "probe-sdk",
+              "description": "Reference skill for Zoom Probe SDK. Use after routing to a preflight workflow when testing browser compatibility, media permissions, audio or video diagnostics, and network readiness before users join."
+            },
+            {
+              "name": "rest-api",
+              "description": "Reference skill for Zoom REST API. Use after choosing an API-based workflow when you need endpoint selection, resource-management patterns, OAuth requirements, rate-limit awareness, or API error debugging."
+            },
+            {
+              "name": "rivet-sdk",
+              "description": "Reference skill for Zoom Rivet SDK. Use after routing to a Rivet-based server workflow when implementing auth handling, webhook consumers, API wrappers, multi-module composition, or Lambda receiver patterns."
+            },
+            {
+              "name": "rtms",
+              "description": "Reference skill for Zoom RTMS. Use after routing to a live-media workflow when processing real-time audio, video, chat, transcripts, screen share, or contact-center voice streams."
+            },
+            {
+              "name": "scribe",
+              "description": "Reference skill for Zoom AI Services Scribe. Use after routing to a transcription workflow when handling uploaded or stored media, Build-platform JWT auth, fast mode transcription, batch jobs, or transcript pipeline design."
+            },
+            {
+              "name": "setup-zoom-mcp",
+              "description": "Decide when Zoom MCP is the right fit and produce a safe setup plan for Claude. Use when planning AI workflows over Zoom data, deciding between MCP and REST, or defining a hybrid MCP architecture."
+            },
+            {
+              "name": "setup-zoom-oauth",
+              "description": "Implement Zoom authentication correctly. Use when setting up app credentials, choosing an OAuth grant, requesting scopes, handling token refresh, or debugging auth failures."
+            },
+            {
+              "name": "start",
+              "description": "Start here for any Zoom integration or app idea. Use when you need to choose the right Zoom surface, shape the architecture, or route into the correct implementation skill without reading the whole Zoom doc set first."
+            },
+            {
+              "name": "team-chat",
+              "description": "Reference skill for Zoom Team Chat. Use after routing to a chat workflow when building user-scoped messaging integrations, chatbot experiences, rich cards, buttons, slash commands, or chat webhooks."
+            },
+            {
+              "name": "ui-toolkit",
+              "description": "Reference skill for Zoom Video SDK UI Toolkit. Use after routing to a web video workflow when you want prebuilt React UI instead of building a fully custom Video SDK interface."
+            },
+            {
+              "name": "video-sdk",
+              "description": "Reference skill for Zoom Video SDK. Use after routing to a custom-session workflow when the user needs full control over the video experience rather than an actual Zoom meeting."
+            },
+            {
+              "name": "virtual-agent",
+              "description": "Reference skill for Zoom Virtual Agent. Use after routing to a virtual-agent workflow when implementing web embeds, Android or iOS wrapper integrations, knowledge-base sync, lifecycle handling, or troubleshooting."
+            },
+            {
+              "name": "webhooks",
+              "description": "Reference skill for Zoom webhooks. Use after routing to an event-driven workflow when implementing subscriptions, signature verification, delivery handling, retries, or event-type selection."
+            },
+            {
+              "name": "websockets",
+              "description": "Reference skill for Zoom WebSockets. Use after routing to a low-latency event workflow when persistent connections, faster event delivery, or security constraints make WebSockets preferable to webhooks."
+            },
+            {
+              "name": "zoom-apps-sdk",
+              "description": "Reference skill for Zoom Apps SDK. Use after routing to an in-client app workflow when building web apps that run inside Zoom meetings, webinars, the main client, or Zoom Phone."
+            },
+            {
+              "name": "zoom-mcp",
+              "description": "Guidance for the bundled Zoom MCP connectors. Use after routing to an MCP workflow when planning or troubleshooting tool-based access to meetings, recordings, meeting assets, or transcripts. Route Zoom Docs requests to the dedicated Docs MCP server and Whiteboard-specific requests to `zoom-mcp/whiteboard`."
+            }
+          ]
+        }
+      },
+      {
+        "name": "bigdata-com",
+        "description": "Official Bigdata.com plugin providing financial research, analytics, and intelligence tools powered by Bigdata MCP.",
+        "source": "https://github.com/Bigdata-com/bigdata-plugins-marketplace.git",
+        "source_path": "plugins/bigdata-com",
+        "author": "RavenPack"
+      },
+      {
+        "name": "miro",
+        "description": "Secure access to Miro boards. Enables AI to read board context, create diagrams, and generate code with enterprise-grade security.",
+        "source": "https://github.com/miroapp/miro-ai.git",
+        "source_path": "claude-plugins/miro",
+        "author": "Miro"
       },
       {
         "name": "planetscale",
@@ -1196,7 +3649,7 @@
       {
         "name": "zapier",
         "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
-        "source": "zapier/zapier-mcp",
+        "source": "https://github.com/zapier/zapier-mcp.git",
         "source_path": "plugins/zapier"
       },
       {
@@ -1247,7 +3700,7 @@
       {
         "name": "ai-firstify",
         "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp",
-        "source": "techwolf-ai/ai-first-toolkit",
+        "source": "https://github.com/techwolf-ai/ai-first-toolkit.git",
         "source_path": "plugins/ai-firstify"
       },
       {
@@ -1266,13 +3719,266 @@
         "source": "https://github.com/figma/mcp-server-guide.git"
       },
       {
+        "name": "adobe-for-creativity",
+        "description": "Brings together Adobe Creative Cloud tools for images, vectors, design, and video. Edit multiple assets at once, adapt for different platforms, and complete multi-step creative workflows for polished results.",
+        "source": "https://github.com/adobe/skills.git",
+        "source_path": "plugins/creative-cloud/adobe-for-creativity"
+      },
+      {
         "name": "pdf-viewer",
         "description": "View, annotate, and sign PDFs in a live interactive viewer. Mark up contracts, fill forms with visual feedback, stamp approvals, and place signatures — then download the annotated copy.",
         "source": "./pdf-viewer",
         "components": {
           "skills": 1,
           "commands": 4
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "view-pdf",
+              "description": "Interactive PDF viewer. Use when the user wants to open, show, or view a PDF and collaborate on it visually — annotate, highlight, stamp, fill form fields, place signature/initials, or review markup together. Not for summarization or text extraction (use native Read instead)."
+            }
+          ],
+          "commands": [
+            {
+              "name": "annotate",
+              "description": "Collaboratively annotate a PDF — propose markup, review together, iterate"
+            },
+            {
+              "name": "fill-form",
+              "description": "Fill PDF form fields interactively with live visual feedback"
+            },
+            {
+              "name": "open",
+              "description": "Open a PDF in the interactive viewer"
+            },
+            {
+              "name": "sign",
+              "description": "Place a signature or initials image on a PDF"
+            }
+          ]
         }
+      },
+      {
+        "name": "box",
+        "description": "Work with your Box content directly from Claude Code — search files, organize folders, collaborate with your team, and use Box AI to answer questions, summarize documents, and extract data without leaving your workflow.",
+        "source": "https://github.com/box/box-for-ai.git"
+      },
+      {
+        "name": "lseg",
+        "description": "Price bonds, analyze yield curves, evaluate FX carry trades, value options, and build macro dashboards using LSEG financial data and analytics.",
+        "source": "https://github.com/LSEG-API-Samples/lseg-claude-plugin.git"
+      },
+      {
+        "name": "sp-global",
+        "description": "S&P Global - Financial data and analytics skills including company tearsheets, earnings previews, and transaction summaries",
+        "source": "https://github.com/kensho-technologies/spglobal-agent-skills.git",
+        "source_path": "plugins/spglobal-plugin"
+      },
+      {
+        "name": "carta-cap-table",
+        "description": "Carta Cap Table plugin — skills and hooks for querying cap tables, grants, SAFEs, 409A valuations, waterfall scenarios, and more",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-cap-table"
+      },
+      {
+        "name": "carta-crm",
+        "description": "Manage the Carta CRM conversationally — search, add, update, and enrich investors, companies, contacts, deals, notes, and fundraisings via the Carta CRM MCP Server",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-crm"
+      },
+      {
+        "name": "carta-investors",
+        "description": "Carta Investors plugin — skills for querying investors data, performance benchmarks, regulatory reporting, AGM deck generation, brand extraction, and more via the Carta MCP server",
+        "source": "https://github.com/carta/plugins.git",
+        "source_path": "plugins/carta-investors"
+      },
+      {
+        "name": "airtable",
+        "description": "Airtable is the database and operations layer for your agents — whether running product, marketing, sales, ops, HR, or a custom business app. It combines structured data with multiplayer visual surfaces (grid, kanban, calendar, gallery, timeline) humans and agents share — plus sync integrations to Jira, Salesforce, Zendesk, Google Drive, and Databricks. Makes Claude fluent in Airtable: bases and schema, records, and collaboration UI. Bundles the official Airtable MCP server.",
+        "source": "https://github.com/Airtable/skills.git",
+        "source_path": "plugins/airtable",
+        "author": "Airtable"
+      },
+      {
+        "name": "desktop-commander",
+        "description": "MCP server for terminal commands, process management, and file operations across text, code, PDF, DOCX, Excel, images, and structured data.",
+        "source": "https://github.com/wonderwhy-er/DesktopCommanderMCP.git",
+        "source_path": "plugins/claude"
+      },
+      {
+        "name": "qodo-skills",
+        "description": "Shift-left code review skills that bring Qodo's quality standards and code review capabilities into your local development workflow. Catch issues before commit, enforce organizational standards, and resolve PR feedback directly in your agent.",
+        "source": "https://github.com/qodo-ai/qodo-skills.git"
+      },
+      {
+        "name": "servicenow-sdk",
+        "description": "Create, edit, and deploy ServiceNow applications with the Fluent SDK effortlessly through Claude. Helps developers build, extend, and manage ServiceNow applications, workflows, and agents using the ServiceNow SDK.",
+        "source": "https://github.com/ServiceNow/sdk.git",
+        "source_path": "providers/claude/plugin"
+      },
+      {
+        "name": "twilio-developer-kit",
+        "description": "Twilio Skills provide procedural knowledge for AI coding agents — which APIs to use, in what order, and what to avoid. Covers SMS, Voice, WhatsApp, Verify, SendGrid, Compliance, and 30+ products.",
+        "source": "https://github.com/twilio/ai.git",
+        "author": "Twilio"
+      },
+      {
+        "name": "vibe-prospecting",
+        "description": "Vibe Prospecting connects Claude to live B2B company and contact data so users can search, match, enrich, filter, and export prospects at scale. It turns natural-language requests into structured GTM workflows for lead generation, CRM enrichment, company research, executive discovery, and multi-step prospecting automation inside Claude Cowork and Claude Code.",
+        "source": "https://github.com/explorium-ai/vibeprospecting-plugin.git"
+      },
+      {
+        "name": "base44",
+        "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills",
+        "source": "https://github.com/base44/skills.git"
+      },
+      {
+        "name": "wix",
+        "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+        "source": "https://github.com/wix/skills.git"
+      },
+      {
+        "name": "datadog",
+        "description": "Use Datadog directly in Claude Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation. This plugin is in preview.",
+        "source": "https://github.com/datadog-labs/claude-code-plugin.git"
+      },
+      {
+        "name": "airwallex-agentos",
+        "description": "Bring Airwallex's global financial infrastructure to Claude. Orchestrate actions across your account in plain language, e.g., set up invoices from a PO, onboard suppliers from invoices, and check current cash position across currencies. AgentOS bundles pre-built finance Skills with MCP servers. A public CLI connects your agent to Airwallex's capabilities.",
+        "source": "https://github.com/airwallex/airwallex-marketplace.git",
+        "source_path": "plugins/airwallex-agentos"
+      },
+      {
+        "name": "langfuse",
+        "description": "Skills for working with Langfuse, the open-source LLM engineering platform for tracing, prompt management, and evaluation.",
+        "source": "https://github.com/langfuse/skills.git"
+      },
+      {
+        "name": "valtown",
+        "description": "Build and deploy on Val Town. Bundles the Val Town MCP server and platform skills (HTTP vals, cron/intervals, SQLite, email, OAuth, React UI, third-party integrations, templates).",
+        "source": "https://github.com/val-town/plugins.git",
+        "source_path": "plugin"
+      },
+      {
+        "name": "learn-with-coursera",
+        "description": "Turn any learning intent into a personalized Coursera experience. Asks three quick questions (topic, familiarity, preferred format), searches Coursera's catalog, and delivers the right next step — a course, hands-on project, short video, or live roleplay — then maps a path forward. Requires the Coursera connector for catalog tools.",
+        "source": "https://github.com/coursera/skills.git",
+        "source_path": "skills",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "learn-with-coursera",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "monday-crm",
+        "description": "Run your monday CRM in plain language. Build a pipeline from scratch, start the day with a ranked deal briefing, spin up a forecast dashboard, audit board health, clean up messy data in bulk, and turn meeting notes into deal updates. Every skill writes back into monday as a real update, doc, or dashboard. Built on the official monday MCP connector.",
+        "source": "https://github.com/mondaycom/mcp.git",
+        "source_path": "plugins/monday-crm"
+      },
+      {
+        "name": "monday-com",
+        "description": "The official monday.com plugin for Claude Cowork. Manage boards, items, docs, and forms across work management, CRM, dev, service, and campaigns. Full read and write access via OAuth.",
+        "source": "https://github.com/mondaycom/monday-claude-cowork-plugin.git"
+      },
+      {
+        "name": "lusha",
+        "description": "Prospect, enrich, and build call-ready lead lists using Lusha's B2B intelligence platform — verified phone numbers, company signals, and lookalike targeting.",
+        "source": "https://github.com/lusha-oss/lusha-mcp-plugin.git"
+      },
+      {
+        "name": "auth0",
+        "description": "Essential Auth0 skills including quickstarts, migration from other providers, and Multi-Factor Authentication (MFA).",
+        "source": "https://github.com/auth0/agent-skills.git",
+        "source_path": "plugins/auth0"
+      },
+      {
+        "name": "buildkite",
+        "description": "Official Buildkite skills for Claude Code, Cursor, and other AI coding agents — pipelines, migration, preflight, agent runtime, CLI, and API",
+        "source": "https://github.com/buildkite/skills.git"
+      },
+      {
+        "name": "clickhouse",
+        "description": "ClickHouse Claude Code plugin: skills (ClickHouse best practices), rules and MCP.",
+        "source": "https://github.com/ClickHouse/clickhouse-claude-code-plugin.git"
+      },
+      {
+        "name": "datarobot-agent-skills",
+        "description": "DataRobot skills for AI/ML workflows — model training, deployment, predictions, feature engineering, monitoring, explainability, data preparation, App Framework CI/CD, and external agent monitoring.",
+        "source": "https://github.com/datarobot-oss/datarobot-agent-skills.git"
+      },
+      {
+        "name": "qdrant-skills",
+        "description": "Agent skills for Qdrant vector search: scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage",
+        "source": "https://github.com/qdrant/skills.git"
+      },
+      {
+        "name": "qt-development-skills",
+        "description": "Agentic engineering skills for Qt software development, including Qt C++/QML code review, QML coding, and Qt C++/QML code documentation. These skills use AI and can make mistakes. Always double-check the output carefully.",
+        "source": "https://github.com/TheQtCompanyRnD/agent-skills.git"
+      },
+      {
+        "name": "exa",
+        "description": "Exa AI web search, deep research, and content extraction. Provides MCP tools and research skills for comprehensive web search, people discovery, company research, academic papers, and more.",
+        "source": "https://github.com/exa-labs/exa-mcp-server.git"
+      },
+      {
+        "name": "dropbox",
+        "description": "The Dropbox plugin for Claude connects your Dropbox files directly to Claude, so you can search, organize, save generated content, and create sharing links without switching tools. It respects your existing Dropbox permissions, and Claude only works with files you already have access to.",
+        "source": "https://github.com/dropbox/dropbox-ai-plugins.git",
+        "source_path": "claude"
+      },
+      {
+        "name": "canva",
+        "description": "Create, edit, review, resize, and brand-check Canva designs with the Canva MCP server.",
+        "source": "https://github.com/canva-sdks/canva-skills.git",
+        "source_path": "plugins/canva"
+      },
+      {
+        "name": "pixeltable",
+        "description": "Build multimodal AI applications with Pixeltable -- tables, computed columns, embedding search, UDFs, tool-calling agents, and 25+ AI provider integrations.",
+        "source": "https://github.com/pixeltable/pixeltable-skill.git"
+      },
+      {
+        "name": "grafana-assistant",
+        "description": "Skills and rules for developing and using the Grafana Assistant app and CLI.",
+        "source": "https://github.com/grafana/ai-marketplace.git",
+        "source_path": "plugins/grafana-assistant"
+      },
+      {
+        "name": "grafana-cloud-mcp",
+        "description": "Hosted MCP server for AI-assisted Grafana Cloud observability — no local installation required.",
+        "source": "https://github.com/grafana/ai-marketplace.git",
+        "source_path": "plugins/grafana-cloud-mcp"
+      },
+      {
+        "name": "grasp",
+        "description": "Deal-work workflows powered by Grasp company lookup, table creation, import, buyer, transaction, table enrichment, contact, and market research tools.",
+        "source": "https://github.com/grasp-ai/grasp-mcp-plugin.git"
+      },
+      {
+        "name": "honeycomb",
+        "description": "Skills, agents, and workflows for Honeycomb observability — query patterns, production investigations, SLOs, OpenTelemetry instrumentation, and Beeline migration. Designed to complement the Honeycomb MCP server.",
+        "source": "https://github.com/honeycombio/agent-skill.git",
+        "source_path": "honeycomb"
+      },
+      {
+        "name": "b12-claude-plugin",
+        "description": "B12 plugin with two skills: Website Generator (create a B12 website from a brief description) and B12 Website Editor (edit a live B12 website using Claude's browser access in Claude Cowork).",
+        "source": "https://github.com/b12io/b12-claude-plugin.git"
+      },
+      {
+        "name": "signoz",
+        "description": "Official SigNoz plugin for MCP setup, docs, queries, dashboards, and alerts",
+        "source": "https://github.com/SigNoz/agent-skills.git",
+        "source_path": "plugins/signoz"
       }
     ]
   },
@@ -1280,32 +3986,34 @@
     "slug": "alirezarezvani-claude-skills",
     "name": "Claude Skills",
     "author": "alirezarezvani",
-    "description": "+192 Claude Code skills & agent plugins for Claude Code, Codex, Gemini CLI, Cursor, and 8 more coding agents — engineering, marketing, product, compliance, C-level advisory.",
+    "description": "345 Claude Code skills & agent skills & plugins (30+ Agents, 70+ custom commands, 330+ skills, customizable references, scripts)for Claude Code, Codex, Gemini CLI, Cursor, and 8 more coding agents — engineering, marketing, product, compliance, C-level advisory, research, business operations, commercial & finance, and your daily productivity skills.",
     "github": "https://github.com/alirezarezvani/claude-skills",
-    "stars": 7463,
+    "stars": 22219,
     "type": "marketplace",
     "tags": [
       "skills",
       "agents",
+      "commands",
       "hooks"
     ],
     "contains": {
-      "plugins": 28,
+      "plugins": 83,
       "components": {
-        "skills": 31,
-        "agents": 8,
+        "skills": 293,
+        "agents": 38,
+        "commands": 23,
         "hooks": 2
       }
     },
     "highlights": [
-      "28 plugins in marketplace",
+      "83 plugins in marketplace",
       "Web UI: https://alirezarezvani.medium.com/"
     ],
     "website": "https://alirezarezvani.medium.com/",
     "plugins_list": [
       {
         "name": "marketing-skills",
-        "description": "43 marketing skills across 7 pods: Content, SEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 51 Python tools, 73 reference docs.",
+        "description": "47 marketing skills across 8 pods: Content, SEO & AEO, CRO, Channels, Growth, Intelligence, Sales enablement, and X/Twitter growth. 62 Python tools, 89 reference docs.",
         "source": "./marketing-skill",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1321,11 +4029,206 @@
           "paid-ads",
           "twitter",
           "x-twitter"
-        ]
+        ],
+        "components": {
+          "skills": 47
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "ab-test-setup",
+              "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking."
+            },
+            {
+              "name": "ad-creative",
+              "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan."
+            },
+            {
+              "name": "aeo",
+              "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO — AEO optimizes for citation in LLM-generated responses, not search rankings. Use when planning content for AI-first search audiences, auditing existing content for E-E-A-T signals, tracking which pages get cited by which LLMs, or building a citation-friendly content strategy. Triggers — 'AEO audit', 'optimize for ChatGPT', 'get cited by Perplexity', 'LLM citation strategy', 'answer engine optimization', 'content for AI search', 'E-E-A-T audit'. Output is a markdown audit report (default) or JSON for pipeline integration. Stdlib-only Python tools."
+            },
+            {
+              "name": "analytics-tracking",
+              "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis."
+            },
+            {
+              "name": "app-store-optimization",
+              "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes."
+            },
+            {
+              "name": "brand-guidelines",
+              "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity."
+            },
+            {
+              "name": "campaign-analytics",
+              "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels."
+            },
+            {
+              "name": "churn-prevention",
+              "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that."
+            },
+            {
+              "name": "cold-email",
+              "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence)."
+            },
+            {
+              "name": "competitor-alternatives",
+              "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables."
+            },
+            {
+              "name": "content-creator",
+              "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks."
+            },
+            {
+              "name": "content-humanizer",
+              "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3)."
+            },
+            {
+              "name": "content-production",
+              "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only."
+            },
+            {
+              "name": "content-strategy",
+              "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit."
+            },
+            {
+              "name": "copy-editing",
+              "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes."
+            },
+            {
+              "name": "copywriting",
+              "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro."
+            },
+            {
+              "name": "email-sequence",
+              "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" or \"lifecycle emails.\" For in-app onboarding, see onboarding-cro."
+            },
+            {
+              "name": "form-cro",
+              "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro."
+            },
+            {
+              "name": "free-tool-strategy",
+              "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead."
+            },
+            {
+              "name": "launch-strategy",
+              "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum."
+            },
+            {
+              "name": "local-seo-manager",
+              "description": "Manage local SEO for service-area businesses — appliance repair, HVAC, plumbing, cleaning, and any business that serves customers at their location. Use when the user wants to: audit Google Business Profile, generate neighborhood service area pages, check NAP consistency across directories, create LocalBusiness schema, or write review responses. Triggers: 'local SEO', 'Google Business Profile', 'GBP', 'service area page', 'NAP consistency', 'local citations', 'LocalBusiness schema', 'review responses', 'Google Maps ranking'. NOT for national SEO (use seo-audit). NOT for general schema (use schema-markup). NOT for AI answer-engine visibility (use aeo)."
+            },
+            {
+              "name": "marketing-context",
+              "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills."
+            },
+            {
+              "name": "marketing-demand-acquisition",
+              "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs. Use when planning demand gen strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships. Default calibration profile is a Series A+ B2B SaaS scaling internationally (EU/US/Canada, hybrid PLG/Sales-Led) — adapt benchmarks for other stages and motions rather than skipping the skill."
+            },
+            {
+              "name": "marketing-ideas",
+              "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category."
+            },
+            {
+              "name": "marketing-ops",
+              "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'"
+            },
+            {
+              "name": "marketing-psychology",
+              "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application."
+            },
+            {
+              "name": "marketing-skills",
+              "description": "Directory and router for the marketing skills library. Use when you need to find the right marketing skill for a task, see what marketing capabilities exist, or get oriented in this plugin. 44 specialist skills across 8 pods (content, SEO + AEO, CRO, channels, growth, intelligence, sales enablement, ops), 59 stdlib Python tools. Routes to one skill — it does not execute marketing work itself."
+            },
+            {
+              "name": "marketing-strategy-pmm",
+              "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies."
+            },
+            {
+              "name": "onboarding-cro",
+              "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" or \"new user experience.\" For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence."
+            },
+            {
+              "name": "page-cro",
+              "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro."
+            },
+            {
+              "name": "paid-ads",
+              "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization."
+            },
+            {
+              "name": "paywall-upgrade-cro",
+              "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value."
+            },
+            {
+              "name": "popup-cro",
+              "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" or \"overlay.\" For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro."
+            },
+            {
+              "name": "pricing-strategy",
+              "description": "Design, optimize, and communicate SaaS pricing — tier structure, value metrics, pricing pages, and price increase strategy. Use when building a pricing model from scratch, redesigning existing pricing, planning a price increase, or improving a pricing page. Trigger keywords: pricing tiers, pricing page, price increase, packaging, value metric, per seat pricing, usage-based pricing, freemium, good-better-best, pricing strategy, monetization, pricing page conversion, Van Westendorp. NOT for broader product strategy — use product-strategist for that. NOT for customer success or renewals — use customer-success-manager for expansion revenue."
+            },
+            {
+              "name": "programmatic-seo",
+              "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" or \"building many pages for SEO.\" For auditing existing SEO issues, see seo-audit."
+            },
+            {
+              "name": "prompt-engineer-toolkit",
+              "description": "Turns marketing prompts into tested, versioned production assets: A/B prompt evaluation against structured test cases, immutable prompt version history with diffs, ready-to-use marketing prompt templates (ad copy, email campaigns, social posts, landing pages, SEO meta), and an LLM-governance playbook for marketing teams (claim discipline, disclosure rules, human-review gates). Use when a marketing team relies on AI-generated content and needs prompt quality to be measurable and safe — or when the user mentions 'prompt engineering,' 'improve my prompts,' 'prompt templates,' 'prompt versioning,' 'AI content workflow,' or 'AI governance for marketing.'"
+            },
+            {
+              "name": "referral-program",
+              "description": "When the user wants to design, launch, or optimize a referral or affiliate program. Use when they mention 'referral program,' 'affiliate program,' 'word of mouth,' 'refer a friend,' 'incentive program,' 'customer referrals,' 'brand ambassador,' 'partner program,' 'referral link,' or 'growth through referrals.' Covers program mechanics, incentive design, and optimization — not just the idea of referrals but the actual system."
+            },
+            {
+              "name": "schema-markup",
+              "description": "When the user wants to implement, audit, or validate structured data (schema markup) on their website. Use when the user mentions 'structured data,' 'schema.org,' 'JSON-LD,' 'rich results,' 'rich snippets,' 'schema markup,' 'FAQ schema,' 'Product schema,' 'HowTo schema,' or 'structured data errors in Search Console.' Also use when someone asks why their content isn't showing rich results or wants to improve AI search visibility. NOT for general SEO audits (use seo-audit) or technical SEO crawl issues (use site-architecture)."
+            },
+            {
+              "name": "seo-audit",
+              "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" or \"SEO health check.\" For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup."
+            },
+            {
+              "name": "signup-flow-cro",
+              "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" or \"account creation flow.\" For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro."
+            },
+            {
+              "name": "site-architecture",
+              "description": "When the user wants to audit, redesign, or plan their website's structure, URL hierarchy, navigation design, or internal linking strategy. Use when the user mentions 'site architecture,' 'URL structure,' 'internal links,' 'site navigation,' 'breadcrumbs,' 'topic clusters,' 'hub pages,' 'orphan pages,' 'silo structure,' 'information architecture,' or 'website reorganization.' Also use when someone has SEO problems and the root cause is structural (not content or schema). NOT for content strategy decisions about what to write (use content-strategy) or for schema markup (use schema-markup)."
+            },
+            {
+              "name": "social-content",
+              "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' or 'viral content.' This skill covers content creation, repurposing, and platform-specific strategies."
+            },
+            {
+              "name": "social-media-analyzer",
+              "description": "Social media campaign analysis and performance tracking. Calculates engagement rates, ROI, and benchmarks across platforms. Use when analyzing social media performance, calculating engagement rate, measuring campaign ROI, comparing platform metrics, or benchmarking against industry standards. Also use when the user mentions \"social media audit,\" \"engagement rate,\" or \"which platform performs best.\""
+            },
+            {
+              "name": "social-media-manager",
+              "description": "When the user wants to develop social media strategy, plan content calendars, manage community engagement, or grow their social presence across platforms. Also use when the user mentions 'social media strategy,' 'social calendar,' 'community management,' 'social media plan,' 'grow followers,' 'engagement rate,' 'social media audit,' or 'which platforms should I use.' For writing individual social posts, see social-content. For analyzing social performance data, see social-media-analyzer."
+            },
+            {
+              "name": "webinar-marketing",
+              "description": "When the user wants to plan, promote, run, or improve a webinar or virtual event to generate and convert demand. Use when the user mentions 'webinar,' 'virtual event,' 'online event,' 'live demo,' 'virtual summit,' 'workshop,' 'masterclass,' 'fireside chat,' 'roundtable,' 'registration funnel,' 'show-up rate,' 'attendance rate,' 'webinar promotion,' 'webinar follow-up,' or 'on-demand webinar.' Also use when they have a webinar that isn't converting — low registrations, low show-up, or attendees who don't buy — and want to diagnose and fix it. Covers the full funnel: registration, promotion, show-up, live engagement, live-to-close, and post-event nurture. Distinct from launch-strategy (full product launches) and email-sequence (lifecycle nurture) — this is the end-to-end webinar/event motion. NOT for in-person field events logistics, and NOT for generic lifecycle email (use email-sequence)."
+            },
+            {
+              "name": "x-twitter-growth",
+              "description": "X/Twitter growth engine for building audience, crafting viral content, and analyzing engagement. Use when the user wants to grow on X/Twitter, write tweets or threads, analyze their X profile, research competitors on X, plan a posting strategy, or optimize engagement. Complements social-content (generic multi-platform) with X-specific depth: algorithm mechanics, thread engineering, reply strategy, profile optimization, and competitive intelligence via web search."
+            },
+            {
+              "name": "youtube-full",
+              "description": "Use when the user needs YouTube transcripts, video search, channel browsing, playlist extraction, or content monitoring. Trigger phrases: 'get the transcript for', 'search YouTube for', 'what are the latest videos on', 'list this playlist', 'monitor this channel', or any request involving a YouTube URL, video ID, or @handle. Do NOT use for downloading video or audio files, YouTube engagement data (likes, comments), or private/age-restricted videos."
+            }
+          ]
+        }
       },
       {
         "name": "c-level-skills",
-        "description": "28 C-level advisory skills: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), and culture frameworks.",
+        "description": "33 C-level advisory skills + c-level-agents plugin layer: virtual board of directors (CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO) plus General Counsel, CDO, CAIO, CCO, and VP of Engineering (DORA delivery throughput analyzer, engineering hiring funnel calculator with conversion + pipeline gap, eng team structure designer with squad/tribe + manager-trigger), executive mentor, founder coach, orchestration (Chief of Staff, board meetings, decision logger), strategic capabilities (board deck builder, scenario war room, competitive intel, M&A playbook), culture frameworks, and 13 cs-* persona agents + 21 /cs:* slash commands (founder-mode router, office-hours intake, multi-role boardroom, strategic sprint pipeline, cross-model consensus, cooldown freeze).",
         "source": "./c-level-advisor",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1336,12 +4239,543 @@
           "strategy",
           "leadership",
           "board",
-          "advisory"
-        ]
+          "advisory",
+          "founder-mode",
+          "boardroom"
+        ],
+        "components": {
+          "skills": 34
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-protocol",
+              "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles."
+            },
+            {
+              "name": "arquiteto-de-empresa",
+              "description": "Company Architect: builds a business from scratch as an OKF (Open Knowledge Format) bundle — a tree of version-controllable .md files with frontmatter type, links forming a graph, and reserved index.md/log.md, readable by humans and agents. Guides the founder through a 12-phase interview (foundation, strategy, market, financial, sales, marketing, product, operations, tech, people, legal, governance), one phase at a time, few questions per block, and generates the concepts as conformant markdown. Trigger when the user wants to create, structure, or document an entire company in folders and .md files; when they mention build my company from scratch, company as code, company knowledge base for AI to read, company wiki for agents, OKF, or knowledge bundle. In English."
+            },
+            {
+              "name": "board-deck-builder",
+              "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes."
+            },
+            {
+              "name": "board-meeting",
+              "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:boardroom, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question."
+            },
+            {
+              "name": "c-level-skills",
+              "description": "Index and router for the C-level advisory bundle: 33 skills covering 14 C-suite roles, orchestration, cross-cutting capabilities, and culture. Use when exploring what the c-level-advisor bundle contains, deciding which advisor skill fits a question, or finding the entry points (cs-onboard interview, chief-of-staff routing, board-meeting protocol)."
+            },
+            {
+              "name": "ceo-advisor",
+              "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy."
+            },
+            {
+              "name": "cfo-advisor",
+              "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy."
+            },
+            {
+              "name": "change-management",
+              "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication."
+            },
+            {
+              "name": "chief-ai-officer-advisor",
+              "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only — does not duplicate engineering AI/ML skills."
+            },
+            {
+              "name": "chief-customer-officer-advisor",
+              "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only — does not duplicate engineering/business-growth tactical skills."
+            },
+            {
+              "name": "chief-data-officer-advisor",
+              "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only."
+            },
+            {
+              "name": "chief-of-staff",
+              "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically. Use when a founder question needs routing to the right advisor — e.g. 'should we raise now or cut burn?' — or when a multi-domain decision needs a board meeting convened."
+            },
+            {
+              "name": "chro-advisor",
+              "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management."
+            },
+            {
+              "name": "ciso-advisor",
+              "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting."
+            },
+            {
+              "name": "cmo-advisor",
+              "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI."
+            },
+            {
+              "name": "company-os",
+              "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning."
+            },
+            {
+              "name": "competitive-intel",
+              "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning."
+            },
+            {
+              "name": "context-engine",
+              "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls. Use when starting any C-suite advisor session, when context looks stale or missing, or before sending company data to an external service."
+            },
+            {
+              "name": "coo-advisor",
+              "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution."
+            },
+            {
+              "name": "cpo-advisor",
+              "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy."
+            },
+            {
+              "name": "cro-advisor",
+              "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity."
+            },
+            {
+              "name": "cs-onboard",
+              "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills. Use when setting up the C-suite advisors for the first time, or when company context is missing or more than 90 days old — e.g. after a fundraise or pivot."
+            },
+            {
+              "name": "cto-advisor",
+              "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy."
+            },
+            {
+              "name": "culture-architect",
+              "description": "Build, measure, and evolve company culture as operational behavior — not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code."
+            },
+            {
+              "name": "decision-logger",
+              "description": "Two-layer memory architecture for board meeting decisions. Manages raw transcripts (Layer 1) and approved decisions (Layer 2). Use when logging decisions after a board meeting, reviewing past decisions with /cs:decisions, or checking overdue action items with /cs:review. Invoked automatically by the board-meeting skill after Phase 5 founder approval."
+            },
+            {
+              "name": "founder-coach",
+              "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome."
+            },
+            {
+              "name": "general-counsel-advisor",
+              "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel — surfaces questions to bring to qualified attorneys."
+            },
+            {
+              "name": "internal-narrative",
+              "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication."
+            },
+            {
+              "name": "intl-expansion",
+              "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams."
+            },
+            {
+              "name": "ma-playbook",
+              "description": "M&A strategy for acquiring companies or being acquired. Due diligence, valuation, integration, and deal structure. Use when evaluating acquisitions, preparing for acquisition, M&A due diligence, integration planning, or deal negotiation."
+            },
+            {
+              "name": "org-health-diagnostic",
+              "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard."
+            },
+            {
+              "name": "scenario-war-room",
+              "description": "Cross-functional what-if modeling for cascading multi-variable scenarios. Unlike single-assumption stress testing, this models compound adversity across all business functions simultaneously. Use when facing complex risk scenarios, strategic decisions with major downside, or when the user asks 'what if X AND Y both happen?'"
+            },
+            {
+              "name": "strategic-alignment",
+              "description": "Cascades strategy from boardroom to individual contributor. Detects and fixes misalignment between company goals and team execution. Covers strategy articulation, cascade mapping, orphan goal detection, silo identification, communication gap analysis, and realignment protocols. Use when teams are pulling in different directions, OKRs don't connect, departments optimize locally at company expense, or when user mentions alignment, strategy cascade, silo, conflicting OKRs, or strategy communication."
+            },
+            {
+              "name": "vpe-advisor",
+              "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing → screen → onsite → offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) — VPE owns delivery operations and how the team ships."
+            }
+          ]
+        }
+      },
+      {
+        "name": "c-level-agents",
+        "description": "Founder-mode executive team plugin: 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff, General Counsel, Chief Data Officer, Chief AI Officer, Chief Customer Officer, VP of Engineering) with distinct cognitive voices, plus 21 /cs:* slash commands — forcing-question office hours (CFO/CMO/CPO/CRO/CTO/CISO/GC/CDO/CAIO/CCO/VPE reviews), strategic sprint pipeline (brief → boardroom → decide → execute → post-mortem), and meta routing (/cs:founder-mode auto-router, /cs:onboard, /cs:cross-eval multi-model consensus, /cs:freeze cooldown lock). Wraps the 33 c-level skills with cognitive gearing, persona voice, and artifact-driven handoffs. The business-domain answer to YC Garry Tan's gstack.",
+        "source": "./c-level-advisor/c-level-agents",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "founder-mode",
+          "boardroom",
+          "office-hours",
+          "executive-agents",
+          "c-suite",
+          "cfo",
+          "cmo",
+          "cro",
+          "cpo",
+          "ciso",
+          "general-counsel",
+          "contract-review",
+          "term-sheet",
+          "ip-strategy",
+          "chief-data-officer",
+          "cdo",
+          "ai-training-data",
+          "data-product-strategy",
+          "data-as-asset",
+          "chief-ai-officer",
+          "caio",
+          "ai-strategy",
+          "model-buildvsbuy",
+          "eu-ai-act",
+          "ai-cost-economics",
+          "chief-customer-officer",
+          "cco",
+          "retention-decomposition",
+          "customer-segmentation",
+          "cs-coverage",
+          "vp-engineering",
+          "vpe",
+          "dora",
+          "delivery-throughput",
+          "engineering-hiring",
+          "eng-team-structure",
+          "decision-logging",
+          "cross-model"
+        ],
+        "components": {
+          "skills": 22,
+          "agents": 13
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "boardroom",
+              "description": "/cs:boardroom <brief> — 6-phase multi-role deliberation across the C-suite with Phase 2 isolation, critic pre-screen, and synthesis. Outputs a board memo. Use when a decision spans multiple executive domains — e.g. a pricing change touching finance, positioning, and product, or a raise-vs-cut runway call."
+            },
+            {
+              "name": "brief",
+              "description": "/cs:brief <topic> — Generate a one-page strategy brief from an office-hours intake. First step in the strategic sprint pipeline. Use when a strategic question needs to be framed before boardroom deliberation — e.g. locking options, assumptions, and success criteria for a pricing change or a market-entry decision."
+            },
+            {
+              "name": "c-level-agents",
+              "description": "Founder-mode executive team. 13 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, GC, CDO, CAIO, CCO, VPE, Chief of Staff) and 21 /cs:* slash commands for forcing-question office hours, multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Use when the founder needs a virtual executive team, when invoking /cs:* commands, or when orchestrating multi-role decisions."
+            },
+            {
+              "name": "caio-review",
+              "description": "/cs:caio-review <plan> — Eval-demanding Chief AI Officer interrogation of any plan that involves AI: model selection, risk classification, cost economics, or AI hiring. Use when shipping an AI feature without an eval set, choosing between API, fine-tune, and self-hosted, or classifying a use case under the EU AI Act."
+            },
+            {
+              "name": "cco-review",
+              "description": "/cs:cco-review <plan> — Retention-obsessed Chief Customer Officer interrogation of any plan that touches customer retention, segmentation, CS team sizing, or CS team hiring. Use when gross retention is slipping, before approving CSM headcount, or when deciding which customer segments to keep or fire."
+            },
+            {
+              "name": "cdo-review",
+              "description": "/cs:cdo-review <plan> — Decision-driven Chief Data Officer interrogation of any plan that touches training data, data architecture, data productization, or data team hiring. Use when validating training-data rights before model work, choosing warehouse vs lakehouse vs mesh, or valuing data assets for productization or M&A."
+            },
+            {
+              "name": "cfo-review",
+              "description": "/cs:cfo-review <plan> — Numerate-skeptic interrogation of any plan that touches money. Unit economics, runway, dilution, capital allocation. Use when a plan commits meaningful spend — e.g. a hiring wave, a fundraise decision, or a new channel budget."
+            },
+            {
+              "name": "ciso-review",
+              "description": "/cs:ciso-review <plan> — Risk-paranoid interrogation of any plan that touches data, compliance, or production access. Use when launching features that handle customer data, before a SOC 2 / ISO audit, or after any incident or near-miss."
+            },
+            {
+              "name": "cmo-review",
+              "description": "/cs:cmo-review <plan> — Narrative-first interrogation of positioning, ICP, message house, and channel mix. Use when launching a campaign or repositioning, or when CAC is rising and the one-sentence positioning test fails."
+            },
+            {
+              "name": "cpo-review",
+              "description": "/cs:cpo-review <plan> — JTBD-driven interrogation of product roadmap, PMF signal, and portfolio focus. Use when committing a quarter's roadmap, deciding whether to kill a feature, or claiming PMF without a retention curve."
+            },
+            {
+              "name": "cro-review",
+              "description": "/cs:cro-review <plan> — Pipeline-paranoid interrogation of revenue, win rate, NRR, and ramp time. Use when the forecast misses pipeline coverage, win rates drop, or before scaling the sales team."
+            },
+            {
+              "name": "cross-eval",
+              "description": "/cs:cross-eval <memo> — Multi-model consensus on a board memo or strategy brief. Claude + Codex + Gemini cross-review with graceful degradation. Use when a high-stakes memo needs an independent sanity check before the boardroom — e.g. a bet-the-company pivot or fundraise terms."
+            },
+            {
+              "name": "cto-review",
+              "description": "/cs:cto-review <plan> — Architecture and scaling interrogation. Tech debt, scaling cliffs, team scaling, build-vs-buy. Use when committing to an architecture, planning for 10x load, or weighing a rebuild against a vendor."
+            },
+            {
+              "name": "decide",
+              "description": "/cs:decide <memo> — Log a decision to two-layer memory via decision-logger. Approved memo becomes durable; raw transcripts kept for reference. Use when the founder has approved a boardroom memo and the decision must become durable company memory — e.g. right after /cs:boardroom concludes."
+            },
+            {
+              "name": "execute",
+              "description": "/cs:execute <decision> — Generate a 90-day execution plan with weekly milestones, DRIs, and check-in cadence from an approved decision. Use when a logged decision needs to become an operating plan — e.g. turning an approved market-entry call into weekly milestones with DRIs."
+            },
+            {
+              "name": "founder-mode",
+              "description": "/cs:founder-mode <question> — Auto-routes any founder question to the right C-role advisor or to /cs:boardroom for multi-role topics. The single-command entry point. Use when a founder asks any strategic question without knowing which advisor or command fits — e.g. 'runway pressure' routes to the CFO, 'gross retention dropped' routes to the CCO."
+            },
+            {
+              "name": "freeze",
+              "description": "/cs:freeze <decision> <days> — Lock a strategic decision for a cooldown period to prevent impulse reversal. Mirrors gstack's safety primitives for the business layer. Use when an irreversible decision was made under pressure — e.g. a layoff plan or multi-year contract — and deserves a cooling-off lock before execution."
+            },
+            {
+              "name": "gc-review",
+              "description": "/cs:gc-review <plan> — General Counsel interrogation of contracts, IP, regulatory, term sheets, and employment-law surface. Use when reviewing a term sheet before signing, redlining a customer MSA, or checking IP assignment and regulatory exposure on a new product."
+            },
+            {
+              "name": "office-hours",
+              "description": "/cs:office-hours <topic> — YC-style 6-question founder interrogation before any advice. Forces clarity on problem, customer, distribution, defensibility, capital, and founder fit. Use when a founder question is too vague to route — e.g. 'should we grow faster?' — or before drafting a strategy brief."
+            },
+            {
+              "name": "onboard",
+              "description": "/cs:onboard — Founder interview that populates ~/.claude/company-context.md using the canonical 7-dimension cs-onboard schema. The first command to run when starting with c-level-agents. Use when setting up the virtual C-suite for a new company, or when advisors lack company context — e.g. before a first /cs:boardroom or after a fundraise changes the numbers."
+            },
+            {
+              "name": "post-mortem",
+              "description": "/cs:post-mortem <decision> — Honest retrospective on an executed decision, scored against original assumptions and dissent. Closes the strategic sprint loop. Use when a decision hits its 90-day review checkpoint or its kill criteria trigger — e.g. scoring last quarter's pricing change against its pre-committed success metrics."
+            },
+            {
+              "name": "vpe-review",
+              "description": "/cs:vpe-review <plan> — Throughput-first VP of Engineering interrogation of any plan that touches delivery, eng hiring, team structure, or production discipline. Use when cycle time balloons, DORA metrics slide, or before committing to an eng hiring wave or a reorg."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-caio-advisor",
+              "description": "Eval-demanding Chief AI Officer advisor for model build-vs-buy decisions, AI risk classification under EU AI Act + US state laws, AI cost economics (API vs self-hosted), and AI team org evolution. Strategic only — does not duplicate engineering AI/ML skills."
+            },
+            {
+              "name": "cs-cco-advisor",
+              "description": "Retention-obsessed Chief Customer Officer advisor for honest retention decomposition (GRR vs NRR), customer segmentation (differential investment), CS team coverage (pooled vs named), and CS team org evolution. Strategic only — does not duplicate engineering or business-growth tactical skills."
+            },
+            {
+              "name": "cs-cdo-advisor",
+              "description": "Decision-driven Chief Data Officer advisor for AI training data rights, data product strategy (warehouse/lakehouse/mesh + build-vs-buy), B2B customer-data-as-asset valuation, and data team org evolution. Strategic only — does not duplicate engineering data skills."
+            },
+            {
+              "name": "cs-cfo-advisor",
+              "description": "Numerate-skeptic CFO advisor for unit economics, runway, fundraising, dilution, and board-grade financial decisions"
+            },
+            {
+              "name": "cs-chief-of-staff",
+              "description": "Routing-and-synthesis chief of staff for orchestrating the virtual boardroom, logging decisions, and surfacing stale ones"
+            },
+            {
+              "name": "cs-chro-advisor",
+              "description": "People-systems CHRO advisor for hiring strategy, comp bands, leveling ladders, org design, and retention"
+            },
+            {
+              "name": "cs-ciso-advisor",
+              "description": "Risk-paranoid CISO advisor for threat modeling, compliance, incident response, and security architecture"
+            },
+            {
+              "name": "cs-cmo-advisor",
+              "description": "Narrative-first CMO advisor for ICP definition, positioning, message house, channel mix, and category creation"
+            },
+            {
+              "name": "cs-coo-advisor",
+              "description": "Execution-OS COO advisor for operating cadence, OKRs, scorecards, DRI clarity, and scaling playbooks"
+            },
+            {
+              "name": "cs-cpo-advisor",
+              "description": "JTBD-driven CPO advisor for product vision, portfolio strategy, PMF, North Star metrics, and roadmap focus"
+            },
+            {
+              "name": "cs-cro-advisor",
+              "description": "Pipeline-paranoid CRO advisor for revenue forecasting, sales motion, NRR, ramp time, and pipeline coverage"
+            },
+            {
+              "name": "cs-general-counsel-advisor",
+              "description": "Risk-paranoid General Counsel advisor for contract review, IP strategy, term sheet decoding, and regulatory landscape mapping. Not legal advice; surfaces questions for outside counsel."
+            },
+            {
+              "name": "cs-vpe-advisor",
+              "description": "Throughput-first VP of Engineering advisor for delivery throughput (DORA 4 metrics), engineering hiring funnel, eng team structure (squad/tribe + manager-trigger), and production discipline. NOT a CTO skill — VPE owns how the team ships, CTO owns what to build."
+            }
+          ]
+        }
+      },
+      {
+        "name": "general-counsel-advisor",
+        "description": "General Counsel advisory for startups: contract risk scanner (12 founder-killer patterns: auto-renew traps, uncapped indemnity, vague IP, MFN pricing, missing DPA, one-sided venue, broad non-solicit, perpetual license-back, etc.) and term sheet analyzer (0-100 founder-friendliness across 12 dimensions). 3 in-depth references: contracts playbook (7 startup contract types), IP + regulatory landscape mapping (HIPAA, GDPR, FDA, fintech, EU AI Act, SOC 2 → ISO sequencing), term sheet decoder (full glossary + founder-friendly defaults). Standalone-installable; also bundled in c-level-skills. Stdlib-only. NOT a substitute for licensed counsel.",
+        "source": "./c-level-advisor/general-counsel-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "general-counsel",
+          "gc",
+          "legal-review",
+          "contract-review",
+          "term-sheet",
+          "ip-strategy",
+          "regulatory",
+          "dpa",
+          "indemnity",
+          "liability-cap"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "general-counsel-advisor",
+              "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel — surfaces questions to bring to qualified attorneys."
+            }
+          ]
+        }
+      },
+      {
+        "name": "arquiteto-de-empresa",
+        "description": "Company Architect: builds a business from scratch as an OKF (Open Knowledge Format) bundle — a tree of versionable .md files with a frontmatter type, links forming a graph, and reserved index.md/log.md, readable by humans and agents alike. Guides the founder through a 12-phase interview (foundation, strategy, market, financial, sales, marketing, product, operations, tech, people, legal, governance), one phase at a time, and generates conformant markdown concepts. 3 stdlib tools: scaffold_bundle (bundle scaffold), okf_linter (validates type/reserved files/links), index_generator (regenerates the index.md files). Standalone-installable; also bundled in c-level-skills. In English.",
+        "source": "./c-level-advisor/arquiteto-de-empresa",
+        "author": "leoal",
+        "tags": [
+          "arquiteto-de-empresa",
+          "company-architect",
+          "okf",
+          "open-knowledge-format",
+          "knowledge-bundle",
+          "business-from-scratch",
+          "company-as-code",
+          "founder",
+          "chief-of-staff"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "arquiteto-de-empresa",
+              "description": "Company Architect: builds a business from scratch as an OKF (Open Knowledge Format) bundle — a tree of version-controllable .md files with frontmatter type, links forming a graph, and reserved index.md/log.md, readable by humans and agents. Guides the founder through a 12-phase interview (foundation, strategy, market, financial, sales, marketing, product, operations, tech, people, legal, governance), one phase at a time, few questions per block, and generates the concepts as conformant markdown. Trigger when the user wants to create, structure, or document an entire company in folders and .md files; when they mention build my company from scratch, company as code, company knowledge base for AI to read, company wiki for agents, OKF, or knowledge bundle. In English."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-arquiteto",
+              "description": "Company Architect — a senior chief of staff who builds a business from scratch as an OKF (Open Knowledge Format) bundle: a tree of version-controllable .md files with frontmatter type, links forming a graph, and reserved index.md/log.md. Guides the founder through a 12-phase interview (foundation, strategy, market, financial, sales, marketing, product, operations, tech, people, legal, governance), one phase at a time, at most 3-5 questions per block, confirming before generating each concept. Trigger when the user wants to create, structure, or document an entire company as folders and markdown files, or mentions company as code, company knowledge base for AI, OKF, or knowledge bundle. Works in English. Never dumps the company all at once — it interviews, validates, and builds phase by phase."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-arquiteto",
+              "description": "/cs:arquiteto — Builds a company from scratch as an OKF bundle (tree of .md with type + link graph). Guides the 12-phase interview, one at a time, and generates conformant markdown concepts. In English."
+            }
+          ]
+        }
+      },
+      {
+        "name": "chief-data-officer-advisor",
+        "description": "Chief Data Officer advisory for startups: AI training data audit (origin × class × use-case matrix with GDPR Art. 6 + EU AI Act citations), data product strategy picker (warehouse vs lakehouse vs mesh + 6-layer build-vs-buy + 12-month sequencing), data asset valuator (strategic value 0-10 + M&A multiplier with carve-out penalties + 3 ranked productization paths). 4 references answering one decision each: training rights, data product strategy, customer-data-as-asset, data team org evolution. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering data skills.",
+        "source": "./c-level-advisor/chief-data-officer-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "chief-data-officer",
+          "cdo",
+          "data-strategy",
+          "ai-training-data",
+          "consent-provenance",
+          "data-product-strategy",
+          "data-mesh",
+          "lakehouse",
+          "data-as-asset",
+          "data-team-org"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "chief-data-officer-advisor",
+              "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only."
+            }
+          ]
+        }
+      },
+      {
+        "name": "vpe-advisor",
+        "description": "VP of Engineering advisory: delivery throughput analyzer (DORA 4 metrics + cycle-time bottleneck identification with typical fixes per stage), engineering hiring funnel calculator (7-stage conversion + pipeline gap + weakest-stage fixes from sourcing to offer-accept), engineering team structure designer (squad/tribe model + manager-trigger + director-trigger + span-of-control). 4 in-depth references citing DORA / Spotify / Conway / Google SRE / Larson / Fournier. Standalone-installable; also bundled in c-level-skills. NOT a CTO skill — VPE owns how the team ships; CTO owns what to build.",
+        "source": "./c-level-advisor/vpe-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "vp-engineering",
+          "vpe",
+          "engineering-operations",
+          "dora",
+          "delivery-throughput",
+          "cycle-time",
+          "engineering-hiring",
+          "hiring-funnel",
+          "eng-team-structure",
+          "squad-tribe",
+          "manager-trigger",
+          "production-discipline"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "vpe-advisor",
+              "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing → screen → onsite → offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) — VPE owns delivery operations and how the team ships."
+            }
+          ]
+        }
+      },
+      {
+        "name": "chief-customer-officer-advisor",
+        "description": "Chief Customer Officer advisory: retention decomposition analyzer (honest GRR vs NRR; 7-category churn taxonomy with preventable% scoring), customer segmentation designer (4-tier framework, ICP fit scoring across 7 weighted signals, kill list + upgrade candidates), CS coverage calculator (pooled vs named CSM ratio math + 12-month hiring plan with quarterly sequencing). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate business-growth tactical CS skills.",
+        "source": "./c-level-advisor/chief-customer-officer-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "chief-customer-officer",
+          "cco",
+          "customer-success",
+          "retention",
+          "gross-retention",
+          "net-retention",
+          "churn-analysis",
+          "customer-segmentation",
+          "cs-coverage",
+          "cs-team-org"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "chief-customer-officer-advisor",
+              "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only — does not duplicate engineering/business-growth tactical skills."
+            }
+          ]
+        }
+      },
+      {
+        "name": "chief-ai-officer-advisor",
+        "description": "Chief AI Officer advisory for startups: model build-vs-buy calculator (API vs fine-tune vs build with 3-year TCO across 6 paths + breakeven that balances economics with practical feasibility), AI risk classifier (EU AI Act tier with 7 Article citations + US state patchwork: NYC LL 144, CO AI Act, IL HB 53, CA SB 1001, IL BIPA + industry overlays for FDA AI/ML, CFPB Circular 2023-03, NYDFS Reg 23, NAIC, ECOA, Fed SR 11-7), AI cost economics (API vs self-hosted breakeven with 2026 pricing across A100/H100, utilization reality, hidden costs). 4 in-depth references each citing 5+ authoritative sources. Standalone-installable; also bundled in c-level-skills. Strategic only — does not duplicate engineering AI/ML skills.",
+        "source": "./c-level-advisor/chief-ai-officer-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "chief-ai-officer",
+          "caio",
+          "ai-strategy",
+          "model-buildvsbuy",
+          "fine-tuning",
+          "eu-ai-act",
+          "ai-risk-tier",
+          "nist-ai-rmf",
+          "ai-cost-economics",
+          "ai-self-hosted-breakeven",
+          "ai-team-org"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "chief-ai-officer-advisor",
+              "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only — does not duplicate engineering AI/ML skills."
+            }
+          ]
+        }
       },
       {
         "name": "engineering-advanced-skills",
-        "description": "35 advanced engineering skills: agent designer, agent workflow designer, AgentHub, RAG architect, database designer, focused-fix, browser-automation, spec-driven-workflow, secrets-vault-manager, sql-database-assistant, migration architect, observability designer, dependency auditor, release manager, API reviewer, CI/CD pipeline builder, MCP server builder, skill security auditor, performance profiler, Helm chart builder, Terraform patterns, and more.",
+        "description": "37 advanced engineering skills: agent designer, agent workflow designer, RAG architect, database designer + schema designer + SQL assistant, migration architect, observability designer, dependency auditor, changelog generator (with semantic version bumper and hotfix/rollback procedures), API design reviewer, API test suite builder, CI/CD pipeline builder, MCP server builder, skill security auditor, skill tester, performance profiler, focused-fix, browser-automation, full-page-screenshot, git-worktree-manager, monorepo-navigator, codebase-onboarding, interview-system-designer, runbook-generator, spec-driven-workflow, secrets-vault-manager, env-secrets-manager, pr-review-expert, self-eval, tc-tracker (task context tracker with lifecycle and handoff format), feature-flags-architect, kubernetes-operator, chaos-engineering, ship-gate (pre-production 8-category audit with deploy-intent intercept), slo-architect (SLO designer, error-budget calculator with multi-window burn-rate alerts, SLO reviewer per Google SRE Workbook), and tech-debt-tracker. Agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw.",
         "source": "./engineering",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1356,11 +4790,170 @@
           "ci-cd",
           "mcp",
           "security-audit"
-        ]
+        ],
+        "components": {
+          "skills": 38
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-designer",
+              "description": "Use when the user asks to design a multi-agent system, pick an orchestration pattern (supervisor/swarm/pipeline), generate tool schemas for agents, or evaluate agent execution logs for cost, latency, and failure bottlenecks. Examples: 'design an agent architecture for research automation', 'generate Anthropic tool schemas from these tool descriptions', 'analyze these agent run logs for bottlenecks'. NOT for Claude Code workflow files (use workflow-builder) or single-agent prompt design (use agent-workflow-designer)."
+            },
+            {
+              "name": "agent-workflow-designer",
+              "description": "Design production-grade multi-agent workflows with clear pattern choice (sequential, parallel, hierarchical), handoff contracts, failure handling, and cost/context controls. Use when architecting a multi-step agent pipeline, choosing between single-agent vs multi-agent approaches, or refactoring an LLM workflow that suffers from context bloat or unreliable handoffs."
+            },
+            {
+              "name": "api-design-reviewer",
+              "description": "Comprehensive REST API design review with automated linting, breaking-change detection, and design scorecards. Catches inconsistent conventions, missing versioning, and design smells before APIs ship. Use when reviewing a PR that adds or changes API endpoints, auditing an existing API for v2 migration, or establishing API standards for a team."
+            },
+            {
+              "name": "api-test-suite-builder",
+              "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests."
+            },
+            {
+              "name": "browser-automation",
+              "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that."
+            },
+            {
+              "name": "changelog-generator",
+              "description": "Produce consistent, auditable release notes from Conventional Commits. Separates commit parsing, semantic-bump logic, and changelog rendering for automated releases with editorial control. Use when cutting a release, generating CHANGELOG.md from git history, computing the next semantic version from commits, automating release notes in CI, or planning a hotfix/rollback. Examples: 'generate the changelog for v1.4.0', 'what version bump do these commits require', 'we need an emergency hotfix process'."
+            },
+            {
+              "name": "chaos-engineering",
+              "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets)."
+            },
+            {
+              "name": "ci-cd-pipeline-builder",
+              "description": "Generate pragmatic CI/CD pipelines from detected project stack signals — fast baseline generation, repeatable checks, environment-aware deployment stages. Use when setting up CI for a new project, refactoring existing pipelines, or standardizing deployment workflows across multiple repos."
+            },
+            {
+              "name": "codebase-onboarding",
+              "description": "Analyze a codebase and generate onboarding documentation for engineers, tech leads, and contractors. Fast fact-gathering and repeatable onboarding outputs. Use when onboarding a new engineer, writing architecture-overview docs for a new project, or producing tech-lead briefings for unfamiliar repos."
+            },
+            {
+              "name": "database-designer",
+              "description": "Use when the user asks to design database schemas, plan data migrations, optimize queries, choose between SQL and NoSQL, or model data relationships."
+            },
+            {
+              "name": "database-schema-designer",
+              "description": "Use when the user asks to create ERD diagrams, normalize database schemas, design table relationships, or plan schema migrations."
+            },
+            {
+              "name": "dependency-auditor",
+              "description": "Audit and manage dependencies across multi-language projects. Identifies vulnerabilities, license conflicts, transitive dependency risks, and safe-upgrade paths. Use when auditing third-party packages before release, investigating a CVE, planning a major version bump, or running a license-compliance review. Examples: 'audit our npm dependencies', 'do we have GPL contamination', 'plan the upgrade to React 19'."
+            },
+            {
+              "name": "engineering-advanced-skills",
+              "description": "Index of 37 advanced engineering agent skills for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Use when browsing or choosing among the POWERFUL-tier engineering skills: agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, changelog/release automation, reliability (SLO/chaos/flags/operators), platform ops."
+            },
+            {
+              "name": "env-secrets-manager",
+              "description": "Manage environment-variable hygiene and secrets safety across local development and production. Practical auditing, drift awareness, rotation readiness. Use when auditing .env files for committed secrets, planning a credential rotation, debugging missing-env-var production incidents, or hardening a new project against secrets leakage."
+            },
+            {
+              "name": "feature-flags-architect",
+              "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command."
+            },
+            {
+              "name": "focused-fix",
+              "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies."
+            },
+            {
+              "name": "full-page-screenshot",
+              "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies."
+            },
+            {
+              "name": "git-worktree-manager",
+              "description": "Run parallel feature work safely with Git worktrees. Standardizes branch isolation, port allocation, environment sync, and cleanup so each worktree behaves like an independent local app. Optimized for multi-agent workflows where each agent or terminal session owns one worktree. Use when running multiple feature branches simultaneously, isolating experimental work, or coordinating multi-agent development across the same repo."
+            },
+            {
+              "name": "interview-system-designer",
+              "description": "This skill should be used when the user asks to \"design interview processes\", \"create hiring pipelines\", \"calibrate interview loops\", \"generate interview questions\", \"design competency matrices\", \"analyze interviewer bias\", \"create scoring rubrics\", \"build question banks\", or \"optimize hiring systems\". Use for designing role-specific interview loops, competency assessments, and hiring calibration systems."
+            },
+            {
+              "name": "kubernetes-operator",
+              "description": "Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern."
+            },
+            {
+              "name": "mcp-server-builder",
+              "description": "Design and ship production-ready MCP (Model Context Protocol) servers from OpenAPI contracts instead of hand-written tool wrappers. Python and TypeScript support, schema validation, safe evolution. Use when exposing an existing API as an MCP server, building tool integrations for Claude or Codex or Cursor, or scaffolding an MCP project from scratch."
+            },
+            {
+              "name": "migration-architect",
+              "description": "Zero-downtime migration planning, compatibility validation, and rollback strategy generation. Tools for system, database, and infrastructure migrations with minimal business impact. Use when planning a database migration, infrastructure cutover, system replacement, or any high-risk transition that needs explicit rollback paths."
+            },
+            {
+              "name": "monorepo-navigator",
+              "description": "Navigate, manage, and optimize monorepos. Covers Turborepo, Nx, pnpm workspaces, and Lerna. Cross-package impact analysis, selective builds/tests on affected packages, remote caching, dependency graph visualization, and structured multi-repo to monorepo migrations. Use when setting up a new monorepo, optimizing CI for a large workspace, debugging cross-package dependency issues, or planning a multi-repo consolidation."
+            },
+            {
+              "name": "observability-designer",
+              "description": "Design production-ready observability strategies combining metrics, logs, and traces. Includes SLI/SLO design, golden-signals monitoring, alert optimization. Use when adding observability to a new service, refactoring alerting that is too noisy, or designing an SLO program before scaling production load."
+            },
+            {
+              "name": "performance-profiler",
+              "description": "Systematic performance profiling for Node.js, Python, and Go applications. Identifies CPU, memory, and I/O bottlenecks, generates flamegraphs, analyzes bundle sizes, optimizes database queries, runs load tests with k6 and Artillery. Always measures before and after. Use when investigating a slow endpoint, planning a performance budget, or hunting a memory leak in production."
+            },
+            {
+              "name": "pr-review-expert",
+              "description": "Use when the user asks to review pull requests, analyze code changes, check for security issues in PRs, or assess code quality of diffs."
+            },
+            {
+              "name": "rag-architect",
+              "description": "Use when the user asks to design a RAG pipeline, choose a chunking strategy or embedding model, pick a vector database, or evaluate retrieval quality (precision@k, recall@k, NDCG). Examples: 'design a RAG system for our docs', 'what chunk size should I use for this corpus', 'evaluate my retriever against ground truth'. NOT for general LLM cost tuning (use llm-cost-optimizer) or agent loops over retrieval (use agenthub)."
+            },
+            {
+              "name": "runbook-generator",
+              "description": "Generate operational runbooks from a service name — deployment, incident response, maintenance, and rollback workflows. Templated structure customizable per environment. Use when documenting on-call procedures for a new service, standardizing incident response across teams, or producing runbooks before launching to production."
+            },
+            {
+              "name": "secrets-vault-manager",
+              "description": "Use when the user asks to set up secret management infrastructure, integrate HashiCorp Vault, configure cloud secret stores (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager), implement secret rotation, or audit secret access patterns."
+            },
+            {
+              "name": "self-eval",
+              "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions."
+            },
+            {
+              "name": "ship-gate",
+              "description": ">"
+            },
+            {
+              "name": "skill-security-auditor",
+              "description": ">"
+            },
+            {
+              "name": "skill-tester",
+              "description": "Validate, test, and score the quality of skills within the claude-skills ecosystem. Comprehensive meta-skill: structure validation, Python script testing (syntax + imports + runtime + output format), multi-dimensional quality scoring with letter grades and tier classification (BASIC/STANDARD/POWERFUL). Use when authoring a new skill, auditing existing skills for tier promotion, setting up pre-commit hooks for skill quality, or integrating skill QA into CI."
+            },
+            {
+              "name": "slo-architect",
+              "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline."
+            },
+            {
+              "name": "spec-driven-workflow",
+              "description": "Use when the user asks to write specs before code, define acceptance criteria, plan features before implementation, generate tests from specifications, or follow spec-first development practices."
+            },
+            {
+              "name": "sql-database-assistant",
+              "description": "Use when the user asks to write SQL queries, optimize database performance, generate migrations, explore database schemas, or work with ORMs like Prisma, Drizzle, TypeORM, or SQLAlchemy."
+            },
+            {
+              "name": "tc-tracker",
+              "description": "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers init/create/update/status/resume/close/export workflows for structured code change documentation."
+            },
+            {
+              "name": "tech-debt-tracker",
+              "description": "Scan codebases for technical debt, score severity, track trends, and generate prioritized remediation plans. Use when users mention tech debt, code quality, refactoring priority, debt scoring, cleanup sprints, or code health assessment. Also use for legacy code modernization planning and maintenance cost estimation."
+            }
+          ]
+        }
       },
       {
         "name": "engineering-skills",
-        "description": "30 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud architect, GCP cloud architect, security pen testing, Snowflake development.",
+        "description": "32 engineering skills: architecture, frontend, backend, fullstack, QA, DevOps, security, AI/ML, data engineering, Playwright (9 sub-skills), self-improving agent, Stripe integration, TDD guide, tech stack evaluator, Google Workspace CLI, a11y audit (WCAG 2.2), Azure cloud architect, GCP cloud architect, security pen testing, Snowflake development, adversarial-reviewer, ai-security, cloud-security, incident-response, red-team, threat-detection. v2.8.1 audits senior-fullstack / senior-frontend / senior-backend against karpathy-coder + Matt Pocock — each ships a 7-question forcing-question library, 4 customization profiles (JSON), deterministic decision engine, composition map into POWERFUL specialists, plus cs-fullstack-engineer / cs-frontend-engineer / cs-backend-engineer orchestrator agents (context: fork) + /cs:fullstack-review, /cs:frontend-review, /cs:backend-review, /cs:engineer-grill slash commands.",
         "source": "./engineering-team",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1379,11 +4972,150 @@
           "gmail",
           "google-drive",
           "google-sheets"
-        ]
+        ],
+        "components": {
+          "skills": 33
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "adversarial-reviewer",
+              "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer."
+            },
+            {
+              "name": "ai-security",
+              "description": "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring."
+            },
+            {
+              "name": "aws-solution-architect",
+              "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization."
+            },
+            {
+              "name": "azure-cloud-architect",
+              "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization."
+            },
+            {
+              "name": "cloud-security",
+              "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping."
+            },
+            {
+              "name": "code-reviewer",
+              "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, Java, C, C++, Rust, Ruby, PHP, and Dart/Flutter. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists."
+            },
+            {
+              "name": "email-template-builder",
+              "description": "Build complete transactional email systems: React Email templates, provider integration (Resend, Postmark, SendGrid, AWS SES), preview server, i18n support, dark mode, spam optimization, analytics tracking. Use when adding transactional email to a new product, migrating between email providers, refactoring legacy email templates for accessibility, or adding internationalization to existing templates."
+            },
+            {
+              "name": "engineering-skills",
+              "description": "Index of the engineering-team skills bundle for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365 (stdlib-only Python tools). Use when browsing or choosing among engineering-team role skills — load only the one specialist SKILL.md you need, never bulk-load the bundle."
+            },
+            {
+              "name": "epic-design",
+              "description": ">"
+            },
+            {
+              "name": "gcp-cloud-architect",
+              "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization."
+            },
+            {
+              "name": "incident-commander",
+              "description": "Comprehensive incident response framework from detection through resolution and post-incident review. Battle-tested SRE/DevOps practices: severity classification, timeline reconstruction, structured post-incident analysis. Use when declaring an incident, coordinating multi-team response during an outage, leading a post-mortem, or setting up on-call practices for a new service."
+            },
+            {
+              "name": "incident-response",
+              "description": "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle."
+            },
+            {
+              "name": "ms365-tenant-manager",
+              "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation."
+            },
+            {
+              "name": "named-persona-adversarial-review",
+              "description": "Code review through the lens of real engineers' documented philosophies (Torvalds, Thompson, Carmack, Kent Beck, Jobs, Cagan). Complements abstract-role adversarial review with named, sourced perspectives. Use when automated review findings feel generic, when a PR has architectural or UX impact, or when the author wants pre-submit hardening beyond standard checks."
+            },
+            {
+              "name": "red-team",
+              "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting."
+            },
+            {
+              "name": "security-pen-testing",
+              "description": "Use when the user asks to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation."
+            },
+            {
+              "name": "senior-architect",
+              "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format."
+            },
+            {
+              "name": "senior-backend",
+              "description": "Designs and implements backend systems including REST APIs, microservices, database architectures, authentication flows, and security hardening. Use when the user asks to \"design REST APIs\", \"optimize database queries\", \"implement authentication\", \"build microservices\", \"review backend code\", \"set up GraphQL\", \"handle database migrations\", or \"load test APIs\". Covers Node.js/Express/Fastify development, PostgreSQL optimization, API security, and backend architecture patterns."
+            },
+            {
+              "name": "senior-computer-vision",
+              "description": "Computer vision engineering skill for object detection, image segmentation, and visual AI systems. Covers CNN and Vision Transformer architectures, YOLO/Faster R-CNN/DETR detection, Mask R-CNN/SAM segmentation, and production deployment with ONNX/TensorRT. Includes PyTorch, torchvision, Ultralytics, Detectron2, and MMDetection frameworks. Use when building detection pipelines, training custom models, optimizing inference, or deploying vision systems."
+            },
+            {
+              "name": "senior-data-engineer",
+              "description": "Data engineering skill for building scalable data pipelines, ETL/ELT systems, and data infrastructure. Expertise in Python, SQL, Spark, Airflow, dbt, Kafka, and modern data stack. Includes data modeling, pipeline orchestration, data quality, and DataOps. Use when designing data architectures, building data pipelines, optimizing data workflows, implementing data governance, or troubleshooting data issues."
+            },
+            {
+              "name": "senior-data-scientist",
+              "description": "World-class senior data scientist skill specialising in statistical modeling, experiment design, causal inference, and predictive analytics. Covers A/B testing (sample sizing, two-proportion z-tests, Bonferroni correction), difference-in-differences, feature engineering pipelines (Scikit-learn, XGBoost), cross-validated model evaluation (AUC-ROC, AUC-PR, SHAP), and MLflow experiment tracking — using Python (NumPy, Pandas, Scikit-learn), R, and SQL. Use when designing or analysing controlled experiments, building and evaluating classification or regression models, performing causal analysis on observational data, engineering features for structured tabular datasets, or translating statistical findings into data-driven business decisions."
+            },
+            {
+              "name": "senior-devops",
+              "description": "Comprehensive DevOps skill for CI/CD, infrastructure automation, containerization, and cloud platforms (AWS, GCP, Azure). Includes pipeline setup, infrastructure as code, deployment automation, and monitoring. Use when setting up pipelines, deploying applications, managing infrastructure, implementing monitoring, or optimizing deployment processes."
+            },
+            {
+              "name": "senior-frontend",
+              "description": "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality."
+            },
+            {
+              "name": "senior-fullstack",
+              "description": "Fullstack development toolkit with project scaffolding for Next.js, FastAPI, MERN, and Django stacks, code quality analysis with security and complexity scoring, and stack selection guidance. Use when the user asks to \"scaffold a new project\", \"create a Next.js app\", \"set up FastAPI with React\", \"analyze code quality\", \"audit my codebase\", \"what stack should I use\", \"generate project boilerplate\", or mentions fullstack development, project setup, or tech stack comparison."
+            },
+            {
+              "name": "senior-ml-engineer",
+              "description": "ML engineering skill for productionizing models, building MLOps pipelines, and integrating LLMs. Covers model deployment, feature stores, drift monitoring, RAG systems, and cost optimization. Use when the user asks about deploying ML models to production, setting up MLOps infrastructure (MLflow, Kubeflow, Kubernetes, Docker), monitoring model performance or drift, building RAG pipelines, or integrating LLM APIs with retry logic and cost controls. Focused on production and operational concerns rather than model research or initial training."
+            },
+            {
+              "name": "senior-prompt-engineer",
+              "description": "Use when the user asks to optimize prompts, design prompt templates, evaluate LLM outputs with an eval set, measure RAG retrieval quality, validate agent/tool configurations, analyze token usage, or design structured-output contracts. Covers eval-driven prompt iteration, RAG metrics (relevance, faithfulness, coverage), agent workflow validation, and token/cost budgeting — all model-agnostic, with three stdlib Python tools."
+            },
+            {
+              "name": "senior-qa",
+              "description": "Generates unit tests, integration tests, and E2E tests for React/Next.js applications. Scans components to create Jest + React Testing Library test stubs, analyzes Istanbul/LCOV coverage reports to surface gaps, scaffolds Playwright test files from Next.js routes, mocks API calls with MSW, creates test fixtures, and configures test runners. Use when the user asks to \"generate tests\", \"write unit tests\", \"analyze test coverage\", \"scaffold E2E tests\", \"set up Playwright\", \"configure Jest\", \"implement testing patterns\", or \"improve test quality\"."
+            },
+            {
+              "name": "senior-secops",
+              "description": "Senior SecOps engineer skill for application security, vulnerability management, compliance verification, and secure development practices. Runs SAST/DAST scans, generates CVE remediation plans, checks dependency vulnerabilities, creates security policies, enforces secure coding patterns, and automates compliance checks against SOC2, PCI-DSS, HIPAA, and GDPR. Use when conducting a security review or audit, responding to a CVE or security incident, hardening infrastructure, implementing authentication or secrets management, running penetration test prep, checking OWASP Top 10 exposure, or enforcing security controls in CI/CD pipelines."
+            },
+            {
+              "name": "senior-security",
+              "description": "Use when the user asks for STRIDE threat modeling, DREAD risk scoring, data-flow-diagram threat analysis, or a quick secret scan — or when a security request needs routing to the right specialist skill (pen-testing, incident response, cloud posture, red team, AI security, threat hunting, secure code review). This skill owns threat modeling; everything else routes to a sibling."
+            },
+            {
+              "name": "stripe-integration-expert",
+              "description": "Production-grade Stripe integrations: subscriptions with trials and proration, one-time payments, usage-based billing, checkout sessions, idempotent webhook handlers, customer portal, and invoicing. Covers Next.js, Express, and Django patterns. Use when integrating Stripe for the first time, debugging webhook reliability issues, migrating from a different payment provider, or adding usage-based billing to an existing subscription product."
+            },
+            {
+              "name": "tdd-guide",
+              "description": "Test-driven development skill for writing unit tests, generating test fixtures and mocks, analyzing coverage gaps, and guiding red-green-refactor workflows across Jest, Pytest, JUnit, Vitest, and Mocha. Use when the user asks to write tests, improve test coverage, practice TDD, generate mocks or stubs, or mentions testing frameworks like Jest, pytest, or JUnit."
+            },
+            {
+              "name": "tech-stack-evaluator",
+              "description": "Technology stack evaluation and comparison with TCO analysis, security assessment, and ecosystem health scoring. Use when comparing frameworks, evaluating technology stacks, calculating total cost of ownership, assessing migration paths, or analyzing ecosystem viability."
+            },
+            {
+              "name": "threat-detection",
+              "description": "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization."
+            }
+          ]
+        }
       },
       {
         "name": "ra-qm-skills",
-        "description": "13 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, SOC 2 compliance.",
+        "description": "14 regulatory affairs & quality management skills for HealthTech/MedTech: ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, GDPR/DSGVO, ISO 27001 ISMS, CAPA management, risk management, clinical evaluation, SOC 2 compliance.",
         "source": "./ra-qm-team",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1395,11 +5127,86 @@
           "fda",
           "gdpr",
           "medtech"
-        ]
+        ],
+        "components": {
+          "skills": 17
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-decision-receipts",
+              "description": "Mint a tamper-evident, post-quantum-signed receipt for a consequential agent action (deploy, delete, pay, grant-access, model decision) so it can be verified later from the certificate alone. Use when an autonomous agent takes a side-effecting action that may need to be proven later, or when satisfying EU AI Act Article 12 record-keeping. Three decisions: whether an action needs a receipt, minting it, verifying it. Signing is delegated to the open-source OpenAgentOntology package. Not after-the-fact log analysis; not a hosted notary; not a legal opinion."
+            },
+            {
+              "name": "capa-officer",
+              "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use when running CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization."
+            },
+            {
+              "name": "eu-ai-act-specialist",
+              "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system — prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute."
+            },
+            {
+              "name": "fda-consultant-specialist",
+              "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QMSR (21 CFR 820, which incorporates ISO 13485:2016 by reference since 2026-02-02; formerly QSR) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QMSR, QSR, ISO 13485 for FDA, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity."
+            },
+            {
+              "name": "gdpr-dsgvo-expert",
+              "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests with Art. 12(3) one-month deadlines. Use when running GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, or data subject rights (DSAR) management (e.g., 'check this service for GDPR risks', 'track an access request deadline'). Final compliance determinations route to the DPO or legal counsel."
+            },
+            {
+              "name": "information-security-manager-iso27001",
+              "description": "ISO 27001 ISMS implementation and cybersecurity governance for HealthTech and MedTech companies. Use when designing an ISMS, running security risk assessments, implementing controls, pursuing ISO 27001 certification, preparing security audits, responding to security incidents, or verifying compliance. Covers ISO 27001, ISO 27002, healthcare security, and medical device cybersecurity."
+            },
+            {
+              "name": "isms-audit-expert",
+              "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows."
+            },
+            {
+              "name": "iso42001-specialist",
+              "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act)."
+            },
+            {
+              "name": "mdr-745-specialist",
+              "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, Art. 86 PSUR schedules, and EUDAMED integration. Use when classifying a medical device under MDR, building or gap-checking a technical file, planning clinical evaluation or PMS/PSUR cadence, or preparing for notified body review (e.g., 'what class is my device under MDR', 'review my PSUR schedule')."
+            },
+            {
+              "name": "qms-audit-expert",
+              "description": "ISO 13485 internal audit expertise for medical device QMS. Covers audit planning, execution, nonconformity classification, and CAPA verification. Use when planning internal audits, executing audits, classifying findings, preparing for external audits, or managing an audit program."
+            },
+            {
+              "name": "quality-documentation-manager",
+              "description": "Document control system management for medical device QMS. Covers document numbering, version control, change management, and 21 CFR Part 11 compliance. Use when working on document control procedures, change control workflows, document numbering, version management, electronic signature compliance, or regulatory documentation review."
+            },
+            {
+              "name": "quality-manager-qmr",
+              "description": "Senior Quality Manager Responsible Person (QMR) for HealthTech and MedTech companies. Provides quality system governance, management review leadership, regulatory compliance oversight, and quality performance monitoring per ISO 13485 Clause 5.5.2. Use when leading management reviews, setting quality policy and objectives, monitoring quality KPIs and cost of quality, or exercising QMR governance and regulatory oversight responsibilities."
+            },
+            {
+              "name": "quality-manager-qms-iso13485",
+              "description": "ISO 13485 Quality Management System implementation and maintenance for medical device organizations. Provides QMS design, documentation control, internal auditing, CAPA management, and certification support. Use when working with medical device quality systems, preparing for ISO 13485 audits, managing regulatory compliance documentation, setting up corrective actions, or building audit preparation programs. Useful for quality management, audit preparation, regulatory compliance, medical device documentation, and corrective action workflows."
+            },
+            {
+              "name": "ra-qm-skills",
+              "description": "Router/index for the 15 regulatory & quality-management skills bundled in this plugin (ISO 13485 QMS, EU MDR 2017/745, FDA submissions under QMSR, ISO 14971 risk, CAPA, document control, ISO 27001/ISMS, ISO 42001 AIMS, EU AI Act, GDPR/DSGVO, SOC 2, auditing). Use when a compliance request doesn't obviously match one skill and you need to pick the right one (e.g., 'prepare us for an ISO 13485 audit', 'is my AI system high-risk under the AI Act')."
+            },
+            {
+              "name": "regulatory-affairs-head",
+              "description": "Senior Regulatory Affairs Manager for HealthTech and MedTech companies. Prepares FDA 510(k), De Novo, and PMA submission packages; analyzes regulatory pathways for new medical devices; drafts responses to FDA deficiency letters and Notified Body queries; develops CE marking technical documentation under EU MDR 2017/745; coordinates multi-market approval strategies across FDA, EU, Health Canada, PMDA, and NMPA; and maintains regulatory intelligence on evolving standards. Use when users need to plan or execute FDA submissions, navigate 510(k) or PMA approval processes, achieve CE marking, prepare pre-submission meeting materials, write regulatory strategy documents, respond to agency queries, or manage compliance documentation for medical device market access."
+            },
+            {
+              "name": "risk-management-specialist",
+              "description": "Medical device risk management specialist implementing ISO 14971 throughout product lifecycle. Provides risk analysis, risk evaluation, risk control, and post-production information analysis. Use when user mentions risk management, ISO 14971, risk analysis, FMEA, fault tree analysis, hazard identification, risk control, risk matrix, benefit-risk analysis, residual risk, risk acceptability, or post-market risk."
+            },
+            {
+              "name": "soc2-compliance",
+              "description": "Use when the user asks to prepare for SOC 2 audits, map Trust Service Criteria, build control matrices, collect audit evidence, perform gap analysis, or assess SOC 2 Type I vs Type II readiness."
+            }
+          ]
+        }
       },
       {
         "name": "product-skills",
-        "description": "14 product skills with 16 Python tools: product manager toolkit (RICE, PRDs), agile product owner, product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, code-to-prd, research summarizer.",
+        "description": "13 bundled product skills with 22 Python tools: product-skills fork-orchestrator with continuous-discovery loop (deterministic 16-lane router, Torres cadence tracker, OST linter, /cs:product + /cs:grill-product + /cs:product-loop), product manager toolkit (RICE, PRDs), product strategist, UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, product analytics, experiment designer, product discovery, roadmap communicator, spec-to-repo. Companion standalone plugins: agile-product-owner, code-to-prd, apple-hig-expert, research-summarizer.",
         "source": "./product-team",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1414,12 +5221,96 @@
           "analytics",
           "experimentation",
           "discovery",
-          "roadmap"
-        ]
+          "discovery",
+          "roadmap",
+          "apple-hig",
+          "design-guidelines"
+        ],
+        "components": {
+          "skills": 13,
+          "agents": 1,
+          "commands": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "competitive-teardown",
+              "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review."
+            },
+            {
+              "name": "experiment-designer",
+              "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor."
+            },
+            {
+              "name": "landing-page-generator",
+              "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert."
+            },
+            {
+              "name": "product-analytics",
+              "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages."
+            },
+            {
+              "name": "product-discovery",
+              "description": "Use when validating product opportunities, mapping assumptions, planning discovery sprints, or testing problem-solution fit before committing delivery resources."
+            },
+            {
+              "name": "product-manager-toolkit",
+              "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use when prioritizing features, synthesizing user research, writing requirement documentation, or developing product strategy."
+            },
+            {
+              "name": "product-skills",
+              "description": "Use when coordinating product work across the 12 bundled product sub-skills (RICE, OKRs, UX research, design tokens, competitive teardown, analytics, experiments, discovery, roadmaps, spec-to-repo, landing pages, SaaS scaffolding) or the 4 standalone product-team plugins (user stories, Apple HIG, code-to-PRD, research summarizer). Triggers on 'help me prioritize', 'plan a product experiment', 'we ship features nobody uses', 'run the discovery loop', 'is our OST sound'. Forks context to route to one sub-skill via a deterministic signal router and returns a digest; can also drive a continuous-discovery loop (Torres cadence tracker + OST linter as machine gates) or a full goal→plan→execute→verify→close run through the repo-wide agent-harness. Distinct from project-management (how to deliver vs what to build), marketing/landing (from-scratch pages), and engineering/agent-harness (the generic loop engine this orchestrator plugs into)."
+            },
+            {
+              "name": "product-strategist",
+              "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level."
+            },
+            {
+              "name": "roadmap-communicator",
+              "description": "Use when preparing roadmap narratives, release notes, changelogs, or stakeholder updates tailored for executives, engineering teams, and customers."
+            },
+            {
+              "name": "saas-scaffolder",
+              "description": "Generates complete, production-ready SaaS project boilerplate including authentication, database schemas, billing integration, API routes, and a working dashboard using Next.js 14+ App Router, TypeScript, Tailwind CSS, shadcn/ui, Drizzle ORM, and Stripe. Use when the user wants to create a new SaaS app, start a subscription-based web project, scaffold a Next.js application, or mentions terms like starter template, boilerplate, new project, or wiring up auth and payments."
+            },
+            {
+              "name": "spec-to-repo",
+              "description": "Use when the user says 'build me an app', 'create a project from this spec', 'scaffold a new repo', 'generate a starter', 'turn this idea into code', 'bootstrap a project', 'I have requirements and need a codebase', or provides a natural-language project specification and expects a complete, runnable repository. Stack-agnostic: Next.js, FastAPI, Rails, Go, Rust, Flutter, and more."
+            },
+            {
+              "name": "ui-design-system",
+              "description": "UI design system toolkit for Senior UI Designer including design token generation, component documentation, responsive design calculations, and developer handoff tools. Use when creating design systems, generating design tokens, maintaining visual consistency, or facilitating design-dev collaboration and developer handoff."
+            },
+            {
+              "name": "ux-researcher-designer",
+              "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use when conducting user research, creating personas, mapping user journeys, planning usability tests, or validating designs."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-product-orchestrator",
+              "description": "Outcome-first product lead. Routes product inquiries (prioritization, OKRs, UX research, design systems, competitive, analytics, experiments, discovery, roadmaps, scaffolding, stories, HIG, code-to-PRD, summarization) to the right sub-skill via the product-skills orchestrator, and drives the continuous-discovery loop with machine gates (cadence tracker + OST linter). Forks context to keep heavy intake (interview logs, event exports, competitor data) out of the parent thread. Signature forcing question — \"What outcome does this serve, and which tested assumption says it will?\""
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-grill-product",
+              "description": "Matt Pocock-style interrogation of a product plan against the product canon (Torres, Cagan Transformed, Reinertsen/WSJF, Amplitude North Star, evals-as-PRD). One forcing question per turn with a recommended answer; refuses to invoke any sub-skill or start a loop until the outcome-defining decisions are locked. Use before running /cs:product or /cs:product-loop on a fuzzy plan."
+            },
+            {
+              "name": "cs-product-loop",
+              "description": "Run the continuous-discovery loop — score the weekly cadence (Torres), act on the named gap, lint the Opportunity Solution Tree as the machine gate, and keep the streak alive with explicit stop states. The product-domain recurring loop; graduates validated assumptions to experiments or PRDs."
+            },
+            {
+              "name": "cs-product",
+              "description": "Top-level product-team router. Classifies a product inquiry across 16 lanes (prioritization, OKRs, UX, design system, competitive, analytics, experiments, discovery, roadmaps, spec-to-repo, landing, SaaS scaffold, stories, HIG, code-to-PRD, summarizer) with a deterministic script and forks context to the right sub-skill via the product-skills orchestrator, returning a ≤200-word digest with one grill challenge."
+            }
+          ]
+        }
       },
       {
         "name": "pm-skills",
-        "description": "6 project management skills with 12 Python tools: senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator.",
+        "description": "9 project management skills with 15 Python tools: pm-skills fork-orchestrator with agentic delivery loop (deterministic 8-lane router, Jira MCP snapshot bridge to Kanban flow metrics + Monte Carlo forecasts, delegation-governance gate, /cs:pm + /cs:grill-pm + /cs:pm-loop), senior PM, scrum master, Jira expert, Confluence expert, Atlassian admin, template creator, meeting analyzer, team communications. Bundled Atlassian Remote MCP.",
         "source": "./project-management",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1429,11 +5320,76 @@
           "jira",
           "confluence",
           "atlassian"
-        ]
+        ],
+        "components": {
+          "skills": 9,
+          "agents": 1,
+          "commands": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "atlassian-admin",
+              "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task."
+            },
+            {
+              "name": "atlassian-templates",
+              "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation."
+            },
+            {
+              "name": "confluence-expert",
+              "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows."
+            },
+            {
+              "name": "jira-expert",
+              "description": "Atlassian Jira expert for creating and managing projects, planning, product discovery, JQL queries, workflows, custom fields, automation, reporting, and all Jira features. Use when setting up or configuring Jira projects, writing JQL and advanced searches, creating dashboards, designing workflows, or performing technical Jira operations."
+            },
+            {
+              "name": "meeting-analyzer",
+              "description": "Analyzes meeting transcripts and recordings to surface behavioral patterns, communication anti-patterns, and actionable coaching feedback. Use this skill whenever the user uploads or points to meeting transcripts (.txt, .md, .vtt, .srt, .docx), asks about their communication habits, wants feedback on how they run meetings, requests speaking ratio analysis, mentions filler words or conflict avoidance, or wants to compare their communication across time periods. Also trigger when users mention tools like Granola, Otter, Fireflies, or Zoom transcripts. Even if the user just says \"look at my meetings\" or \"how do I come across in meetings\" — use this skill."
+            },
+            {
+              "name": "pm-skills",
+              "description": "Use when coordinating project-delivery work across the 8 project-management sub-skills — sprint/velocity analytics, portfolio health, Jira/JQL, Confluence, Atlassian admin, templates, meeting analysis, team comms. Triggers on 'our sprints feel off', 'project health report', 'audit our Jira permissions', 'when will it be done', 'run the delivery loop'. Forks context to route to one sub-skill via a deterministic signal router and returns a digest; can also drive a full goal→plan→execute→verify→close delivery loop through the repo-wide agent-harness with Jira MCP data bridged into the domain's analytics tools. Distinct from product-team (what to build vs how to deliver it), business-operations (internal ops), and engineering/agent-harness (the generic loop engine this orchestrator plugs into)."
+            },
+            {
+              "name": "scrum-master",
+              "description": "Advanced Scrum Master skill for data-driven agile team analysis and coaching. Use when the user asks about sprint planning, velocity tracking, retrospectives, standup facilitation, backlog grooming, story points, burndown charts, blocker resolution, or agile team health. Runs Python scripts to analyse sprint JSON exports from Jira or similar tools: velocity_analyzer.py for Monte Carlo sprint forecasting, sprint_health_scorer.py for multi-dimension health scoring, and retrospective_analyzer.py for action-item and theme tracking. Produces confidence-interval forecasts, health grade reports, and improvement-velocity trends for high-performing Scrum teams."
+            },
+            {
+              "name": "senior-pm",
+              "description": "Senior Project Manager for enterprise software, SaaS, and digital transformation projects. Specializes in portfolio management, quantitative risk analysis, resource optimization, stakeholder alignment, and executive reporting. Uses advanced methodologies including EMV analysis, Monte Carlo simulation, WSJF prioritization, and multi-dimensional health scoring. Use when a user needs help with project plans, project status reports, risk assessments, resource allocation, project roadmaps, milestone tracking, team capacity planning, portfolio health reviews, program management, or executive-level project reporting — especially for enterprise-scale initiatives with multiple workstreams, complex dependencies, or multi-million dollar budgets."
+            },
+            {
+              "name": "team-communications",
+              "description": "Write internal company communications — 3P updates (Progress/Plans/Problems), company-wide newsletters, FAQ roundups, incident reports, leadership updates, status reports, project updates, and general internal comms. Use this skill any time the user asks to draft, edit, or format something meant for internal audiences. Trigger on keywords like \"3P\", \"weekly update\", \"newsletter\", \"FAQ\", \"internal comms\", \"status report\", \"company update\", \"team update\", \"incident report\", or any request to summarize work for leadership, teammates, or the broader company. Even casual requests like \"write my update\" or \"summarize what my team did this week\" should trigger this skill."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-pm-orchestrator",
+              "description": "Flow-first delivery lead. Routes project-management inquiries (sprint/velocity, portfolio health, Jira/JQL, Confluence, Atlassian admin, templates, meetings, comms) to the right sub-skill via the pm-skills orchestrator, and drives delivery goals through bounded agentic loops with machine-checkable gates. Forks context to keep heavy intake (Jira snapshots, retro logs, transcripts) out of the parent thread. Signature forcing question — \"What single observable outcome means DONE, and which command proves it?\""
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-grill-pm",
+              "description": "Matt Pocock-style interrogation of a delivery plan against the PM canon (Kanban Guide 2025, Vacanti, DORA 2025, EBM, Klein, GitLab async-first). One forcing question per turn with a recommended answer; refuses to invoke any sub-skill or start a loop until the lane-defining decisions are locked. Use before running /cs:pm or /cs:pm-loop on a fuzzy plan."
+            },
+            {
+              "name": "cs-pm-loop",
+              "description": "Drive a project-delivery goal through a bounded agentic loop — Jira MCP snapshot → flow/sprint analytics bridge → routed sub-skill execution → machine-verified gates → close refused until everything is verified or human-waived. The PM-domain adapter over engineering/agent-harness."
+            },
+            {
+              "name": "cs-pm",
+              "description": "Top-level project-management router. Classifies a PM inquiry across 8 lanes (sprint/flow, portfolio health, Jira, Confluence, admin, templates, meetings, comms) with a deterministic script and forks context to the right sub-skill via the pm-skills orchestrator, returning a ≤200-word digest with a named owner and one grill challenge."
+            }
+          ]
+        }
       },
       {
         "name": "business-growth-skills",
-        "description": "4 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer.",
+        "description": "5 business & growth skills: customer success manager, sales engineer, revenue operations, contract & proposal writer.",
         "source": "./business-growth",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1442,11 +5398,38 @@
           "revenue-operations",
           "business-growth",
           "proposals"
-        ]
+        ],
+        "components": {
+          "skills": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "business-growth-skills",
+              "description": "Router/index for the 4 business & growth skills bundled in this plugin: customer-success-manager (health scoring, churn risk, expansion), sales-engineer (RFP analysis, competitive matrices, PoC planning), revenue-operations (pipeline, forecast accuracy, GTM efficiency), and contract-and-proposal-writer. Use when a growth/revenue request doesn't obviously match one skill and you need to pick the right one (e.g., 'which accounts are at risk', 'should we bid on this RFP')."
+            },
+            {
+              "name": "contract-and-proposal-writer",
+              "description": "Generate professional, jurisdiction-aware business documents: freelance contracts, project proposals, SOWs, NDAs, and MSAs. Structured Markdown output with docx conversion instructions. Covers US (Delaware), EU (GDPR), UK, and DACH (German law) jurisdictions. Not a substitute for legal counsel — use as strong starting points. Use when drafting a freelance contract, preparing a client proposal, writing an SOW for a new engagement, or producing an NDA before sharing sensitive material."
+            },
+            {
+              "name": "customer-success-manager",
+              "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments."
+            },
+            {
+              "name": "revenue-operations",
+              "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams."
+            },
+            {
+              "name": "sales-engineer",
+              "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'."
+            }
+          ]
+        }
       },
       {
         "name": "finance-skills",
-        "description": "2 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting) and SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, projections). 7 Python automation tools.",
+        "description": "3 finance skills: financial analyst (ratio analysis, DCF valuation, budgeting, forecasting), SaaS metrics coach (ARR, MRR, churn, CAC, LTV, NRR, Quick Ratio, projections), and business investment advisor. 7 Python automation tools.",
         "source": "./finance",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1462,7 +5445,26 @@
           "churn",
           "ltv",
           "cac"
-        ]
+        ],
+        "components": {
+          "skills": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "finance-skills",
+              "description": "Router/index for the 2 finance skills bundled in this plugin: financial-analyst (ratio analysis, DCF valuation, budget variance, rolling forecasts) and saas-metrics-coach (ARR/MRR, churn, CAC/LTV, NRR, quick ratio). Use when a finance request doesn't obviously match one skill and you need to pick the right one (e.g., 'analyze these financials', 'how healthy are my SaaS metrics')."
+            },
+            {
+              "name": "financial-analyst",
+              "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis."
+            },
+            {
+              "name": "saas-metrics-coach",
+              "description": "SaaS financial health advisor. Use when a user shares revenue or customer numbers, or mentions ARR, MRR, churn, LTV, CAC, NRR, or asks how their SaaS business is doing."
+            }
+          ]
+        }
       },
       {
         "name": "pw",
@@ -1479,14 +5481,78 @@
           "testrail"
         ],
         "components": {
-          "skills": 9,
+          "skills": 10,
           "agents": 3,
           "hooks": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "browserstack",
+              "description": ">-"
+            },
+            {
+              "name": "coverage",
+              "description": ">-"
+            },
+            {
+              "name": "fix",
+              "description": ">-"
+            },
+            {
+              "name": "generate",
+              "description": ">-"
+            },
+            {
+              "name": "init",
+              "description": ">-"
+            },
+            {
+              "name": "migrate",
+              "description": ">-"
+            },
+            {
+              "name": "pw",
+              "description": "Production-grade Playwright testing toolkit. Use when the user mentions Playwright tests, end-to-end testing, browser automation, fixing flaky tests, test migration, CI/CD testing, or test suites. Generate tests, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55 templates, 3 agents, smart reporting."
+            },
+            {
+              "name": "report",
+              "description": ">-"
+            },
+            {
+              "name": "review",
+              "description": ">-"
+            },
+            {
+              "name": "testrail",
+              "description": ">-"
+            }
+          ],
+          "agents": [
+            {
+              "name": "migration-planner",
+              "description": ">-"
+            },
+            {
+              "name": "test-architect",
+              "description": ">-"
+            },
+            {
+              "name": "test-debugger",
+              "description": ">-"
+            }
+          ],
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
         "name": "self-improving-agent",
-        "description": "Curate auto-memory, promote learnings to CLAUDE.md and rules, extract patterns into skills.",
+        "description": "Curate auto-memory, promote learnings to CLAUDE.md and rules, extract patterns into skills. Ships 5 slash commands (/si:review, /si:promote, /si:extract, /si:status, /si:remember) and 2 sub-agents (memory-analyst, skill-extractor).",
         "source": "./engineering-team/self-improving-agent",
         "author": "Alireza Rezvani",
         "tags": [
@@ -1496,9 +5562,53 @@
           "learning"
         ],
         "components": {
-          "skills": 5,
+          "skills": 6,
           "agents": 2,
           "hooks": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "extract",
+              "description": "Turn a proven pattern or debugging solution into a standalone reusable skill with SKILL.md, reference docs, and examples. Use when the user runs /si:extract or asks to package a recurring solution from memory into a skill."
+            },
+            {
+              "name": "promote",
+              "description": "Graduate a proven pattern from auto-memory (MEMORY.md) to CLAUDE.md or .claude/rules/ for permanent enforcement. Use when the user runs /si:promote or asks to make a learned behavior permanent."
+            },
+            {
+              "name": "remember",
+              "description": "Explicitly save important knowledge to auto-memory with timestamp and context. Use when a discovery is too important to rely on auto-capture."
+            },
+            {
+              "name": "review",
+              "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics. Use when the user runs /si:review or asks what has been learned and what should be promoted or pruned."
+            },
+            {
+              "name": "self-improving-agent",
+              "description": "Curate Claude Code's auto-memory into durable project knowledge. Analyze MEMORY.md for patterns, promote proven learnings to CLAUDE.md and .claude/rules/, extract recurring solutions into reusable skills. Use when: (1) reviewing what Claude has learned about your project, (2) graduating a pattern from notes to enforced rules, (3) turning a debugging solution into a skill, (4) checking memory health and capacity."
+            },
+            {
+              "name": "status",
+              "description": "Memory health dashboard showing line counts, topic files, capacity, stale entries, and recommendations. Use when the user runs /si:status or asks how full or healthy the agent memory is."
+            }
+          ],
+          "agents": [
+            {
+              "name": "memory-analyst",
+              "description": "Read-only analyst for `~/.claude/projects/<project>/memory/`. Identifies promotion candidates (entries proven enough for CLAUDE.md), stale references, consolidation opportunities, conflicts with existing CLAUDE.md rules, and reports health metrics (capacity, freshness, organization). Spawned by `/si:review`."
+            },
+            {
+              "name": "skill-extractor",
+              "description": "Transforms a proven pattern or debugging solution into a standalone, portable skill package. Generates `SKILL.md` with proper frontmatter, reference docs, and examples that work in any project (no hardcoded paths or project-specific values). Spawned by `/si:extract` when a recurring solution should become reusable."
+            }
+          ],
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -1516,92 +5626,43 @@
           "evaluators"
         ],
         "components": {
-          "skills": 5,
+          "skills": 6,
           "agents": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "autoresearch-agent",
+              "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo."
+            },
+            {
+              "name": "loop",
+              "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling. Use when the user runs /ar:loop or asks to run an autoresearch experiment continuously on a schedule."
+            },
+            {
+              "name": "resume",
+              "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating. Use when the user runs /ar:resume or asks to pick up a previously started autoresearch experiment."
+            },
+            {
+              "name": "run",
+              "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard. Use when the user runs /ar:run or asks for one manual autoresearch iteration."
+            },
+            {
+              "name": "setup",
+              "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator. Use when the user runs /ar:setup or asks to start optimizing a file with the autoresearch loop."
+            },
+            {
+              "name": "status",
+              "description": "Show experiment dashboard with results, active loops, and progress. Use when the user runs /ar:status or asks how an autoresearch experiment is going."
+            }
+          ],
+          "agents": [
+            {
+              "name": "experiment-runner",
+              "description": ""
+            }
+          ]
         }
-      },
-      {
-        "name": "content-creator",
-        "description": "SEO-optimized marketing content with brand voice analysis, content frameworks, and social media templates.",
-        "source": "./marketing-skill/content-creator",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "content",
-          "marketing",
-          "seo",
-          "brand-voice"
-        ]
-      },
-      {
-        "name": "demand-gen",
-        "description": "Multi-channel demand generation, paid media optimization, SEO strategy, and partnership programs.",
-        "source": "./marketing-skill/marketing-demand-acquisition",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "demand-gen",
-          "paid-media",
-          "acquisition"
-        ]
-      },
-      {
-        "name": "fullstack-engineer",
-        "description": "Full-stack engineering with React, Node, databases, and deployment.",
-        "source": "./engineering-team/senior-fullstack",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "fullstack",
-          "react",
-          "node",
-          "engineering"
-        ]
-      },
-      {
-        "name": "aws-architect",
-        "description": "AWS serverless architecture design with IaC templates, cost optimization, and CI/CD pipelines.",
-        "source": "./engineering-team/aws-solution-architect",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "aws",
-          "serverless",
-          "cloud",
-          "architecture"
-        ]
-      },
-      {
-        "name": "product-manager",
-        "description": "Product management toolkit with RICE scoring, customer interview analysis, and PRD generation.",
-        "source": "./product-team/product-manager-toolkit",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "product",
-          "prd",
-          "rice",
-          "prioritization"
-        ]
-      },
-      {
-        "name": "scrum-master",
-        "description": "Sprint health analysis, velocity tracking, and retrospective facilitation.",
-        "source": "./project-management/scrum-master",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "scrum",
-          "agile",
-          "sprint",
-          "velocity"
-        ]
-      },
-      {
-        "name": "skill-security-auditor",
-        "description": "Security audit and vulnerability scanner for AI agent skills. Scans for malicious patterns, prompt injection, data exfiltration, and unsafe file operations.",
-        "source": "./engineering/skill-security-auditor",
-        "author": "Alireza Rezvani",
-        "tags": [
-          "security",
-          "audit",
-          "vulnerability",
-          "scanner"
-        ]
       },
       {
         "name": "google-workspace-cli",
@@ -1616,7 +5677,18 @@
           "google-sheets",
           "google-calendar",
           "workspace-admin"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "google-workspace-cli",
+              "description": "Google Workspace administration via the gws CLI (github.com/googleworkspace/cli). Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits and use local recipe templates and persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling."
+            }
+          ]
+        }
       },
       {
         "name": "code-to-prd",
@@ -1639,7 +5711,18 @@
           "django",
           "fastapi",
           "express"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "code-to-prd",
+              "description": "Reverse-engineer any codebase into a complete Product Requirements Document (PRD). Analyzes routes, components, state management, API integrations, and user interactions to produce business-readable documentation detailed enough for engineers or AI agents to fully reconstruct every page and endpoint. Works with frontend frameworks (React, Vue, Angular, Svelte, Next.js, Nuxt), backend frameworks (NestJS, Django, Express, FastAPI), and fullstack applications. Use when users mention: generate PRD, reverse-engineer requirements, code to documentation, extract product specs from code, document page logic, analyze page fields and interactions, create a functional inventory, write requirements from an existing codebase, document API endpoints, or analyze backend routes."
+            }
+          ]
+        }
       },
       {
         "name": "agenthub",
@@ -1659,8 +5742,50 @@
           "optimization"
         ],
         "components": {
-          "skills": 7,
+          "skills": 8,
           "agents": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agenthub",
+              "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo."
+            },
+            {
+              "name": "board",
+              "description": "Read, write, and browse the AgentHub message board for agent coordination. Use when the user runs /hub:board or asks to post, read, or inspect coordination messages between competing AgentHub agents."
+            },
+            {
+              "name": "eval",
+              "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session. Use when the user runs /hub:eval or asks to score, compare, or pick a winner among completed AgentHub agents."
+            },
+            {
+              "name": "init",
+              "description": "Create a new AgentHub collaboration session with task, agent count, and evaluation criteria. Use when the user runs /hub:init or asks to start a multi-agent competition on a task."
+            },
+            {
+              "name": "merge",
+              "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees. Use when the user runs /hub:merge or asks to land the winning AgentHub result and tidy the session."
+            },
+            {
+              "name": "run",
+              "description": "One-shot lifecycle command that chains init → baseline → spawn → eval → merge in a single invocation. Use when the user runs /hub:run or asks to execute a full AgentHub competition end-to-end."
+            },
+            {
+              "name": "spawn",
+              "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task. Use when the user runs /hub:spawn or asks to start the competing agents for an initialized AgentHub session."
+            },
+            {
+              "name": "status",
+              "description": "Show DAG state, agent progress, and branch status for an AgentHub session. Use when the user runs /hub:status or asks how the AgentHub agents are doing."
+            }
+          ],
+          "agents": [
+            {
+              "name": "hub-coordinator",
+              "description": "Coordinator for AgentHub multi-agent collaboration sessions. Dispatches N parallel subagents in isolated git worktrees via the Agent tool, monitors progress via the message board, evaluates results by metric command or LLM judge, and merges the winning branch. Acts as the main Claude Code session role for `/hub:*` commands."
+            }
+          ]
         }
       },
       {
@@ -1676,7 +5801,18 @@
           "screen-reader",
           "contrast",
           "keyboard-navigation"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "a11y-audit",
+              "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines."
+            }
+          ]
+        }
       },
       {
         "name": "executive-mentor",
@@ -1692,8 +5828,42 @@
           "leadership"
         ],
         "components": {
-          "skills": 5,
+          "skills": 6,
           "agents": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "board-prep",
+              "description": "Board meeting preparation for the adversarial scenario, not the friendly one. Forces numbers-cold mastery, anticipates hard questions, builds a narrative that acknowledges weakness without losing the room. Use when preparing for a board meeting, an investor update, fundraising presentation, or any high-stakes adversarial review where every number must live in your head not just on a slide."
+            },
+            {
+              "name": "challenge",
+              "description": "Pre-mortem plan analysis. Imagine the plan failed 12 months from now and work backwards to find the weaknesses. Surfaces assumptions, dependencies, and execution risks before committing resources. Use when before significant resource commitment, before presenting to a board or investors, when feedback has been one-sidedly positive, or when there is pressure to move fast and figure it out later."
+            },
+            {
+              "name": "executive-mentor",
+              "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for brutal board meetings, dissects decisions with no good options, and forces honest post-mortems. Use when you need someone to find the holes before the board does, make a decision you've been avoiding, or understand what actually went wrong."
+            },
+            {
+              "name": "hard-call",
+              "description": "/em:hard-call — Framework for decisions with no good options. Use when every option is painful and a structured 10/10/10 + regret-minimization pass is needed — e.g. choosing between a layoff and a down round, or killing a beloved product line."
+            },
+            {
+              "name": "postmortem",
+              "description": "/em:postmortem — Honest analysis of what went wrong. Use after a failed launch, missed quarter, or bad hire to run a blameless 5-Whys retrospective with a change register — e.g. dissecting why the Q3 release slipped six weeks."
+            },
+            {
+              "name": "stress-test",
+              "description": "/em:stress-test — Business assumption stress testing. Use before betting on a plan whose core assumptions are unvalidated — e.g. stress-testing 'enterprise buyers will tolerate a 6-month pilot' or a hockey-stick revenue model."
+            }
+          ],
+          "agents": [
+            {
+              "name": "devils-advocate",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -1707,7 +5877,18 @@
           "dockerfile",
           "docker-compose",
           "devops"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "docker-development",
+              "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns."
+            }
+          ]
+        }
       },
       {
         "name": "helm-chart-builder",
@@ -1720,7 +5901,18 @@
           "k8s",
           "chart",
           "deployment"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "helm-chart-builder",
+              "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test."
+            }
+          ]
+        }
       },
       {
         "name": "terraform-patterns",
@@ -1733,7 +5925,18 @@
           "infrastructure",
           "devops",
           "cloud"
-        ]
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "terraform-patterns",
+              "description": "Terraform infrastructure-as-code agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Covers module design patterns, state management strategies, provider configuration, security hardening, policy-as-code with Sentinel/OPA, and CI/CD plan/apply workflows. Use when: user wants to design Terraform modules, manage state backends, review Terraform security, implement multi-region deployments, or follow IaC best practices."
+            }
+          ]
+        }
       },
       {
         "name": "research-summarizer",
@@ -1746,6 +5949,1425 @@
           "analysis",
           "insights",
           "product"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "research-summarizer",
+              "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw."
+            }
+          ]
+        }
+      },
+      {
+        "name": "code-tour",
+        "description": "Create CodeTour .tour files — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. 10 developer personas, all CodeTour step types, SMIG description formula.",
+        "source": "./engineering/code-tour",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "codetour",
+          "walkthrough",
+          "onboarding",
+          "code-review",
+          "documentation"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "code-tour",
+              "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request."
+            }
+          ]
+        }
+      },
+      {
+        "name": "demo-video",
+        "description": "Create polished demo videos from screenshots and scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts with story structure, scene design system, and narration guidance.",
+        "source": "./engineering/demo-video",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "video",
+          "demo",
+          "product-demo",
+          "walkthrough",
+          "ffmpeg",
+          "tts"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "demo-video",
+              "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content."
+            }
+          ]
+        }
+      },
+      {
+        "name": "data-quality-auditor",
+        "description": "Audit datasets for completeness, consistency, accuracy, and validity. 3 stdlib-only Python tools: data profiler with DQS scoring, missing value analyzer with MCAR/MAR/MNAR classification, and multi-method outlier detector.",
+        "source": "./engineering/data-quality-auditor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "data-quality",
+          "profiling",
+          "outlier-detection",
+          "missing-values",
+          "data-audit"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "data-quality-auditor",
+              "description": "Audit datasets for completeness, consistency, accuracy, and validity. Profile data distributions, detect anomalies and outliers, surface structural issues, and produce an actionable remediation plan. Use when the user asks to check data quality, profile a dataset, hunt outliers or missing values, or validate data before analysis or model training."
+            }
+          ]
+        }
+      },
+      {
+        "name": "statistical-analyst",
+        "description": "Hypothesis testing, A/B experiment analysis, sample size calculation, and confidence intervals. 3 stdlib-only Python tools: Z-test/t-test/chi-square with effect sizes, sample size calculator with power tradeoffs, and Wilson score confidence intervals.",
+        "source": "./engineering/statistical-analyst",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "statistics",
+          "hypothesis-testing",
+          "ab-testing",
+          "sample-size",
+          "confidence-interval"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "statistical-analyst",
+              "description": "Run hypothesis tests, analyze A/B experiment results, calculate sample sizes, and interpret statistical significance with effect sizes. Use when you need to validate whether observed differences are real, size an experiment correctly before launch, or interpret test results with confidence."
+            }
+          ]
+        }
+      },
+      {
+        "name": "apple-hig-expert",
+        "description": "Master Apple's Human Interface Guidelines (HIG) with focus on 2026 Liquid Glass aesthetics. Design and audit iOS, macOS, and visionOS apps for full compliance and premium feel. Includes hig_checker Python tool for tap targets and contrast.",
+        "source": "./product-team/apple-hig-expert",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "apple-hig",
+          "design-guidelines",
+          "ios-design",
+          "macos-design",
+          "visionos",
+          "liquid-glass",
+          "accessibility",
+          "ui-design"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "apple-hig-expert",
+              "description": "Audits and designs iOS/macOS/watchOS/visionOS interfaces against the Apple Human Interface Guidelines, including the Liquid Glass design language (announced WWDC25, shipped with iOS 26/macOS Tahoe, Sept 2025). Use when reviewing an Apple-platform mockup or app for HIG compliance, checking contrast or tap-target sizes, or designing native-feeling Apple UI (e.g., 'audit my iOS app against the HIG', 'is this text readable on Liquid Glass?')."
+            }
+          ]
+        }
+      },
+      {
+        "name": "llm-wiki",
+        "description": "A second brain for Claude Code + Obsidian inspired by Karpathy's LLM Wiki gist. Turn any LLM CLI into a disciplined wiki maintainer: incrementally ingest sources into a persistent, interlinked markdown vault; update entity/concept/source pages; flag contradictions; maintain index and append-only log. Knowledge compounds instead of being re-derived by RAG on every query. Ships 3 sub-agents (wiki-ingestor, wiki-librarian, wiki-linter), 5 slash commands (/wiki-init, /wiki-ingest, /wiki-query, /wiki-lint, /wiki-log), 8 Python tools (stdlib only: init_vault, ingest_source, update_index, append_log, wiki_search BM25, lint_wiki, graph_analyzer, export_marp), 8 reference docs, full vault templates (CLAUDE.md, AGENTS.md, cursorrules, 5 page templates), and a worked example vault. Cross-tool compatible with Claude Code, Codex CLI, Cursor, Antigravity, OpenCode, and Gemini CLI.",
+        "source": "./engineering/llm-wiki",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "knowledge-management",
+          "obsidian",
+          "second-brain",
+          "pkm",
+          "wiki",
+          "rag-alternative",
+          "karpathy",
+          "memex",
+          "incremental-knowledge",
+          "cross-tool"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 3,
+          "commands": 5
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "llm-wiki",
+              "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query."
+            }
+          ],
+          "agents": [
+            {
+              "name": "wiki-ingestor",
+              "description": "Dispatched sub-agent that ingests a new source into an LLM Wiki vault. Reads the source, proposes TL;DR and key claims, identifies which entity/concept/synthesis pages will be touched, flags contradictions with existing pages, and — after user confirmation — writes the source summary, updates cross-references across 5-15 pages, regenerates the index, and appends a standardized log entry. Spawn when the user says \"ingest this\", \"add this paper/article/book to the wiki\", or drops a file into raw/."
+            },
+            {
+              "name": "wiki-librarian",
+              "description": "Dispatched sub-agent that answers queries against an LLM Wiki vault. Reads index.md first, drills into 3-10 relevant pages across categories, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back into the wiki as a new comparison or synthesis page. Spawn when the user asks a substantive question the wiki might answer, says \"what does the wiki say about X\", \"compare A and B across my sources\", or wants to explore a topic."
+            },
+            {
+              "name": "wiki-linter",
+              "description": "Dispatched sub-agent that runs a periodic health check on an LLM Wiki vault. Runs mechanical checks via scripts (orphans, broken links, stale pages, missing frontmatter, duplicate titles, log gaps), does semantic checks (contradictions, stale claims, cross-reference gaps, concepts missing their own page), and produces a markdown report with suggested actions. Spawn weekly, after batch ingests, or when the user says \"check the wiki\" / \"lint my wiki\" / \"audit the vault\"."
+            }
+          ],
+          "commands": [
+            {
+              "name": "wiki-ingest",
+              "description": "Ingest a source file from raw/ into the LLM Wiki — read, discuss, write summary page, update cross-references across 5-15 pages, regenerate index, append to log. Usage /wiki-ingest <path-to-source>"
+            },
+            {
+              "name": "wiki-init",
+              "description": "Bootstrap a fresh LLM Wiki vault with the three-layer structure, schema files, and starter templates. Usage /wiki-init <path> --topic \"<topic>\" [--tool all|claude-code|codex|cursor|antigravity]"
+            },
+            {
+              "name": "wiki-lint",
+              "description": "Run a health check on the LLM Wiki vault — mechanical checks (orphans, broken links, stale pages, missing frontmatter, log gap, duplicates) plus semantic checks (contradictions, cross-reference gaps, concepts missing their own page). Outputs a markdown report with suggested actions. Usage /wiki-lint [--stale-days N] [--log-gap-days N]"
+            },
+            {
+              "name": "wiki-log",
+              "description": "Show recent entries from the LLM Wiki log (wiki/log.md). Uses the standardized ## [YYYY-MM-DD] header format so grep + tail works. Usage /wiki-log [--last N] [--op ingest|query|lint|...]"
+            },
+            {
+              "name": "wiki-query",
+              "description": "Query the LLM Wiki — reads index.md first, drills into 3-10 relevant pages, synthesizes an answer with inline [[wikilink]] citations, and offers to file the answer back as a new comparison or synthesis page. Usage /wiki-query \"<question>\""
+            }
+          ]
+        }
+      },
+      {
+        "name": "karpathy-coder",
+        "description": "Active coding discipline enforcer based on Karpathy's 4 principles: surface assumptions, simplify, make surgical changes, define verifiable goals. Ships 4 Python tools (complexity_checker, diff_surgeon, assumption_linter, goal_verifier), a review agent, /karpathy-check command, and pre-commit hook. All stdlib-only.",
+        "source": "./engineering/karpathy-coder",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "code-quality",
+          "karpathy",
+          "simplicity",
+          "surgical-changes",
+          "complexity",
+          "anti-patterns",
+          "review",
+          "discipline"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "karpathy-coder",
+              "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding."
+            }
+          ],
+          "agents": [
+            {
+              "name": "karpathy-reviewer",
+              "description": "Reviews staged git changes against Karpathy's 4 coding principles. Runs complexity_checker on changed files, diff_surgeon on the diff, and produces a verdict with specific fix recommendations. Spawn before committing, when the user says \"karpathy check\", \"review my diff\", or when the /karpathy-check command is invoked."
+            }
+          ],
+          "commands": [
+            {
+              "name": "karpathy-check",
+              "description": "Run Karpathy's 4-principle review on staged changes or the last commit. Checks complexity, diff noise, hidden assumptions, and goal verification. Usage /karpathy-check [--last-commit]"
+            }
+          ]
+        }
+      },
+      {
+        "name": "feature-flags-architect",
+        "description": "End-to-end feature-flag discipline: classify, ship, ramp, retire. Detects stale flags as debt, generates phased rollout plans (ring/linear/log/cohort), and audits every flag for a documented kill switch. 3 stdlib Python tools, 4 references on flag taxonomy + provider trade-offs (LaunchDarkly/GrowthBook/Statsig/Unleash/Flipt/DIY) + rollout strategies + lifecycle. /flag-cleanup slash command. Cross-tool compatible.",
+        "source": "./engineering/feature-flags-architect",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "feature-flags",
+          "progressive-delivery",
+          "rollout",
+          "kill-switch",
+          "launchdarkly",
+          "growthbook",
+          "statsig",
+          "unleash",
+          "flipt",
+          "release-engineering"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "feature-flags-architect",
+              "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command."
+            }
+          ]
+        }
+      },
+      {
+        "name": "kubernetes-operator",
+        "description": "End-to-end Kubernetes Operator discipline: CRD design, reconcile-loop patterns, and OperatorHub Capability Levels. Ships CRD validator, reconcile-loop linter, and capability auditor (3 stdlib Python tools), 4 references on the operator pattern + CRD design + reconcile patterns + framework comparison (controller-runtime/kubebuilder/operator-sdk/metacontroller/KOPF), CRD + Go controller skeletons, and /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
+        "source": "./engineering/kubernetes-operator",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "kubernetes",
+          "operator",
+          "crd",
+          "controller-runtime",
+          "kubebuilder",
+          "operator-sdk",
+          "metacontroller",
+          "kopf",
+          "reconcile",
+          "devops"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "kubernetes-operator",
+              "description": "Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern."
+            }
+          ]
+        }
+      },
+      {
+        "name": "chaos-engineering",
+        "description": "End-to-end chaos engineering discipline: design experiments with hypothesis + steady-state metric + blast radius + abort criteria, calculate risk score against error budget, and generate blameless postmortems. 3 stdlib Python tools (experiment_designer, blast_radius_calculator, experiment_postmortem), 4 references on chaos principles + experiment design + 7-attack taxonomy + tooling landscape (Chaos Toolkit/Mesh/Litmus/Gremlin/AWS FIS/DIY), templates, and /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (chaos targets).",
+        "source": "./engineering/chaos-engineering",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "chaos-engineering",
+          "resilience",
+          "fault-injection",
+          "gameday",
+          "sre",
+          "reliability",
+          "chaos-mesh",
+          "litmus",
+          "gremlin",
+          "aws-fis"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "chaos-engineering",
+              "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets)."
+            }
+          ]
+        }
+      },
+      {
+        "name": "slo-architect",
+        "description": "End-to-end SLO/SLI/error-budget discipline per Google SRE Workbook. Ships SLO designer (refuses to render without required fields), error-budget calculator with multi-window burn-rate alert thresholds (PromQL-shaped), and SLO reviewer that catches the 7 common bugs. 4 references on principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. Asset templates for SLO YAML and error budget policy. /slo-design slash command. NOT a generic observability skill.",
+        "source": "./engineering/slo-architect",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "slo",
+          "sli",
+          "sla",
+          "error-budget",
+          "burn-rate",
+          "sre",
+          "reliability",
+          "google-sre-workbook",
+          "observability"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "slo-architect",
+              "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline."
+            }
+          ]
+        }
+      },
+      {
+        "name": "write-a-skill",
+        "description": "Skill-author skill: create new agent skills with proper structure, progressive disclosure, and bundled resources. Derived from Matt Pocock's MIT-licensed write-a-skill with: (1) 3 stdlib Python validation tools (description validator, structure validator, review-checklist runner — all enforcing Matt's 6-item checklist), (2) 4 references citing 7-8 authoritative sources each (progressive disclosure principles, description design patterns, quality gates, companion tooling), (3) cs-skill-author persona agent + /cs:write-a-skill slash command. Matt's voice and 3-phase workflow (Gather → Draft → Review) preserved verbatim per MIT.",
+        "source": "./engineering/write-a-skill",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "skill-authoring",
+          "matt-pocock",
+          "progressive-disclosure",
+          "validators",
+          "review-checklist",
+          "skill-quality",
+          "meta-skill"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "write-a-skill",
+              "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, build, or author a new skill."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-skill-author",
+              "description": "Skill-author persona. Forcing-question interrogator before any new-skill commit. Runs Matt Pocock's 6-item review checklist as a 6-question gate. Refuses to accept skills with stale time-bound claims, vague descriptions, missing \"Use when\" triggers, or SKILL.md > 100 lines without progressive disclosure."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-write-a-skill",
+              "description": "/cs:write-a-skill <name-or-description> — Author a new agent skill with Matt Pocock's 3-phase workflow (Gather → Draft → Review). Runs 6 review-checklist items + 3 validator tools as a gate. Use when starting a new skill in this repo."
+            }
+          ]
+        }
+      },
+      {
+        "name": "workflow-builder",
+        "description": "Workflow-builder skill: design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool (CLAUDE_CODE_WORKFLOWS=1, /workflows). Every session opens with an intake question set; when the user is vague, a stdlib recommendation engine infers and proposes a topology with rationale instead of stalling. Ships 3 stdlib Python tools (intake recommendation engine, .js validator enforcing pure-literal-meta / no-non-determinism / guarded-loop / parallel-thunk rules, topology scaffolder), 3 references citing 7-8 authoritative sources each (API surface, orchestration patterns, decision + intake guide), templates + a runnable example, cs-workflow-architect persona agent + /cs:workflow-build slash command. Use when building, scaffolding, or running a custom Claude Code workflow or orchestrating sub-agents (fan-out, pipeline, loop, judge-panel).",
+        "source": "./engineering/workflow-builder",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "workflow",
+          "claude-code-workflows",
+          "multi-agent",
+          "orchestration",
+          "deterministic",
+          "fan-out",
+          "pipeline",
+          "sub-agents",
+          "meta-skill"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "workflow-builder",
+              "description": "Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants to build, create, author, scaffold, or run a custom Claude Code workflow, orchestrate sub-agents (fan-out, pipeline, loop, judge-panel), or automate a repeatable multi-step task across fresh-context agents."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-workflow-architect",
+              "description": "Workflow-architect persona. Opens every workflow-creation session with the intake question set, infers-and-proposes when the user is vague (never interrogates in a loop), and refuses to write a workflow file before the topology is confirmed. Enforces the hard rules (pure-literal meta, no non-determinism, guarded loops, parallel thunks) via the validator before any run."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-workflow-build",
+              "description": "/cs:workflow-build <task-description> — Design and write a deterministic Claude Code workflow (.js). Opens with intake questions, infers-and-proposes a topology when the request is vague, then scaffolds + validates the file. Use when building or running a custom Claude Code workflow."
+            }
+          ]
+        }
+      },
+      {
+        "name": "caveman",
+        "description": "Ultra-compressed communication mode. Cuts token usage 20-50% (75% upper bound) by dropping filler, articles, pleasantries, and hedging while keeping full technical accuracy. Derived from Matt Pocock's MIT-licensed caveman with: (1) 3 stdlib Python tools (deterministic compressor, token-savings estimator with $/Mtok cost extrapolation, lint that detects banned vocab with code-block + exception-zone whitelisting), (2) 3 references citing 7-8 sources (compression principles, when caveman backfires, companion tooling), (3) cs-caveman-mode persona agent + /cs:caveman slash command. Matt's persistence rules + auto-clarity exception preserved verbatim per MIT.",
+        "source": "./engineering/caveman",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "token-compression",
+          "matt-pocock",
+          "terse-mode",
+          "caveman",
+          "cost-reduction",
+          "communication"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "caveman",
+              "description": ">"
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-caveman-mode",
+              "description": "Caveman-mode operator. Persistent ultra-compressed communication mode. Drops articles, filler, pleasantries, and hedging while preserving all technical substance. Auto-clarity exception for security warnings, irreversible actions, multi-step sequences, and clarification requests. Activated by user phrases (\"caveman mode\", \"talk like caveman\", \"use caveman\", \"less tokens\", \"be brief\") or /cs:caveman command."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-caveman",
+              "description": "/cs:caveman — Activate persistent caveman-mode. Ultra-compressed responses with technical substance preserved. Auto-clarity exception for warnings + destructive ops. Stays active until 'stop caveman' / 'normal mode'."
+            }
+          ]
+        }
+      },
+      {
+        "name": "zero-hallucination-coder",
+        "description": "A disciplined coding pipeline that grounds code in verified structure before a line is written: Discuss -> Map -> Decompose -> Execute -> Verify, with a lazy-senior-dev YAGNI ladder that deletes unnecessary code first. No invented APIs, no assumed imports, no placeholder code. Opt-in for high-stakes, complex, or multi-file work; not for trivial edits. Synthesizes four MIT/open-source projects (Ralph atomic loop, GSD Core context engineering, Graphify KNOWN/INFERRED/UNKNOWN mapping, Ponytail lazy-senior hierarchy). Contributed via PR #854.",
+        "source": "./engineering/zero-hallucination-coder",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "zero-hallucination",
+          "coding-pipeline",
+          "context-engineering",
+          "codebase-mapping",
+          "yagni",
+          "plan-before-code",
+          "engineering"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "zero-hallucination-coder",
+              "description": "Runs a disciplined Discuss -> Map -> Decompose -> Execute -> Verify loop that grounds code in verified structure — no invented APIs, no assumed imports, no placeholder code — with a lazy-senior-dev YAGNI ladder that deletes unnecessary code before it is written. Use when a coding task is high-stakes, complex, or spans existing code (auth, databases, migrations, multi-file features), or when the user explicitly asks to plan carefully before coding, avoid hallucinated code, or work rigorously. Not for trivial edits, typos, or throwaway one-off scripts — those do not need the full loop."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agent-harness",
+        "description": "Turn any domain folder of skills into a bounded agentic loop: a manifest builder inventories a domain's skills/tools/checks, a goal compiler turns a goal into a verifiable task plan (refusing vague goals with forcing questions), and a JSON-backed loop controller drives execute->verify->close with retry caps, controller-run verification (no verification theater), human escalation on exhausted budgets, and a close gate that refuses while any task is unverified or unwaived. Ships 3 stdlib Python tools, 18 committed per-domain harness manifests + JSON schema, 3 references citing the 2024-2026 agent-harness canon (Anthropic long-running harnesses, verifier's law, SWE-agent, Ralph loop, Cognition), harness-runner agent + /cs:harness command. Use when an agent or subagent should pick up a goal, define its tasks, complete and verify them, and close the loop.",
+        "source": "./engineering/agent-harness",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "agent-harness",
+          "agentic-loop",
+          "verification-gate",
+          "goal-compiler",
+          "loop-controller",
+          "stop-conditions",
+          "escalation",
+          "multi-agent",
+          "engineering"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-harness",
+              "description": "Turn any domain folder of skills into a bounded agentic loop: compile a goal into a verifiable task plan, execute tasks with the domain's own tools, verify every task with machine-run checks, retry with caps, escalate to a human when budgets exhaust, and refuse to close until everything is verified or explicitly waived. Use when you want an agent or subagent to pick up a goal and drive it to a verified close across one of this repo's 18 domains ('run this goal through the engineering harness', 'set up an agentic loop for marketing work', 'make the finance domain self-verifying'). NOT for authoring Claude Code Workflow-tool .js scripts (workflow-builder), N-agent tournaments on one task (agenthub), single-file metric optimization (autoresearch-agent), or discovering published loop recipes (loop-library)."
+            }
+          ],
+          "agents": [
+            {
+              "name": "harness-runner",
+              "description": "Drives one agent-harness loop iteration to completion — reads the plan and state files, executes exactly one task with the task skill's own tools, lets the controller verify it, and reports the directive. Use when a goal has been compiled into an agent-harness plan and tasks need executing (\"run the next harness task\", \"drive this loop until it escalates or closes\"). Use PROACTIVELY after goal_compiler.py writes a plan. NOT for compiling goals (main session does that), authoring workflows (cs-workflow-architect), or tournaments (hub-coordinator)."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-harness",
+              "description": "Compile a goal into a verified agent-harness loop for a domain and drive it to close — /cs:harness <domain> <goal>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "grill-me",
+        "description": "Relentless plan-and-design interrogator. Walks the decision tree one branch at a time, asking forcing questions sequentially with recommended answers. Explores codebase before asking. Derived from Matt Pocock's MIT-licensed grill-me with: (1) 3 stdlib Python tools (decision-tree extractor across 6 branch kinds, question generator with dependency-aware ordering, JSON-backed session tracker for multi-day grills), (2) 3 references citing 7-8 sources (6 forcing-question patterns, when to stop grilling, companion tooling), (3) cs-grill-master persona agent + /cs:grill-me slash command. Matt's relentless one-at-a-time interview discipline preserved verbatim per MIT.",
+        "source": "./engineering/grill-me",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "plan-interrogation",
+          "matt-pocock",
+          "forcing-questions",
+          "decision-tree",
+          "design-review",
+          "stress-test",
+          "socratic-method"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "grill-me",
+              "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\"."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-grill-master",
+              "description": "Relentless plan-and-design interrogator. Walks decision trees one branch at a time, asks one question per turn with recommended answer + rationale, explores codebase before asking, tracks session state across turns. Refuses to bundle questions. Refuses to ask questions the codebase can answer."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-grill-me",
+              "description": "/cs:grill-me <path-to-plan> — Start a relentless interrogation of a plan or design. Walks decision tree one branch at a time. One question per turn with recommended answer. Explores codebase before asking."
+            }
+          ]
+        }
+      },
+      {
+        "name": "handoff-engineering",
+        "description": "Conversation-handoff document generator. Compacts the current session into a markdown handoff for a fresh agent — references existing artifacts (PRDs, plans, ADRs, issues, commits) by path/URL instead of duplicating them. Derived from Matt Pocock's MIT-licensed handoff with: (1) 3 stdlib Python tools (template generator tailored to 5 next-session emphases, artifact deduplicator across 5 categories of duplication, skill recommender matching content to 14 skills in this repo), (2) 4 references citing 7-8 sources (handoff structure, deduplication discipline, next-session skill matching, companion tooling), (3) cs-handoff-author persona agent + /cs:handoff slash command. Matt's no-duplication discipline + mktemp convention preserved verbatim per MIT.",
+        "source": "./engineering/handoff",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "session-handoff",
+          "matt-pocock",
+          "continuity",
+          "context-transfer",
+          "documentation",
+          "no-duplication"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "handoff",
+              "description": "Compact the current conversation into a handoff document for another agent to pick up. References existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path or URL instead of duplicating them. Use when user wants to hand off the conversation to a fresh agent or starts a new session that picks up prior work."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-handoff-author",
+              "description": "Conversation-handoff author. Compacts the current session into a markdown handoff for a fresh agent. Tailors content to next-session focus. Refuses to duplicate content from PRDs/plans/ADRs/issues/commits — references them by path or URL instead. Recommends specific skills for the next session."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-handoff",
+              "description": "/cs:handoff <next-session-focus> — Compact the current conversation into a handoff document for a fresh agent. Tailored to next-session focus (deploy/review/debug/design/test). Replaces PRD/ADR/issue/commit content with references. Recommends specific skills for the next session."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agile-product-owner",
+        "description": "Agile product ownership for backlog management and sprint execution. INVEST-compliant user story generation, acceptance criteria patterns (Given/When/Then, rule-based, checklist), epic breakdown with 5 split techniques, sprint planning with velocity-based capacity math, and weighted backlog prioritization. Includes user_story_generator Python tool and 2 reference guides.",
+        "source": "./product-team/agile-product-owner",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "agile",
+          "scrum",
+          "product-owner",
+          "user-stories",
+          "sprint-planning",
+          "backlog",
+          "acceptance-criteria",
+          "epic-breakdown"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agile-product-owner",
+              "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use when writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing the backlog."
+            }
+          ]
+        }
+      },
+      {
+        "name": "capture-skill",
+        "description": "Brain-dump-to-action workspace skill. Routes vague captures into discoverable actions via classify→cluster→connect→clarify intake. Path-B from megaprompt 05.",
+        "source": "./productivity/capture",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "capture",
+          "brain-dump",
+          "productivity",
+          "gtd",
+          "workspace",
+          "path-b-megaprompt"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "capture",
+              "description": "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into something coherent. Also trigger when the user pastes or dictates a long, unstructured block of mixed ideas — even without the exact phrase — the intent is the same. Fast-to-action by design: no upfront intake. Output is four sections (Projects/Ideas, Tasks, Connections, How I Can Help) ending with a directive question. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-capture",
+              "description": "Brain-dump organizer persona. Catches unstructured streams of mixed thoughts/tasks/ideas and transforms them into a 4-section actionable system with zero information loss. Refuses to fabricate workspace connections. Refuses to corporate-ify the user's voice. Refuses to act on dump items without explicit pick. Asks at most ONE mid-organization clarifying question per dump."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-capture",
+              "description": "/cs:capture <dump-text-or-path> — Explicit invocation of the brain-dump organizer. Captures an unstructured stream of thoughts/tasks/ideas and returns a 4-section actionable system (Projects/Ideas, Tasks, Connections, How I Can Help). Compressed format for small dumps. Max 1 clarifying question. No fabricated connections. No corporate-ifying."
+            }
+          ]
+        }
+      },
+      {
+        "name": "email-pair",
+        "description": "Email-workflow skill pair: inbox-setup builds your taxonomy/KB; inbox-triage classifies + drafts (drafts-only, never auto-send). KB-file contract between them. Path-B from megaprompts 06+07.",
+        "source": "./productivity/email",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "email",
+          "inbox",
+          "triage",
+          "gmail",
+          "outlook",
+          "productivity",
+          "path-b-megaprompt"
+        ],
+        "components": {
+          "skills": 2,
+          "agents": 2,
+          "commands": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "inbox-setup",
+              "description": "One-time setup skill that builds a personalized inbox triage knowledge base via interactive interview. Interviews the user about their email patterns, business context, reply style, and priorities using grill-me discipline (one question at a time, forcing format where possible, dependency-ordered, each question explains why I'm asking), then generates the knowledge base files that power the companion 'inbox-triage' skill. Run this once before using inbox-triage for the first time. Re-run when business, pricing, or priorities change significantly. Triggers: 'set up my inbox', 'configure inbox triage', 'set up my email system', 'configure email triage', 'build my email knowledge base', 'initialize email management', 'set up inbox triage', 'onboard email triage', or any variation where someone wants to get the email triage system running for the first time."
+            },
+            {
+              "name": "inbox-triage",
+              "description": "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run with KB-default preferences); asks at most 2 grill-me override questions when invocation is outside normal cadence or includes category-skip intent. Searches recent emails, classifies them via the user's taxonomy, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report in the user's preferred format, and updates the knowledge base with learnings. Designed to run on a recurring schedule (1-3x daily) or on demand. Use when the user wants their inbox processed, in any variation (e.g., 'triage my inbox', 'inbox triage', 'check my email', 'run email triage', 'process my inbox', 'what's new in my email', 'handle my email', 'email triage'). Requires the inbox-setup skill to have been run first."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-inbox-setup",
+              "description": "One-time email-triage onboarding persona. Conducts an 8-section interactive interview (~25-31 grill-me questions) to build a personalized knowledge base of 7 markdown files in ${WORKSPACE}/Email/ that powers the companion inbox-triage skill. Refuses to batch questions. Refuses to skip the sample-emails ask (S3). Refuses to overwrite existing files without per-file consent on re-run. Refuses to persist sensitive credentials."
+            },
+            {
+              "name": "cs-inbox-triage",
+              "description": "Recurring email-triage execution persona. Reads the 7-file KB produced by inbox-setup, classifies recent emails via the user's taxonomy, researches new senders, generates recommendations, drafts replies, delivers a report, and updates the KB with learnings. NEVER SENDS — drafts only, non-negotiable. Halts with clear message if KB files are missing (directs user to run inbox-setup first). Light-intake — max 2 optional override questions."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-inbox-setup",
+              "description": "/cs:inbox-setup — Interactive 8-section interview that builds a personalized 7-file email-triage knowledge base. ~25-31 grill-me questions, one at a time. Run ONCE; re-run when business/pricing/priorities change. Companion to /cs:inbox-triage."
+            },
+            {
+              "name": "cs-inbox-triage",
+              "description": "/cs:inbox-triage — Recurring email triage execution. Reads 7-file KB built by /cs:inbox-setup. Classifies recent emails, drafts replies (NEVER SENDS), delivers report, updates KB. Run 1-3x/day or on demand. Halts with clear message if KB missing."
+            }
+          ]
+        }
+      },
+      {
+        "name": "reflect-skill",
+        "description": "Light-prompt reflection skill. Single forcing question + structured journal capture. Path-B sibling of capture from megaprompt 08.",
+        "source": "./productivity/reflect",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "reflect",
+          "journaling",
+          "productivity",
+          "forcing-question",
+          "path-b-megaprompt"
+        ],
+        "components": {
+          "skills": 1,
+          "agents": 1,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "reflect",
+              "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck — that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from."
+            }
+          ],
+          "agents": [
+            {
+              "name": "cs-reflect",
+              "description": "Mid-conversation reflection persona. Halts the current thread, re-reads full conversation from original goal forward, runs 5-dimension analysis (Macro / Gap / Reflective / Bias / Contextual), and delivers flowing prose ending with Continue / Pivot / Pause recommendation. Refuses to manufacture problems when path is solid. Refuses vague reassurance. Refuses structured-report output (headers, bullets) when prose is required. Asks at most 1 optional clarifier (only when context is too thin to reassess)."
+            }
+          ],
+          "commands": [
+            {
+              "name": "cs-reflect",
+              "description": "/cs:reflect — Mid-conversation reflection: halts current thread, re-reads full conversation from original goal forward, runs 5-dimension analysis (Macro / Gap / Reflective / Bias / Contextual), ends with Continue / Pivot / Pause recommendation. Flowing prose, no headers. Honest output — no manufactured problems."
+            }
+          ]
+        }
+      },
+      {
+        "name": "handoff-productivity",
+        "description": "Compact the current conversation into a handoff document for another agent to pick up. Configurable save location, redaction enforcement, SessionStart auto-load + SessionEnd reminder, self-check fidelity script, --refresh flag, mtime-guarded cleanup. Inspired by Matt Pocock's handoff (MIT).",
+        "source": "./productivity/handoff",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "handoff",
+          "productivity",
+          "session-continuity",
+          "redaction",
+          "session-start-hook",
+          "session-end-hook",
+          "self-check",
+          "matt-pocock"
+        ]
+      },
+      {
+        "name": "andreessen",
+        "description": "Marc Andreessen-mode decision and productivity skill. Market-first operator that pressure-tests ventures/ideas/features/bets (market > team > product; product/market fit is the only milestone; bias to build) and runs the 3x5-card + Anti-Todo routine. Fixed anti-sycophancy operating prompt: counterargument first, no disclaimers, explicit confidence levels, no capitulation. Issues hard verdicts backed by deterministic stdlib tools.",
+        "source": "./productivity/andreessen",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "andreessen",
+          "pmarca",
+          "productivity",
+          "product-market-fit",
+          "market-first",
+          "anti-sycophancy",
+          "decision-making",
+          "anti-todo"
+        ]
+      },
+      {
+        "name": "roast",
+        "description": "Pressure-test a business idea before you build it. Convenes a 5-angle adversarial panel — The Critic (what kills this?), The Champion (the 10x upside?), The Analyst (does the logic hold?), The Investigator (what does the market say?), The Customer (would I actually pay?) — fired in parallel as independent reviewers, then a Judge synthesizes one GO / RESHAPE / KILL verdict with explicit confidence and the cheapest 48-hour test to de-risk it. Never averages the scores: a weighted synthesizer with demand/fatal-flaw/logic veto gates produces the call, backed by deterministic stdlib tools.",
+        "source": "./productivity/roast",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "roast",
+          "pressure-test",
+          "stress-test",
+          "idea-validation",
+          "adversarial-panel",
+          "go-no-go",
+          "anti-sycophancy",
+          "productivity"
+        ]
+      },
+      {
+        "name": "landing",
+        "description": "Single-file HTML landing-page generator with 4 design styles, brand palette validation, GSAP animation patterns, kebab-slug URL hygiene. Path-B from megaprompt 04.",
+        "source": "./marketing/landing",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "landing-page",
+          "html",
+          "marketing",
+          "generator",
+          "gsap",
+          "brand",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "pulse",
+        "description": "Multi-source recency research. Reddit/HN/X/web sentiment + trending. Research-pack convention (1 q/sec, three-count tracking). Path-B from megaprompt 01.",
+        "source": "./research/pulse",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "pulse",
+          "sentiment",
+          "reddit",
+          "hn",
+          "trending",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "deep-research",
+        "description": "Disciplined multi-source meta-research for high-stakes questions — the heavyweight alternative to the fast research router. 9-phase pipeline (reframe into falsifiable hypotheses, plan, capability discovery, parallel sub-agent fan-out, score & triangulate, synthesize + adversarial pass, verify, refresh targets). Triangulates every thesis against >=3 independent differently-typed sources; per-source files with verbatim quotes; never fabricates a citation. Auditable, reusable folder + delta-update refresh protocol. Contributed via PR #851.",
+        "source": "./research/deep-research",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "deep-research",
+          "meta-research",
+          "triangulation",
+          "adversarial",
+          "multi-source",
+          "hypothesis-validation"
+        ]
+      },
+      {
+        "name": "litreview",
+        "description": "Academic literature orientation skill. PICO/SPIDER frameworks, systematic review structure, 8-section DOCX guide. Research-pack convention. Path-B from megaprompt 09.",
+        "source": "./research/litreview",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "literature-review",
+          "pico",
+          "spider",
+          "systematic-review",
+          "academic",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "grants",
+        "description": "NIH grant-funding intelligence skill. RePORTER/NOSI/study-section navigation, R01/R21/K-award strategy. Research-pack convention. Path-B from megaprompt 11.",
+        "source": "./research/grants",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "grants",
+          "nih",
+          "r01",
+          "k-award",
+          "reporter",
+          "nosi",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "dossier",
+        "description": "Decision-grade entity research. Due-diligence/background-check/competitor-prep with tier-weighted verdict + citation tracker. Research-pack convention. Path-B from megaprompt 02.",
+        "source": "./research/dossier",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "dossier",
+          "due-diligence",
+          "background-check",
+          "competitor",
+          "entity-research",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "patent",
+        "description": "Patent prior-art + IP landscape skill. FTO/novelty/family-resolver via 3-pass Jaccard heuristic. Research-pack convention. Path-B from megaprompt 12.",
+        "source": "./research/patent",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "patent",
+          "prior-art",
+          "fto",
+          "freedom-to-operate",
+          "ip-landscape",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "syllabus",
+        "description": "Course supplementary-reading skill. Topic-grouper + bundled Node.js DOCX generator for syllabus-anchored reading lists. Research-pack convention. Path-B from megaprompt 10.",
+        "source": "./research/syllabus",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "syllabus",
+          "curriculum",
+          "reading-list",
+          "docx",
+          "course",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "notebooklm",
+        "description": "Google NotebookLM browser-automation skill. 4 actions (read/extract, add-source, Studio outputs, create notebook). Screenshot-first + find-before-click + fire-and-notify async discipline. Path-B from megaprompt 03.",
+        "source": "./research/notebooklm",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "notebooklm",
+          "google",
+          "browser-automation",
+          "studio",
+          "audio-overview",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "research-orchestrator",
+        "description": "Research orchestrator (hybrid router + fallback). Deterministic SIGNALS classification routes to 6 specialists (pulse/litreview/grants/dossier/patent/syllabus) at >=2 signals, else runs own 8-step plan-decompose-search-synthesize-cite fallback. Routing transparency mandatory. Path-B from megaprompt 13.",
+        "source": "./research/research",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research",
+          "router",
+          "orchestrator",
+          "classifier",
+          "fallback",
+          "hybrid-architecture",
+          "research-pack",
+          "path-b-megaprompt"
+        ]
+      },
+      {
+        "name": "aeo",
+        "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO (which optimizes for search rankings), AEO optimizes for citation in LLM-generated responses. 3 stdlib Python tools (aeo_audit, aeo_optimizer, citation_tracker), 3 references citing 8 sources each, industry-aware thresholds for 8 industries (saas/healthcare/finance/legal/ecommerce/b2b/media/education). Ported from alirezarezvani/aeo-box.",
+        "source": "./marketing-skill/skills/aeo",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "aeo",
+          "answer-engine-optimization",
+          "llm-citation",
+          "eeat",
+          "chatgpt",
+          "perplexity",
+          "claude",
+          "gemini",
+          "marketing",
+          "seo-complement"
+        ]
+      },
+      {
+        "name": "security-guidance",
+        "description": "PreToolUse security reminder hook for Claude Code. Catches 12 common security anti-patterns in Edit/Write/MultiEdit operations BEFORE they happen — command injection (exec, os.system, subprocess shell=True), XSS (innerHTML, dangerouslySetInnerHTML, document.write), SQL injection (f-string queries, .format), unsafe deserialization (pickle, yaml.unsafe_load), code injection (eval, new Function), and GitHub Actions workflow injection. Session-state caching prevents duplicate warnings; 30-day auto-cleanup. Disable per-session with ENABLE_SECURITY_REMINDER=0. Ported from David Dworken at Anthropic.",
+        "source": "./engineering/security-guidance",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "security",
+          "hook",
+          "pretooluse",
+          "command-injection",
+          "xss",
+          "sql-injection",
+          "eval",
+          "pickle",
+          "engineering",
+          "static-analysis"
+        ]
+      },
+      {
+        "name": "business-operations-skills",
+        "description": "Internal BizOps domain. v2.8.0 ships 7 skills: orchestrator + process-mapper (BPMN/bottleneck/cycle-time, Lean+TOC) + vendor-management (scorecard+SLA+3rd-party risk, NIST SP 800-161/ISO 27036) + capacity-planner (Erlang-C queueing math for ops teams, NOT engineering) + internal-comms (ADKAR+Kotter 8-step, NOT marketing) + knowledge-ops (SOP+runbook+KB hygiene with 5W2H, context: fork) + procurement-optimizer (UNSPSC spend categorization + supplier consolidation). Orchestrator uses context: fork to route inquiries via Matt Pocock grill discipline (one question per turn, recommended answer, canon-cited challenge). Every SKILL.md ships a Forcing-question library section. 18 stdlib Python tools, 24+ reference docs. Distinct from business-growth (external sales) and c-level-advisor (strategic).",
+        "source": "./business-operations",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "bizops",
+          "operations",
+          "process-mapping",
+          "bottleneck",
+          "vendor-management",
+          "sla",
+          "third-party-risk",
+          "lean",
+          "theory-of-constraints",
+          "value-stream",
+          "capacity-planning",
+          "erlang-c",
+          "queueing-theory",
+          "internal-comms",
+          "change-management",
+          "adkar",
+          "kotter",
+          "knowledge-ops",
+          "sop",
+          "runbook",
+          "5w2h",
+          "procurement",
+          "spend-categorization",
+          "unspsc",
+          "supplier-consolidation",
+          "matt-pocock",
+          "grill-with-docs"
+        ]
+      },
+      {
+        "name": "commercial-skills",
+        "description": "Per-deal-and-packaging Commercial domain. v2.8.0 ships 8 skills: orchestrator + pricing-strategist (model picker + Van Westendorp WTP + packaging) + deal-desk (deal scorer + discount approval routing + redline) + partnerships-architect (5-tier classifier + joint GTM + revshare modeler) + channel-economics (cost-to-serve + ROI + mix optimizer) + commercial-policy (data-backed discount matrix + exception flow + linter) + rfp-responder (Shipley structured RFP/RFI/RFQ + win-theme + winrate predictor, context: fork) + commercial-forecaster (4Q-weighted bookings + cohort NRR/GRR + funnel-confidence with mandatory assumption disclosure). Hard rules: pricing outputs model+range (never a single number), deal outputs route to named human approver (never auto-approve), forecast outputs surface conversion assumption, RFP never invents claims for GAP requirements. 21 stdlib Python tools, 28+ reference docs. Distinct from business-growth (sales execution), c-level-advisor/cro-advisor (strategic), finance (close+report).",
+        "source": "./commercial",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "commercial",
+          "pricing",
+          "deal-desk",
+          "discount-approval",
+          "van-westendorp",
+          "wtp",
+          "packaging",
+          "saas-pricing",
+          "redline",
+          "margin",
+          "partnerships",
+          "channel-partners",
+          "joint-gtm",
+          "revshare",
+          "channel-economics",
+          "cost-to-serve",
+          "channel-roi",
+          "commercial-policy",
+          "discount-matrix",
+          "exception-flow",
+          "rfp",
+          "rfi",
+          "shipley-method",
+          "winrate-predictor",
+          "bookings-forecast",
+          "cohort-arr",
+          "funnel-confidence",
+          "matt-pocock",
+          "grill-with-docs"
+        ]
+      },
+      {
+        "name": "universal-scraping-architect",
+        "description": "A universal scraping skill with intelligent routing, token budget tracking, and quota awareness. Supports Firecrawl (BYOK, free-tier compatible) and local Python extraction via requests/BeautifulSoup/pandas.",
+        "source": "./engineering/universal-scraping-architect",
+        "author": "Mehansh Barthwal",
+        "tags": [
+          "scraping",
+          "data-extraction",
+          "firecrawl",
+          "beautifulsoup4",
+          "pandas",
+          "automation"
+        ]
+      },
+      {
+        "name": "research-ops-skills",
+        "description": "Enterprise / cross-functional Research Operations domain — the managed counterpart to the academic research/ domain. v2.9.0 ships 5 skills: orchestrator (context: fork) + clinical-research (study design: protocol synopsis + endpoint selection + sample-size/power for means/proportions/survival + phase-gate feasibility) + research-finance (R&D program budgeting with F&A split + burn/runway + capitalize-vs-expense routing + portfolio ROI) + market-research (TAM/SAM/SOM computed both top-down and bottoms-up + survey sampling with FPC and per-segment minima + Kotler segmentation scoring) + product-research (goal-matched study design + method-based saturation with confidence + insight synthesis that flags single-source anecdotes). Hard rules: clinical outputs are estimates with a named clinical owner (never fact), finance outputs surface assumptions and route capex-vs-opex to a named finance owner (never auto-decide), market sizes show method + assumptions (never a single number), product insights require recurrence across independent participants. Each sub-skill ships per-skill onboarding questions (onboard.py), a customization config consumed by every tool, and an isolated opt-in autoresearch evaluator (ar_evaluator.py) bridging to engineering/autoresearch-agent. 24 stdlib Python tools (12 analysis + 12 onboarding/customization/autoresearch), 12 reference docs. Distinct from ra-qm-team (regulatory/QM submission), finance (corporate close/valuation), research/grants (funding discovery), product-team (persona/journey/live experiments), marketing-skill (campaign analytics).",
+        "source": "./research-ops",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "research-ops",
+          "research-operations",
+          "clinical-research",
+          "study-design",
+          "endpoint-selection",
+          "sample-size",
+          "power-analysis",
+          "phase-gate",
+          "biostatistics",
+          "research-finance",
+          "rd-budget",
+          "burn-rate",
+          "runway",
+          "fa-rate",
+          "capitalize-vs-expense",
+          "portfolio-roi",
+          "market-research",
+          "tam-sam-som",
+          "market-sizing",
+          "survey-design",
+          "sampling",
+          "segmentation",
+          "competitive-intelligence",
+          "product-research",
+          "ux-research",
+          "jtbd",
+          "usability",
+          "saturation",
+          "insight-synthesis",
+          "research-repository",
+          "onboarding",
+          "customization",
+          "autoresearch",
+          "matt-pocock",
+          "grill-with-docs"
+        ]
+      },
+      {
+        "name": "markdown-html-skills",
+        "description": "Convert long markdown files into world-class single-file interactive HTML — DOMAIN COMPLETE at v2.10.3 (5 skills). v2.10.3 adds md-slides — the slide-deck converter (arrow-key / Space / PgDn / Home / End / P keyboard navigation + presenter mode with split-view clock + speaker notes + next-slide preview + URL-hash deep linking like #3 + @media print page-per-slide for browser-native PDF export; reuses md-document's markdown parser; vanilla JS only; Prism.js opt-in via --syntax for code-heavy decks). Joins md-review (v2.10.2 code-review converter: 2-col diff + severity-tagged margin annotations + WCAG-1.4.1 badges + mandatory named reviewer footer), md-document (v2.10.1 long-form converter: sticky TOC + scrollspy + search + code-copy + Prism autoloader), markdown-html-orchestrator (v2.10.0 context: fork; deterministic doc-type classifier; refuses < 100 lines per Shihipar; refuses without onboarding), and design-system (v2.10.0 10-question onboarding wizard; WCAG-AA 12-token palette; project > global > defaults precedence; MARKDOWN_HTML_NO_CONFIG=1 bypass). 15 stdlib-only Python tools, 15 references citing 5-7 sources each, 4 template/schema assets. Inspired by Thariq Shihipar's Claude Code HTML output essay (Medium, 2026).",
+        "source": "./markdown-html",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "markdown",
+          "html",
+          "documentation",
+          "code-review",
+          "slides",
+          "design-system",
+          "single-file-html",
+          "brand-palette",
+          "wcag",
+          "onboarding",
+          "customization",
+          "shihipar",
+          "matt-pocock",
+          "grill-with-docs",
+          "context-fork"
+        ]
+      },
+      {
+        "name": "youtube-full",
+        "description": "YouTube transcripts, video search, channel browsing, playlist extraction, and upload monitoring via TranscriptAPI. BYOK — 100 free credits. OSS fallbacks: youtube-transcript-api / yt-dlp.",
+        "source": "./marketing-skill/skills/youtube-full",
+        "author": "therohitdas",
+        "tags": [
+          "youtube",
+          "transcript",
+          "video",
+          "channel",
+          "playlist",
+          "search",
+          "content-monitoring",
+          "marketing",
+          "transcriptapi"
+        ]
+      },
+      {
+        "name": "compliance-os",
+        "description": "Compliance OS — meta-orchestrator for multi-framework compliance programs spanning 9 frameworks (ISO 27001, ISO 13485, ISO 42001, ISO 14971, EU AI Act, MDR 745, GDPR, SOC 2, FDA QSR). Framework selector, cross-framework control mapper, audit simulator, and consolidated evidence-pool generator (stdlib Python), plus 3 cs-* compliance agents and 3 /cs:* readiness commands.",
+        "source": "./compliance-os",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "compliance",
+          "iso-27001",
+          "iso-42001",
+          "eu-ai-act",
+          "gdpr",
+          "soc2",
+          "audit",
+          "evidence",
+          "framework-mapping"
+        ]
+      },
+      {
+        "name": "snowflake-development",
+        "description": "Snowflake SQL, data pipelines (Dynamic Tables, Streams+Tasks), Cortex AI functions, Snowpark Python, and dbt integration. Includes query helper script, reference guides, and troubleshooting.",
+        "source": "./engineering-team/snowflake-development",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "snowflake",
+          "sql",
+          "data-pipelines",
+          "snowpark",
+          "dbt",
+          "cortex",
+          "data-warehouse"
+        ]
+      },
+      {
+        "name": "behuman",
+        "description": "Self-Mirror consciousness loop for human-like AI responses. Adds inner dialogue (Self → Mirror → Conscious Response) to make AI output feel authentic, not robotic. Zero dependencies — pure prompt technique.",
+        "source": "./engineering/behuman",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "prompting",
+          "voice",
+          "authenticity",
+          "self-mirror",
+          "writing"
+        ]
+      },
+      {
+        "name": "claude-coach",
+        "description": "Personal Claude power-user coach. Delivers a personalized, ranked cheat-code glossary on first activation, then surfaces at most one tip per turn when it would genuinely improve the next attempt. Ships cheat-codes glossary, coaching-rules decision tree, three stdlib Python tools, cs-claude-coach agent, and /cs:claude-coach command.",
+        "source": "./engineering/claude-coach",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "claude-code",
+          "coaching",
+          "power-user",
+          "tips",
+          "productivity"
+        ]
+      },
+      {
+        "name": "grill-with-docs",
+        "description": "Docs-anchored grilling session — interrogates a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), updating those files inline as terminology and decisions crystallise. Derived from Matt Pocock's MIT-licensed grill-with-docs with stdlib validators (CONTEXT.md linter, ADR scanner, glossary-code consistency), reference docs, cs-grill-with-docs agent, and /cs:grill-with-docs command.",
+        "source": "./engineering/grill-with-docs",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "planning",
+          "adr",
+          "context",
+          "ubiquitous-language",
+          "interrogation",
+          "matt-pocock"
+        ]
+      },
+      {
+        "name": "llm-cost-optimizer",
+        "description": "Cut LLM API spend via model routing, prompt caching, prompt compression, and per-feature cost observability. Use when AI costs are too high, choosing between models, or launching an AI feature without cost architecture. NOT for RAG design or prompt quality (separate skills).",
+        "source": "./engineering/llm-cost-optimizer",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "llm",
+          "cost-optimization",
+          "token-usage",
+          "model-routing",
+          "prompt-caching",
+          "observability"
+        ]
+      },
+      {
+        "name": "prompt-governance",
+        "description": "Manage prompts in production at scale: prompt versioning, A/B testing, prompt registries, regression prevention, and eval pipelines for production AI features. NOT for writing individual prompts, RAG design, or cost reduction (separate skills).",
+        "source": "./engineering/prompt-governance",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "prompts",
+          "versioning",
+          "ab-testing",
+          "registry",
+          "evals",
+          "regression",
+          "production-ai"
+        ]
+      },
+      {
+        "name": "business-investment-advisor",
+        "description": "Business investment analysis and capital allocation advisor. Evaluates equipment, real estate, new-business, hiring, and technology investments with ROI, IRR, NPV, payback period, build-vs-buy, lease-vs-buy, and vendor evaluation frameworks for allocating limited budget.",
+        "source": "./finance/business-investment-advisor",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "investment",
+          "capital-allocation",
+          "roi",
+          "irr",
+          "npv",
+          "build-vs-buy",
+          "finance"
+        ]
+      },
+      {
+        "name": "video-content-strategist",
+        "description": "Video content strategy: video scripts, YouTube channel optimization and SEO, short-form video pipelines (Reels, TikTok, Shorts), and repurposing long-form content into video. NOT for written blog content or caption-only social posts (separate skills).",
+        "source": "./marketing-skill/video-content-strategist",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "video",
+          "youtube",
+          "short-form",
+          "scripts",
+          "content-strategy",
+          "tiktok",
+          "reels"
+        ]
+      },
+      {
+        "name": "compliance-team-eu-ai-act",
+        "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance specialist: AI system risk classifier (Articles 5/6/50 + Annex III), conformity assessment planner (Article 43 + Annex IV checklist), and obligation tracker (provider/deployer/importer/distributor + GPAI Articles 51-55). Article-level references and cross-framework mapping to ISO 42001, NIST AI RMF, GDPR. Stdlib-only.",
+        "source": "./ra-qm-team/compliance-team-eu-ai-act",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "eu-ai-act",
+          "compliance",
+          "risk-classification",
+          "conformity-assessment",
+          "gpai",
+          "ai-regulation"
+        ]
+      },
+      {
+        "name": "compliance-team-iso42001",
+        "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist: AIMS gap analyzer (Clauses 4-10 coverage + remediation priority), AI risk register builder (Annex A 38 controls per ISO 23894), and AIMS audit scheduler (Clause 9.2 cadence + auditor independence). Cross-framework mapping to EU AI Act, NIST AI RMF, ISO 23894. Stdlib-only.",
+        "source": "./ra-qm-team/compliance-team-iso42001",
+        "author": "Alireza Rezvani",
+        "tags": [
+          "iso-42001",
+          "aims",
+          "ai-governance",
+          "risk-register",
+          "internal-audit",
+          "compliance"
+        ]
+      },
+      {
+        "name": "collab-proof",
+        "description": "Assisted retrospective: after a session, calibrates what Claude contributed vs what the developer drove. LLM-assessed 4-frame analysis with explicit rubric, zero dependencies.",
+        "source": "./engineering/collab-proof",
+        "author": "dong7812",
+        "tags": [
+          "ai-collaboration",
+          "session-retrospective",
+          "git-analysis",
+          "decision-logging",
+          "collab-proof"
+        ]
+      }
+    ]
+  },
+  {
+    "slug": "claude-octopus",
+    "name": "Claude Octopus",
+    "author": "nyldn",
+    "description": "Surface AI blindspots before you ship. Put up to 8 AI models on every research, design or coding task.",
+    "github": "https://github.com/nyldn/claude-octopus",
+    "stars": 3798,
+    "type": "marketplace",
+    "tags": [
+      "skills",
+      "commands"
+    ],
+    "contains": {
+      "plugins": 2
+    },
+    "highlights": [
+      "2 plugins in marketplace",
+      "Plugin declares: 58 skills, 50 commands",
+      "Web UI: https://reddit.com/r/ClaudeOctopus/"
+    ],
+    "website": "https://reddit.com/r/ClaudeOctopus/",
+    "plugins_list": [
+      {
+        "name": "octo",
+        "description": "v9.52.0 - Reliability wave: tangle contextual review correction loop with hard round ceiling, progress-supervised review rounds (per-agent stall watch, descendant-tree kills), council diversity and agy pin fixes, marketplace generator source-of-truth fix, provider troubleshooting runbook and cost-expectations docs. 32 personas, 50 commands, 58 skills. Run /octo:setup.",
+        "source": "https://github.com/nyldn/claude-octopus.git",
+        "author": "nyldn",
+        "tags": [
+          "multi-llm",
+          "multi-agent",
+          "orchestration",
+          "claude-code-plugin",
+          "codex",
+          "gemini",
+          "code-review",
+          "automation"
+        ]
+      },
+      {
+        "name": "img",
+        "description": "Generate and edit images with OpenAI GPT Image 2 and Gemini 3.1 Flash Image Preview.",
+        "source": "https://github.com/nyldn/img.git",
+        "author": "nyldn",
+        "tags": [
+          "image-generation",
+          "gpt-image-2",
+          "gemini-3.1-flash-image-preview",
+          "claude-code-plugin",
+          "codex"
         ]
       }
     ]
@@ -1756,7 +7378,7 @@
     "author": "davepoon",
     "description": "A single hub to find Claude Skills, Agents, Commands, Hooks, Plugins, and Marketplace collections to extend Claude Code, Claude Desktop, Agent SDK and OpenClaw",
     "github": "https://github.com/davepoon/buildwithclaude",
-    "stars": 2653,
+    "stars": 3164,
     "type": "marketplace",
     "tags": [
       "skills",
@@ -1765,20 +7387,77 @@
       "hooks"
     ],
     "contains": {
-      "plugins": 53,
+      "plugins": 78,
       "components": {
-        "skills": 134,
-        "commands": 357,
-        "agents": 234,
-        "hooks": 59
+        "skills": 35,
+        "commands": 190,
+        "agents": 131,
+        "hooks": 28
       }
     },
     "highlights": [
-      "53 plugins in marketplace",
+      "78 plugins in marketplace",
       "Web UI: https://www.buildwithclaude.com"
     ],
     "website": "https://buildwithclaude.com/",
     "plugins_list": [
+      {
+        "name": "tlsradar",
+        "description": "SSL/TLS certificate scanning, free Let's Encrypt issuance (private key stays local), and ongoing certificate-expiry monitoring — through a single remote MCP server. Free anonymous scans and cert issuance need no account; OAuth via /mcp unlocks ongoing monitoring.",
+        "source": "./plugins/tlsradar",
+        "author": "TLS Radar",
+        "tags": [
+          "ssl",
+          "tls",
+          "certificates",
+          "monitoring",
+          "letsencrypt",
+          "security",
+          "mcp"
+        ],
+        "components": {
+          "skills": 2,
+          "commands": 6
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "README",
+              "description": ""
+            },
+            {
+              "name": "certificate-monitoring",
+              "description": "Use when the user asks about SSL/TLS certificates, certificate expiration, monitoring domains for cert health, or issuing free Let's Encrypt certificates. Triggers include \"is my cert expiring\", \"scan ssl on X\", \"check certificate\", \"monitor this domain\", \"issue a free cert\", \"renew certificate\", \"Let's Encrypt\", \"TLS Radar\". This skill picks the right TLS Radar tool for each question."
+            }
+          ],
+          "commands": [
+            {
+              "name": "tls-cert",
+              "description": "Issue a free 90-day Let's Encrypt certificate"
+            },
+            {
+              "name": "tls-diagnose",
+              "description": "Verify the TLS Radar plugin's connection and configuration"
+            },
+            {
+              "name": "tls-monitor",
+              "description": "Manage ongoing certificate monitoring (list, add, remove)"
+            },
+            {
+              "name": "tls-renew",
+              "description": "Renew a Let's Encrypt certificate before it expires"
+            },
+            {
+              "name": "tls-scan",
+              "description": "Run a free SSL/TLS scan on a domain (no account required)"
+            },
+            {
+              "name": "tls-upgrade",
+              "description": "Open TLS Radar pricing or upgrade your plan"
+            }
+          ]
+        }
+      },
       {
         "name": "cashflow",
         "description": "Personal finance ledger for AI agents. Connect bank accounts via Plaid, query spending, track recurring bills, categorize transactions, and get financial recaps through MCP tools with OAuth authentication.",
@@ -1796,6 +7475,234 @@
         ],
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "recap",
+              "description": "Triggered by \"monthly recap\", \"how did I do this month\", \"spending summary\", \"financial review\", \"weekly recap\", \"quarterly review\", \"year in review\""
+            },
+            {
+              "name": "tidy",
+              "description": "Triggered by \"tidy up\", \"clean up transactions\", \"categorize uncategorized\", \"organize my transactions\""
+            }
+          ]
+        }
+      },
+      {
+        "name": "claude-ops",
+        "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and 4 parallel C-suite agents (YOLO mode).",
+        "source": "./plugins/claude-ops",
+        "author": "Lifecycle Innovations Limited",
+        "tags": [
+          "business",
+          "operations",
+          "communications",
+          "whatsapp",
+          "email",
+          "slack",
+          "telegram",
+          "infrastructure",
+          "revenue",
+          "stripe",
+          "monitoring",
+          "datadog",
+          "yolo",
+          "orchestration",
+          "daemon"
+        ],
+        "components": {
+          "skills": 30,
+          "agents": 14,
+          "hooks": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "ops-comms",
+              "description": "Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, notion, or natural language like \"send [msg] to [contact]\"."
+            },
+            {
+              "name": "ops-daemon",
+              "description": "Check claude-ops background daemon end-to-end and auto-fix common issues. Detects stale plist paths after plugin upgrades, missing service commands, dead processes, corrupt health files, and bash version mismatches."
+            },
+            {
+              "name": "ops-dash",
+              "description": "Interactive pixel-art command center dashboard. Visual business HQ with instant hotkey navigation to all ops commands, live status indicators, fire alerts, C-suite reports, settings, sharing, and FAQ."
+            },
+            {
+              "name": "ops-deploy",
+              "description": "Deploy status across all projects. Shows ECS service versions, Vercel deployments, recent deploys, pending deploys, and CI/CD pipeline state."
+            },
+            {
+              "name": "ops-doctor",
+              "description": "Health check and auto-repair for the ops plugin. Diagnoses manifest errors, broken permissions, invalid configs, stale caches, and missing files — then spawns an agent to fix everything automatically."
+            },
+            {
+              "name": "ops-ecom",
+              "description": "Shopify store command center. Orders, inventory, fulfillment, analytics, and store health. Works with any Shopify store via Admin API."
+            },
+            {
+              "name": "ops-fires",
+              "description": "Production incidents dashboard. Reads ECS health, Sentry errors, CI failures. Offers to dispatch fix agents for active fires."
+            },
+            {
+              "name": "ops-go",
+              "description": "Token-efficient morning briefing. Pre-gathers all data via shell scripts, then presents a unified business dashboard with prioritized actions."
+            },
+            {
+              "name": "ops-gtm",
+              "description": "Go-to-market strategy planner. Generates a complete GTM plan across paid, unpaid, marketing, sales, and AI-automation channels for any project — and hands executable campaigns off to /marketing."
+            },
+            {
+              "name": "ops-inbox",
+              "description": "Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations."
+            },
+            {
+              "name": "ops-integrate",
+              "description": "Add any SaaS API as a first-class integration. Provide the service name — ops-integrate discovers auth patterns, tests connectivity, and registers the API in your partner registry so it's available to other skills."
+            },
+            {
+              "name": "ops-linear",
+              "description": "Linear command center. Shows current sprint, creates/updates issues, manages priorities, syncs with GSD phases."
+            },
+            {
+              "name": "ops-marketing",
+              "description": "Marketing command center. Email campaigns (Klaviyo), paid ads (Meta/Google), analytics (GA4), SEO, and social media metrics. One dashboard for all marketing channels."
+            },
+            {
+              "name": "ops-merge",
+              "description": "Autonomous PR merge pipeline. Scans all repos for open PRs, dispatches subagents to fix CI, resolve conflicts, address review comments, then merges. Use --main to also sync dev↔main branches."
+            },
+            {
+              "name": "ops-monitor",
+              "description": "Unified APM and monitoring surface. Polls Datadog, New Relic, and OpenTelemetry backends for active alerts, error traces, and entity health. Use --watch for live polling every 60 seconds. Use --setup to configure monitoring credentials."
+            },
+            {
+              "name": "ops-next",
+              "description": "Business-level \"what should I do next\". Priority stack — fires > unread comms > ready-to-merge PRs > Linear sprint > revenue-generating GSD work. Uses pre-gathered data and routes to the right skill."
+            },
+            {
+              "name": "ops-orchestrate",
+              "description": "Autonomous multi-project orchestration engine. Audits all registered projects, structures work into dependency-wired tasks, dispatches parallel agents (subagents or Agent Teams), audits completions, and ships PRs. Registry-driven — works for any user with a configured project registry."
+            },
+            {
+              "name": "ops-package",
+              "description": "Ship parcels via any configured carrier — MyParcel, Sendcloud, DHL Parcel NL, PostNL, DPD, UPS, FedEx. Auto-selects the first carrier whose credentials are configured, or pass --carrier <name> to override. Verbs: ship, label, track, list, carriers."
+            },
+            {
+              "name": "ops-projects",
+              "description": "Portfolio dashboard for all GSD-tracked projects. Scans ~/Projects and ~/gsd-workspaces for .planning/ directories, shows phase status, git state, blockers, and next actions for every project. Run /ops projects to see the full portfolio."
+            },
+            {
+              "name": "ops-revenue",
+              "description": "Revenue and costs tracker. AWS spend via aws ce, credits tracker, project revenue stages. Shows burn rate, runway estimate, credits expiring."
+            },
+            {
+              "name": "ops-settings",
+              "description": "Post-setup credential manager. Shows current integration status (configured/missing/expired) and lets you update individual credentials without re-running the full setup wizard. Runs a smoke test after each update."
+            },
+            {
+              "name": "ops-speedup",
+              "description": "Cross-platform, hardware-adaptive system optimizer. Auto-detects macOS / Linux / WSL / Windows (MINGW/Cygwin/MSYS2) and CPU/RAM/disk/GPU profile, then picks the right cleanup strategy. Scans reclaimable disk space, memory pressure, runaway processes, startup bloat, network issues. CleanMyMac built into Claude Code."
+            },
+            {
+              "name": "ops-status",
+              "description": "Lightweight green/red status panel for every configured integration. No gather, no actions."
+            },
+            {
+              "name": "ops-triage",
+              "description": "Cross-platform issue triage. Pulls from Sentry (MCP), Linear (MCP), GitHub Issues (gh). Cross-references against code to find already-fixed issues. Auto-resolves fixed ones. Dispatches agents for active issues."
+            },
+            {
+              "name": "ops-voice",
+              "description": "Voice operations — make phone calls (Bland AI), text-to-speech (ElevenLabs), transcribe audio (Whisper/Groq). Replace OpenClaw voice capabilities."
+            },
+            {
+              "name": "ops-whatsapp-biz",
+              "description": "WhatsApp Business Cloud API — send approved template messages at scale, manage templates with approval tracking, and integrate product catalogs. Separate from wacli personal WhatsApp."
+            },
+            {
+              "name": "ops-yolo",
+              "description": "YOLO mode. Spawns 4 parallel C-suite agents (CEO, CTO, CFO, COO). Each analyzes the business from their perspective using ALL available data. Produces unfiltered Hard Truths report. After user types YOLO, autonomously runs the business for a day using /loop."
+            },
+            {
+              "name": "ops",
+              "description": "Business operations command center. Routes to the right ops command based on what you need — briefing, inbox, fires, projects, comms, triage, linear, revenue, deploy, or yolo mode."
+            },
+            {
+              "name": "setup",
+              "description": "Interactive setup wizard for the claude-ops plugin. Installs missing CLIs, configures env vars for each channel (Telegram, WhatsApp, Email, Slack, Notion, Linear, Sentry, Vercel), builds the project registry, and saves user preferences. Run once after installing the plugin or any time to reconfigure."
+            },
+            {
+              "name": "uninstall",
+              "description": "Completely remove claude-ops plugin, all stored credentials, cached files, shell exports, and MCP registrations. Confirms each step before deletion."
+            }
+          ],
+          "agents": [
+            {
+              "name": "comms-scanner",
+              "description": "Scans all communication channels for FULL inbox state (not just unread). Classifies each conversation as NEEDS_REPLY, WAITING, or HANDLED. Returns structured JSON. Used by ops-inbox and ops-go."
+            },
+            {
+              "name": "daemon-agent",
+              "description": "Manages the ops background daemon — start, stop, restart services, check health"
+            },
+            {
+              "name": "doctor-agent",
+              "description": "Diagnoses and auto-fixes ops plugin configuration errors, manifest issues, broken permissions, invalid JSON, and stale cache copies."
+            },
+            {
+              "name": "infra-monitor",
+              "description": "Multi-service infrastructure health checker. Probes every AWS service the caller has IAM access to (ECS, EC2, RDS, Lambda, S3, CloudFront, ALB/NLB, API Gateway, SQS, SNS, DynamoDB, ElastiCache, Route 53, ACM, CloudWatch, Budgets, IAM) plus Vercel and GitHub Actions. Returns structured JSON with service health, accessible/inaccessible service lists, and severity-ranked anomaly flags. Used by ops-fires and ops-deploy."
+            },
+            {
+              "name": "marketing-optimizer",
+              "description": "Cross-platform ad budget optimization — reads Meta + Google Ads data, computes blended ROAS for top-line health plus segmented (brand/non-brand, prospecting/retargeting) ROAS, and recommends specific budget shifts."
+            },
+            {
+              "name": "memory-extractor",
+              "description": "Background agent that extracts user profiles, contact cards, and behavioral patterns from chat history. Runs as a daemon service every 30 min."
+            },
+            {
+              "name": "monitor-agent",
+              "description": "Lightweight APM and metrics probe agent. Queries Datadog, New Relic, and OpenTelemetry backends for active alerts, error traces, and entity health. Returns structured JSON. Read-only — used by ops-monitor skill."
+            },
+            {
+              "name": "project-scanner",
+              "description": "Git, PR, and CI status scanner across all registered repos. Returns structured JSON with branch state, uncommitted files, open PRs, and CI status for each project."
+            },
+            {
+              "name": "revenue-tracker",
+              "description": "Revenue, billing, and credits analysis agent. Pulls real revenue data from Stripe (SaaS) and RevenueCat (mobile subs), queries AWS Cost Explorer for spend, and cross-references project revenue stages. Returns structured financial snapshot."
+            },
+            {
+              "name": "triage-agent",
+              "description": "Investigates a specific issue from Sentry, Linear, or GitHub. Finds the root cause in code, checks if it's already fixed, and either confirms resolution or creates a fix branch with a PR."
+            },
+            {
+              "name": "yolo-ceo",
+              "description": "Strategic priority agent. Analyzes the business from a CEO perspective — growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating. Runs in parallel with CTO/CFO/COO."
+            },
+            {
+              "name": "yolo-cfo",
+              "description": "Financial analysis agent. Follows the money — AWS burn rate, runway, ROI on current work, credits expiry, cost anomalies. No optimism without data."
+            },
+            {
+              "name": "yolo-coo",
+              "description": "Operations execution agent. Finds what's falling through the cracks — stale work, broken processes, missing automation, communication failures. What the CEO doesn't see."
+            },
+            {
+              "name": "yolo-cto",
+              "description": "Technical health agent. Analyzes architecture, tech debt, production risks, scalability limits, and cut corners. Brutally honest about what will break."
+            }
+          ],
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -1814,7 +7721,126 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "setup",
+              "description": "Configure claude-hud as your Claude Code statusline"
+            }
+          ]
         }
+      },
+      {
+        "name": "claude-pager",
+        "description": "Native desktop notifications when Claude Code needs your attention",
+        "source": "./plugins/claude-pager",
+        "author": "Bharat Gupta",
+        "tags": [
+          "notifications",
+          "alerts",
+          "desktop",
+          "sound",
+          "pager",
+          "idle",
+          "permission",
+          "task-completion",
+          "productivity"
+        ],
+        "components": {
+          "hooks": 1
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "slopmop",
+        "description": "Quality gates for AI-assisted codebases. Provides refit onboarding, the swab/scour/buff/sail remediation loop, and barnacle friction reporting as a Claude skill and slash commands.",
+        "source": "./plugins/slopmop",
+        "author": "ScienceIsNeato",
+        "tags": [
+          "quality-gate",
+          "linting",
+          "testing",
+          "code-quality",
+          "ci-cd",
+          "ai",
+          "llm",
+          "vibe-coding",
+          "remediation",
+          "pre-pr",
+          "claude-code-plugin"
+        ],
+        "components": {
+          "skills": 1,
+          "commands": 6
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "slopmop",
+              "description": ">-"
+            }
+          ],
+          "commands": [
+            {
+              "name": "sm-barnacle",
+              "description": "Report slop-mop tooling friction with a structured barnacle"
+            },
+            {
+              "name": "sm-buff",
+              "description": "Triage pull request CI results and review feedback with slop-mop"
+            },
+            {
+              "name": "sm-refit",
+              "description": "Run slop-mop's one-time repository onboarding remediation rail"
+            },
+            {
+              "name": "sm-sail",
+              "description": "Auto-advance the slop-mop workflow loop for this repository"
+            },
+            {
+              "name": "sm-scour",
+              "description": "Run slop-mop's comprehensive pre-PR sweep for this repository"
+            },
+            {
+              "name": "sm-swab",
+              "description": "Run slop-mop's fast iterative development validation loop"
+            }
+          ]
+        }
+      },
+      {
+        "name": "archcore",
+        "description": "Make your AI agent code with your project's architecture, rules, and decisions. Git-native context (folder conventions, ADRs, team standards) so new code lands in the right place and decisions persist across sessions and agents.",
+        "source": "archcore-ai/plugin",
+        "author": "Archcore",
+        "tags": [
+          "claude-code",
+          "cursor",
+          "claude-code-plugin",
+          "mcp",
+          "ai-agents",
+          "ai-coding",
+          "context-engineering",
+          "architecture",
+          "adr",
+          "knowledge-management",
+          "rules",
+          "decisions",
+          "conventions",
+          "git-native",
+          "skills",
+          "subagents",
+          "spec-driven",
+          "documentation"
+        ]
       },
       {
         "name": "agents-blockchain-web3",
@@ -1830,6 +7856,18 @@
         ],
         "components": {
           "agents": 2
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "blockchain-developer",
+              "description": "Develop smart contracts, DeFi protocols, and Web3 applications. Expertise in Solidity, security auditing, and gas optimization. Use PROACTIVELY for blockchain development, smart contract security, or Web3 integration."
+            },
+            {
+              "name": "hyperledger-fabric-developer",
+              "description": "Develop enterprise blockchain solutions with Hyperledger Fabric v2.5 LTS and v3.x. Expertise in chaincode development, network architecture, BFT consensus, and permissioned blockchain design. Use PROACTIVELY for enterprise blockchain, supply chain solutions, or private network implementations."
+            }
+          ]
         }
       },
       {
@@ -1848,6 +7886,26 @@
         ],
         "components": {
           "agents": 4
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "business-analyst",
+              "description": "Analyze metrics, create reports, and track KPIs. Builds dashboards, revenue models, and growth projections. Use PROACTIVELY for business metrics or investor updates."
+            },
+            {
+              "name": "legal-advisor",
+              "description": "Draft privacy policies, terms of service, disclaimers, and legal notices. Creates GDPR-compliant texts, cookie policies, and data processing agreements. Use PROACTIVELY for legal documentation, compliance texts, or regulatory requirements."
+            },
+            {
+              "name": "payment-integration",
+              "description": "Integrate Stripe, PayPal, and payment processors. Handles checkout flows, subscriptions, webhooks, and PCI compliance. Use PROACTIVELY when implementing payments, billing, or subscription features."
+            },
+            {
+              "name": "quant-analyst",
+              "description": "Build financial models, backtest trading strategies, and analyze market data. Implements risk metrics, portfolio optimization, and statistical arbitrage. Use PROACTIVELY for quantitative finance, trading algorithms, or risk analysis."
+            }
+          ]
         }
       },
       {
@@ -1867,6 +7925,30 @@
         ],
         "components": {
           "agents": 5
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "arbitrage-bot",
+              "description": "Identify and execute cryptocurrency arbitrage opportunities across exchanges and DeFi protocols. Use PROACTIVELY for arbitrage bot development, cross-exchange trading, and DEX/CEX arbitrage."
+            },
+            {
+              "name": "crypto-analyst",
+              "description": "Perform cryptocurrency market analysis, on-chain analytics, and sentiment analysis. Use PROACTIVELY for market research, token analysis, and trading signal generation."
+            },
+            {
+              "name": "crypto-risk-manager",
+              "description": "Implement risk management systems for cryptocurrency trading and DeFi positions. Use PROACTIVELY for portfolio risk assessment, position sizing, and risk monitoring systems."
+            },
+            {
+              "name": "crypto-trader",
+              "description": "Build cryptocurrency trading systems, implement trading strategies, and integrate with exchange APIs. Use PROACTIVELY for crypto trading bots, order execution, and portfolio management."
+            },
+            {
+              "name": "defi-strategist",
+              "description": "Design and implement DeFi yield strategies, liquidity provision, and protocol interactions. Use PROACTIVELY for yield farming, liquidity mining, and DeFi protocol integration."
+            }
+          ]
         }
       },
       {
@@ -1880,6 +7962,7 @@
           "data-ai",
           "ai-engineer",
           "context-manager",
+          "data-analyst",
           "data-engineer",
           "data-scientist",
           "hackathon-ai-strategist",
@@ -1891,7 +7974,59 @@
           "task-decomposition-expert"
         ],
         "components": {
-          "agents": 11
+          "agents": 12
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ai-engineer",
+              "description": "Build LLM applications, RAG systems, and prompt pipelines. Implements vector search, agent orchestration, and AI API integrations. Use PROACTIVELY for LLM features, chatbots, or AI-powered applications."
+            },
+            {
+              "name": "context-manager",
+              "description": "Manages context across multiple agents and long-running tasks. Use PROACTIVELY when coordinating complex multi-agent workflows or when context needs to be preserved across multiple sessions. MUST BE USED for projects exceeding 10k tokens."
+            },
+            {
+              "name": "data-analyst",
+              "description": "Quantitative analysis, statistical insights, and data-driven research. Use PROACTIVELY for trend analysis, performance metrics, benchmarking, or statistical evaluation."
+            },
+            {
+              "name": "data-engineer",
+              "description": "Build ETL pipelines, data warehouses, and streaming architectures. Implements Spark jobs, Airflow DAGs, and Kafka streams. Use PROACTIVELY for data pipeline design or analytics infrastructure."
+            },
+            {
+              "name": "data-scientist",
+              "description": "Data analysis expert for SQL queries, BigQuery operations, and data insights. Use proactively for data analysis tasks and queries."
+            },
+            {
+              "name": "hackathon-ai-strategist",
+              "description": "Expert guidance on hackathon strategy, AI solution ideation, and project evaluation. Provides judge-perspective feedback, brainstorms winning AI concepts, and assesses project feasibility for tight timeframes."
+            },
+            {
+              "name": "llms-maintainer",
+              "description": "Generates and maintains llms.txt roadmap files for AI crawler navigation. Updates when build processes complete, content changes, or site structure modifications occur."
+            },
+            {
+              "name": "ml-engineer",
+              "description": "Implement ML pipelines, model serving, and feature engineering. Handles TensorFlow/PyTorch deployment, A/B testing, and monitoring. Use PROACTIVELY for ML model integration or production deployment."
+            },
+            {
+              "name": "mlops-engineer",
+              "description": "Build ML pipelines, experiment tracking, and model registries. Implements MLflow, Kubeflow, and automated retraining. Handles data versioning and reproducibility. Use PROACTIVELY for ML infrastructure, experiment management, or pipeline automation."
+            },
+            {
+              "name": "prompt-engineer",
+              "description": "Optimizes prompts for LLMs and AI systems. Use when building AI features, improving agent performance, or crafting system prompts. Expert in prompt patterns and techniques."
+            },
+            {
+              "name": "search-specialist",
+              "description": "You are a search specialist expert at finding and synthesizing information from the web. Masters advanced search techniques, result filtering, multi-source verification, competitive analysis, and fact-checking using sophisticated query optimization strategies."
+            },
+            {
+              "name": "task-decomposition-expert",
+              "description": "Break down complex user goals into actionable tasks and identify optimal combinations of tools, agents, and workflows for system integration."
+            }
+          ]
         }
       },
       {
@@ -1908,6 +8043,18 @@
         ],
         "components": {
           "agents": 2
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "accessibility-specialist",
+              "description": "Ensure web applications meet WCAG 2.1 AA/AAA standards. Implements ARIA attributes, keyboard navigation, and screen reader support. Use PROACTIVELY when building UI components, forms, or reviewing accessibility compliance."
+            },
+            {
+              "name": "ui-ux-designer",
+              "description": "Design user interfaces and experiences with modern design principles, accessibility standards, and design systems. Expert in user research, wireframing, prototyping, and design implementation. Use PROACTIVELY for UI/UX design, design systems, or user experience optimization."
+            }
+          ]
         }
       },
       {
@@ -1926,13 +8073,66 @@
           "graphql-architect",
           "ios-developer",
           "laravel-vue-developer",
+          "legacy-modernizer",
           "mobile-developer",
           "nextjs-app-router-developer",
           "react-performance-optimization",
           "wordpress-developer"
         ],
         "components": {
-          "agents": 11
+          "agents": 12
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "backend-architect",
+              "description": "Design RESTful APIs, microservice boundaries, and database schemas. Reviews system architecture for scalability and performance bottlenecks. Use PROACTIVELY when creating new backend services or APIs."
+            },
+            {
+              "name": "directus-developer",
+              "description": "Build and customize Directus applications with extensions, hooks, and API integrations. Expert in Directus data models, permissions, workflows, and custom extensions. Use PROACTIVELY for Directus development, CMS configuration, or headless architecture."
+            },
+            {
+              "name": "drupal-developer",
+              "description": "Build and customize Drupal applications with custom modules, themes, and integrations. Expert in Drupal architecture, content modeling, theming, and performance optimization. Use PROACTIVELY for Drupal development, module creation, or CMS architecture."
+            },
+            {
+              "name": "frontend-developer",
+              "description": "Build Next.js applications with React components, shadcn/ui, and Tailwind CSS. Expert in SSR/SSG, app router, and modern frontend patterns. Use PROACTIVELY for Next.js development, UI component creation, or frontend architecture."
+            },
+            {
+              "name": "graphql-architect",
+              "description": "Design GraphQL schemas, resolvers, and federation. Optimizes queries, solves N+1 problems, and implements subscriptions. Use PROACTIVELY for GraphQL API design or performance issues."
+            },
+            {
+              "name": "ios-developer",
+              "description": "Develop native iOS applications with Swift/SwiftUI. Masters UIKit/SwiftUI, Core Data, networking, and app lifecycle. Use PROACTIVELY for iOS-specific features, App Store optimization, or native iOS development."
+            },
+            {
+              "name": "laravel-vue-developer",
+              "description": "Build full-stack Laravel applications with Vue3 frontend. Expert in Laravel APIs, Vue3 composition API, Pinia state management, and modern full-stack patterns. Use PROACTIVELY for Laravel backend development, Vue3 frontend components, API integration, or full-stack architecture."
+            },
+            {
+              "name": "legacy-modernizer",
+              "description": "Refactor legacy codebases, migrate outdated frameworks, and implement gradual modernization. Handles technical debt, dependency updates, and backward compatibility. Use PROACTIVELY for legacy system updates, framework migrations, or technical debt reduction."
+            },
+            {
+              "name": "mobile-developer",
+              "description": "Develop React Native or Flutter apps with native integrations. Handles offline sync, push notifications, and app store deployments. Use PROACTIVELY for mobile features, cross-platform code, or app optimization."
+            },
+            {
+              "name": "nextjs-app-router-developer",
+              "description": "Build modern Next.js applications using App Router with Server Components, Server Actions, PPR, and advanced caching strategies. Expert in Next.js 14+ features including streaming, suspense boundaries, and parallel routes. Use PROACTIVELY for Next.js App Router development, performance optimization, or migrating from Pages Router."
+            },
+            {
+              "name": "react-performance-optimization",
+              "description": "You are a React Performance Optimization specialist focusing on identifying, analyzing, and resolving performance bottlenecks in React applications. Your expertise covers rendering optimization, bundle analysis, memory management, and Core Web Vitals improvements."
+            },
+            {
+              "name": "wordpress-developer",
+              "description": "Build professional WordPress solutions with custom themes, plugins, and advanced functionality. Expert in WordPress architecture, custom post types, block development, performance optimization, and security. Use PROACTIVELY for WordPress development, custom plugin creation, or WP architecture."
+            }
+          ]
         }
       },
       {
@@ -1955,6 +8155,42 @@
         ],
         "components": {
           "agents": 8
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "cloud-architect",
+              "description": "Design AWS/Azure/GCP infrastructure, implement Terraform IaC, and optimize cloud costs. Handles auto-scaling, multi-region deployments, and serverless architectures. Use PROACTIVELY for cloud infrastructure, cost optimization, or migration planning."
+            },
+            {
+              "name": "database-admin",
+              "description": "Manage database operations, backups, replication, and monitoring. Handles user permissions, maintenance tasks, and disaster recovery. Use PROACTIVELY for database setup, operational issues, or recovery procedures."
+            },
+            {
+              "name": "database-optimization",
+              "description": "Database performance specialist focusing on query optimization, indexing strategies, schema design, connection pooling, and database monitoring. Covers SQL optimization, NoSQL tuning, and architecture best practices."
+            },
+            {
+              "name": "database-optimizer",
+              "description": "Optimize SQL queries, design efficient indexes, and handle database migrations. Solves N+1 problems, slow queries, and implements caching. Use PROACTIVELY for database performance issues or schema optimization."
+            },
+            {
+              "name": "deployment-engineer",
+              "description": "Configure CI/CD pipelines, Docker containers, and cloud deployments. Handles GitHub Actions, Kubernetes, and infrastructure automation. Use PROACTIVELY when setting up deployments, containers, or CI/CD workflows."
+            },
+            {
+              "name": "devops-troubleshooter",
+              "description": "Debug production issues, analyze logs, and fix deployment failures. Masters monitoring tools, incident response, and root cause analysis. Use PROACTIVELY for production debugging or system outages."
+            },
+            {
+              "name": "network-engineer",
+              "description": "Debug network connectivity, configure load balancers, and analyze traffic patterns. Handles DNS, SSL/TLS, CDN setup, and network security. Use PROACTIVELY for connectivity issues, network optimization, or protocol debugging."
+            },
+            {
+              "name": "terraform-specialist",
+              "description": "Write Terraform modules and manage infrastructure as code. Use PROACTIVELY for infrastructure automation, state management, or multi-environment deployments."
+            }
+          ]
         }
       },
       {
@@ -1981,6 +8217,58 @@
         ],
         "components": {
           "agents": 12
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "c-developer",
+              "description": "C programming expert for systems programming and embedded development. Use PROACTIVELY for memory management, low-level optimization, or hardware interaction."
+            },
+            {
+              "name": "cpp-engineer",
+              "description": "Write idiomatic C++ code with modern features, RAII, smart pointers, and STL algorithms. Handles templates, move semantics, and performance optimization. Use PROACTIVELY for C++ refactoring, memory safety, or complex C++ patterns."
+            },
+            {
+              "name": "golang-expert",
+              "description": "Write idiomatic Go code with goroutines, channels, and interfaces. Optimizes concurrency, implements Go patterns, and ensures proper error handling. Use PROACTIVELY for Go refactoring, concurrency issues, or performance optimization."
+            },
+            {
+              "name": "java-developer",
+              "description": "Master modern Java with streams, concurrency, and JVM optimization. Handles Spring Boot, reactive programming, and enterprise patterns. Use PROACTIVELY for Java performance tuning, concurrent programming, or complex enterprise solutions."
+            },
+            {
+              "name": "javascript-developer",
+              "description": "JavaScript expert for modern ES6+, async patterns, and Node.js. Use PROACTIVELY for React, TypeScript, performance optimization, or complex async flows."
+            },
+            {
+              "name": "php-developer",
+              "description": "Write idiomatic PHP code with design patterns, SOLID principles, and modern best practices. Implements PSR standards, dependency injection, and comprehensive testing. Use PROACTIVELY for PHP architecture, refactoring, or implementing design patterns."
+            },
+            {
+              "name": "python-expert",
+              "description": "Write idiomatic Python code with advanced features like decorators, generators, and async/await. Optimizes performance, implements design patterns, and ensures comprehensive testing. Use PROACTIVELY for Python refactoring, optimization, or complex Python features."
+            },
+            {
+              "name": "rails-expert",
+              "description": "Build scalable Rails applications with modern patterns and best practices. Implements service objects, background jobs, and API design. Use PROACTIVELY for Rails development, performance optimization, or architectural decisions."
+            },
+            {
+              "name": "ruby-expert",
+              "description": "Write idiomatic Ruby code following best practices and design patterns. Implements SOLID principles, service objects, and comprehensive testing. Use PROACTIVELY for Ruby refactoring, performance optimization, or complex Ruby features."
+            },
+            {
+              "name": "rust-expert",
+              "description": "Write idiomatic Rust code with ownership, lifetimes, and type safety. Implements concurrent systems, async programming, and memory-safe abstractions. Use PROACTIVELY for Rust development, systems programming, or performance-critical code."
+            },
+            {
+              "name": "sql-expert",
+              "description": "Write complex SQL queries and optimize database performance. Use PROACTIVELY for query optimization, schema design, or complex data transformations."
+            },
+            {
+              "name": "typescript-expert",
+              "description": "Write type-safe TypeScript with advanced type system features, generics, and utility types. Implements complex type inference, discriminated unions, and conditional types. Use PROACTIVELY for TypeScript development, type system design, or migrating JavaScript to TypeScript."
+            }
+          ]
         }
       },
       {
@@ -2010,6 +8298,70 @@
         ],
         "components": {
           "agents": 15
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-security-audit",
+              "description": "Conduct security audits for REST APIs and identify vulnerabilities. Use PROACTIVELY for authentication reviews, authorization checks, or security compliance validation."
+            },
+            {
+              "name": "architect-review",
+              "description": "Reviews code changes for architectural consistency and patterns. Use PROACTIVELY after any structural changes, new services, or API modifications. Ensures SOLID principles, proper layering, and maintainability."
+            },
+            {
+              "name": "code-reviewer",
+              "description": "Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code."
+            },
+            {
+              "name": "command-expert",
+              "description": "Create CLI commands for automation and tooling. Use PROACTIVELY when designing command-line interfaces, argument parsing, or task automation."
+            },
+            {
+              "name": "debugger",
+              "description": "Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues, build failures, runtime errors, or unexpected test results."
+            },
+            {
+              "name": "dx-optimizer",
+              "description": "Developer Experience specialist. Improves tooling, setup, and workflows. Use PROACTIVELY when setting up new projects, after team feedback, or when development friction is noticed."
+            },
+            {
+              "name": "error-detective",
+              "description": "Search logs for error patterns and identify root causes. Use PROACTIVELY when debugging issues, analyzing logs, or investigating production errors."
+            },
+            {
+              "name": "incident-responder",
+              "description": "Handles production incidents with urgency and precision. Use IMMEDIATELY when production issues occur. Coordinates debugging, implements fixes, and documents post-mortems."
+            },
+            {
+              "name": "mcp-security-auditor",
+              "description": "You are an MCP Security Auditor specializing in reviewing MCP server implementations for vulnerabilities, designing authentication systems, and ensuring compliance. Use when implementing OAuth 2.1, designing RBAC, conducting security reviews, or auditing MCP servers."
+            },
+            {
+              "name": "mcp-server-architect",
+              "description": "Designs and implements MCP servers with transport layers, tool/resource/prompt definitions, completion support, session management, and protocol compliance. Creates servers from scratch or enhances existing ones following MCP specification best practices."
+            },
+            {
+              "name": "mcp-testing-engineer",
+              "description": "Tests, debugs, and ensures quality for MCP servers including JSON schema validation, protocol compliance, security vulnerability assessment, load testing, and comprehensive debugging. Provides automated testing strategies and detailed quality reports."
+            },
+            {
+              "name": "performance-engineer",
+              "description": "Profile applications, optimize bottlenecks, and implement caching strategies. Handles load testing, CDN setup, and query optimization. Use PROACTIVELY for performance issues or optimization tasks."
+            },
+            {
+              "name": "review-agent",
+              "description": "You are a specialized quality assurance agent for knowledge management systems. Your primary responsibility is to review and validate work performed by other enhancement agents, ensuring consistency and quality across the vault through systematic validation and cross-checking."
+            },
+            {
+              "name": "security-auditor",
+              "description": "Review code for vulnerabilities, implement secure authentication, and ensure OWASP compliance. Handles JWT, OAuth2, CORS, CSP, and encryption. Use PROACTIVELY for security reviews, auth flows, or vulnerability fixes."
+            },
+            {
+              "name": "test-automator",
+              "description": "Create comprehensive test suites with unit, integration, and e2e tests. Sets up CI pipelines, mocking strategies, and test data. Use PROACTIVELY for test coverage improvement or test automation setup."
+            }
+          ]
         }
       },
       {
@@ -2026,65 +8378,323 @@
           "risk-manager",
           "sales-automator",
           "social-media-clip-creator",
-          "social-media-copywriter"
+          "social-media-copywriter",
+          "twitter-ai-influencer-manager"
         ],
         "components": {
-          "agents": 6
+          "agents": 7
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "content-marketer",
+              "description": "Write blog posts, social media content, and email newsletters. Optimizes for SEO and creates content calendars. Use PROACTIVELY for marketing content or social media posts."
+            },
+            {
+              "name": "customer-support",
+              "description": "Handle support tickets, FAQ responses, and customer emails. Creates help docs, troubleshooting guides, and canned responses. Use PROACTIVELY for customer inquiries or support documentation."
+            },
+            {
+              "name": "risk-manager",
+              "description": "You are a risk manager specializing in portfolio protection and risk measurement. Monitor portfolio risk, R-multiples, and position limits. Creates hedging strategies, calculates expectancy, and implements stop-losses for comprehensive risk assessment and trade tracking."
+            },
+            {
+              "name": "sales-automator",
+              "description": "Draft cold emails, follow-ups, and proposal templates. Creates pricing pages, case studies, and sales scripts. Use PROACTIVELY for sales outreach or lead nurturing."
+            },
+            {
+              "name": "social-media-clip-creator",
+              "description": "Creates optimized video clips for social media platforms from longer content. Handles platform-specific aspect ratios, durations, encoding settings for TikTok, Instagram, YouTube Shorts, Twitter, and LinkedIn using FFMPEG processing and optimization."
+            },
+            {
+              "name": "social-media-copywriter",
+              "description": "You are an expert social media copywriter specializing in podcast promotion. Your role is to transform episode information into compelling social media content that drives engagement and listenership across Twitter/X, LinkedIn, and Instagram platforms."
+            },
+            {
+              "name": "twitter-ai-influencer-manager",
+              "description": "Interact with Twitter around AI thought leaders and influencers. Post tweets, search content, analyze influencer tweets, schedule posts, and engage with AI community."
+            }
+          ]
         }
       },
       {
         "name": "agents-specialized-domains",
-        "description": "Domain-specific expert agents for research, documentation, and specialized tasks",
+        "description": "Domain-specific expert agents for validation, knowledge-graph, and other specialized tasks",
         "source": "./plugins/agents-specialized-domains",
         "author": "BuildWithClaude Community",
         "tags": [
           "agents",
           "subagents",
           "specialized-domains",
-          "academic-research-synthesizer",
-          "academic-researcher",
-          "agent-expert",
-          "api-documenter",
-          "audio-quality-controller",
-          "comprehensive-researcher",
           "connection-agent",
-          "data-analyst",
-          "docusaurus-expert",
-          "episode-orchestrator",
           "game-developer",
-          "legacy-modernizer",
-          "markdown-syntax-formatter",
-          "market-research-analyst",
-          "mcp-deployment-orchestrator",
-          "mcp-expert",
-          "mcp-registry-navigator",
           "metadata-agent",
           "moc-agent",
+          "query-clarifier",
+          "report-generator",
+          "tag-agent",
+          "text-comparison-validator",
+          "url-context-validator",
+          "url-link-extractor"
+        ],
+        "components": {
+          "agents": 10
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "connection-agent",
+              "description": "Analyzes and suggests meaningful links between related content in knowledge management systems. Identifies entity-based connections, keyword overlaps, orphaned notes, and generates actionable link suggestions for manual curation."
+            },
+            {
+              "name": "game-developer",
+              "description": "Build games with Unity, Unreal Engine, or web technologies. Implements game mechanics, physics, AI, and optimization. Use PROACTIVELY for game development, engine integration, or gameplay programming."
+            },
+            {
+              "name": "metadata-agent",
+              "description": "Handles frontmatter standardization and metadata addition across vault files. Ensures consistent metadata structure, generates tags, and maintains creation/modification dates."
+            },
+            {
+              "name": "moc-agent",
+              "description": "Identifies and generates missing Maps of Content (MOCs) and organizes orphaned assets. Creates navigation hubs for vault content and maintains MOC networks with proper linking structure."
+            },
+            {
+              "name": "query-clarifier",
+              "description": "Analyze research queries for clarity and determine if clarification is needed. Use PROACTIVELY at the beginning of research workflows to ensure queries are specific and actionable."
+            },
+            {
+              "name": "report-generator",
+              "description": "You are the Report Generator, a specialized expert in transforming synthesized research findings into comprehensive, well-structured final reports. Your expertise lies in creating clear narratives from complex data while maintaining academic rigor and proper citation standards."
+            },
+            {
+              "name": "tag-agent",
+              "description": "Normalizes and hierarchically organizes tag taxonomy for knowledge management systems. Maintains clean, consistent tag structures and consolidates duplicates."
+            },
+            {
+              "name": "text-comparison-validator",
+              "description": "Compare extracted text from images with existing markdown files to ensure accuracy and consistency. Detects discrepancies, errors, and formatting inconsistencies."
+            },
+            {
+              "name": "url-context-validator",
+              "description": "Validate URLs for both technical functionality and contextual appropriateness. Goes beyond link checking to analyze content relevance and alignment."
+            },
+            {
+              "name": "url-link-extractor",
+              "description": "Find, extract, and catalog all URLs and links within website codebases. Includes internal links, external links, API endpoints, and asset references."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agents-documentation",
+        "description": "Agents for writing, formatting, and validating documentation and technical content",
+        "source": "./plugins/agents-documentation",
+        "author": "BuildWithClaude Community",
+        "tags": [
+          "agents",
+          "subagents",
+          "documentation",
+          "api-documenter",
+          "docusaurus-expert",
+          "markdown-syntax-formatter"
+        ],
+        "components": {
+          "agents": 3
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-documenter",
+              "description": "Create OpenAPI/Swagger specs, generate SDKs, and write developer documentation. Handles versioning, examples, and interactive docs. Use PROACTIVELY for API documentation or client library generation."
+            },
+            {
+              "name": "docusaurus-expert",
+              "description": "Configure and troubleshoot Docusaurus documentation sites. Specializes in configuration, theming, content management, sidebar organization, and build issues. Use PROACTIVELY when working with Docusaurus v2/v3 sites, especially in docs_to_claude folder."
+            },
+            {
+              "name": "markdown-syntax-formatter",
+              "description": "Converts text with visual formatting into proper markdown syntax, fixes markdown formatting issues, and ensures consistent document structure. Handles lists, headings, code blocks, and emphasis markers."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agents-research",
+        "description": "Agents for academic, market, and technical research, synthesis, and reporting",
+        "source": "./plugins/agents-research",
+        "author": "BuildWithClaude Community",
+        "tags": [
+          "agents",
+          "subagents",
+          "research",
+          "academic-research-synthesizer",
+          "academic-researcher",
+          "comprehensive-researcher",
+          "market-research-analyst",
+          "research-brief-generator",
+          "research-coordinator",
+          "research-orchestrator",
+          "research-synthesizer",
+          "technical-researcher"
+        ],
+        "components": {
+          "agents": 9
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "academic-research-synthesizer",
+              "description": "Synthesize academic research from multiple sources with citations. Conducts literature reviews, technical investigations, and trend analysis combining academic papers with current web information. Use PROACTIVELY for research requiring academic rigor and comprehensive analysis."
+            },
+            {
+              "name": "academic-researcher",
+              "description": "Find and analyze scholarly sources, research papers, and academic literature. Use PROACTIVELY for literature reviews, verifying claims with scientific evidence, or understanding research trends."
+            },
+            {
+              "name": "comprehensive-researcher",
+              "description": "Conduct in-depth research with multiple sources, cross-verification, and structured reports. Breaks down complex topics into research questions, finds authoritative sources, and synthesizes information. Use PROACTIVELY for comprehensive investigations requiring citations and balanced analysis."
+            },
+            {
+              "name": "market-research-analyst",
+              "description": "Conducts comprehensive market research and competitive analysis for business strategy and investment decisions. Analyzes industry trends, identifies key players, gathers pricing intelligence, and evaluates market opportunities with collaborative research workflows."
+            },
+            {
+              "name": "research-brief-generator",
+              "description": "Transforms user research queries into structured, actionable research briefs with specific questions, keywords, source preferences, and success criteria. Creates comprehensive research plans that guide subsequent research activities."
+            },
+            {
+              "name": "research-coordinator",
+              "description": "Strategically plan and coordinate complex research tasks across multiple specialists. Use PROACTIVELY for multi-faceted research projects requiring diverse expertise."
+            },
+            {
+              "name": "research-orchestrator",
+              "description": "You are the Research Orchestrator, an elite coordinator responsible for managing comprehensive research projects using the Open Deep Research methodology. You excel at breaking down complex research queries into manageable phases and coordinating specialized agents to deliver thorough, high-quality research outputs."
+            },
+            {
+              "name": "research-synthesizer",
+              "description": "Consolidate and synthesize findings from multiple research sources into unified analysis. Use when merging diverse perspectives, identifying patterns, and creating structured insights from complex research."
+            },
+            {
+              "name": "technical-researcher",
+              "description": "Analyze code repositories, technical documentation, and implementation details. Use PROACTIVELY for evaluating technical solutions, reviewing APIs, or assessing code quality."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agents-media-content",
+        "description": "Agents for podcasts, audio/video, transcription, OCR, and content production pipelines",
+        "source": "./plugins/agents-media-content",
+        "author": "BuildWithClaude Community",
+        "tags": [
+          "agents",
+          "subagents",
+          "media-content",
+          "audio-quality-controller",
+          "episode-orchestrator",
           "ocr-grammar-fixer",
           "ocr-quality-assurance",
           "podcast-content-analyzer",
           "podcast-metadata-specialist",
           "podcast-transcriber",
           "podcast-trend-scout",
-          "project-supervisor-orchestrator",
-          "query-clarifier",
-          "report-generator",
-          "research-brief-generator",
-          "research-coordinator",
-          "research-orchestrator",
-          "research-synthesizer",
           "seo-podcast-optimizer",
-          "tag-agent",
-          "technical-researcher",
-          "text-comparison-validator",
           "timestamp-precision-specialist",
-          "twitter-ai-influencer-manager",
-          "url-context-validator",
-          "url-link-extractor",
           "visual-analysis-ocr"
         ],
         "components": {
-          "agents": 41
+          "agents": 11
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "audio-quality-controller",
+              "description": "Analyzes, enhances, and standardizes audio quality for professional-grade content. Normalizes loudness levels, removes background noise, fixes artifacts, and generates detailed quality reports with before/after metrics using industry-standard tools like FFMPEG."
+            },
+            {
+              "name": "episode-orchestrator",
+              "description": "Manages episode-based workflows by coordinating multiple specialized agents in sequence. Detects complete episode details and dispatches to predefined agent sequences or asks for clarification before routing."
+            },
+            {
+              "name": "ocr-grammar-fixer",
+              "description": "You are an OCR Grammar Fixer specializing in cleaning up text processed through OCR that contains recognition errors, spacing issues, or grammatical problems. Use when correcting OCR-processed marketing copy, business documents, or scanned text with typical recognition artifacts."
+            },
+            {
+              "name": "ocr-quality-assurance",
+              "description": "You are an OCR Quality Assurance specialist performing final review and validation of OCR-corrected text against original image sources. Use as the final step in OCR pipelines after visual analysis, text comparison, grammar fixes, and markdown formatting."
+            },
+            {
+              "name": "podcast-content-analyzer",
+              "description": "Analyze podcast transcripts to identify engaging segments and viral moments. Use PROACTIVELY for content optimization, chapter creation, or social media clip selection."
+            },
+            {
+              "name": "podcast-metadata-specialist",
+              "description": "You are a Podcast Metadata Specialist generating comprehensive metadata, show notes, chapter markers, and platform-specific descriptions for podcast episodes. Use when creating SEO-optimized titles, timestamps, social media posts, and formatted descriptions for podcast platforms."
+            },
+            {
+              "name": "podcast-transcriber",
+              "description": "You are a Podcast Transcriber specializing in extracting accurate transcripts from audio/video files with timestamp precision. Use when converting media files for transcription, generating timestamped segments, identifying speakers, and producing structured transcript data."
+            },
+            {
+              "name": "podcast-trend-scout",
+              "description": "You are a Podcast Trend Scout identifying emerging tech topics and news for podcast episodes. Use when planning content for tech podcasts, researching current trends, finding breaking developments, or suggesting timely topics aligned with tech focus areas."
+            },
+            {
+              "name": "seo-podcast-optimizer",
+              "description": "You are an SEO consultant specializing in tech podcasts. Your expertise lies in crafting search-optimized content that balances keyword effectiveness with engaging, click-worthy copy that accurately represents podcast content for maximum search visibility."
+            },
+            {
+              "name": "timestamp-precision-specialist",
+              "description": "Extract frame-accurate timestamps from audio/video files for podcast editing. Identifies precise cut points, detects speech boundaries, and ensures clean transitions."
+            },
+            {
+              "name": "visual-analysis-ocr",
+              "description": "Extract and analyze text content from PNG images while preserving original formatting and structure. Converts visual hierarchy into markdown format."
+            }
+          ]
+        }
+      },
+      {
+        "name": "agents-ai-agents",
+        "description": "Agents for multi-agent orchestration, MCP tooling, and agentic workflows",
+        "source": "./plugins/agents-ai-agents",
+        "author": "BuildWithClaude Community",
+        "tags": [
+          "agents",
+          "subagents",
+          "ai-agents",
+          "agent-expert",
+          "mcp-deployment-orchestrator",
+          "mcp-expert",
+          "mcp-registry-navigator",
+          "project-supervisor-orchestrator"
+        ],
+        "components": {
+          "agents": 5
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "agent-expert",
+              "description": "Create and optimize specialized Claude Code agents. Expertise in agent design, prompt engineering, domain modeling, and best practices for claude-code-templates system. Use PROACTIVELY when designing new agents or improving existing ones."
+            },
+            {
+              "name": "mcp-deployment-orchestrator",
+              "description": "Deploys MCP servers to production with containerization, Kubernetes deployments, autoscaling, monitoring, and high-availability operations. Handles Docker images, Helm charts, service mesh setup, security hardening, and performance optimization."
+            },
+            {
+              "name": "mcp-expert",
+              "description": "Create Model Context Protocol integrations and server configurations. Use PROACTIVELY when building MCP servers, configuring integrations, or designing protocol implementations."
+            },
+            {
+              "name": "mcp-registry-navigator",
+              "description": "You are an MCP Registry Navigator specializing in discovering, evaluating, and integrating MCP servers from various registries. Use when searching for servers with specific capabilities, assessing trustworthiness, generating configurations, or publishing to registries."
+            },
+            {
+              "name": "project-supervisor-orchestrator",
+              "description": "You are a Project Supervisor Orchestrator managing complex multi-step workflows that coordinate multiple specialized agents in sequence. Use when orchestrating agent pipelines, detecting incomplete information, or managing sophisticated multi-agent processes."
+            }
+          ]
         }
       },
       {
@@ -2103,6 +8713,26 @@
         ],
         "components": {
           "commands": 4
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "design-rest-api",
+              "description": "Design RESTful API architecture"
+            },
+            {
+              "name": "doc-api",
+              "description": "Generate API documentation from code"
+            },
+            {
+              "name": "generate-api-documentation",
+              "description": "Auto-generate API reference documentation"
+            },
+            {
+              "name": "implement-graphql-api",
+              "description": "Implement GraphQL API endpoints"
+            }
+          ]
         }
       },
       {
@@ -2118,6 +8748,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "act",
+              "description": "Follow RED-GREEN-REFACTOR cycle approach for test-driven development"
+            }
+          ]
         }
       },
       {
@@ -2143,6 +8781,54 @@
         ],
         "components": {
           "commands": 11
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-changelog",
+              "description": "Generate and maintain project changelog"
+            },
+            {
+              "name": "changelog-demo-command",
+              "description": "Demo changelog automation features"
+            },
+            {
+              "name": "ci-setup",
+              "description": "Setup continuous integration pipeline"
+            },
+            {
+              "name": "containerize-application",
+              "description": "Containerize application for deployment"
+            },
+            {
+              "name": "hotfix-deploy",
+              "description": "Deploy critical hotfixes quickly"
+            },
+            {
+              "name": "prepare-release",
+              "description": "Prepare and validate release packages"
+            },
+            {
+              "name": "release",
+              "description": "Prepare a new release by updating changelog, version, and documentation"
+            },
+            {
+              "name": "rollback-deploy",
+              "description": "Rollback deployment to previous version"
+            },
+            {
+              "name": "run-ci",
+              "description": "Run CI checks and fix any errors until all tests pass"
+            },
+            {
+              "name": "setup-automated-releases",
+              "description": "Setup automated release workflows"
+            },
+            {
+              "name": "setup-kubernetes-deployment",
+              "description": "Configure Kubernetes deployment manifests"
+            }
+          ]
         }
       },
       {
@@ -2174,7 +8860,87 @@
           "write-tests"
         ],
         "components": {
-          "commands": 18
+          "commands": 19
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-mutation-testing",
+              "description": "Setup mutation testing for code quality"
+            },
+            {
+              "name": "add-property-based-testing",
+              "description": "Implement property-based testing framework"
+            },
+            {
+              "name": "agent-preflight",
+              "description": "Preflight a repo before AI agents change files"
+            },
+            {
+              "name": "check",
+              "description": "Run project checks and fix any errors without committing"
+            },
+            {
+              "name": "clean",
+              "description": "Fix all linting and formatting issues across the codebase"
+            },
+            {
+              "name": "code_analysis",
+              "description": "Perform comprehensive code analysis with quality metrics and recommendations"
+            },
+            {
+              "name": "e2e-setup",
+              "description": "Configure end-to-end testing suite"
+            },
+            {
+              "name": "generate-test-cases",
+              "description": "Generate comprehensive test cases automatically"
+            },
+            {
+              "name": "generate-tests",
+              "description": "Generate comprehensive test suite for $ARGUMENTS following project testing conventions and best practices."
+            },
+            {
+              "name": "optimize",
+              "description": "Analyze code performance and propose three specific optimization improvements"
+            },
+            {
+              "name": "repro-issue",
+              "description": "Reproduce a specific issue by creating a failing test case"
+            },
+            {
+              "name": "setup-comprehensive-testing",
+              "description": "Setup complete testing infrastructure"
+            },
+            {
+              "name": "setup-load-testing",
+              "description": "Configure load and performance testing"
+            },
+            {
+              "name": "setup-visual-testing",
+              "description": "Setup visual regression testing"
+            },
+            {
+              "name": "tdd",
+              "description": "Test-driven development workflow with Red-Green-Refactor process and branch management"
+            },
+            {
+              "name": "test-changelog-automation",
+              "description": "Automate changelog testing workflow"
+            },
+            {
+              "name": "test-coverage",
+              "description": "Analyze and report test coverage"
+            },
+            {
+              "name": "testing_plan_integration",
+              "description": "I need you to create an integration testing plan for $ARGUMENTS"
+            },
+            {
+              "name": "write-tests",
+              "description": "Write unit and integration tests"
+            }
+          ]
         }
       },
       {
@@ -2193,6 +8959,26 @@
         ],
         "components": {
           "commands": 4
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "context-prime",
+              "description": "Load project context by reading README.md and exploring relevant project files"
+            },
+            {
+              "name": "initref",
+              "description": "Build reference documentation by creating markdown files and updating CLAUDE.md"
+            },
+            {
+              "name": "prime",
+              "description": "Load project context by reading key documentation files and exploring project structure"
+            },
+            {
+              "name": "rsi",
+              "description": "Read project commands and documentation to optimize AI-assisted development process"
+            }
+          ]
         }
       },
       {
@@ -2210,6 +8996,22 @@
         ],
         "components": {
           "commands": 3
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-database-migrations",
+              "description": "Create and manage database migrations"
+            },
+            {
+              "name": "design-database-schema",
+              "description": "Design optimized database schemas"
+            },
+            {
+              "name": "optimize-database-performance",
+              "description": "Optimize database queries and performance"
+            }
+          ]
         }
       },
       {
@@ -2234,6 +9036,50 @@
         ],
         "components": {
           "commands": 10
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-to-changelog",
+              "description": "Add a new entry to the project's CHANGELOG.md file following Keep a Changelog format"
+            },
+            {
+              "name": "create-architecture-documentation",
+              "description": "Generate comprehensive architecture documentation"
+            },
+            {
+              "name": "create-docs",
+              "description": "Analyze GitHub issue and create technical specification with implementation plan"
+            },
+            {
+              "name": "create-onboarding-guide",
+              "description": "Create developer onboarding guide"
+            },
+            {
+              "name": "docs",
+              "description": "Update or generate YAML documentation for SQL models with proper descriptions and tests"
+            },
+            {
+              "name": "explain-issue-fix",
+              "description": "Explain how tasks in an issue were implemented with detailed breakdown"
+            },
+            {
+              "name": "load-llms-txt",
+              "description": "READ the llms.txt file from https://raw.githubusercontent.com/ethpandaops/xatu-data/refs/heads/master/llms.txt via `curl`. Do nothing else and await further instructions."
+            },
+            {
+              "name": "migration-guide",
+              "description": "Create migration guides for updates"
+            },
+            {
+              "name": "troubleshooting-guide",
+              "description": "Generate troubleshooting documentation"
+            },
+            {
+              "name": "update-docs",
+              "description": "Update implementation documentation including specs, status, and best practices"
+            }
+          ]
         }
       },
       {
@@ -2264,6 +9110,74 @@
         ],
         "components": {
           "commands": 16
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "svelte-a11y",
+              "description": "Audit and improve accessibility in Svelte/SvelteKit applications, ensuring WCAG compliance and inclusive user experiences."
+            },
+            {
+              "name": "svelte-component",
+              "description": "Create new Svelte components with best practices, proper structure, and optional TypeScript support."
+            },
+            {
+              "name": "svelte-debug",
+              "description": "Help debug Svelte and SvelteKit issues by analyzing error messages, stack traces, and common problems."
+            },
+            {
+              "name": "svelte-migrate",
+              "description": "Migrate Svelte/SvelteKit projects between versions, adopt new features like runes, and handle breaking changes."
+            },
+            {
+              "name": "svelte-optimize",
+              "description": "Optimize Svelte/SvelteKit applications for performance, including bundle size reduction, rendering optimization, and loading performance."
+            },
+            {
+              "name": "svelte-scaffold",
+              "description": "Scaffold new SvelteKit projects, features, or modules with best practices and optimal project structure."
+            },
+            {
+              "name": "svelte-storybook-migrate",
+              "description": "Migrate Storybook configurations and stories to newer versions, including Svelte CSF v5 and @storybook/sveltekit framework."
+            },
+            {
+              "name": "svelte-storybook-mock",
+              "description": "Mock SvelteKit modules and functionality in Storybook stories for isolated component development."
+            },
+            {
+              "name": "svelte-storybook-setup",
+              "description": "Initialize and configure Storybook for SvelteKit projects with optimal settings and structure."
+            },
+            {
+              "name": "svelte-storybook-story",
+              "description": "Create comprehensive Storybook stories for Svelte components using modern patterns and best practices."
+            },
+            {
+              "name": "svelte-storybook-troubleshoot",
+              "description": "Diagnose and fix common Storybook issues in SvelteKit projects, including build errors, module problems, and configuration issues."
+            },
+            {
+              "name": "svelte-storybook",
+              "description": "General-purpose Storybook assistance for SvelteKit projects, including setup guidance, best practices, and common tasks."
+            },
+            {
+              "name": "svelte-test-coverage",
+              "description": "Analyze test coverage, identify testing gaps, and provide recommendations for improving test coverage in Svelte/SvelteKit projects."
+            },
+            {
+              "name": "svelte-test-fix",
+              "description": "Troubleshoot and fix failing tests in Svelte/SvelteKit projects, including debugging test issues and resolving common testing problems."
+            },
+            {
+              "name": "svelte-test-setup",
+              "description": "Set up comprehensive testing infrastructure for Svelte/SvelteKit projects, including unit testing, component testing, and E2E testing frameworks."
+            },
+            {
+              "name": "svelte-test",
+              "description": "Create comprehensive tests for Svelte components and SvelteKit routes, including unit tests, component tests, and E2E tests."
+            }
+          ]
         }
       },
       {
@@ -2279,6 +9193,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "unity-project-setup",
+              "description": "Sets up a professional Unity project with industry-standard structure and configurations"
+            }
+          ]
         }
       },
       {
@@ -2305,6 +9227,58 @@
         ],
         "components": {
           "commands": 12
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bidirectional-sync",
+              "description": "Enable bidirectional GitHub-Linear synchronization"
+            },
+            {
+              "name": "bulk-import-issues",
+              "description": "Bulk import GitHub issues to Linear"
+            },
+            {
+              "name": "cross-reference-manager",
+              "description": "Manage cross-platform reference links"
+            },
+            {
+              "name": "issue-to-linear-task",
+              "description": "Convert GitHub issues to Linear tasks"
+            },
+            {
+              "name": "linear-task-to-issue",
+              "description": "Convert Linear tasks to GitHub issues"
+            },
+            {
+              "name": "sync-automation-setup",
+              "description": "Setup automated synchronization workflows"
+            },
+            {
+              "name": "sync-conflict-resolver",
+              "description": "Resolve synchronization conflicts automatically"
+            },
+            {
+              "name": "sync-issues-to-linear",
+              "description": "Sync GitHub issues to Linear workspace"
+            },
+            {
+              "name": "sync-linear-to-issues",
+              "description": "Sync Linear tasks to GitHub issues"
+            },
+            {
+              "name": "sync-pr-to-task",
+              "description": "Link pull requests to Linear tasks"
+            },
+            {
+              "name": "sync-status",
+              "description": "Monitor GitHub-Linear sync health status"
+            },
+            {
+              "name": "task-from-pr",
+              "description": "Create Linear tasks from pull requests"
+            }
+          ]
         }
       },
       {
@@ -2321,7 +9295,27 @@
           "use-stepper"
         ],
         "components": {
-          "commands": 3
+          "commands": 4
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "five",
+              "description": "Apply the Five Whys root cause analysis technique to systematically investigate issues"
+            },
+            {
+              "name": "mermaid",
+              "description": "Create entity relationship diagrams using Mermaid from SQL/database files"
+            },
+            {
+              "name": "share-your-story",
+              "description": "Open the Build with Claude contribution guide for writing a community story"
+            },
+            {
+              "name": "use-stepper",
+              "description": "Use structured stepper approach for problem-solving and project development"
+            }
+          ]
         }
       },
       {
@@ -2338,6 +9332,18 @@
         ],
         "components": {
           "commands": 2
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-performance-monitoring",
+              "description": "Setup application performance monitoring"
+            },
+            {
+              "name": "setup-monitoring-observability",
+              "description": "Setup monitoring and observability tools"
+            }
+          ]
         }
       },
       {
@@ -2358,6 +9364,34 @@
         ],
         "components": {
           "commands": 6
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "implement-caching-strategy",
+              "description": "Design and implement caching solutions"
+            },
+            {
+              "name": "optimize-build",
+              "description": "Optimize build processes and speed"
+            },
+            {
+              "name": "optimize-bundle-size",
+              "description": "Reduce and optimize bundle sizes"
+            },
+            {
+              "name": "performance-audit",
+              "description": "Audit application performance metrics"
+            },
+            {
+              "name": "setup-cdn-optimization",
+              "description": "Configure CDN for optimal delivery"
+            },
+            {
+              "name": "system-behavior-simulator",
+              "description": "Simulate system performance under various loads with capacity planning, bottleneck identification, and optimization strategies."
+            }
+          ]
         }
       },
       {
@@ -2378,6 +9412,34 @@
         ],
         "components": {
           "commands": 6
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "modernize-deps",
+              "description": "Update and modernize project dependencies"
+            },
+            {
+              "name": "setup-development-environment",
+              "description": "Setup complete development environment"
+            },
+            {
+              "name": "setup-formatting",
+              "description": "Configure code formatting tools"
+            },
+            {
+              "name": "setup-linting",
+              "description": "Setup code linting and quality tools"
+            },
+            {
+              "name": "setup-monorepo",
+              "description": "Configure monorepo project structure"
+            },
+            {
+              "name": "setup-rate-limiting",
+              "description": "Implement API rate limiting"
+            }
+          ]
         }
       },
       {
@@ -2409,6 +9471,78 @@
         ],
         "components": {
           "commands": 17
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-package",
+              "description": "Add and configure new project dependencies"
+            },
+            {
+              "name": "create-command",
+              "description": "Create a new command following existing patterns and organizational structure"
+            },
+            {
+              "name": "create-feature",
+              "description": "Scaffold new feature with boilerplate code"
+            },
+            {
+              "name": "create-jtbd",
+              "description": "Create a Jobs to be Done (JTBD) document for a product feature focusing on user needs"
+            },
+            {
+              "name": "create-prd",
+              "description": "Create a Product Requirements Document (PRD) for a product feature"
+            },
+            {
+              "name": "create-prp",
+              "description": "Create a comprehensive Product Requirement Prompt (PRP) with research and context gathering"
+            },
+            {
+              "name": "init-project",
+              "description": "Initialize new project with essential structure"
+            },
+            {
+              "name": "milestone-tracker",
+              "description": "Track and monitor project milestone progress"
+            },
+            {
+              "name": "pac-configure",
+              "description": "Configure and initialize a project following the Product as Code specification for structured, version-controlled product management"
+            },
+            {
+              "name": "pac-create-epic",
+              "description": "Create a new epic following the Product as Code specification with guided workflow"
+            },
+            {
+              "name": "pac-create-ticket",
+              "description": "Create a new ticket within an epic following the Product as Code specification"
+            },
+            {
+              "name": "pac-update-status",
+              "description": "Update ticket status and track progress in Product as Code workflow"
+            },
+            {
+              "name": "pac-validate",
+              "description": "Validate Product as Code project structure and files for specification compliance"
+            },
+            {
+              "name": "project-health-check",
+              "description": "Analyze overall project health and metrics"
+            },
+            {
+              "name": "project-timeline-simulator",
+              "description": "Simulate project outcomes with variable modeling, risk assessment, and resource optimization scenarios."
+            },
+            {
+              "name": "project-to-linear",
+              "description": "Sync project structure to Linear workspace"
+            },
+            {
+              "name": "todo",
+              "description": "Manage project todos in a todos.md file with add, complete, remove, and list operations"
+            }
+          ]
         }
       },
       {
@@ -2425,6 +9559,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "big-features-interview",
+              "description": "Interview to flesh out a plan/spec"
+            }
+          ]
         }
       },
       {
@@ -2443,6 +9585,26 @@
         ],
         "components": {
           "commands": 4
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "add-authentication-system",
+              "description": "Implement secure user authentication system"
+            },
+            {
+              "name": "dependency-audit",
+              "description": "Audit dependencies for security vulnerabilities"
+            },
+            {
+              "name": "security-audit",
+              "description": "Perform comprehensive security assessment"
+            },
+            {
+              "name": "security-hardening",
+              "description": "Harden application security configuration"
+            }
+          ]
         }
       },
       {
@@ -2465,6 +9627,42 @@
         ],
         "components": {
           "commands": 8
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "business-scenario-explorer",
+              "description": "Explore multiple business timeline scenarios with constraint validation and decision optimization."
+            },
+            {
+              "name": "constraint-modeler",
+              "description": "Model world constraints with assumption validation, dependency mapping, and scenario boundary definition."
+            },
+            {
+              "name": "decision-tree-explorer",
+              "description": "Explore decision branches with probability weighting, expected value analysis, and scenario-based optimization."
+            },
+            {
+              "name": "digital-twin-creator",
+              "description": "Create systematic digital twins with data quality validation and real-world calibration loops."
+            },
+            {
+              "name": "future-scenario-generator",
+              "description": "Generate and analyze future scenarios with plausibility scoring, trend integration, and uncertainty quantification."
+            },
+            {
+              "name": "market-response-modeler",
+              "description": "Model customer and market responses with segment analysis, behavioral prediction, and response optimization."
+            },
+            {
+              "name": "simulation-calibrator",
+              "description": "Test and refine simulation accuracy with validation loops, bias detection, and continuous improvement frameworks."
+            },
+            {
+              "name": "timeline-compressor",
+              "description": "Accelerate scenario testing with rapid iteration cycles, confidence intervals, and compressed decision timelines."
+            }
+          ]
         }
       },
       {
@@ -2491,6 +9689,58 @@
         ],
         "components": {
           "commands": 12
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "architecture-review",
+              "description": "Review and improve system architecture"
+            },
+            {
+              "name": "decision-quality-analyzer",
+              "description": "Analyze decision quality with scenario testing, bias detection, and team decision-making process optimization."
+            },
+            {
+              "name": "dependency-mapper",
+              "description": "Map and analyze project dependencies"
+            },
+            {
+              "name": "estimate-assistant",
+              "description": "Generate accurate project time estimates"
+            },
+            {
+              "name": "issue-triage",
+              "description": "Triage and prioritize issues effectively"
+            },
+            {
+              "name": "memory-spring-cleaning",
+              "description": "Clean and organize project memory"
+            },
+            {
+              "name": "migration-assistant",
+              "description": "Assist with system migration planning"
+            },
+            {
+              "name": "retrospective-analyzer",
+              "description": "Analyze team retrospectives for insights"
+            },
+            {
+              "name": "session-learning-capture",
+              "description": "Capture and document session learnings"
+            },
+            {
+              "name": "sprint-planning",
+              "description": "Plan and organize sprint workflows"
+            },
+            {
+              "name": "standup-report",
+              "description": "Generate daily standup reports"
+            },
+            {
+              "name": "team-workload-balancer",
+              "description": "Balance team workload distribution"
+            }
+          ]
         }
       },
       {
@@ -2506,6 +9756,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "migrate-to-typescript",
+              "description": "Migrate JavaScript project to TypeScript"
+            }
+          ]
         }
       },
       {
@@ -2534,6 +9792,66 @@
         ],
         "components": {
           "commands": 14
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "all-tools",
+              "description": "Display all available development tools"
+            },
+            {
+              "name": "architecture-scenario-explorer",
+              "description": "Explore architectural decisions through systematic scenario analysis with trade-off evaluation and future-proofing assessment."
+            },
+            {
+              "name": "check-file",
+              "description": "Perform comprehensive analysis of $ARGUMENTS to identify code quality issues, security vulnerabilities, and optimization opportunities."
+            },
+            {
+              "name": "clean-branches",
+              "description": "Clean up merged and stale git branches"
+            },
+            {
+              "name": "code-permutation-tester",
+              "description": "Test multiple code variations through simulation before implementation with quality gates and performance prediction."
+            },
+            {
+              "name": "code-review",
+              "description": "Perform comprehensive code quality review"
+            },
+            {
+              "name": "code-to-task",
+              "description": "Convert code analysis to Linear tasks"
+            },
+            {
+              "name": "debug-error",
+              "description": "Systematically debug and fix errors"
+            },
+            {
+              "name": "directory-deep-dive",
+              "description": "Analyze directory structure and purpose"
+            },
+            {
+              "name": "explain-code",
+              "description": "Analyze and explain code functionality"
+            },
+            {
+              "name": "generate-linear-worklog",
+              "description": "You are tasked with generating a technical work log comment for a Linear issue based on recent git commits."
+            },
+            {
+              "name": "git-status",
+              "description": "Show detailed git repository status"
+            },
+            {
+              "name": "refactor-code",
+              "description": "Intelligently refactor and improve code quality"
+            },
+            {
+              "name": "ultra-think",
+              "description": "Deep analysis and problem solving mode"
+            }
+          ]
         }
       },
       {
@@ -2560,6 +9878,58 @@
         ],
         "components": {
           "commands": 12
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bug-fix",
+              "description": "Systematic workflow for fixing bugs including issue creation, branch management, and PR submission"
+            },
+            {
+              "name": "commit-fast",
+              "description": "Automatically create and execute a git commit using the first suggested commit message"
+            },
+            {
+              "name": "commit",
+              "description": "Create well-formatted git commits with conventional commit messages and emoji"
+            },
+            {
+              "name": "create-pr",
+              "description": "Create a new branch, commit changes, and submit a pull request with automatic commit splitting"
+            },
+            {
+              "name": "create-pull-request",
+              "description": "Guide for creating pull requests using GitHub CLI with proper templates and conventions"
+            },
+            {
+              "name": "create-worktrees",
+              "description": "Manage git worktrees for open PRs and create new branch worktrees"
+            },
+            {
+              "name": "fix-github-issue",
+              "description": "Analyze and fix a GitHub issue with comprehensive testing and verification"
+            },
+            {
+              "name": "fix-issue",
+              "description": "Fix a specific issue or problem with the given identifier or description"
+            },
+            {
+              "name": "fix-pr",
+              "description": "Fetch unresolved comments for current branch's PR and fix them"
+            },
+            {
+              "name": "husky",
+              "description": "Verify repository is in working state by running CI checks and fixing issues"
+            },
+            {
+              "name": "pr-review",
+              "description": "Conduct comprehensive PR review from multiple perspectives (PM, Developer, QA, Security)"
+            },
+            {
+              "name": "update-branch-name",
+              "description": "Update current git branch name based on analysis of changes made"
+            }
+          ]
         }
       },
       {
@@ -2583,6 +9953,46 @@
         ],
         "components": {
           "commands": 9
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "find",
+              "description": "Search and locate tasks across all orchestrations using various criteria."
+            },
+            {
+              "name": "log",
+              "description": "Log work from orchestrated tasks to external project management tools like Linear, Obsidian, Jira, or GitHub Issues."
+            },
+            {
+              "name": "move",
+              "description": "Move tasks between status folders following the task management protocol."
+            },
+            {
+              "name": "remove",
+              "description": "Safely remove a task from the orchestration system, updating all references and dependencies."
+            },
+            {
+              "name": "report",
+              "description": "Generate comprehensive reports on task execution, progress, and metrics."
+            },
+            {
+              "name": "resume",
+              "description": "Resume work on existing task orchestrations after session loss or context switch."
+            },
+            {
+              "name": "start",
+              "description": "Initiates the task orchestration workflow using the three-agent system (task-orchestrator, task-decomposer, and dependency-analyzer) to create a comprehensive execution plan."
+            },
+            {
+              "name": "status",
+              "description": "Check the current status of tasks in the orchestration system with various filtering and reporting options."
+            },
+            {
+              "name": "sync",
+              "description": "Synchronize task status with git commits, ensuring consistency between version control and task tracking."
+            }
+          ]
         }
       },
       {
@@ -2600,6 +10010,26 @@
         ],
         "components": {
           "hooks": 4
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "build-on-change",
+              "description": "Automatically trigger build processes when source files change"
+            },
+            {
+              "name": "dependency-checker",
+              "description": "Monitor and audit dependencies for security vulnerabilities and updates"
+            },
+            {
+              "name": "no-ask-human",
+              "description": "Detect when Claude Code asks questions and remind it to decide autonomously instead"
+            },
+            {
+              "name": "slack-notifications",
+              "description": "Send Slack notifications when Claude Code finishes working"
+            }
+          ]
         }
       },
       {
@@ -2618,6 +10048,26 @@
         ],
         "components": {
           "hooks": 4
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "change-tracker",
+              "description": "Track file changes in a simple log"
+            },
+            {
+              "name": "file-backup",
+              "description": "Automatically backup files before editing"
+            },
+            {
+              "name": "lint-on-save",
+              "description": "Automatically run linting tools after file modifications"
+            },
+            {
+              "name": "smart-formatting",
+              "description": "Smart code formatting based on file type"
+            }
+          ]
         }
       },
       {
@@ -2634,6 +10084,18 @@
         ],
         "components": {
           "hooks": 2
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "format-javascript-files",
+              "description": "Automatically format JavaScript/TypeScript files after any Edit operation using prettier"
+            },
+            {
+              "name": "format-python-files",
+              "description": "Automatically format Python files after any Edit operation using black formatter"
+            }
+          ]
         }
       },
       {
@@ -2650,7 +10112,27 @@
           "smart-commit"
         ],
         "components": {
-          "hooks": 3
+          "hooks": 4
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "auto-git-add",
+              "description": "Automatically stage modified files with git add after editing"
+            },
+            {
+              "name": "conventional-commits",
+              "description": "Enforce Conventional Commits — validates git commit messages before the command runs and blocks non-conforming ones"
+            },
+            {
+              "name": "git-add-changes",
+              "description": "Automatically stage changes in git after file modifications for easier commit workflow"
+            },
+            {
+              "name": "smart-commit",
+              "description": "Intelligent git commit creation with automatic message generation and validation"
+            }
+          ]
         }
       },
       {
@@ -2675,6 +10157,50 @@
         ],
         "components": {
           "hooks": 10
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "discord-detailed-notifications",
+              "description": "Send detailed Discord notifications with session information and rich embeds"
+            },
+            {
+              "name": "discord-error-notifications",
+              "description": "Send Discord notifications for long-running operations and important events"
+            },
+            {
+              "name": "discord-notifications",
+              "description": "Send Discord notifications when Claude Code finishes working"
+            },
+            {
+              "name": "notify-before-bash",
+              "description": "Show notification before any Bash command execution for security awareness"
+            },
+            {
+              "name": "simple-notifications",
+              "description": "Send simple desktop notifications when Claude Code operations complete"
+            },
+            {
+              "name": "slack-detailed-notifications",
+              "description": "Send detailed Slack notifications with session information and rich blocks"
+            },
+            {
+              "name": "slack-error-notifications",
+              "description": "Send Slack notifications when Claude Code encounters long-running operations or when tools take significant time"
+            },
+            {
+              "name": "telegram-detailed-notifications",
+              "description": "Send detailed Telegram notifications with session information and metrics"
+            },
+            {
+              "name": "telegram-error-notifications",
+              "description": "Send Telegram notifications for long-running operations and important events"
+            },
+            {
+              "name": "telegram-notifications",
+              "description": "Send Telegram notifications when Claude Code finishes working"
+            }
+          ]
         }
       },
       {
@@ -2690,6 +10216,18 @@
         ],
         "components": {
           "hooks": 2
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "context-monitor",
+              "description": "Monitor context window remaining capacity with graduated warnings (CAUTION → WARNING → CRITICAL → EMERGENCY)"
+            },
+            {
+              "name": "performance-monitor",
+              "description": "Monitor system performance during Claude Code operations"
+            }
+          ]
         }
       },
       {
@@ -2704,10 +10242,7 @@
           "file-protection",
           "file-protection-hook",
           "security-scanner"
-        ],
-        "components": {
-          "hooks": 4
-        }
+        ]
       },
       {
         "name": "hooks-testing",
@@ -2720,10 +10255,7 @@
           "testing",
           "run-tests-after-changes",
           "test-runner"
-        ],
-        "components": {
-          "hooks": 2
-        }
+        ]
       },
       {
         "name": "mcp-servers-docker",
@@ -2759,10 +10291,7 @@
           "subagents",
           "all",
           "bundle"
-        ],
-        "components": {
-          "agents": 117
-        }
+        ]
       },
       {
         "name": "all-commands",
@@ -2774,10 +10303,7 @@
           "slash-commands",
           "all",
           "bundle"
-        ],
-        "components": {
-          "commands": 175
-        }
+        ]
       },
       {
         "name": "all-hooks",
@@ -2789,10 +10315,7 @@
           "automation",
           "all",
           "bundle"
-        ],
-        "components": {
-          "hooks": 28
-        }
+        ]
       },
       {
         "name": "all-skills",
@@ -2813,10 +10336,7 @@
           "communication",
           "analytics",
           "composio"
-        ],
-        "components": {
-          "skills": 121
-        }
+        ]
       },
       {
         "name": "nextjs-expert",
@@ -2832,11 +10352,7 @@
           "route-handlers",
           "server-actions",
           "authentication"
-        ],
-        "components": {
-          "skills": 5,
-          "commands": 3
-        }
+        ]
       },
       {
         "name": "frontend-design-pro",
@@ -2856,11 +10372,7 @@
           "dribbble",
           "coolors",
           "google-fonts"
-        ],
-        "components": {
-          "skills": 6,
-          "commands": 3
-        }
+        ]
       },
       {
         "name": "obsidian-skills",
@@ -2882,6 +10394,21 @@
         ]
       },
       {
+        "name": "origin",
+        "description": "AI work memory for Claude Code: brief, capture, recall, handoff, and distill, backed by a local daemon and MCP so decisions, lessons, project context, and wiki pages carry across sessions.",
+        "source": "./plugins/origin",
+        "author": "Qi-Xuan Lu",
+        "tags": [
+          "memory",
+          "claude-code",
+          "mcp",
+          "local-first",
+          "context",
+          "handoff",
+          "wiki"
+        ]
+      },
+      {
         "name": "project-boundary",
         "description": "Security hook that blocks destructive commands and file operations outside the project directory",
         "source": "./plugins/project-boundary",
@@ -2893,6 +10420,233 @@
           "guard",
           "project-boundary"
         ]
+      },
+      {
+        "name": "shipwright",
+        "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously. 9-phase pipeline, 4 stacks, enterprise-grade safety hooks.",
+        "source": "./plugins/shipwright",
+        "author": "Nate Nelson",
+        "tags": [
+          "app-builder",
+          "autonomous-agent",
+          "pipeline",
+          "scaffolding",
+          "testing",
+          "deployment",
+          "product-agent"
+        ]
+      },
+      {
+        "name": "codex-hud",
+        "description": "Display OpenAI Codex usage and rate limits inside Claude Code. Real-time statusline integration with claude-hud (auto-installed via /codex-hud:setup).",
+        "source": "./plugins/codex-hud",
+        "author": "Haenara Shin",
+        "tags": [
+          "codex",
+          "openai",
+          "usage",
+          "rate-limits",
+          "monitoring",
+          "statusline",
+          "hud"
+        ]
+      },
+      {
+        "name": "magic-cc-codex-worker",
+        "description": "Turns OpenAI Codex into a pool of parallel agent workers inside Claude Code. Each worker runs in its own git worktree so parallel edits don't collide. Resumable sessions via Codex's native thread_id, dual-model PR review with materialized detached worktree, and role-based specialization (implementer/reviewer/planner/generic).",
+        "source": "./plugins/magic-cc-codex-worker",
+        "author": "Wenqing Yu",
+        "tags": [
+          "codex",
+          "mcp",
+          "agent",
+          "claude-code",
+          "orchestration",
+          "worktree",
+          "parallel",
+          "multi-agent",
+          "pr-review"
+        ]
+      },
+      {
+        "name": "vibe-prospecting",
+        "description": "Power your chat with live B2B data to create lead lists, research companies, enrich contacts, personalize outreach, and inspect business signals, tech stacks, events, and website changes. 150M+ businesses and 800M+ professionals via the Explorium MCP.",
+        "source": "./plugins/vibe-prospecting",
+        "author": "vibeprospecting.ai",
+        "tags": [
+          "b2b",
+          "prospecting",
+          "leads",
+          "sales",
+          "enrichment",
+          "companies",
+          "contacts",
+          "mcp",
+          "explorium"
+        ]
+      },
+      {
+        "name": "backlogd",
+        "description": "Turn Claude Code into a problem-driven scrum team. You file problems as Linear issues; an agent team runs the empirical Scrum loop (scope, solve, review, adapt) and owns the solutions. An independent reviewer gates every increment against its acceptance criteria, the Definition of Done, and a standards corpus. Runs on your Claude subscription via the official Linear MCP over OAuth — no API keys.",
+        "source": "nicolai-bernsen/backlogd",
+        "author": "Nicolai Bernsen",
+        "tags": [
+          "claude-code",
+          "linear",
+          "scrum",
+          "agents",
+          "product-management",
+          "orchestration"
+        ]
+      },
+      {
+        "name": "kegg-mcp-server",
+        "description": "Query the KEGG bioinformatics database — pathways, genes, compounds, drugs, enzymes, diseases, reactions, and more via 34 read-only MCP tools. No API key required.",
+        "source": "./plugins/kegg-mcp-server",
+        "author": "Lucas Servi",
+        "tags": [
+          "mcp",
+          "kegg",
+          "bioinformatics",
+          "pathways",
+          "genomics",
+          "metabolomics",
+          "systems-biology",
+          "science"
+        ]
+      },
+      {
+        "name": "claude-wayfinder",
+        "description": "Helps Claude make deterministic, auditable choices about which agent and skills to use for a given task — replacing prose-scanning agent/skill selection with a typed scoring kernel that returns one of seven typed decisions with confidence, rationale, and alternatives.",
+        "source": "glitchwerks/claude-wayfinder",
+        "author": "Christopher Beaulieu",
+        "tags": [
+          "dispatch",
+          "routing",
+          "matcher",
+          "claude-code",
+          "deterministic",
+          "agent-selection",
+          "auditable"
+        ]
+      },
+      {
+        "name": "claude-prospector",
+        "description": "Claude Code efficiency and hygiene toolkit. Surfaces token spend across the 5h / 7d / Sonnet-7d billing windows with per-model / per-agent / per-skill attribution, and audits your effective Claude Code configuration (custom + plugin agents and skills) for overlap and conflicts. Ships an interactive dashboard, a conversational usage-analysis skill, and a structured config-audit skill.",
+        "source": "glitchwerks/claude-prospector",
+        "author": "Christopher Beaulieu",
+        "tags": [
+          "claude-code",
+          "usage",
+          "tokens",
+          "billing",
+          "dashboard",
+          "observability",
+          "audit",
+          "config-hygiene"
+        ]
+      },
+      {
+        "name": "claude-github-tools",
+        "description": "GitHub workflow skills for Claude Code - issue creation, PR review triage, backlog summaries/quick-wins, release status, and GitHub Actions authoring. Seven skills; three pure-LLM, four script-backed via an auto-materialized plugin venv.",
+        "source": "glitchwerks/claude-github-tools",
+        "author": "Christopher Beaulieu",
+        "tags": [
+          "claude-code",
+          "github",
+          "issues",
+          "pull-requests",
+          "github-actions",
+          "ci",
+          "workflow"
+        ]
+      },
+      {
+        "name": "ultracost",
+        "description": "Per-stage model routing + pre-flight cost gate for Claude Code ultracode dynamic workflows. Pins an explicit model + effort on every agent() subagent stage, estimates cost before launch, and ships a static guard + PreToolUse gate that flag stages which would silently inherit the session's Opus model. Zero dependencies, no telemetry, MIT.",
+        "source": "danielkremen818/ultracost",
+        "author": "Daniel Kremen",
+        "tags": [
+          "claude-code",
+          "claude-code-plugin",
+          "ultracode",
+          "dynamic-workflows",
+          "subagents",
+          "model-routing",
+          "cost-optimization",
+          "finops"
+        ]
+      },
+      {
+        "name": "forge",
+        "description": "Full-lifecycle SDLC orchestrator: a 12-stage pipeline (SRS, architecture, spec, plan, build, eval, deploy, monitor, release) driven by specialized agents, persistent cross-session memory, auto-reflection, gate enforcement, and semantic skill mining that proposes new skills from recurring workflows.",
+        "source": "tonmoy007/forge-plugins",
+        "author": "Saddam",
+        "tags": [
+          "sdlc",
+          "orchestration",
+          "agents",
+          "pipeline",
+          "memory",
+          "skills",
+          "automation",
+          "workflow"
+        ]
+      },
+      {
+        "name": "codex-orchestrator",
+        "description": "Orchestrate OpenAI Codex from Claude through supervised checkpoint slices, server-enforced quality gates, persistent plans and hypotheses, worktree isolation, and per-task model and effort control.",
+        "source": "tomtastisch/codex-orchestrator",
+        "author": "Tom Werner",
+        "tags": [
+          "claude-code",
+          "codex",
+          "mcp",
+          "orchestration",
+          "multi-agent",
+          "checkpoint",
+          "worktrees",
+          "quality-gates"
+        ]
+      },
+      {
+        "name": "claude-md-kit",
+        "description": "Scaffold and audit CLAUDE.md files from inside Claude Code: /claude-md-new builds one from battle-tested templates using your repo's real commands; /claude-md-audit grades an existing one and returns worst-first fixes.",
+        "source": "./plugins/claude-md-kit",
+        "author": "Fabler Labs",
+        "tags": [
+          "claude-md",
+          "agents-md",
+          "templates",
+          "scaffolding",
+          "code-quality"
+        ]
+      },
+      {
+        "name": "fabler-relay",
+        "description": "Human-in-the-loop request queue for autonomous agents: file a blocker (account creation, CAPTCHA-gated step, purchase approval) to a human operator via MCP, poll for the result, keep working. Talks to your own self-hosted Cloudflare Worker.",
+        "source": "./plugins/fabler-relay",
+        "author": "Fabler Labs",
+        "tags": [
+          "mcp",
+          "human-in-the-loop",
+          "hitl",
+          "approvals",
+          "autonomous-agents"
+        ]
+      },
+      {
+        "name": "fabler-x402-tools",
+        "description": "Nine MCP tools for security audits, web scraping, OG rendering, and funding spreads. Default setup is inspect-only and requires no wallet key. Optional x402 auto-payment requires X402_BUYER_PRIVATE_KEY; use only a dedicated low-balance wallet funded with what you are willing to spend.",
+        "source": "./plugins/fabler-x402-tools",
+        "author": "Fabler Labs",
+        "tags": [
+          "mcp",
+          "x402",
+          "usdc",
+          "security",
+          "ai-agents"
+        ]
       }
     ]
   },
@@ -2902,7 +10656,7 @@
     "author": "lackeyjb",
     "description": "Claude Code Skill for browser automation with Playwright. Model-invoked - Claude autonomously writes and executes custom automation for testing and validation.",
     "github": "https://github.com/lackeyjb/playwright-skill",
-    "stars": 2219,
+    "stars": 2891,
     "type": "plugin",
     "tags": [
       "skills"
@@ -2911,139 +10665,12 @@
     "highlights": []
   },
   {
-    "slug": "claude-octopus",
-    "name": "Claude Octopus",
-    "author": "nyldn",
-    "description": "Multi-LLM orchestration plugin for Claude Code — 8 providers (Codex, Gemini, Claude, Perplexity, OpenRouter, Copilot, Qwen, Ollama), 47 commands, 50 skills, Double Diamond workflows",
-    "github": "https://github.com/nyldn/claude-octopus",
-    "stars": 2132,
-    "type": "plugin",
-    "tags": [
-      "skills",
-      "agents",
-      "commands",
-      "hooks"
-    ],
-    "contains": {
-      "skills": 50,
-      "commands": 47
-    },
-    "highlights": [
-      "Plugin declares: 50 skills, 47 commands",
-      "Web UI: https://reddit.com/r/ClaudeOctopus/"
-    ],
-    "website": "https://reddit.com/r/ClaudeOctopus/",
-    "plugin_manifest": {
-      "skills": [
-        "./.claude/skills/skill-prd.md",
-        "./.claude/skills/skill-security-framing.md",
-        "./.claude/skills/skill-content-pipeline.md",
-        "./.claude/skills/skill-thought-partner.md",
-        "./.claude/skills/skill-meta-prompt.md",
-        "./.claude/skills/skill-context-detection.md",
-        "./.claude/skills/flow-discover.md",
-        "./.claude/skills/flow-define.md",
-        "./.claude/skills/flow-develop.md",
-        "./.claude/skills/flow-deliver.md",
-        "./.claude/skills/sys-configure.md",
-        "./.claude/skills/skill-debate.md",
-        "./.claude/skills/skill-code-review.md",
-        "./.claude/skills/skill-architecture.md",
-        "./.claude/skills/skill-security-audit.md",
-        "./.claude/skills/skill-deep-research.md",
-        "./.claude/skills/skill-writing-plans.md",
-        "./.claude/skills/skill-tdd.md",
-        "./.claude/skills/skill-debug.md",
-        "./.claude/skills/skill-doc-delivery.md",
-        "./.claude/skills/skill-finish-branch.md",
-        "./.claude/skills/skill-verify.md",
-        "./.claude/skills/skill-parallel-agents.md",
-        "./.claude/skills/skill-knowledge-work.md",
-        "./.claude/skills/skill-task-management-v2.md",
-        "./.claude/skills/skill-visual-feedback.md",
-        "./.claude/skills/skill-decision-support.md",
-        "./.claude/skills/skill-iterative-loop.md",
-        "./.claude/skills/skill-audit.md",
-        "./.claude/skills/skill-intent-contract.md",
-        "./.claude/skills/skill-quick.md",
-        "./.claude/skills/extract-skill.md",
-        "./.claude/skills/skill-status.md",
-        "./.claude/skills/skill-issues.md",
-        "./.claude/skills/skill-rollback.md",
-        "./.claude/skills/skill-resume.md",
-        "./.claude/skills/skill-ship.md",
-        "./.claude/skills/skill-deck.md",
-        "./.claude/skills/flow-spec.md",
-        "./.claude/skills/flow-parallel.md",
-        "./.claude/skills/skill-doctor.md",
-        "./.claude/skills/skill-claw.md",
-        "./.claude/skills/skill-factory.md",
-        "./.claude/skills/skill-staged-review.md",
-        "./.claude/skills/skill-ui-ux-design.md",
-        "./.claude/skills/skill-coverage-audit.md",
-        "./.claude/skills/skill-doc-sync.md",
-        "./.claude/skills/skill-cost-projections.md",
-        "./.claude/skills/skill-design-lineage.md",
-        "./.claude/skills/skill-copilot-provider.md"
-      ],
-      "commands": [
-        "./.claude/commands/auto.md",
-        "./.claude/commands/octo.md",
-        "./.claude/commands/prd.md",
-        "./.claude/commands/pipeline.md",
-        "./.claude/commands/brainstorm.md",
-        "./.claude/commands/meta-prompt.md",
-        "./.claude/commands/prd-score.md",
-        "./.claude/commands/setup.md",
-        "./.claude/commands/km.md",
-        "./.claude/commands/dev.md",
-        "./.claude/commands/review.md",
-        "./.claude/commands/security.md",
-        "./.claude/commands/debug.md",
-        "./.claude/commands/tdd.md",
-        "./.claude/commands/loop.md",
-        "./.claude/commands/docs.md",
-        "./.claude/commands/embrace.md",
-        "./.claude/commands/discover.md",
-        "./.claude/commands/define.md",
-        "./.claude/commands/develop.md",
-        "./.claude/commands/deliver.md",
-        "./.claude/commands/multi.md",
-        "./.claude/commands/plan.md",
-        "./.claude/commands/quick.md",
-        "./.claude/commands/extract.md",
-        "./.claude/commands/model-config.md",
-        "./.claude/commands/deck.md",
-        "./.claude/commands/scheduler.md",
-        "./.claude/commands/schedule.md",
-        "./.claude/commands/spec.md",
-        "./.claude/commands/parallel.md",
-        "./.claude/commands/sentinel.md",
-        "./.claude/commands/claw.md",
-        "./.claude/commands/doctor.md",
-        "./.claude/commands/factory.md",
-        "./.claude/commands/staged-review.md",
-        "./.claude/commands/design-ui-ux.md",
-        "./.claude/commands/debate.md",
-        "./.claude/commands/research.md",
-        "./.claude/commands/resume.md",
-        "./.claude/commands/careful.md",
-        "./.claude/commands/freeze.md",
-        "./.claude/commands/guard.md",
-        "./.claude/commands/unfreeze.md",
-        "./.claude/commands/costs.md",
-        "./.claude/commands/retro.md",
-        "./.claude/commands/history.md"
-      ]
-    }
-  },
-  {
     "slug": "claude-code-plugins-plus-skills",
     "name": "Claude Code Plugins Plus Skills",
     "author": "jeremylongshore",
-    "description": "340 plugins + 1367 agent skills for Claude Code. Open-source marketplace with CCPI package manager, interactive tutorials, and production orchestration patterns.",
+    "description": "425 plugins, 2,810 skills, 200 agents for Claude Code. Open-source marketplace at tonsofskills.com with the ccpi CLI package manager.",
     "github": "https://github.com/jeremylongshore/claude-code-plugins-plus-skills",
-    "stars": 1731,
+    "stars": 2501,
     "type": "marketplace",
     "tags": [
       "skills",
@@ -3051,47 +10678,53 @@
       "commands"
     ],
     "contains": {
-      "plugins": 416,
+      "plugins": 464,
       "components": {
         "skills": 73,
-        "commands": 50,
+        "commands": 49,
         "agents": 2
       }
     },
     "highlights": [
-      "416 plugins in marketplace",
+      "464 plugins in marketplace",
       "Web UI: https://tonsofskills.com"
     ],
     "website": "https://tonsofskills.com",
     "plugins_list": [
       {
         "name": "000-jeremy-content-consistency-validator",
-        "description": "Read-only validator that generates comprehensive discrepancy reports comparing messaging consistency across ANY HTML-based website (WordPress, Hugo, Next.js, React, Vue, static HTML, etc.), GitHub repositories, and local documentation. Detects mixed messaging without making changes.",
+        "description": "Read-only consistency validator: 9 deterministic drift checks across docs, code, tests, and CI, adjudicated by a per-fact-class authority registry (sot-map.yaml) — no global source-of-truth ranking, LLM-judged findings advisory-only, golden-fixture gated. Invoked by /release Phase 1.6.",
         "source": "./plugins/productivity/000-jeremy-content-consistency-validator",
         "author": "Jeremy Longshore",
         "tags": [
           "documentation",
           "consistency",
           "validation",
-          "website",
-          "github",
+          "drift-detection",
+          "source-of-truth",
+          "authority-registry",
           "content-audit",
-          "messaging",
           "quality-assurance",
-          "wordpress",
-          "hugo",
-          "nextjs",
-          "react",
-          "vue",
-          "static-site",
-          "jekyll",
-          "gatsby",
-          "sop",
+          "release-gate",
           "standards"
         ],
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "validate-consistency",
+              "description": "|"
+            }
+          ],
+          "commands": [
+            {
+              "name": "validate-consistency",
+              "description": "Run the document consistency audit via the validate-consistency skill"
+            }
+          ]
         }
       },
       {
@@ -3111,6 +10744,14 @@
         ],
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "yaml-master",
+              "description": "'Execute proactive YAML intelligence: automatically activates when working"
+            }
+          ]
         }
       },
       {
@@ -3135,6 +10776,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "vertex-ai-media-master",
+              "description": "'Execute automatic activation for all google vertex ai multimodal operations"
+            }
+          ],
+          "commands": [
+            {
+              "name": "vertex-campaign",
+              "description": "Generate complete multimodal marketing campaigns using Vertex AI - video,..."
+            }
+          ]
         }
       },
       {
@@ -3159,6 +10814,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "google-cloud-agent-sdk-master",
+              "description": "'Execute automatic activation for all google cloud agent development"
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-agent",
+              "description": "Create a production-ready Google Cloud agent using ADK and Agent Starter..."
+            }
+          ]
         }
       },
       {
@@ -3174,6 +10843,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "auditing-access-control",
+              "description": "Audit access control implementations for security vulnerabilities and"
+            }
+          ],
+          "commands": [
+            {
+              "name": "audit-access",
+              "description": "DESCRIPTION_PLACEHOLDER"
+            }
+          ]
         }
       },
       {
@@ -3193,6 +10876,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "scanning-accessibility",
+              "description": "'Validate WCAG compliance and accessibility standards (ARIA, keyboard"
+            }
+          ],
+          "commands": [
+            {
+              "name": "a11y-scan",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3208,6 +10905,46 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-context-loader",
+              "description": "'Execute proactive auto-loading: automatically detects and loads agents.md"
+            }
+          ],
+          "commands": [
+            {
+              "name": "sync-agent-context",
+              "description": "Merge all AGENTS.md files into CLAUDE.md for unified agent context"
+            }
+          ]
+        }
+      },
+      {
+        "name": "agency-os",
+        "description": "Run your work like an AI agency, from a single Notion board. Agents discuss, plan, and execute tasks in parallel with dependency ordering and model routing.",
+        "source": "./plugins/ai-agency/agency-os",
+        "author": "AutomateLab",
+        "tags": [
+          "notion",
+          "task-management",
+          "ai-agency",
+          "autonomous-agent",
+          "workflow",
+          "project-management",
+          "claude-code"
+        ],
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agency-os",
+              "description": "|"
+            }
+          ]
         }
       },
       {
@@ -3227,6 +10964,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "commit",
+              "description": "Generate an AI-powered conventional commit message from your git diff and..."
+            }
+          ]
         }
       },
       {
@@ -3244,6 +10995,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "validating-ai-ethics-and-fairness",
+              "description": "'Validate AI/ML models and datasets for bias, fairness, and ethical concerns."
+            }
+          ],
+          "commands": [
+            {
+              "name": "validate-ethics",
+              "description": "Execute AI/ML task with intelligent automation"
+            }
+          ]
         }
       },
       {
@@ -3260,6 +11025,28 @@
         "components": {
           "skills": 1,
           "commands": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "log",
+              "description": "Log a new AI experiment with terminal report"
+            },
+            {
+              "name": "report",
+              "description": "Generate comprehensive terminal report of AI experiments"
+            },
+            {
+              "name": "search",
+              "description": "Search AI experiments and display formatted results"
+            }
+          ]
         }
       },
       {
@@ -3281,6 +11068,14 @@
         ],
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "optimizing-prompts",
+              "description": "'Execute this skill optimizes prompts for large language models (llms)"
+            }
+          ]
         }
       },
       {
@@ -3307,6 +11102,34 @@
           "skills": 1,
           "agents": 1,
           "commands": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "orchestrating-multi-agent-systems",
+              "description": "'Execute orchestrate multi-agent systems with handoffs, routing, and"
+            }
+          ],
+          "agents": [
+            {
+              "name": "multi-agent-orchestrator",
+              "description": "Coordinates multi-agent systems by decomposing tasks, routing to the right specialist, managing handoffs with full context, and aggregating outputs into a cohesive result. Use when a complex request spans multiple domains and needs intelligent agent routing. Trigger with \\\"orchestrate this task\\\", \\\"route to the right agent\\\"."
+            }
+          ],
+          "commands": [
+            {
+              "name": "ai-agent-create",
+              "description": "Create a new specialized AI agent with custom tools, handoff rules, and..."
+            },
+            {
+              "name": "ai-agents-setup",
+              "description": "Initialize a multi-agent orchestration project with AI SDK v5 agents,..."
+            },
+            {
+              "name": "ai-agents-test",
+              "description": "Test your multi-agent system with a sample task, showing agent handoffs,..."
+            }
+          ]
         }
       },
       {
@@ -3323,6 +11146,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "creating-alerting-rules",
+              "description": "'Execute this skill enables AI assistant to create intelligent alerting"
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-alerts",
+              "description": "Create intelligent alerting rules"
+            }
+          ]
         }
       },
       {
@@ -3340,6 +11177,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "detecting-data-anomalies",
+              "description": "'Process identify anomalies and outliers in datasets using machine learning"
+            }
+          ],
+          "commands": [
+            {
+              "name": "detect-anomaly",
+              "description": "Execute AI/ML task with intelligent automation"
+            }
+          ]
         }
       },
       {
@@ -3357,6 +11208,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "creating-ansible-playbooks",
+              "description": "'Execute use when you need to work with Ansible automation."
+            }
+          ],
+          "commands": [
+            {
+              "name": "ansible-playbook",
+              "description": "Create Ansible playbooks for configuration management"
+            }
+          ]
         }
       },
       {
@@ -3373,6 +11238,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "building-api-authentication",
+              "description": "'Build secure API authentication systems with OAuth2, JWT, API keys,"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "build-auth-system",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3389,6 +11272,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "processing-api-batches",
+              "description": "'Optimize bulk API requests with batching, throttling, and parallel execution."
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "implement-batch-processing",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3405,6 +11306,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "managing-api-cache",
+              "description": "'Implement intelligent API response caching with Redis, Memcached, and"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "implement-caching",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3421,6 +11340,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "generating-api-contracts",
+              "description": "'Generate API contracts and OpenAPI specifications from code or design"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "generate-contract",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3438,6 +11375,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "generating-api-docs",
+              "description": "'Create comprehensive API documentation with examples, authentication"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "generate-api-docs",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3454,6 +11409,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "handling-api-errors",
+              "description": "'Implement standardized error handling with proper HTTP status codes"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "implement-error-handling",
+              "description": "Implement standardized API error handling"
+            }
+          ]
         }
       },
       {
@@ -3471,6 +11444,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "emitting-api-events",
+              "description": "'Build event-driven APIs with webhooks, Server-Sent Events, and real-time"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "implement-events",
+              "description": "Implement event-driven API architecture"
+            }
+          ]
         }
       },
       {
@@ -3489,6 +11480,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "fuzzing-apis",
+              "description": "'Configure perform API fuzzing to discover edge cases, crashes, and security"
+            }
+          ],
+          "commands": [
+            {
+              "name": "fuzz-api",
+              "description": "Fuzz test APIs with malformed inputs and edge cases"
+            }
+          ]
         }
       },
       {
@@ -3505,6 +11510,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "building-api-gateway",
+              "description": "'Create API gateways with routing, load balancing, rate limiting, and"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "build-api-gateway",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3521,6 +11544,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "load-testing-apis",
+              "description": "'Execute comprehensive load and stress testing to validate API performance"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "run-load-test",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3537,6 +11578,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "migrating-apis",
+              "description": "'Implement API migrations between versions, platforms, or frameworks"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "migrate-api",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3553,6 +11612,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "mocking-apis",
+              "description": "'Generate mock API servers for testing and development with realistic"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-mock-server",
+              "description": "Create a mock API server for testing"
+            }
+          ]
         }
       },
       {
@@ -3569,6 +11646,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "monitoring-apis",
+              "description": "'Build real-time API monitoring dashboards with metrics, alerts, and"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-monitoring",
+              "description": "Create API monitoring dashboard"
+            }
+          ]
         }
       },
       {
@@ -3585,6 +11680,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "rate-limiting-apis",
+              "description": "'Implement sophisticated rate limiting with sliding windows, token buckets,"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "add-rate-limiting",
+              "description": "Add rate limiting to API endpoints"
+            }
+          ]
         }
       },
       {
@@ -3601,6 +11714,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "logging-api-requests",
+              "description": "'Monitor and log API requests with correlation IDs, performance metrics,"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "setup-logging",
+              "description": "Set up API request logging"
+            }
+          ]
         }
       },
       {
@@ -3617,6 +11748,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            },
+            {
+              "name": "validating-api-responses",
+              "description": "'Validate API responses against schemas to ensure contract compliance"
+            }
+          ],
+          "commands": [
+            {
+              "name": "validate-api-responses",
+              "description": "Validate API responses against schemas"
+            }
+          ]
         }
       },
       {
@@ -3634,6 +11783,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            },
+            {
+              "name": "validating-api-schemas",
+              "description": "'Validate API schemas against OpenAPI, JSON Schema, and GraphQL specifications."
+            }
+          ],
+          "commands": [
+            {
+              "name": "validate-schemas",
+              "description": "Validate API schemas"
+            }
+          ]
         }
       },
       {
@@ -3650,6 +11817,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "generating-api-sdks",
+              "description": "'Generate client SDKs in multiple languages from OpenAPI specifications."
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "generate-sdk",
+              "description": "Generate client SDKs from OpenAPI specs"
+            }
+          ]
         }
       },
       {
@@ -3666,6 +11851,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "scanning-api-security",
+              "description": "'Detect API security vulnerabilities including injection, broken auth,"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "scan-api-security",
+              "description": "Scan API for security vulnerabilities"
+            }
+          ]
         }
       },
       {
@@ -3684,6 +11887,20 @@
         "components": {
           "skills": 1,
           "agents": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "automating-api-testing",
+              "description": "'Test automate API endpoint testing including request generation, validation,"
+            }
+          ],
+          "agents": [
+            {
+              "name": "api-tester",
+              "description": "Generates and executes REST and GraphQL API test suites covering happy paths, auth scenarios, edge cases, and contract validation, then reports results with coverage metrics. Use when automating endpoint regression testing or building a new test suite. Trigger with \"test this API\", \"generate API tests\"."
+            }
+          ]
         }
       },
       {
@@ -3700,6 +11917,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            },
+            {
+              "name": "throttling-apis",
+              "description": "'Implement API throttling policies to protect backend services from overload."
+            }
+          ],
+          "commands": [
+            {
+              "name": "implement-throttling",
+              "description": "Implement API throttling and quotas"
+            }
+          ]
         }
       },
       {
@@ -3716,6 +11951,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "skill-adapter",
+              "description": ""
+            },
+            {
+              "name": "versioning-apis",
+              "description": "'Implement API versioning with backward compatibility, deprecation notices,"
+            }
+          ],
+          "commands": [
+            {
+              "name": "manage-api-versions",
+              "description": "Manage API versions with proper migration strategies"
+            }
+          ]
         }
       },
       {
@@ -3733,6 +11986,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "creating-apm-dashboards",
+              "description": "'Execute this skill enables AI assistant to create application performance"
+            }
+          ],
+          "commands": [
+            {
+              "name": "create-dashboard",
+              "description": "Create APM monitoring dashboards"
+            }
+          ]
         }
       },
       {
@@ -3749,6 +12016,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "profiling-application-performance",
+              "description": "'Execute this skill enables AI assistant to profile application performance,"
+            }
+          ],
+          "commands": [
+            {
+              "name": "profile",
+              "description": "Profile application performance metrics"
+            }
+          ]
         }
       },
       {
@@ -3766,6 +12047,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "finding-arbitrage-opportunities",
+              "description": "'Detect profitable arbitrage opportunities across CEX, DEX, and cross-chain"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "find-arbitrage",
+              "description": ">"
+            }
+          ]
         }
       },
       {
@@ -3781,6 +12080,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "validating-authentication-implementations",
+              "description": "Validate authentication mechanisms for security weaknesses and compliance."
+            }
+          ],
+          "commands": [
+            {
+              "name": "validate-auth",
+              "description": "DESCRIPTION_PLACEHOLDER"
+            }
+          ]
         }
       },
       {
@@ -3798,6 +12111,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "configuring-auto-scaling-policies",
+              "description": "'Configure use when you need to work with auto-scaling."
+            }
+          ],
+          "commands": [
+            {
+              "name": "auto-scale",
+              "description": "Configure auto-scaling policies for applications and infrastructure"
+            }
+          ]
         }
       },
       {
@@ -3815,6 +12142,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "building-automl-pipelines",
+              "description": "'Build automated machine learning pipelines with feature engineering,"
+            }
+          ],
+          "commands": [
+            {
+              "name": "build-automl",
+              "description": "Execute AI/ML task with intelligent automation"
+            }
+          ]
         }
       },
       {
@@ -3831,6 +12172,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "implementing-backup-strategies",
+              "description": "'Execute use when you need to work with backup and recovery."
+            }
+          ],
+          "commands": [
+            {
+              "name": "backup-strategy",
+              "description": "Design a backup strategy with schedules, retention, storage tiers, and recovery."
+            }
+          ]
         }
       },
       {
@@ -3849,6 +12204,24 @@
         "components": {
           "skills": 2,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "exploring-blockchain-data",
+              "description": "'Process query and analyze blockchain data including blocks, transactions,"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ],
+          "commands": [
+            {
+              "name": "explore",
+              "description": "Explore blockchain transactions, addresses, and contracts"
+            }
+          ]
         }
       },
       {
@@ -3865,6 +12238,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "detecting-performance-bottlenecks",
+              "description": "'Execute this skill enables AI assistant to detect and resolve performance"
+            }
+          ],
+          "commands": [
+            {
+              "name": "detect-bottlenecks",
+              "description": "Detect performance bottlenecks in application"
+            }
+          ]
         }
       },
       {
@@ -3883,6 +12270,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "testing-browser-compatibility",
+              "description": "'Test across multiple browsers and devices for cross-browser compatibility."
+            }
+          ],
+          "commands": [
+            {
+              "name": "browser-test",
+              "description": "Cross-browser testing across browsers, devices, and cloud providers"
+            }
+          ]
         }
       },
       {
@@ -3899,6 +12300,20 @@
         "components": {
           "skills": 1,
           "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "optimizing-cache-performance",
+              "description": "'Execute this skill enables AI assistant to analyze and improve application"
+            }
+          ],
+          "commands": [
+            {
+              "name": "optimize-cache",
+              "description": "Optimize caching strategies and implementation"
+            }
+          ]
         }
       },
       {
@@ -3914,6 +12329,18 @@
         ],
         "components": {
           "skills": 2
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "calendar-to-workflow",
+              "description": "'Converts calendar events and schedules into Claude Code workflows, meeting"
+            },
+            {
+              "name": "skill-adapter",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -3926,11 +12353,7 @@
           "scaling",
           "forecasting",
           "infrastructure"
-        ],
-        "components": {
-          "skills": 1,
-          "commands": 1
-        }
+        ]
       },
       {
         "name": "chaos-engineering-toolkit",
@@ -4778,6 +13201,25 @@
         ]
       },
       {
+        "name": "engineer-design-diagram",
+        "description": "Generate production-grade engineering design diagrams (architecture, sequence, delta, drift) as self-contained dark-themed HTML files with accessible inline SVG. Grounds every diagram in real repo topology via DCI — package manifests, docker-compose, k8s, terraform, import graph. Four modes: generate, diff, trace, watch. Semantic OKLCH palette; Mermaid fallback for large graphs.",
+        "source": "./plugins/devops/engineer-design-diagram",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "architecture",
+          "diagram",
+          "visualization",
+          "svg",
+          "html",
+          "pr-review",
+          "drift-detection",
+          "sequence-diagram",
+          "engineering-design",
+          "documentation",
+          "onboarding"
+        ]
+      },
+      {
         "name": "environment-config-manager",
         "description": "Manage environment configurations and secrets across deployments",
         "source": "./plugins/devops/environment-config-manager",
@@ -4932,6 +13374,22 @@
           "formatting",
           "hooks",
           "automation"
+        ]
+      },
+      {
+        "name": "freshie-inventory-manager",
+        "description": "Interactive command center for the freshie ecosystem inventory database — conversational wizard with subagents for discovery scans, compliance grading, batch remediation, querying, reporting, and email PDF delivery across 50 tables of plugin/skill/pack metadata",
+        "source": "./plugins/database/freshie-inventory-manager",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "database",
+          "inventory",
+          "freshie",
+          "compliance",
+          "sqlite",
+          "ecosystem",
+          "audit",
+          "subagents"
         ]
       },
       {
@@ -5139,6 +13597,24 @@
           "test-runner",
           "e2e",
           "api-testing"
+        ]
+      },
+      {
+        "name": "kobiton-automate",
+        "description": "Real mobile devices on demand via Kobiton's remote MCP — no emulators, no flaky CI. 12 tools across Devices, Sessions, and Apps surfaces, plus specialist agents for device picking, Appium capability reconciliation, and session triage.",
+        "source": "./plugins/testing/kobiton-automate",
+        "author": "Kobiton Inc.",
+        "tags": [
+          "mobile",
+          "testing",
+          "appium",
+          "automation",
+          "devices",
+          "ios",
+          "android",
+          "real-device",
+          "mcp",
+          "kobiton"
         ]
       },
       {
@@ -5561,7 +14037,7 @@
       {
         "name": "openbb-terminal",
         "description": "Open-source investment research terminal integration - comprehensive equity analysis, crypto tracking, macro indicators, portfolio optimization, and AI-powered financial insights using OpenBB Platform",
-        "source": "./plugins/finance/openbb-terminal",
+        "source": "./plugins/business-tools/openbb-terminal",
         "author": "Jeremy Longshore",
         "tags": [
           "finance",
@@ -5649,7 +14125,7 @@
       },
       {
         "name": "penetration-tester",
-        "description": "Automated penetration testing for web applications with OWASP Top 10 coverage",
+        "description": "25-skill pentest pack with engagement governance, network/code/dependency scans, OWASP Top 10 mapping, and exec-readable reporting. Heavy-hitter compliant; chain-of-custody attestable.",
         "source": "./plugins/security/penetration-tester",
         "author": "Jeremy Longshore",
         "tags": [
@@ -5657,7 +14133,12 @@
           "penetration-testing",
           "pentesting",
           "owasp",
-          "exploitation"
+          "owasp-top-10",
+          "vulnerability-scanning",
+          "dependency-audit",
+          "license-compliance",
+          "engagement-governance",
+          "chain-of-custody"
         ]
       },
       {
@@ -5728,6 +14209,25 @@
         ]
       },
       {
+        "name": "code-cleanup",
+        "description": "Comprehensive codebase cleanup across 11 quality dimensions — dead code, duplication, weak types, circular deps, defensive cruft, legacy code, AI slop, type consolidation, security, performance, and async patterns. Confidence scoring and build verification gates.",
+        "source": "./plugins/testing/code-cleanup",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "code-quality",
+          "cleanup",
+          "refactoring",
+          "dead-code",
+          "deduplication",
+          "type-safety",
+          "security",
+          "performance",
+          "async",
+          "tech-debt",
+          "code-review"
+        ]
+      },
+      {
         "name": "project-health-auditor",
         "description": "Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots",
         "source": "./plugins/mcp/project-health-auditor",
@@ -5740,6 +14240,21 @@
           "git-churn",
           "test-coverage",
           "analytics"
+        ]
+      },
+      {
+        "name": "promptbook",
+        "description": "Opt-in session analytics for Claude Code. After setup consent, tracks prompts, tokens, build time, and lines changed per session. Publishes shareable build cards on promptbook.gg. Strict consent gating — no data transmitted without explicit opt-in. Background submission after session end.",
+        "source": "./plugins/business-tools/promptbook",
+        "author": "Promptbook",
+        "tags": [
+          "analytics",
+          "telemetry",
+          "builds",
+          "portfolio",
+          "tracking",
+          "metrics",
+          "sessions"
         ]
       },
       {
@@ -6048,7 +14563,7 @@
       },
       {
         "name": "jeremy-plugin-tool",
-        "description": "Production-grade plugin creator with nixtla-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
+        "description": "Production-grade plugin creator with marketplace-validated quality standards. 4 Agent Skills automate creating, validating, auditing, and versioning plugins in the claude-code-plugins marketplace",
         "source": "./plugins/examples/jeremy-plugin-tool",
         "author": "Claude Code Plugins",
         "tags": [
@@ -6621,6 +15136,38 @@
         ]
       },
       {
+        "name": "jeremy-google-adk",
+        "description": "Google Agent Development Kit (ADK) starter for building production AI agents — ReAct single-agent or multi-agent orchestration (Sequential/Parallel/Loop), tool wiring, evaluation harness, and optional Vertex AI Agent Engine deployment.",
+        "source": "./plugins/ai-ml/jeremy-google-adk",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "google",
+          "adk",
+          "agent-development-kit",
+          "ai-agents",
+          "react-pattern",
+          "multi-agent",
+          "vertex-ai",
+          "agent-engine"
+        ]
+      },
+      {
+        "name": "jeremy-vertex-ai",
+        "description": "Build and deploy generative AI agents on Vertex AI: Gemini model selection, RAG with grounded retrieval, function calling, multimodal extraction, evaluation, and Agent Engine deployment with operational guardrails.",
+        "source": "./plugins/ai-ml/jeremy-vertex-ai",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "vertex-ai",
+          "gemini",
+          "google-cloud",
+          "generative-ai",
+          "rag",
+          "agent-engine",
+          "function-calling",
+          "multimodal"
+        ]
+      },
+      {
         "name": "jeremy-genkit-terraform",
         "description": "Terraform modules for Firebase Genkit infrastructure and deployments",
         "source": "./plugins/devops/jeremy-genkit-terraform",
@@ -6829,7 +15376,7 @@
       },
       {
         "name": "jeremy-adk-software-engineer",
-        "description": "ADK software engineer for creating production-ready agents (placeholder - to be implemented)",
+        "description": "ADK software engineer for creating production-ready Agent Development Kit agents with clean structure, testability, safe tool usage, and deployment automation",
         "source": "./plugins/ai-ml/jeremy-adk-software-engineer",
         "author": "Jeremy Longshore",
         "tags": [
@@ -6840,7 +15387,7 @@
         ]
       },
       {
-        "name": "geepers",
+        "name": "geepers-agents",
         "description": "Multi-agent orchestration system with 51 specialized agents for development workflows, code quality, deployment, research, and more. Built with MCP tools and Claude Code plugin agents.",
         "source": "./plugins/community/geepers-agents",
         "author": "Luke Steuber",
@@ -6891,51 +15438,9 @@
         ]
       },
       {
-        "name": "jeremy-google-adk",
-        "description": "Google Agent Development Kit (ADK) SDK starter kit for building Claude-powered AI agents with React patterns, multi-agent orchestration, and tool integration",
-        "source": "./plugins/jeremy-google-adk",
-        "author": "Jeremy Longshore",
-        "tags": [
-          "google",
-          "adk",
-          "agent-development-kit",
-          "sdk",
-          "ai-agents",
-          "claude",
-          "react-pattern",
-          "multi-agent",
-          "orchestration",
-          "tools",
-          "framework",
-          "scaffolding",
-          "starter-kit"
-        ]
-      },
-      {
-        "name": "jeremy-vertex-ai",
-        "description": "Comprehensive Vertex AI integration plugin for building generative AI agents with Gemini, Vertex AI Studio, and production deployment on Google Cloud",
-        "source": "./plugins/jeremy-vertex-ai",
-        "author": "Jeremy Longshore",
-        "tags": [
-          "vertex-ai",
-          "google-cloud",
-          "gemini",
-          "generative-ai",
-          "agent-builder",
-          "ai-studio",
-          "mlops",
-          "llm",
-          "embedding",
-          "rag",
-          "vector-search",
-          "cloud-run",
-          "gcp"
-        ]
-      },
-      {
         "name": "mattyp-changelog",
         "description": "Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or PR summaries. Trigger with /changelog-weekly, /changelog-custom, or /changelog-validate.",
-        "source": "./plugins/automation/mattyp-changelog",
+        "source": "./plugins/devops/mattyp-changelog",
         "author": "Mattyp",
         "tags": [
           "changelog",
@@ -7312,18 +15817,20 @@
         ]
       },
       {
-        "name": "langchain-pack",
-        "description": "Complete LangChain integration skill pack with 24 skills covering chains, agents, RAG pipelines, memory, and LLM application development. Flagship tier vendor pack.",
-        "source": "./plugins/saas-packs/langchain-pack",
+        "name": "langchain-py-pack",
+        "description": "LangChain 1.0 + LangGraph 1.0 skill pack for Python. Pain-first skills anchored to a 68-entry pain catalog covering content blocks, streaming token accounting, structured-output, vector stores, checkpointing, HITL, middleware, Deep Agents, and native OTEL. Expanding toward 34 skills across four epics.",
+        "source": "./plugins/saas-packs/langchain-py-pack",
         "author": "Jeremy Longshore",
         "tags": [
           "langchain",
+          "langgraph",
+          "python",
           "llm",
-          "chains",
           "agents",
           "rag",
-          "memory",
-          "ai-applications",
+          "checkpointing",
+          "streaming",
+          "middleware",
           "langsmith"
         ]
       },
@@ -7354,6 +15861,22 @@
           "meetings",
           "ai-notes",
           "meeting-intelligence"
+        ]
+      },
+      {
+        "name": "ga4-pack",
+        "description": "Claude Code skill pack for Google Analytics 4 — 5 starter skills covering auth (OAuth + service account), Data API v1 queries (runReport, filters, sampling), Realtime API, canonical reports (DAU/MAU/retention/top pages/funnel), and BigQuery export with event-level SQL recipes.",
+        "source": "./plugins/saas-packs/ga4-pack",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "google-analytics",
+          "ga4",
+          "analytics",
+          "data-api",
+          "bigquery",
+          "reporting",
+          "dau-mau",
+          "cohort-retention"
         ]
       },
       {
@@ -7404,7 +15927,7 @@
       },
       {
         "name": "databricks-pack",
-        "description": "Complete Databricks integration skill pack with 24 skills covering Delta Lake, MLflow, notebooks, clusters, and data engineering workflows. Flagship tier vendor pack.",
+        "description": "DEPRECATED (v1) — these 24 documentation skills are removed in v2.0.0, which rebuilds the pack as 5 live-detection skills + a shared databricks-workspace-mcp server. See the README migration map before upgrading.",
         "source": "./plugins/saas-packs/databricks-pack",
         "author": "Jeremy Longshore",
         "tags": [
@@ -7633,6 +16156,20 @@
           "learnings",
           "hooks",
           "automation"
+        ]
+      },
+      {
+        "name": "contributing-clanker",
+        "description": "Local-only OSS contribution command center with 41 deterministic gates against AI-slop failure modes. Helps maintainers triage contributor PRs, check for typical AI-generated patterns (over-engineering, false claims, fabricated tests, license violations), and approve / request-changes from a single dashboard.",
+        "source": "./plugins/community/contributing-clanker",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "oss",
+          "contributions",
+          "github",
+          "ai-slop-prevention",
+          "code-review",
+          "open-source"
         ]
       },
       {
@@ -8118,19 +16655,6 @@
         ]
       },
       {
-        "name": "windsurf",
-        "description": "Windsurf AI IDE skill pack with 30 skills covering code flows, AI workflows, workspace management, and productivity features.",
-        "source": "./plugins/saas-packs/skill-databases/windsurf",
-        "author": "Jeremy Longshore",
-        "tags": [
-          "windsurf",
-          "ai-ide",
-          "code-editor",
-          "cascade",
-          "ai-coding"
-        ]
-      },
-      {
         "name": "abridge-pack",
         "description": "Claude Code skill pack for Abridge (18 skills)",
         "source": "./plugins/saas-packs/abridge-pack",
@@ -8363,7 +16887,7 @@
       },
       {
         "name": "coreweave-pack",
-        "description": "Claude Code skill pack for CoreWeave (24 skills)",
+        "description": "Claude Code skill pack for CoreWeave (23 skills)",
         "source": "./plugins/saas-packs/coreweave-pack",
         "author": "Jeremy Longshore",
         "tags": [
@@ -8520,7 +17044,7 @@
       },
       {
         "name": "hubspot-pack",
-        "description": "Claude Code skill pack for HubSpot (30 skills)",
+        "description": "Claude Code skill pack for HubSpot (10 production-engineer skills)",
         "source": "./plugins/saas-packs/hubspot-pack",
         "author": "Jeremy Longshore",
         "tags": [
@@ -8677,14 +17201,19 @@
       },
       {
         "name": "podium-pack",
-        "description": "Claude Code skill pack for Podium (18 skills)",
+        "description": "Claude Code skill pack for Podium (10 production-engineer skills covering OAuth, webhook reliability, rate-limit survival, call transcripts, webchat, review automation, history export, RAG context, multi-location routing, contact dedup)",
         "source": "./plugins/saas-packs/podium-pack",
         "author": "Jeremy Longshore",
         "tags": [
           "podium",
           "saas",
           "sdk",
-          "integration"
+          "integration",
+          "oauth2",
+          "webhooks",
+          "rag",
+          "call-transcripts",
+          "multi-location"
         ]
       },
       {
@@ -8785,14 +17314,16 @@
       },
       {
         "name": "shopify-pack",
-        "description": "Claude Code skill pack for Shopify (30 skills)",
+        "description": "Claude Code skill pack for Shopify (38 skills covering e-commerce development, storefront APIs, and app integration)",
         "source": "./plugins/saas-packs/shopify-pack",
         "author": "Jeremy Longshore",
         "tags": [
           "shopify",
           "saas",
           "sdk",
-          "integration"
+          "integration",
+          "e-commerce",
+          "storefront-api"
         ]
       },
       {
@@ -8919,6 +17450,20 @@
         ]
       },
       {
+        "name": "zero-tech-debt",
+        "description": "Rebuild a feature as if the correct product architecture existed from day one. Removes compatibility cruft, dead abstractions, and historical compromises instead of preserving them. Methodology-only — surfaces refactor candidates and walks a 7-step workflow before any deletion.",
+        "source": "./plugins/skill-enhancers/zero-tech-debt",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "refactoring",
+          "tech-debt",
+          "architecture",
+          "cleanup",
+          "modernization",
+          "code-quality"
+        ]
+      },
+      {
         "name": "executive-assistant-skills",
         "description": "AI-powered executive assistant skills that fully replace a human EA. Research meeting attendees, draft emails, create meeting briefs, and manage action items.",
         "source": "./plugins/business-tools/executive-assistant-skills",
@@ -8989,6 +17534,586 @@
           "devops",
           "mcp"
         ]
+      },
+      {
+        "name": "framecraft",
+        "description": "Generate polished demo videos from a single prompt. Orchestrates Playwright, FFmpeg, and Edge TTS MCP servers to produce 1920x1080 videos with voiceover, transitions, and CSS animations.",
+        "source": "./plugins/community/framecraft",
+        "author": "vaddisrinivas",
+        "tags": [
+          "demo-video",
+          "video-generation",
+          "playwright",
+          "ffmpeg",
+          "edge-tts",
+          "mcp"
+        ]
+      },
+      {
+        "name": "tweetclaw",
+        "description": "X/Twitter automation - post, reply, like, retweet, follow, DM, search, extract data, monitor accounts, run giveaways. 121 endpoints via Xquik REST API.",
+        "source": "./plugins/devops/tweetclaw",
+        "author": "Burak Bayir",
+        "tags": [
+          "twitter",
+          "x",
+          "automation",
+          "social-media",
+          "tweets",
+          "monitoring",
+          "giveaway",
+          "scraping"
+        ]
+      },
+      {
+        "name": "shipwright",
+        "description": "Describe your app in plain English — Shipwright builds, tests, and deploys it autonomously via a 9-phase pipeline.",
+        "source": "./plugins/ai-agency/shipwright",
+        "author": "Nate Nelson",
+        "tags": [
+          "app-builder",
+          "code-generator",
+          "autonomous-agent",
+          "pipeline",
+          "nextjs",
+          "supabase",
+          "sveltekit",
+          "astro",
+          "ai-agency"
+        ]
+      },
+      {
+        "name": "hyperfocus",
+        "description": "ADHD-friendly output formatting for Claude Code. Restructures responses with evidence-based cognitive accessibility: chunking, visual hierarchy, front-loaded key points, and progressive disclosure.",
+        "source": "./plugins/productivity/hyperfocus",
+        "author": "Nestor Magalhaes",
+        "tags": [
+          "accessibility",
+          "adhd",
+          "neurodivergent",
+          "formatting",
+          "readability",
+          "productivity",
+          "cognitive-accessibility"
+        ]
+      },
+      {
+        "name": "plane",
+        "description": "Plane is a team behavior observatory — synthesizes Plane API data into observations about how teams actually behave under pressure (cycle velocity vs. plan, ownership churn, reviewer gate strength, priority drift, cross-project load). Reads from the live mcp__plane MCP server.",
+        "source": "./plugins/productivity/plane",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "plane",
+          "project-management",
+          "team-behavior",
+          "observability",
+          "productivity",
+          "agent-skills",
+          "forge-generated"
+        ]
+      },
+      {
+        "name": "local-tts",
+        "description": "Offline text-to-speech via VoxCPM2 — 30 languages, voice design, voice cloning. Runs locally on Apple Silicon.",
+        "source": "./plugins/ai-ml/local-tts",
+        "author": "Bubble Invest",
+        "tags": [
+          "tts",
+          "text-to-speech",
+          "voice",
+          "voice-cloning",
+          "voice-design",
+          "offline",
+          "voxcpm",
+          "apple-silicon",
+          "audio",
+          "narration"
+        ]
+      },
+      {
+        "name": "boycott-filter",
+        "description": "Personal boycott list managed conversationally by your AI agent. Chrome extension warns you on pages from brands you've decided to avoid.",
+        "source": "./plugins/community/boycott-filter",
+        "author": "Bubble Invest",
+        "tags": [
+          "boycott",
+          "consumer",
+          "shopping",
+          "brands",
+          "chrome-extension",
+          "conversational",
+          "privacy",
+          "ethical-consumption"
+        ]
+      },
+      {
+        "name": "web-analytics",
+        "description": "Push-based web analytics intelligence team — self-hosted Umami via MCP (primary) + GA4 (fallback). 9 specialist agents fetch data, detect anomalies, analyze funnels, verify claims adversarially, and deliver narrative reports across your entire site portfolio. Three tiers: 30-second pulse, 2-min brief, 5-min full deep-dive. Console / email / Slack delivery.",
+        "source": "./plugins/analytics/web-analytics",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "analytics",
+          "umami",
+          "ga4",
+          "traffic",
+          "mcp",
+          "self-hosted",
+          "multi-agent",
+          "push-based"
+        ]
+      },
+      {
+        "name": "aomi",
+        "description": "Aomi for AI agents: drive natural-language EVM transactions (chat, fork-simulate, sign) and scaffold new Aomi apps from API specs. Non-custodial, account-abstraction-first. 40+ protocol apps: Polymarket, 1inch, GMX, Hyperliquid, Aave, Uniswap. Bundle ships two skills: aomi-transact and aomi-build.",
+        "source": "./plugins/crypto/aomi",
+        "author": "aomi-labs",
+        "tags": [
+          "crypto",
+          "defi",
+          "web3",
+          "evm",
+          "ethereum",
+          "wallet",
+          "account-abstraction",
+          "trading",
+          "agent",
+          "mcp"
+        ]
+      },
+      {
+        "name": "cli-power-skills",
+        "description": "Agentic CLI tool skills — 7 domain-grouped skills covering 26 CLI tools",
+        "source": "./plugins/productivity/cli-power-skills",
+        "author": "Yuriy Kotik",
+        "tags": [
+          "cli-tools",
+          "agentic-skills",
+          "data-processing",
+          "security",
+          "web-crawling",
+          "python",
+          "ci-cd"
+        ]
+      },
+      {
+        "name": "claude-workflow-skills",
+        "description": "Common Claude Code workflow skills — promote, audit-plugin, audit-standards, improve, and triage",
+        "source": "./plugins/productivity/claude-workflow-skills",
+        "author": "Alister Lewis-Bowen",
+        "tags": [
+          "workflow",
+          "promote",
+          "release",
+          "audit",
+          "standards",
+          "improve",
+          "triage",
+          "git",
+          "review",
+          "pull-request"
+        ]
+      },
+      {
+        "name": "cli-ux-tester",
+        "description": "Expert UX evaluator for CLIs and developer APIs, rates usability across 11 criteria with parallel evaluation agents",
+        "source": "./plugins/testing/cli-ux-tester",
+        "author": "Alister Lewis-Bowen",
+        "tags": [
+          "CLI",
+          "UX",
+          "testing",
+          "developer-experience",
+          "terminal",
+          "usability"
+        ]
+      },
+      {
+        "name": "skyvern",
+        "description": "AI browser automation via CLI — navigate sites, fill forms, extract data, handle logins",
+        "source": "./plugins/productivity/skyvern",
+        "author": "Skyvern-AI"
+      },
+      {
+        "name": "tonone",
+        "description": "23-agent engineering + product team with 125 skills for Claude Code",
+        "source": "./plugins/ai-agency/tonone",
+        "author": "tonone-ai",
+        "tags": [
+          "agents",
+          "engineering-team",
+          "infrastructure",
+          "devops",
+          "backend",
+          "security",
+          "observability",
+          "frontend",
+          "ml",
+          "mobile",
+          "embedded",
+          "analytics",
+          "testing",
+          "platform",
+          "sales",
+          "revenue",
+          "customer-success",
+          "content-marketing",
+          "pr",
+          "community",
+          "finance",
+          "people",
+          "operations",
+          "support"
+        ]
+      },
+      {
+        "name": "x-bug-triage",
+        "description": "Closed-loop bug triage — X complaints → clusters → repo evidence → owner routing → Slack review → filed issues",
+        "source": "./plugins/mcp/x-bug-triage",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "mcp",
+          "triage",
+          "x-api",
+          "bug-tracking",
+          "clustering"
+        ]
+      },
+      {
+        "name": "hyperflow",
+        "description": "Advanced multi-agent orchestration with persistent cross-session memory, per-step multi-level review, persona stitching, and adaptive flow profiles",
+        "source": "./plugins/ai-agency/hyperflow",
+        "author": "Mohammed Abdelhady",
+        "tags": [
+          "claude-code-plugin",
+          "multi-agent",
+          "dynamic-workflows",
+          "workflow-chain",
+          "triageflow",
+          "personas",
+          "flow-profiles",
+          "code-review",
+          "project-memory",
+          "multi-tool"
+        ]
+      },
+      {
+        "name": "claudebase",
+        "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+        "source": "./plugins/productivity/claudebase",
+        "author": "Rohit Hazra",
+        "tags": [
+          "github",
+          "sync",
+          "backup",
+          "config",
+          "profiles",
+          "settings"
+        ]
+      },
+      {
+        "name": "ejentum-anti-deception",
+        "description": "Cognitive scaffold for validation requests, ethical reasoning, or adversarial framings. Calls harness_anti_deception on the ejentum MCP server to retrieve an integrity scaffold (deception pattern, integrity procedure, suppression vectors). Catches sycophantic capitulation, hallucination, and authority-driven softening. Requires ejentum-mcp and EJENTUM_API_KEY.",
+        "source": "./plugins/community/ejentum-anti-deception",
+        "author": "Ejentum"
+      },
+      {
+        "name": "ejentum-code",
+        "description": "Cognitive scaffold for code generation, refactoring, or architecture tasks. Calls harness_code on the ejentum MCP server to retrieve a structured scaffold (failure pattern, procedure, correct-pattern example, verification step) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+        "source": "./plugins/community/ejentum-code",
+        "author": "Ejentum"
+      },
+      {
+        "name": "ejentum-memory",
+        "description": "Cognitive scaffold for sharpening perceptions and observations across multi-turn context. Calls harness_memory on the ejentum MCP server to retrieve a perception scaffold (perception failure, detection procedure, suppression vectors) that sharpens an existing observation. Requires ejentum-mcp and EJENTUM_API_KEY.",
+        "source": "./plugins/community/ejentum-memory",
+        "author": "Ejentum"
+      },
+      {
+        "name": "ejentum-reasoning",
+        "description": "Cognitive scaffold for analytical, planning, or multi-step decision tasks. Calls harness_reasoning on the ejentum MCP server to retrieve a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs before generating. Requires ejentum-mcp and EJENTUM_API_KEY.",
+        "source": "./plugins/community/ejentum-reasoning",
+        "author": "Ejentum"
+      },
+      {
+        "name": "over-50s-health",
+        "description": "Evidence-based health, fitness, nutrition, and longevity guidance for adults 50+",
+        "source": "./plugins/productivity/over-50s-health",
+        "author": "Alister Lewis-Bowen",
+        "tags": [
+          "health",
+          "fitness",
+          "nutrition",
+          "longevity",
+          "50+"
+        ]
+      },
+      {
+        "name": "obsidian-project-documentation",
+        "description": "Automatically documents technical projects in Obsidian vaults during Claude Code sessions",
+        "source": "./plugins/productivity/obsidian-project-documentation",
+        "author": "Alister Lewis-Bowen",
+        "tags": [
+          "obsidian",
+          "documentation",
+          "notes",
+          "projects"
+        ]
+      },
+      {
+        "name": "pair-programmer",
+        "description": "Graduated assistance framework to prevent skill atrophy when coding with AI",
+        "source": "./plugins/productivity/pair-programmer",
+        "author": "Alister Lewis-Bowen",
+        "tags": [
+          "pair-programming",
+          "coding",
+          "skill-development",
+          "graduated-assistance"
+        ]
+      },
+      {
+        "name": "governed-second-brain",
+        "description": "Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident, hash-chained audit trail. Install via `npx governed-second-brain init <folder>`.",
+        "source": "./plugins/mcp/governed-second-brain",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "memory",
+          "knowledge",
+          "governance",
+          "qmd",
+          "brain",
+          "citations",
+          "local-first",
+          "second-brain"
+        ]
+      },
+      {
+        "name": "claudebase",
+        "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+        "source": "./plugins/productivity/claudebase",
+        "author": "Rohit Hazra",
+        "tags": [
+          "github",
+          "sync",
+          "backup",
+          "config",
+          "profiles",
+          "settings"
+        ]
+      },
+      {
+        "name": "databricks-workspace-mcp",
+        "description": "MCP server for the Databricks control plane — 8 read-only tools for cluster forensics, instance pools, DLT pipeline event logs, and Unity Catalog external locations / storage credentials. The endpoint families no managed Databricks MCP exposes; pairs with the managed SQL MCP for system.* reads.",
+        "source": "./plugins/mcp/databricks-workspace-mcp",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "mcp",
+          "model-context-protocol",
+          "databricks",
+          "lakehouse",
+          "unity-catalog",
+          "clusters",
+          "dlt",
+          "finops"
+        ]
+      },
+      {
+        "name": "beads-dolt",
+        "description": "⚠️ Renamed to dolt-mcp-vcs. Deprecated alias — kept so existing `beads-dolt` installs keep resolving; please install dolt-mcp-vcs instead. Same plugin: a Dolt/DoltHub version-control toolkit shipping the beads (bd) task-tracker adapter.",
+        "source": "./plugins/mcp/dolt-mcp-vcs",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "beads",
+          "bd",
+          "dolt",
+          "dolthub",
+          "task-tracking",
+          "mcp",
+          "version-control",
+          "sql"
+        ]
+      },
+      {
+        "name": "publishing-skills",
+        "description": "Four composable skills that turn an AI agent into a platform-agnostic long-tail SEO publishing pipeline — topic research, drafting, SVG figures, and an editorial calendar. Ships Ghost, WordPress, and static-site adapters.",
+        "source": "./plugins/productivity/publishing-skills",
+        "author": "AutomateLab",
+        "tags": [
+          "ghost",
+          "blogging",
+          "seo",
+          "content-creation",
+          "publishing",
+          "claude-code",
+          "ai-writing"
+        ]
+      },
+      {
+        "name": "dolt-mcp-vcs",
+        "description": "Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt backend, with a verb-class mutation gate that keeps destructive ops recommend-only. Ships the beads (bd) task-tracker as use-case adapter #1. Formerly beads-dolt.",
+        "source": "./plugins/mcp/dolt-mcp-vcs",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "dolt-mcp-vcs",
+          "dolt",
+          "dolthub",
+          "dolt-mcp",
+          "version-control",
+          "vcs",
+          "mcp",
+          "sql",
+          "beads",
+          "bd"
+        ]
+      },
+      {
+        "name": "hermes-tweet",
+        "description": "Hermes Agent X/Twitter research, monitoring, drafts, exports, and approved actions",
+        "source": "./plugins/community/hermes-tweet",
+        "author": "Xquik",
+        "tags": [
+          "hermes-agent",
+          "hermes-plugin",
+          "xquik",
+          "twitter",
+          "x",
+          "social-media",
+          "automation"
+        ]
+      },
+      {
+        "name": "x-twitter-scraper",
+        "description": "X/Twitter REST API and MCP skill for tweet search, profile data, follower exports, media downloads, monitoring, webhooks, and confirmation-gated actions.",
+        "source": "./plugins/api-development/x-twitter-scraper",
+        "author": "Xquik"
+      },
+      {
+        "name": "servicegraph",
+        "description": "ServiceGraph business datasets for founders — 18 skills for finding agencies, firms, and directories via metrics-enriched data (110k+ US professional-services agencies, product and business directories, newsletters)",
+        "source": "./plugins/mcp/servicegraph",
+        "author": "Artur Briugeman",
+        "tags": [
+          "servicegraph",
+          "service-providers",
+          "agencies",
+          "law-firms",
+          "consulting",
+          "accounting",
+          "marketing",
+          "lead-generation",
+          "professional-services",
+          "us-firms",
+          "product-directories",
+          "saas-directories",
+          "mcp-directories",
+          "ai-directories",
+          "product-launch",
+          "backlinks"
+        ]
+      },
+      {
+        "name": "schedule-after-usage-reset",
+        "description": "Find the real Claude usage-limit reset time from the Anthropic usage API and schedule a deferred task to run right after the limit lifts (macOS)",
+        "source": "./plugins/productivity/schedule-after-usage-reset",
+        "author": "patricksong1993",
+        "tags": [
+          "schedule",
+          "usage-reset",
+          "rate-limit",
+          "claude-code",
+          "automation"
+        ]
+      },
+      {
+        "name": "claudebase",
+        "description": "Back up, restore, and sync your Claude Code config to a private GitHub repo with named profiles",
+        "source": "./plugins/productivity/claudebase",
+        "author": "Rohit Hazra",
+        "tags": [
+          "github",
+          "sync",
+          "backup",
+          "config",
+          "profiles",
+          "settings"
+        ]
+      },
+      {
+        "name": "mnemos",
+        "description": "Persistent memory for Claude Code — capture, digest, and recall project knowledge across sessions with a dependency-free Go CLI and hook integration.",
+        "source": "./plugins/community/mnemos",
+        "author": "André Figueira",
+        "tags": [
+          "memory",
+          "mcp",
+          "claude-code",
+          "persistent-memory",
+          "agent-memory",
+          "knowledge-graph",
+          "context",
+          "skill",
+          "observations",
+          "provenance",
+          "learning-loop",
+          "golang"
+        ]
+      },
+      {
+        "name": "portaljs",
+        "description": "Agent skills that build data portals — scaffold a portal, add datasets, charts and maps, connect CKAN, and generate DCAT/Croissant metadata",
+        "source": "./plugins/community/portaljs",
+        "author": "Datopian",
+        "tags": [
+          "portaljs",
+          "data-portal",
+          "ckan",
+          "nextjs",
+          "data-catalog"
+        ]
+      },
+      {
+        "name": "llm-box",
+        "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English with 20+ nodes and 15+ LLM providers.",
+        "source": "./plugins/community/llm-box",
+        "author": "alib8b8",
+        "tags": [
+          "workflow",
+          "automation",
+          "terminal",
+          "cli",
+          "yaml",
+          "llm",
+          "mcp"
+        ]
+      },
+      {
+        "name": "j-rig",
+        "description": "Skill Refiner — the eval-guided SKILL.md improvement loop. Thin wrapper over the published @intentsolutions/refiner CLI (bootstrap/score/propose/apply/status) with a 3-layer cost-tiered hook architecture (sinker/line/hook) that gates skill quality at edit time, end of turn, and commit time.",
+        "source": "./plugins/productivity/j-rig",
+        "author": "Jeremy Longshore",
+        "tags": [
+          "skill-refiner",
+          "eval-guided",
+          "skill-md",
+          "meta-tooling",
+          "hooks"
+        ]
+      },
+      {
+        "name": "agent-safety-preflight",
+        "description": "Local Claude Code command that generates a repo-risk receipt before AI-agent edits.",
+        "source": "./plugins/security/agent-safety-preflight",
+        "author": "el-zachariah",
+        "tags": [
+          "security",
+          "claude-code",
+          "agent-safety",
+          "preflight",
+          "repo-risk",
+          "mcp",
+          "hooks",
+          "ai-agent"
+        ]
       }
     ]
   },
@@ -8998,7 +18123,7 @@
     "author": "timescale",
     "description": "MCP server and Claude plugin for Postgres skills and documentation. Helps AI coding tools generate better PostgreSQL code.",
     "github": "https://github.com/timescale/pg-aiguide",
-    "stars": 1656,
+    "stars": 1786,
     "type": "plugin",
     "tags": [
       "mcps"
@@ -9014,7 +18139,7 @@
     "author": "CloudAI-X",
     "description": "Universal Claude Code workflow plugin with agents, skills, hooks, and commands",
     "github": "https://github.com/CloudAI-X/claude-workflow-v2",
-    "stars": 1305,
+    "stars": 1383,
     "type": "plugin",
     "tags": [
       "skills"
@@ -9023,12 +18148,84 @@
     "highlights": []
   },
   {
+    "slug": "superpowers-marketplace",
+    "name": "Superpowers Marketplace",
+    "author": "obra",
+    "description": "Curated Claude Code plugin marketplace",
+    "github": "https://github.com/obra/superpowers-marketplace",
+    "stars": 1143,
+    "type": "marketplace",
+    "tags": [
+      "commands",
+      "mcps",
+      "skills"
+    ],
+    "contains": {
+      "plugins": 10
+    },
+    "highlights": [
+      "10 plugins in marketplace"
+    ],
+    "plugins_list": [
+      {
+        "name": "superpowers",
+        "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
+        "source": "https://github.com/obra/superpowers.git"
+      },
+      {
+        "name": "superpowers-chrome",
+        "description": "Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
+        "source": "https://github.com/obra/superpowers-chrome.git"
+      },
+      {
+        "name": "elements-of-style",
+        "description": "Writing guidance based on William Strunk Jr.'s The Elements of Style (1918) - foundational rules for clear, concise, grammatically correct writing",
+        "source": "https://github.com/obra/the-elements-of-style.git"
+      },
+      {
+        "name": "episodic-memory",
+        "description": "Semantic search for Claude Code and Codex conversations. Remember past discussions, decisions, and patterns across sessions. Gives you memory that persists between sessions.",
+        "source": "https://github.com/obra/episodic-memory.git"
+      },
+      {
+        "name": "superpowers-lab",
+        "description": "Experimental skills for Superpowers: tmux automation for interactive CLIs, MCP server discovery, duplicate function detection, headless Windows VM",
+        "source": "https://github.com/obra/superpowers-lab.git"
+      },
+      {
+        "name": "superpowers-developing-for-claude-code",
+        "description": "Skills and resources for developing Claude Code plugins, skills, MCP servers, and extensions. Includes comprehensive official documentation and self-update mechanism.",
+        "source": "https://github.com/obra/superpowers-developing-for-claude-code.git"
+      },
+      {
+        "name": "superpowers-dev",
+        "description": "DEV BRANCH: YOU MUST UNINSTALL OTHER VERSIONS OF SUPERPOWERS BEFORE INSTALLING THIS",
+        "source": "https://github.com/obra/superpowers.git"
+      },
+      {
+        "name": "claude-session-driver",
+        "description": "Launch, control, and monitor other Claude Code sessions as workers via tmux",
+        "source": "https://github.com/obra/claude-session-driver.git"
+      },
+      {
+        "name": "private-journal-mcp",
+        "description": "Private journaling MCP server with semantic search. Multi-section entries (reflections, observations, project notes, technical insights), local AI embeddings, and full-text retrieval.",
+        "source": "https://github.com/obra/private-journal-mcp.git"
+      },
+      {
+        "name": "double-shot-latte",
+        "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
+        "source": "https://github.com/obra/double-shot-latte.git"
+      }
+    ]
+  },
+  {
     "slug": "n-skills",
     "name": "N Skills",
     "author": "numman-ali",
     "description": "Curated plugin marketplace for AI agents - works with Claude Code, Codex, and openskills",
     "github": "https://github.com/numman-ali/n-skills",
-    "stars": 943,
+    "stars": 1029,
     "type": "marketplace",
     "tags": [
       "skills"
@@ -9050,6 +18247,14 @@
         "author": "Numman Ali",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "zai-cli",
+              "description": "|"
+            }
+          ]
         }
       },
       {
@@ -9059,6 +18264,14 @@
         "author": "Numman Ali",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "gastown",
+              "description": "Multi-agent orchestrator for Claude Code. Use when user mentions gastown, gas town, gt commands, bd commands, convoys, polecats, crew, rigs, slinging work, multi-agent coordination, beads, hooks, molecules, workflows, the witness, the mayor, the refinery, the deacon, dogs, escalation, or wants to run multiple AI agents on projects simultaneously. Handles installation, workspace setup, work tracking, agent lifecycle, crash recovery, and all gt/bd CLI operations."
+            }
+          ]
         }
       },
       {
@@ -9068,6 +18281,14 @@
         "author": "Sawyer Hood",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "dev-browser",
+              "description": "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include \"go to [url]\", \"click on\", \"fill out the form\", \"take a screenshot\", \"scrape\", \"automate\", \"test the website\", \"log into\", or any browser interaction request."
+            }
+          ]
         }
       },
       {
@@ -9077,6 +18298,14 @@
         "author": "Numman Ali",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "orchestration",
+              "description": "Multi-agent orchestration for complex tasks. Use when tasks require parallel work, multiple agents, or sophisticated coordination. Triggers include requests for features, reviews, refactoring, testing, documentation, or any work that benefits from decomposition into parallel subtasks. This skill defines how to orchestrate work using cc-mirror tasks for persistent dependency tracking and TodoWrite for real-time session visibility."
+            }
+          ]
         }
       },
       {
@@ -9086,76 +18315,2137 @@
         "author": "Numman Ali",
         "components": {
           "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "open-source-maintainer",
+              "description": "End-to-end GitHub repository maintenance for open-source projects. Use when asked to triage issues, review PRs, analyze contributor activity, generate maintenance reports, or maintain a repository. Triggers include \"triage\", \"maintain\", \"review PRs\", \"analyze issues\", \"repo maintenance\", \"what needs attention\", \"open source maintenance\", or any request to understand and act on GitHub issues/PRs. Supports human-in-the-loop workflows with persistent memory across sessions."
+            }
+          ]
         }
       }
     ]
   },
   {
-    "slug": "superpowers-marketplace",
-    "name": "Superpowers Marketplace",
-    "author": "obra",
-    "description": "Curated Claude Code plugin marketplace",
-    "github": "https://github.com/obra/superpowers-marketplace",
-    "stars": 747,
+    "slug": "agentsys",
+    "name": "Agentsys",
+    "author": "agent-sh",
+    "description": "AI writes code. This automates everything else · 24 plugins · 49 agents · 44 skills · for Claude Code, OpenCode, Codex, Cursor, Kiro.",
+    "github": "https://github.com/agent-sh/agentsys",
+    "stars": 890,
     "type": "marketplace",
     "tags": [
+      "agents",
       "commands",
+      "hooks",
       "mcps",
       "skills"
     ],
     "contains": {
-      "plugins": 9
+      "plugins": 25
     },
     "highlights": [
-      "9 plugins in marketplace"
+      "25 plugins in marketplace",
+      "Web UI: https://agent-sh.github.io/agentsys/"
+    ],
+    "website": "https://agent-sh.github.io/agentsys/",
+    "plugins_list": [
+      {
+        "name": "next-task",
+        "description": "Master workflow orchestrator: autonomous workflow with model optimization (opus/sonnet/haiku), two-file state management, workflow enforcement gates, 8 specialist agents",
+        "source": "https://github.com/agent-sh/next-task.git"
+      },
+      {
+        "name": "prepare-delivery",
+        "description": "Pre-ship quality gates: deslop, simplify, agnix, enhance, review loop, delivery validation, docs sync",
+        "source": "https://github.com/agent-sh/prepare-delivery.git"
+      },
+      {
+        "name": "gate-and-ship",
+        "description": "Quality gates then ship - chains /prepare-delivery then /ship in one command",
+        "source": "https://github.com/agent-sh/gate-and-ship.git"
+      },
+      {
+        "name": "ship",
+        "description": "Complete PR workflow: commit to production, skips review when called from next-task, removes task from registry on cleanup, automatic rollback",
+        "source": "https://github.com/agent-sh/ship.git"
+      },
+      {
+        "name": "deslop",
+        "description": "3-phase AI slop detection: regex patterns (HIGH), multi-pass analyzers (MEDIUM), CLI tools (LOW)",
+        "source": "https://github.com/agent-sh/deslop.git"
+      },
+      {
+        "name": "audit-project",
+        "description": "Multi-agent iterative code review until zero issues remain",
+        "source": "https://github.com/agent-sh/audit-project.git"
+      },
+      {
+        "name": "drift-detect",
+        "description": "Deep repository analysis to realign project plans with code reality - detects drift, gaps, and creates prioritized reconstruction plans",
+        "source": "https://github.com/agent-sh/drift-detect.git"
+      },
+      {
+        "name": "enhance",
+        "description": "Master enhancement orchestrator: parallel analyzer execution for plugins, agents, docs, CLAUDE.md, and prompts with unified reporting",
+        "source": "https://github.com/agent-sh/enhance.git"
+      },
+      {
+        "name": "skill-curator",
+        "description": "Canonical guidance for writing, reviewing, and maintaining production-grade SKILL.md files across agent tools",
+        "source": "https://github.com/agent-sh/skill-curator.git"
+      },
+      {
+        "name": "system-prompt-curator",
+        "description": "Production-grade system prompt curation for autonomous coding agents and multi-agent orchestration",
+        "source": "https://github.com/agent-sh/system-prompt-curator.git"
+      },
+      {
+        "name": "sync-docs",
+        "description": "Standalone documentation sync: find outdated refs, update CHANGELOG, flag stale examples based on code changes",
+        "source": "https://github.com/agent-sh/sync-docs.git"
+      },
+      {
+        "name": "repo-intel",
+        "description": "Unified static analysis via agent-analyzer - git history, AST symbols, project metadata, and doc-code sync",
+        "source": "https://github.com/agent-sh/repo-intel.git"
+      },
+      {
+        "name": "perf",
+        "description": "Rigorous performance investigation workflow with baselines, profiling, hypotheses, and evidence-backed decisions",
+        "source": "https://github.com/agent-sh/perf.git"
+      },
+      {
+        "name": "learn",
+        "description": "Research topics online and create comprehensive learning guides with RAG-optimized indexes",
+        "source": "https://github.com/agent-sh/learn.git"
+      },
+      {
+        "name": "banthis",
+        "description": "Durable negative behavior memory: persist user-defined banned agent behaviors into CLAUDE.md or AGENTS.md",
+        "source": "https://github.com/agent-sh/banthis.git"
+      },
+      {
+        "name": "agnix",
+        "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 414 rules across 10+ AI tools",
+        "source": "https://github.com/agent-sh/agnix.git"
+      },
+      {
+        "name": "consult",
+        "description": "Cross-tool AI consultation: get second opinions from Gemini CLI, Codex CLI, Claude Code, OpenCode, or Copilot CLI with model and thinking effort control",
+        "source": "https://github.com/agent-sh/consult.git"
+      },
+      {
+        "name": "debate",
+        "description": "Structured multi-round debate between AI tools with proposer/challenger roles and verdict",
+        "source": "https://github.com/agent-sh/debate.git"
+      },
+      {
+        "name": "skillers",
+        "description": "Learn from workflow patterns across sessions and suggest skills, hooks, and agents to automate repetitive work",
+        "source": "https://github.com/agent-sh/skillers.git"
+      },
+      {
+        "name": "onboard",
+        "description": "Codebase onboarding - automated data collection and interactive project orientation",
+        "source": "https://github.com/agent-sh/onboard.git"
+      },
+      {
+        "name": "can-i-help",
+        "description": "Find where to contribute to any project - matches developer skills to test gaps, stale docs, bugspots, and open issues",
+        "source": "https://github.com/agent-sh/can-i-help.git"
+      },
+      {
+        "name": "zig-lsp",
+        "description": "Zig language server for Claude Code via ZLS - automatic diagnostics after every edit, jump-to-definition, find-references, and hover. Requires zls in PATH",
+        "source": "https://github.com/agent-sh/zig-lsp.git"
+      },
+      {
+        "name": "mojo",
+        "description": "Teach agents to write idiomatic, correct, performant, current Mojo (v1.0.0b1) - syntax, ownership and CPU/memory optimization (copies, SIMD, vectorize/parallelize), GPU kernels (DeviceContext/LayoutTensor), and Mojo/Python interop; prevents stale pre-2025 syntax",
+        "source": "https://github.com/agent-sh/mojo.git"
+      },
+      {
+        "name": "ada-spark",
+        "description": "Teach agents to write idiomatic, correct, current Ada and SPARK (Ada 2022) - contracts (aspects, Pre'Class), the Alire ecosystem, SPARK proof (AoRTE, assurance levels, ownership/borrow), embedded (Ravenscar/Jorvik), and GNAT/GNAT SAS tooling; blocks stale pre-2022 advice (GNAT Community, pragma contracts, CodePeer)",
+        "source": "https://github.com/agent-sh/ada-spark.git"
+      },
+      {
+        "name": "orientation",
+        "description": "Reconstruct the real history of code (goal, shipped vs in-flight, coupled files) from Codex, Claude Code, and Eigen transcripts, surfaced via the get-oriented skill - so agents stop guessing the story of code they didn't write this session",
+        "source": "https://github.com/agent-sh/orientation.git"
+      }
+    ]
+  },
+  {
+    "slug": "ccplugins-awesome-claude-code-plugins",
+    "name": "Awesome Claude Code Plugins",
+    "author": "ccplugins",
+    "description": "Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP servers, and hooks for Claude Code",
+    "github": "https://github.com/ccplugins/awesome-claude-code-plugins",
+    "stars": 875,
+    "type": "marketplace",
+    "tags": [
+      "agents",
+      "commands"
+    ],
+    "contains": {
+      "plugins": 118,
+      "components": {
+        "commands": 34,
+        "agents": 16
+      }
+    },
+    "highlights": [
+      "118 plugins in marketplace",
+      "Web UI: https://claudecodeplugins.dev"
+    ],
+    "website": "https://claudecodeplugins.dev",
+    "plugins_list": [
+      {
+        "name": "documentation-generator",
+        "description": "Create comprehensive documentation for code, APIs, and projects.",
+        "source": "./plugins/documentation-generator",
+        "author": "Anonymous",
+        "tags": [
+          "documentation"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "documentation-generator",
+              "description": "Generate comprehensive documentation for code and APIs"
+            }
+          ]
+        }
+      },
+      {
+        "name": "lyra",
+        "description": "Lyra - a master-level AI prompt optimization specialist.",
+        "source": "./plugins/lyra",
+        "author": " Anand Tyagi",
+        "tags": [
+          "workflow"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "lyra",
+              "description": "Lyra - a master-level AI prompt optimization specialist."
+            }
+          ]
+        }
+      },
+      {
+        "name": "analyze-codebase",
+        "description": "Generate comprehensive analysis and documentation of entire codebase",
+        "source": "./plugins/analyze-codebase",
+        "author": " Anand Tyagi",
+        "tags": [
+          "explore",
+          "plan"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "analyze-codebase",
+              "description": "Generate comprehensive analysis and documentation of entire codebase"
+            }
+          ]
+        }
+      },
+      {
+        "name": "update-claudemd",
+        "description": "Automatically update CLAUDE.md file based on recent code changes",
+        "source": "./plugins/update-claudemd",
+        "author": " Anand Tyagi",
+        "tags": [
+          "code-review"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "update-claudemd",
+              "description": "Automatically update CLAUDE.md file based on recent code changes"
+            }
+          ]
+        }
+      },
+      {
+        "name": "ultrathink",
+        "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents—Architect, Research, Coder, and Tester—to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax.",
+        "source": "./plugins/ultrathink",
+        "author": "Jeronim Morina",
+        "tags": [
+          "plan",
+          "explore",
+          "refactoring",
+          "testing",
+          "code-review",
+          "workflow",
+          "debugging"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "ultrathink",
+              "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents—Architect, Research, Coder, and Tester—to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax."
+            }
+          ]
+        }
+      },
+      {
+        "name": "code-review",
+        "description": "Perform a comprehensive code review of recent changes",
+        "source": "./plugins/code-review",
+        "author": " Anand Tyagi",
+        "tags": [
+          "code-review"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "code-review",
+              "description": "Perform a comprehensive code review of recent changes"
+            }
+          ]
+        }
+      },
+      {
+        "name": "refractor",
+        "description": "Refactor code following best practices and design patterns",
+        "source": "./plugins/refractor",
+        "author": " Anand Tyagi",
+        "tags": [
+          "refactoring"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "refractor",
+              "description": "Refactor code following best practices and design patterns"
+            }
+          ]
+        }
+      },
+      {
+        "name": "code-review-assistant",
+        "description": "Get comprehensive code reviews with suggestions for improvements, best practices, and potential issues.",
+        "source": "./plugins/code-review-assistant",
+        "author": "Anonymous",
+        "tags": [
+          "code-review"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "code-review-assistant",
+              "description": "Comprehensive code review with improvement suggestions"
+            }
+          ]
+        }
+      },
+      {
+        "name": "bug-detective",
+        "description": "Systematically debug issues with step-by-step troubleshooting approaches.",
+        "source": "./plugins/bug-detective",
+        "author": "Anonymous",
+        "tags": [
+          "debugging"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bug-detective",
+              "description": "Systematic debugging assistant with troubleshooting steps"
+            }
+          ]
+        }
+      },
+      {
+        "name": "audit",
+        "description": "Perform security audit on codebase",
+        "source": "./plugins/audit",
+        "author": " Anand Tyagi",
+        "tags": [
+          "code-review",
+          "security"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "audit",
+              "description": "Perform security audit on codebase"
+            }
+          ]
+        }
+      },
+      {
+        "name": "plan",
+        "description": "For easy problems, start here. For harder problems, do this after Explore.",
+        "source": "./plugins/plan",
+        "author": "Galen Ward",
+        "tags": [
+          "plan"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "plan",
+              "description": "For easy problems, start here. For harder problems, do this after Explore."
+            }
+          ]
+        }
+      },
+      {
+        "name": "claude-desktop-extension",
+        "description": "This command provides the context necessary for Claude Code to create the Desktop Extension or .dxt file of an MCP.",
+        "source": "./plugins/claude-desktop-extension",
+        "author": " Anand Tyagi",
+        "tags": [
+          "workflow"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "claude-desktop-extension",
+              "description": "This command provides the context necessary for Claude Code to create the Desktop Extension or .dxt file of an MCP."
+            }
+          ]
+        }
+      },
+      {
+        "name": "optimize",
+        "description": "Analyze and optimize code performance",
+        "source": "./plugins/optimize",
+        "author": " Anand Tyagi",
+        "tags": [
+          "performance"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "optimize",
+              "description": "Analyze and optimize code performance"
+            }
+          ]
+        }
+      },
+      {
+        "name": "commit",
+        "description": "Creates git commits using conventional commit format with appropriate emojis, following project standards and creating descriptive messages that explain the purpose of changes.",
+        "source": "./plugins/commit",
+        "author": "evmts",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "commit",
+              "description": "Creates git commits using conventional commit format with appropriate emojis, following project standards and creating descriptive messages that explain the purpose of changes."
+            }
+          ]
+        }
+      },
+      {
+        "name": "explore",
+        "description": "Helps Claude read a planning document and explore related files to get familiar with a topic. Asking Claude to prepare to discuss seems to work better than asking it to prepare to do specific work.\n\nThis is followed by Plan, then Execute.",
+        "source": "./plugins/explore",
+        "author": "Galen Ward",
+        "tags": [
+          "explore"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "explore",
+              "description": "Helps Claude read a planning document and explore related files to get familiar with a topic. Asking Claude to prepare to discuss seems to work better than asking it to prepare to do specific work."
+            }
+          ]
+        }
+      },
+      {
+        "name": "generate-api-docs",
+        "description": "Generate API documentation for endpoints",
+        "source": "./plugins/generate-api-docs",
+        "author": " Anand Tyagi",
+        "tags": [
+          "documentation"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "generate-api-docs",
+              "description": "Generate API documentation for endpoints"
+            }
+          ]
+        }
+      },
+      {
+        "name": "debug-session",
+        "description": "Ask Claude Code to help you debug an issue",
+        "source": "./plugins/debug-session",
+        "author": " Anand Tyagi",
+        "tags": [
+          "debugging"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "debug-session",
+              "description": "Start a comprehensive debugging session"
+            }
+          ]
+        }
+      },
+      {
+        "name": "test-file",
+        "description": "Generate comprehensive tests for a specific file",
+        "source": "./plugins/test-file",
+        "author": " Anand Tyagi",
+        "tags": [
+          "testing"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "test-file",
+              "description": "Generate comprehensive tests for a specific file"
+            }
+          ]
+        }
+      },
+      {
+        "name": "double-check",
+        "description": "An easy way to force agent to think again if it's statement that the \"Job is done and production ready\" is actually done - usually it's not. Thanks to this command you don't have to check after the agent if they did their job.",
+        "source": "./plugins/double-check",
+        "author": "Robert S",
+        "tags": [
+          "plan",
+          "code-review",
+          "workflow"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "double-check",
+              "description": "An easy way to force agent to think again if it's statement that the \"Job is done and production ready\" is actually done - usually it's not. Thanks to this command you don't have to check after the agent if they did their job."
+            }
+          ]
+        }
+      },
+      {
+        "name": "create-worktrees",
+        "description": "Creates git worktrees for all open PRs or specific branches, handling branches with slashes, cleaning up stale worktrees, and supporting custom branch creation for development.",
+        "source": "./plugins/create-worktrees",
+        "author": "evmts",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-worktrees",
+              "description": "Creates git worktrees for all open PRs or specific branches, handling branches with slashes, cleaning up stale worktrees, and supporting custom branch creation for development."
+            }
+          ]
+        }
+      },
+      {
+        "name": "pr-review",
+        "description": "Reviews pull request changes to provide feedback, check for issues, and suggest improvements before merging into the main codebase.",
+        "source": "./plugins/pr-review",
+        "author": "arkavo-org",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "pr-review",
+              "description": "Reviews pull request changes to provide feedback, check for issues, and suggest improvements before merging into the main codebase."
+            }
+          ]
+        }
+      },
+      {
+        "name": "update-branch-name",
+        "description": "Updates branch names with proper prefixes and formats, enforcing naming conventions, supporting semantic prefixes, and managing remote branch updates.",
+        "source": "./plugins/update-branch-name",
+        "author": "giselles-ai",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "update-branch-name",
+              "description": "Updates branch names with proper prefixes and formats, enforcing naming conventions, supporting semantic prefixes, and managing remote branch updates."
+            }
+          ]
+        }
+      },
+      {
+        "name": "analyze-issue",
+        "description": "Fetches GitHub issue details to create comprehensive implementation specifications, analyzing requirements and planning structured approach with clear implementation steps.",
+        "source": "./plugins/analyze-issue",
+        "author": "jerseycheese",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "analyze-issue",
+              "description": "Fetches GitHub issue details to create comprehensive implementation specifications, analyzing requirements and planning structured approach with clear implementation steps."
+            }
+          ]
+        }
+      },
+      {
+        "name": "discuss",
+        "description": "Collaborative technical discussion with proactive requirements gathering",
+        "source": "./plugins/discuss",
+        "author": "Bohdan Triapitsyn",
+        "tags": [
+          "plan"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "discuss",
+              "description": "Collaborative technical discussion with proactive requirements gathering"
+            }
+          ]
+        }
+      },
+      {
+        "name": "bug-fix",
+        "description": "Streamlines bug fixing by creating a GitHub issue first, then a feature branch for implementing and thoroughly testing the solution before merging.",
+        "source": "./plugins/bug-fix",
+        "author": "danielscholl",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bug-fix",
+              "description": "Streamlines bug fixing by creating a GitHub issue first, then a feature branch for implementing and thoroughly testing the solution before merging."
+            }
+          ]
+        }
+      },
+      {
+        "name": "openapi-expert",
+        "description": "Use this agent to update, synchronize, or validate the OpenAPI specification (openapi.yml) against the actual REST API implementation. This includes adding new endpoints, updating request/response schemas, fixing discrepancies between the spec and code, or ensuring complete API documentation coverage.",
+        "source": "./plugins/openapi-expert",
+        "author": "Meiring de Wet",
+        "tags": [
+          "documentation",
+          "openapi",
+          "workflow"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "openapi-expert",
+              "description": "|"
+            }
+          ]
+        }
+      },
+      {
+        "name": "create-pr",
+        "description": "Streamlines pull request creation by handling the entire workflow: creating a new branch, committing changes, formatting modified files with Biome, and submitting the PR.",
+        "source": "./plugins/create-pr",
+        "author": "toyamarinyon",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-pr",
+              "description": "Streamlines pull request creation by handling the entire workflow: creating a new branch, committing changes, formatting modified files with Biome, and submitting the PR."
+            }
+          ]
+        }
+      },
+      {
+        "name": "create-pull-request",
+        "description": "Provides comprehensive PR creation guidance with GitHub CLI, enforcing title conventions, following template structure, and offering concrete command examples with best practices.",
+        "source": "./plugins/create-pull-request",
+        "author": "liam-hq",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-pull-request",
+              "description": "Provides comprehensive PR creation guidance with GitHub CLI, enforcing title conventions, following template structure, and offering concrete command examples with best practices."
+            }
+          ]
+        }
+      },
+      {
+        "name": "fix-github-issue",
+        "description": "Analyzes and fixes GitHub issues using a structured approach with GitHub CLI for issue details, implementing necessary code changes, running tests, and creating proper commit messages.",
+        "source": "./plugins/fix-github-issue",
+        "author": "jeremymailen",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-github-issue",
+              "description": "Analyzes and fixes GitHub issues using a structured approach with GitHub CLI for issue details, implementing necessary code changes, running tests, and creating proper commit messages."
+            }
+          ]
+        }
+      },
+      {
+        "name": "fix-issue",
+        "description": "Addresses GitHub issues by taking issue number as parameter, analyzing context, implementing solution, and testing/validating the fix for proper integration.",
+        "source": "./plugins/fix-issue",
+        "author": "metabase",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-issue",
+              "description": "Addresses GitHub issues by taking issue number as parameter, analyzing context, implementing solution, and testing/validating the fix for proper integration."
+            }
+          ]
+        }
+      },
+      {
+        "name": "fix-pr",
+        "description": "Fetches and fixes unresolved PR comments by automatically retrieving feedback, addressing reviewer concerns, making targeted code improvements, and streamlining the review process.",
+        "source": "./plugins/fix-pr",
+        "author": "metabase",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-pr",
+              "description": "Fetches and fixes unresolved PR comments by automatically retrieving feedback, addressing reviewer concerns, making targeted code improvements, and streamlining the review process."
+            }
+          ]
+        }
+      },
+      {
+        "name": "husky",
+        "description": "Sets up and manages Husky Git hooks by configuring pre-commit hooks, establishing commit message standards, integrating with linting tools, and ensuring code quality on commits.",
+        "source": "./plugins/husky",
+        "author": "evmts",
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "husky",
+              "description": "Sets up and manages Husky Git hooks by configuring pre-commit hooks, establishing commit message standards, integrating with linting tools, and ensuring code quality on commits."
+            }
+          ]
+        }
+      },
+      {
+        "name": "2-commit-fast",
+        "description": "Automates git commit process by selecting the first suggested message, generating structured commits with consistent formatting while skipping manual confirmation and removing Claude co-Contributorship footer",
+        "source": "./plugins/2-commit-fast",
+        "author": "steadycursor"
+      },
+      {
+        "name": "pr-issue-resolve",
+        "description": "this is to analyze the PRs and solve the requested changes in them\n",
+        "source": "./plugins/pr-issue-resolve",
+        "author": "safayavatsal",
+        "tags": [
+          "code-review",
+          "testing",
+          "refactoring",
+          "debugging",
+          "security",
+          "performance"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "pr-issue-resolve",
+              "description": "this is to analyze the PRs and solve the requested changes in them"
+            }
+          ]
+        }
+      },
+      {
+        "name": "github-issue-fix",
+        "description": "This is a detailed way you can analyze the GitHub issues and let Claude handle them in best possible way.",
+        "source": "./plugins/github-issue-fix",
+        "author": "safayavatsal",
+        "tags": [
+          "debugging",
+          "refactoring",
+          "testing",
+          "security"
+        ],
+        "components": {
+          "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "github-issue-fix",
+              "description": "This is a detailed way you can analyze the GitHub issues and let Claude handle them in best possible way."
+            }
+          ]
+        }
+      },
+      {
+        "name": "accessibility-expert",
+        "description": "Examples:",
+        "source": "./plugins/accessibility-expert",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "ai-engineer",
+        "description": "Use this agent when implementing AI/ML features, integrating language models, building recommendation systems, or adding intelligent automation to applications. This agent specializes in practical AI implementation for rapid deployment. Examples:\\n\\n<example>\\nContext: Adding AI features to an app\\nuser: \"We need AI-powered content recommendations\"\\nassistant: \"I'll implement a smart recommendation engine. Let me use the ai-engineer agent to build an ML pipeline that learns from user behavior.\"\\n<commentary>\\nRecommendation systems require careful ML implementation and continuous learning capabilities.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Integrating language models\\nuser: \"Add an AI chatbot to help users navigate our app\"\\nassistant: \"I'll integrate a conversational AI assistant. Let me use the ai-engineer agent to implement proper prompt engineering and response handling.\"\\n<commentary>\\nLLM integration requires expertise in prompt design, token management, and response streaming.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing computer vision features\\nuser: \"Users should be able to search products by taking a photo\"\\nassistant: \"I'll implement visual search using computer vision. Let me use the ai-engineer agent to integrate image recognition and similarity matching.\"\\n<commentary>\\nComputer vision features require efficient processing and accurate model selection.\\n</commentary>\\n</example>",
+        "source": "./plugins/ai-engineer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ai-engineer",
+              "description": "Use this agent when implementing AI/ML features, integrating language models, building recommendation systems, or adding intelligent automation to applications. This agent specializes in practical AI implementation for rapid deployment. Examples:\\n\\n<example>\\nContext: Adding AI features to an app\\nuser: \"We need AI-powered content recommendations\"\\nassistant: \"I'll implement a smart recommendation engine. Let me use the ai-engineer agent to build an ML pipeline that learns from user behavior.\"\\n<commentary>\\nRecommendation systems require careful ML implementation and continuous learning capabilities.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Integrating language models\\nuser: \"Add an AI chatbot to help users navigate our app\"\\nassistant: \"I'll integrate a conversational AI assistant. Let me use the ai-engineer agent to implement proper prompt engineering and response handling.\"\\n<commentary>\\nLLM integration requires expertise in prompt design, token management, and response streaming.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing computer vision features\\nuser: \"Users should be able to search products by taking a photo\"\\nassistant: \"I'll implement visual search using computer vision. Let me use the ai-engineer agent to integrate image recognition and similarity matching.\"\\n<commentary>\\nComputer vision features require efficient processing and accurate model selection.\\n</commentary>\\n</example>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "ai-ethics-governance-specialist",
+        "description": "Use this agent when you need to implement AI ethics frameworks, governance policies, and responsible AI practices for B2B applications. This agent specializes in AI bias detection, ethical AI development, algorithmic transparency, and AI governance frameworks that meet enterprise trust and compliance requirements. Examples:",
+        "source": "./plugins/ai-ethics-governance-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ai-ethics-governance-specialist",
+              "description": "Use this agent when you need to implement AI ethics frameworks, governance policies, and responsible AI practices for B2B applications. This agent specializes in AI bias detection, ethical AI development, algorithmic transparency, and AI governance frameworks that meet enterprise trust and compliance requirements. Examples:"
+            }
+          ]
+        }
+      },
+      {
+        "name": "analytics-reporter",
+        "description": "Use this agent when analyzing metrics, generating insights from data, creating performance reports, or making data-driven recommendations. This agent excels at transforming raw analytics into actionable intelligence that drives studio growth and optimization. Examples:\\n\\n<example>\\nContext: Monthly performance review needed",
+        "source": "./plugins/analytics-reporter",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "analytics-reporter",
+              "description": "Use this agent when analyzing metrics, generating insights from data, creating performance reports, or making data-driven recommendations. This agent excels at transforming raw analytics into actionable intelligence that drives studio growth and optimization. Examples:\\n\\n<example>\\nContext: Monthly performance review needed"
+            }
+          ]
+        }
+      },
+      {
+        "name": "angelos-symbo",
+        "description": "Use this agent when you need to create or convert prompts using the SYMBO (symbolic) notation system. This agent MUST be activated whenever generating SYMBO prompts or converting existing prompts to symbolic format. Examples: <example>Context: User wants to create a symbolic prompt for a task management system. user: 'Create a SYMBO prompt for a project task tracker with memory and learning capabilities' assistant: 'I'll use the angelos-symbo agent to create this symbolic prompt following SYMBO notation rules' <commentary>The user is requesting a SYMBO prompt, so the angelos-symbo agent must be used to ensure proper symbolic notation and rule compliance.</commentary></example> <example>Context: User has a natural language prompt they want converted to SYMBO format. user: 'Convert this prompt to SYMBO notation: You are an AI that helps with code reviews by analyzing code quality, suggesting improvements, and tracking common issues across projects' assistant: 'I need to convert this to SYMBO notation using the angelos-symbo agent' <commentary>Since this involves SYMBO prompt generation/conversion, the angelos-symbo agent must be activated.</commentary></example>",
+        "source": "./plugins/angelos-symbo",
+        "author": "normalnormie",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "angelos-symbo",
+              "description": "Use this agent when you need to create or convert prompts using the SYMBO (symbolic) notation system. This agent MUST be activated whenever generating SYMBO prompts or converting existing prompts to symbolic format. Examples: <example>Context: User wants to create a symbolic prompt for a task management system. user: 'Create a SYMBO prompt for a project task tracker with memory and learning capabilities' assistant: 'I'll use the angelos-symbo agent to create this symbolic prompt following SYMBO notation rules' <commentary>The user is requesting a SYMBO prompt, so the angelos-symbo agent must be used to ensure proper symbolic notation and rule compliance.</commentary></example> <example>Context: User has a natural language prompt they want converted to SYMBO format. user: 'Convert this prompt to SYMBO notation: You are an AI that helps with code reviews by analyzing code quality, suggesting improvements, and tracking common issues across projects' assistant: 'I need to convert this to SYMBO notation using the angelos-symbo agent' <commentary>Since this involves SYMBO prompt generation/conversion, the angelos-symbo agent must be activated.</commentary></example>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "api-integration-specialist",
+        "description": "Use this agent when you need to design and implement internal API architecture, developer experience, and API infrastructure for B2B applications. This agent specializes in REST API design, GraphQL implementation, API documentation, SDK development, and developer portal creation. Handles API performance optimization, versioning strategies, and internal service communication. Examples:",
+        "source": "./plugins/api-integration-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-integration-specialist",
+              "description": "Use this agent when you need to design and implement internal API architecture, developer experience, and API infrastructure for B2B applications. This agent specializes in REST API design, GraphQL implementation, API documentation, SDK development, and developer portal creation. Handles API performance optimization, versioning strategies, and internal service communication. Examples:"
+            }
+          ]
+        }
+      },
+      {
+        "name": "api-tester",
+        "description": "Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring APIs are robust, performant, and meet specifications before deployment. Examples:\\n\\n<example>\\nContext: Testing API performance under load",
+        "source": "./plugins/api-tester",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-tester",
+              "description": "Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring APIs are robust, performant, and meet specifications before deployment. Examples:\\n\\n<example>\\nContext: Testing API performance under load"
+            }
+          ]
+        }
+      },
+      {
+        "name": "app-store-optimizer",
+        "description": "Use this agent when preparing app store listings, researching keywords, optimizing app metadata, improving conversion rates, or analyzing app store performance. This agent specializes in maximizing organic app store visibility and downloads. Examples:\\n\\n<example>\\nContext: Preparing for app launch",
+        "source": "./plugins/app-store-optimizer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "app-store-optimizer",
+              "description": "Use this agent when preparing app store listings, researching keywords, optimizing app metadata, improving conversion rates, or analyzing app store performance. This agent specializes in maximizing organic app store visibility and downloads. Examples:\\n\\n<example>\\nContext: Preparing for app launch"
+            }
+          ]
+        }
+      },
+      {
+        "name": "b2b-project-shipper",
+        "description": "PROACTIVELY use this agent when approaching B2B launch milestones, enterprise release deadlines, or B2B go-to-market activities. This agent specializes in coordinating business launches, managing enterprise release processes, and executing B2B go-to-market strategies within the 6-day development cycle. Should be triggered automatically when enterprise release dates are set, B2B launch plans are needed, or business market positioning is discussed. Examples:",
+        "source": "./plugins/b2b-project-shipper",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "b2b-project-shipper",
+              "description": "PROACTIVELY use this agent when approaching B2B launch milestones, enterprise release deadlines, or B2B go-to-market activities. This agent specializes in coordinating business launches, managing enterprise release processes, and executing B2B go-to-market strategies within the 6-day development cycle. Should be triggered automatically when enterprise release dates are set, B2B launch plans are needed, or business market positioning is discussed. Examples:"
+            }
+          ]
+        }
+      },
+      {
+        "name": "backend-architect",
+        "description": "Use this agent when designing APIs, building server-side logic, implementing databases, or architecting scalable backend systems. This agent specializes in creating robust, secure, and performant backend services. Examples:\\n\\n<example>\\nContext: Designing a new API\\nuser: \"We need an API for our social sharing feature\"\\nassistant: \"I'll design a RESTful API with proper authentication and rate limiting. Let me use the backend-architect agent to create a scalable backend architecture.\"\\n<commentary>\\nAPI design requires careful consideration of security, scalability, and maintainability.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Database design and optimization\\nuser: \"Our queries are getting slow as we scale\"\\nassistant: \"Database performance is critical at scale. I'll use the backend-architect agent to optimize queries and implement proper indexing strategies.\"\\n<commentary>\\nDatabase optimization requires deep understanding of query patterns and indexing strategies.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing authentication system\\nuser: \"Add OAuth2 login with Google and GitHub\"\\nassistant: \"I'll implement secure OAuth2 authentication. Let me use the backend-architect agent to ensure proper token handling and security measures.\"\\n<commentary>\\nAuthentication systems require careful security considerations and proper implementation.\\n</commentary>\\n</example>",
+        "source": "./plugins/backend-architect",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "backend-architect",
+              "description": "Use this agent when designing APIs, building server-side logic, implementing databases, or architecting scalable backend systems. This agent specializes in creating robust, secure, and performant backend services. Examples:\\n\\n<example>\\nContext: Designing a new API\\nuser: \"We need an API for our social sharing feature\"\\nassistant: \"I'll design a RESTful API with proper authentication and rate limiting. Let me use the backend-architect agent to create a scalable backend architecture.\"\\n<commentary>\\nAPI design requires careful consideration of security, scalability, and maintainability.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Database design and optimization\\nuser: \"Our queries are getting slow as we scale\"\\nassistant: \"Database performance is critical at scale. I'll use the backend-architect agent to optimize queries and implement proper indexing strategies.\"\\n<commentary>\\nDatabase optimization requires deep understanding of query patterns and indexing strategies.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing authentication system\\nuser: \"Add OAuth2 login with Google and GitHub\"\\nassistant: \"I'll implement secure OAuth2 authentication. Let me use the backend-architect agent to ensure proper token handling and security measures.\"\\n<commentary>\\nAuthentication systems require careful security considerations and proper implementation.\\n</commentary>\\n</example>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "brand-guardian",
+        "description": "Use this agent when establishing brand guidelines, ensuring visual consistency, managing brand assets, or evolving brand identity. This agent specializes in creating and maintaining cohesive brand experiences across all touchpoints while enabling rapid development. Examples:\\n\\n<example>\\nContext: Creating brand guidelines for a new app",
+        "source": "./plugins/brand-guardian",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "brand-guardian",
+              "description": "Use this agent when establishing brand guidelines, ensuring visual consistency, managing brand assets, or evolving brand identity. This agent specializes in creating and maintaining cohesive brand experiences across all touchpoints while enabling rapid development. Examples:\\n\\n<example>\\nContext: Creating brand guidelines for a new app"
+            }
+          ]
+        }
+      },
+      {
+        "name": "ceo-quality-controller-agent",
+        "description": "Universal quality control orchestrator and final authority for any software development project. Dynamically discovers and coordinates with available sub-agents, performs comprehensive multi-dimensional quality assessment, security validation, and deployment readiness verification. Adapts to any project type, programming language, or development framework while maintaining enterprise-grade quality standards. Examples: <example>Context: Code changes ready for review across any project. user: 'Please review this code before commit' assistant: 'I'll use the 1-ceo-quality-control-agent to orchestrate comprehensive quality validation, discover available specialists, and perform final security scanning before approval.' <commentary>Universal quality control requires comprehensive validation across all dimensions regardless of project type.</commentary></example> <example>Context: Multi-agent work completion needing validation. user: 'Several agents completed their tasks, need quality review' assistant: 'Let me engage the 1-ceo-quality-control-agent to coordinate comprehensive validation across all completed work and ensure quality standards.' <commentary>Multi-agent coordination and quality validation applies to any development project.</commentary></example>",
+        "source": "./plugins/ceo-quality-controller-agent",
+        "author": "Beau Lewis",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ceo-quality-controller-agent",
+              "description": "Universal quality control orchestrator and final authority for any software development project. Dynamically discovers and coordinates with available sub-agents, performs comprehensive multi-dimensional quality assessment, security validation, and deployment readiness verification. Adapts to any project type, programming language, or development framework while maintaining enterprise-grade quality standards. Examples: <example>Context: Code changes ready for review across any project. user: 'Please review this code before commit' assistant: 'I'll use the 1-ceo-quality-control-agent to orchestrate comprehensive quality validation, discover available specialists, and perform final security scanning before approval.' <commentary>Universal quality control requires comprehensive validation across all dimensions regardless of project type.</commentary></example> <example>Context: Multi-agent work completion needing validation. user: 'Several agents completed their tasks, need quality review' assistant: 'Let me engage the 1-ceo-quality-control-agent to coordinate comprehensive validation across all completed work and ensure quality standards.' <commentary>Multi-agent coordination and quality validation applies to any development project.</commentary></example>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "changelog-generator",
+        "description": "Changelog Generator subagent",
+        "source": "./plugins/changelog-generator",
+        "author": "Joe Heitzeberg",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "changelog-generator",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "code-architect",
+        "description": "Use this agent when you need to design scalable architecture and folder structures for new features or projects. Examples include: when starting a new feature module, refactoring existing code organization, planning microservice boundaries, designing component hierarchies, or establishing project structure conventions. For example: user: 'I need to add a user authentication system to my app' -> assistant: 'I'll use the code-architect agent to design the architecture and folder structure for your authentication system' -> <uses agent>. Another example: user: 'How should I organize my e-commerce product catalog feature?' -> assistant: 'Let me use the code-architect agent to design a scalable structure for your product catalog' -> <uses agent>.",
+        "source": "./plugins/code-architect",
+        "author": "abhishek shah",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-architect",
+              "description": "Use this agent when you need to design scalable architecture and folder structures for new features or projects. Examples include: when starting a new feature module, refactoring existing code organization, planning microservice boundaries, designing component hierarchies, or establishing project structure conventions. For example: user: 'I need to add a user authentication system to my app' -> assistant: 'I'll use the code-architect agent to design the architecture and folder structure for your authentication system' -> <uses agent>. Another example: user: 'How should I organize my e-commerce product catalog feature?' -> assistant: 'Let me use the code-architect agent to design a scalable structure for your product catalog' -> <uses agent>."
+            }
+          ]
+        }
+      },
+      {
+        "name": "code-reviewer",
+        "description": "Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code.",
+        "source": "./plugins/code-reviewer",
+        "author": "Anand Tyagi",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-reviewer",
+              "description": "Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code."
+            }
+          ]
+        }
+      },
+      {
+        "name": "codebase-documenter",
+        "description": "Use this agent when you need to analyze a service or codebase component and create comprehensive documentation in CLAUDE.md files. This agent should be invoked after implementing new services, major refactoring, or when documentation needs updating to reflect the current codebase structure. Examples: <example>Context: The user has just implemented a new authentication service and wants to document it properly. user: 'I just finished implementing the auth service, can you document how it works?' assistant: 'I'll use the codebase-documenter agent to analyze the authentication service and create detailed documentation in CLAUDE.md' <commentary>Since the user has completed a service implementation and needs documentation, use the Task tool to launch the codebase-documenter agent to create comprehensive CLAUDE.md documentation.</commentary></example> <example>Context: The user wants to ensure a newly added API module is properly documented for the team. user: 'We need documentation for the new payment processing API I just added' assistant: 'Let me use the codebase-documenter agent to analyze the payment processing API and create proper documentation' <commentary>The user needs documentation for a new API module, so use the codebase-documenter agent to create CLAUDE.md files with setup instructions and architectural notes.</commentary></example>",
+        "source": "./plugins/codebase-documenter",
+        "author": "Anand Tyagi",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "codebase-documenter",
+              "description": "Use this agent when you need to analyze a service or codebase component and create comprehensive documentation in CLAUDE.md files. This agent should be invoked after implementing new services, major refactoring, or when documentation needs updating to reflect the current codebase structure. Examples: <example>Context: The user has just implemented a new authentication service and wants to document it properly. user: 'I just finished implementing the auth service, can you document how it works?' assistant: 'I'll use the codebase-documenter agent to analyze the authentication service and create detailed documentation in CLAUDE.md' <commentary>Since the user has completed a service implementation and needs documentation, use the Task tool to launch the codebase-documenter agent to create comprehensive CLAUDE.md documentation.</commentary></example> <example>Context: The user wants to ensure a newly added API module is properly documented for the team. user: 'We need documentation for the new payment processing API I just added' assistant: 'Let me use the codebase-documenter agent to analyze the payment processing API and create proper documentation' <commentary>The user needs documentation for a new API module, so use the codebase-documenter agent to create CLAUDE.md files with setup instructions and architectural notes.</commentary></example>"
+            }
+          ]
+        }
+      },
+      {
+        "name": "compliance-automation-specialist",
+        "description": "Use this agent when you need to automate compliance processes for SOC 2, ISO 27001, GDPR, HIPAA, and other enterprise regulatory requirements. This agent specializes in compliance automation, audit preparation, continuous monitoring, and regulatory framework implementation for B2B platforms. Examples:",
+        "source": "./plugins/compliance-automation-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ],
+        "components": {
+          "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "compliance-automation-specialist",
+              "description": "Use this agent when you need to automate compliance processes for SOC 2, ISO 27001, GDPR, HIPAA, and other enterprise regulatory requirements. This agent specializes in compliance automation, audit preparation, continuous monitoring, and regulatory framework implementation for B2B platforms. Examples:"
+            }
+          ]
+        }
+      },
+      {
+        "name": "content-creator",
+        "description": "Content Creator subagent",
+        "source": "./plugins/content-creator",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "context7-docs-fetcher",
+        "description": "Use this agent when you need to fetch and utilize documentation from Context7 for specific libraries or frameworks. Examples: <example>Context: User is building a React application and needs documentation about hooks. user: 'I need to implement useState and useEffect in my React component' assistant: 'I'll use the context7-docs-fetcher agent to get the latest React documentation about hooks' <commentary>Since the user needs specific React documentation, use the context7-docs-fetcher agent to fetch relevant docs and provide accurate guidance.</commentary></example> <example>Context: User is working with Express.js and MongoDB and needs setup guidance. user: 'How do I create a REST API with Express and connect to MongoDB?' assistant: 'Let me use the context7-docs-fetcher agent to get the current documentation for both Express.js and MongoDB' <commentary>The user needs documentation for multiple libraries, so use the context7-docs-fetcher agent to fetch comprehensive docs.</commentary></example>",
+        "source": "./plugins/context7-docs-fetcher",
+        "author": "normalnormie",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "customer-success-manager",
+        "description": "Use this agent when you need to optimize customer success operations for B2B enterprise clients. This agent specializes in customer health monitoring, expansion revenue identification, churn prevention, enterprise account management, and customer lifecycle optimization. Handles enterprise onboarding, adoption tracking, and strategic account growth. Examples:",
+        "source": "./plugins/customer-success-manager",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "data-privacy-engineer",
+        "description": "Use this agent when you need to implement data privacy engineering, GDPR compliance, data protection frameworks, and privacy-by-design principles for B2B applications. This agent specializes in privacy engineering, data minimization, consent management, and global privacy regulation compliance for enterprise platforms. Examples:",
+        "source": "./plugins/data-privacy-engineer",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "data-scientist",
+        "description": "Data analysis expert for SQL queries, BigQuery operations, and data insights. Use proactively for data analysis tasks and queries.",
+        "source": "./plugins/data-scientist",
+        "author": "Anand Tyagi",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "database-performance-optimizer",
+        "description": "Use this agent when you need to optimize database performance for B2B applications at enterprise scale. This agent specializes in multi-tenant database optimization, query performance tuning, indexing strategies, connection pooling, and database scaling for SaaS platforms. Handles PostgreSQL, MySQL, MongoDB, and cloud database optimizations. Examples:",
+        "source": "./plugins/database-performance-optimizer",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "debugger",
+        "description": "Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.",
+        "source": "./plugins/debugger",
+        "author": "Anand Tyagi",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "deployment-engineer",
+        "description": "Use this agent when setting up CI/CD pipelines, configuring Docker containers, deploying applications to cloud platforms, setting up Kubernetes clusters, implementing infrastructure as code, or automating deployment workflows. Examples: <example>Context: User is setting up a new project and needs deployment automation. user: \"I've built a FastAPI application and need to deploy it to production with proper CI/CD\" assistant: \"I'll use the deployment-engineer agent to set up a complete deployment pipeline with Docker, GitHub Actions, and production-ready configurations.\"</example> <example>Context: User mentions containerization or deployment issues. user: \"Our deployment process is manual and error-prone. We need to automate it.\" assistant: \"Let me use the deployment-engineer agent to design an automated CI/CD pipeline that eliminates manual steps and ensures reliable deployments.\"</example>",
+        "source": "./plugins/deployment-engineer",
+        "author": "Jure Šunić",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "desktop-app-dev",
+        "description": "Desktop App Dev subagent",
+        "source": "./plugins/desktop-app-dev",
+        "author": "safayavatsal",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "devops-automator",
+        "description": "Use this agent when setting up CI/CD pipelines, configuring cloud infrastructure, implementing monitoring systems, or automating deployment processes. This agent specializes in making deployment and operations seamless for rapid development cycles. Examples:\\n\\n<example>\\nContext: Setting up automated deployments\\nuser: \"We need automatic deployments when we push to main\"\\nassistant: \"I'll set up a complete CI/CD pipeline. Let me use the devops-automator agent to configure automated testing, building, and deployment.\"\\n<commentary>\\nAutomated deployments require careful pipeline configuration and proper testing stages.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Infrastructure scaling issues\\nuser: \"Our app crashes when we get traffic spikes\"\\nassistant: \"I'll implement auto-scaling and load balancing. Let me use the devops-automator agent to ensure your infrastructure handles traffic gracefully.\"\\n<commentary>\\nScaling requires proper infrastructure setup with monitoring and automatic responses.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Monitoring and alerting setup\\nuser: \"We have no idea when things break in production\"\\nassistant: \"Observability is crucial for rapid iteration. I'll use the devops-automator agent to set up comprehensive monitoring and alerting.\"\\n<commentary>\\nProper monitoring enables fast issue detection and resolution in production.\\n</commentary>\\n</example>",
+        "source": "./plugins/devops-automator",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "enterprise-integrator-architect",
+        "description": "Use this agent when you need to design and implement complex external enterprise system integrations for B2B applications. This agent specializes in connecting your platform with Salesforce, HubSpot, Microsoft 365, Google Workspace, SAP, Oracle ERP, and other critical third-party business software. Handles external API orchestration, data synchronization with enterprise systems, webhook management for third-party services, and enterprise-grade integration patterns. Examples:",
+        "source": "./plugins/enterprise-integrator-architect",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "enterprise-onboarding-specialist",
+        "description": "Use this agent when you need to design and optimize complex enterprise customer onboarding processes involving multiple stakeholders, change management, and organizational adoption. This agent specializes in enterprise implementation strategy, stakeholder management, change management, and large-scale rollout coordination for B2B platforms. Examples:",
+        "source": "./plugins/enterprise-onboarding-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "enterprise-security-reviewer",
+        "description": "Use this agent for comprehensive B2B security assessments, enterprise compliance validation, multi-tenant security reviews, and security audit preparation. This agent specializes in SOC 2, GDPR, ISO 27001 compliance and enterprise-grade security implementations for B2B SaaS platforms. Examples:",
+        "source": "./plugins/enterprise-security-reviewer",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "experiment-tracker",
+        "description": "PROACTIVELY use this agent when experiments are started, modified, or when results need analysis. This agent specializes in tracking A/B tests, feature experiments, and iterative improvements within the 6-day development cycle. Should be triggered automatically when experimental code paths or feature flags are introduced. Examples:\\n\\n<example>\\nContext: When implementing feature flags or A/B test variants\\nuser: \"Add a feature flag to test the new onboarding flow\"\\nassistant: \"I've implemented the feature flag for the onboarding flow A/B test. Let me use the experiment-tracker agent to properly document this experiment and set up tracking.\"\\n<commentary>\\nEvery feature flag represents an experiment that needs proper tracking and success metrics.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After deploying experimental features\\nuser: \"The new viral sharing feature is now live for 10% of users\"\\nassistant: \"Great! The viral sharing feature is deployed. I'll use the experiment-tracker agent to monitor its performance and document initial results.\"\\n<commentary>\\nLive experiments need immediate tracking setup to capture valuable data from the start.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When reaching experiment milestones\\nuser: \"It's been a week since we launched the TikTok integration test\"\\nassistant: \"Perfect timing for analysis. Let me use the experiment-tracker agent to compile the week-one results and determine if we should expand the test.\"\\n<commentary>\\nRegular experiment checkpoints ensure data-driven decisions about feature rollouts.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Before making product decisions\\nuser: \"Should we keep the AI avatar feature or remove it?\"\\nassistant: \"Let me analyze the experiment data to inform this decision. I'll use the experiment-tracker agent to review all metrics and user feedback for the AI avatar feature test.\"\\n<commentary>\\nProduct decisions should be backed by experiment data, not gut feelings.\\n</commentary>\\n</example>",
+        "source": "./plugins/experiment-tracker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "feedback-synthesizer",
+        "description": "Use this agent when you need to analyze user feedback from multiple sources, identify patterns in user complaints or requests, synthesize insights from reviews, or prioritize feature development based on user input. This agent excels at turning raw feedback into actionable product insights. Examples:\\n\\n<example>\\nContext: Weekly review of user feedback",
+        "source": "./plugins/feedback-synthesizer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "finance-tracker",
+        "description": "Use this agent when managing budgets, optimizing costs, forecasting revenue, or analyzing financial performance. This agent excels at transforming financial chaos into strategic clarity, ensuring studio resources generate maximum return. Examples:\\n\\n<example>\\nContext: Planning next quarter's development budget",
+        "source": "./plugins/finance-tracker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "flutter-mobile-app-dev",
+        "description": "Use this agent when you need expert assistance with Flutter mobile development tasks, including code analysis, widget creation, debugging, performance optimization, or architectural decisions. Examples: <example>Context: User is working on a Flutter app and faces issues with navigation. user: 'My Navigator.push isn't updating the UI correctly when moving to a new screen' assistant: 'Let me use the flutter-dev agent to analyze your navigation setup and provide a solution' <commentary>Since this is a Flutter-specific navigation issue, use the flutter-dev agent to provide expert guidance on Navigator problems.</commentary></example> <example>Context: User wants to create a custom widget that aligns with their app's design system. user: 'I need to create a custom button widget that matches our app's design system' assistant: 'I'll use the flutter-dev agent to create a button widget that aligns with your existing codebase structure and design patterns' <commentary>The user needs a Flutter widget that follows existing patterns, so use the flutter-dev agent.</commentary></example>",
+        "source": "./plugins/flutter-mobile-app-dev",
+        "author": "safayavatsal",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "frontend-developer",
+        "description": "Use this agent when building user interfaces, implementing React/Vue/Angular components, handling state management, or optimizing frontend performance. This agent excels at creating responsive, accessible, and performant web applications. Examples:\\n\\n<example>\\nContext: Building a new user interface\\nuser: \"Create a dashboard for displaying user analytics\"\\nassistant: \"I'll build an analytics dashboard with interactive charts. Let me use the frontend-developer agent to create a responsive, data-rich interface.\"\\n<commentary>\\nComplex UI components require frontend expertise for proper implementation and performance.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Fixing UI/UX issues\\nuser: \"The mobile navigation is broken on small screens\"\\nassistant: \"I'll fix the responsive navigation issues. Let me use the frontend-developer agent to ensure it works perfectly across all device sizes.\"\\n<commentary>\\nResponsive design issues require deep understanding of CSS and mobile-first development.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Optimizing frontend performance\\nuser: \"Our app feels sluggish when loading large datasets\"\\nassistant: \"Performance optimization is crucial for user experience. I'll use the frontend-developer agent to implement virtualization and optimize rendering.\"\\n<commentary>\\nFrontend performance requires expertise in React rendering, memoization, and data handling.\\n</commentary>\\n</example>",
+        "source": "./plugins/frontend-developer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "growth-hacker",
+        "description": "Growth Hacker subagent",
+        "source": "./plugins/growth-hacker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "infrastructure-maintainer",
+        "description": "Use this agent when monitoring system health, optimizing performance, managing scaling, or ensuring infrastructure reliability. This agent excels at keeping studio applications running smoothly while preparing for growth and preventing disasters. Examples:\\n\\n<example>\\nContext: App experiencing slow performance",
+        "source": "./plugins/infrastructure-maintainer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "instagram-curator",
+        "description": "Instagram Curator subagent",
+        "source": "./plugins/instagram-curator",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "joker",
+        "description": "Use this agent when you need to lighten the mood, create funny content, or add humor to any situation. This agent specializes in dad jokes, programming puns, and startup humor. Examples:\\n\\n<example>\\nContext: Team needs a laugh during a stressful sprint\\nuser: \"We've been debugging for hours and everyone's frustrated\"\\nassistant: \"Time for a morale boost! Let me use the joker agent to share some programming humor.\"\\n<commentary>\\nHumor can help reset team energy during challenging moments.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating fun error messages\\nuser: \"Our 404 page is boring\"\\nassistant: \"Let's make that error page memorable! I'll use the joker agent to create some funny 404 messages.\"\\n<commentary>\\nHumorous error pages can turn frustration into delight.\\n</commentary>\\n</example>",
+        "source": "./plugins/joker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "legal-advisor",
+        "description": "Use this agent when you need legal advisory, compliance documentation, RFP response creation, and enterprise contract support for B2B applications. This agent specializes in legal document creation, regulatory analysis, enterprise procurement compliance, and RFP winning strategies. Transforms complex legal requirements into competitive advantages. Examples:",
+        "source": "./plugins/legal-advisor",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "legal-compliance-checker",
+        "description": "Use this agent when reviewing terms of service, privacy policies, ensuring regulatory compliance, or handling legal requirements. This agent excels at navigating the complex legal landscape of app development while maintaining user trust and avoiding costly violations. Examples:\\n\\n<example>\\nContext: Launching app in European markets",
+        "source": "./plugins/legal-compliance-checker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "mobile-app-builder",
+        "description": "Use this agent when developing native iOS or Android applications, implementing React Native features, or optimizing mobile performance. This agent specializes in creating smooth, native-feeling mobile experiences. Examples:\\n\\n<example>\\nContext: Building a new mobile app\\nuser: \"Create a TikTok-style video feed for our app\"\\nassistant: \"I'll build a performant video feed with smooth scrolling. Let me use the mobile-app-builder agent to implement native performance optimizations.\"\\n<commentary>\\nVideo feeds require careful mobile optimization for smooth scrolling and memory management.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing mobile-specific features\\nuser: \"Add push notifications and biometric authentication\"\\nassistant: \"I'll implement native push notifications and Face ID/fingerprint auth. Let me use the mobile-app-builder agent to ensure proper platform integration.\"\\n<commentary>\\nNative features require platform-specific implementation and proper permissions handling.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Cross-platform development\\nuser: \"We need this feature on both iOS and Android\"\\nassistant: \"I'll implement it using React Native for code reuse. Let me use the mobile-app-builder agent to ensure native performance on both platforms.\"\\n<commentary>\\nCross-platform development requires balancing code reuse with platform-specific optimizations.\\n</commentary>\\n</example>",
+        "source": "./plugins/mobile-app-builder",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "mobile-ux-optimizer",
+        "description": "Use this agent when you need to optimize UI/UX components or interfaces for mobile-first experiences, analyze existing design themes, or ensure mobile usability standards are met. Examples: <example>Context: User has created a desktop-focused component and needs it optimized for mobile. user: 'I've built this navigation component but it's not working well on mobile devices' assistant: 'Let me use the mobile-ux-optimizer agent to analyze and improve this component for mobile-first experience' <commentary>The user needs mobile optimization expertise, so use the mobile-ux-optimizer agent to provide specific mobile UX improvements.</commentary></example> <example>Context: User is implementing a new feature and wants to ensure it follows the existing design theme. user: 'I'm adding a new form component to the app, can you help make sure it matches our design system?' assistant: 'I'll use the mobile-ux-optimizer agent to ensure this form component aligns with your existing theme and mobile-first principles' <commentary>Since this involves both theme consistency and mobile optimization, the mobile-ux-optimizer agent is the right choice.</commentary></example>",
+        "source": "./plugins/mobile-ux-optimizer",
+        "author": "abhishek shah",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "model-context-protocol-mcp-expert",
+        "description": "Model Context Protocol Mcp Expert subagent",
+        "source": "./plugins/model-context-protocol-mcp-expert",
+        "author": "Community",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "monitoring-observability-specialist",
+        "description": "Use this agent when you need to implement comprehensive monitoring, observability, and alerting systems for enterprise B2B applications. This agent specializes in APM, logging, metrics, distributed tracing, SLA monitoring, and proactive incident management for business-critical systems. Examples:",
+        "source": "./plugins/monitoring-observability-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "n8n-workflow-builder",
+        "description": "Use this agent when you need to design, build, or validate n8n automation workflows. This agent specializes in creating efficient n8n workflows using proper validation techniques and MCP tools integration.\\n\\nExamples:\\n- <example>\\n  Context: User wants to create a Slack notification workflow when a new GitHub issue is created.\\n  user: \"I need to create an n8n workflow that sends a Slack message whenever a new GitHub issue is opened\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to design and build this GitHub-to-Slack automation workflow with proper validation.\"\\n  <commentary>\\n  The user needs n8n workflow creation, so use the n8n-workflow-builder agent to handle the complete workflow design, validation, and deployment process.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User has an existing n8n workflow that needs debugging and optimization.\\n  user: \"My n8n workflow keeps failing at the HTTP Request node, can you help me fix it?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to analyze and debug your workflow, focusing on the HTTP Request node configuration.\"\\n  <commentary>\\n  Since this involves n8n workflow troubleshooting and validation, use the n8n-workflow-builder agent to diagnose and fix the issue.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User wants to understand n8n best practices and available nodes for a specific use case.\\n  user: \"What are the best n8n nodes for processing CSV data and sending email reports?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to explore the available nodes and recommend the best approach for CSV processing and email automation.\"\\n  <commentary>\\n  This requires n8n expertise and node discovery, so use the n8n-workflow-builder agent to provide comprehensive guidance.\\n  </commentary>\\n</example>",
+        "source": "./plugins/n8n-workflow-builder",
+        "author": "Jure Šunić",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "onomastophes",
+        "description": "Use proactively for generating creative non-olympian Greek god names with rich backstories, mythological authenticity, and modern accessibility for storytelling projects",
+        "source": "./plugins/onomastophes",
+        "author": "normalnormie",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "performance-benchmarker",
+        "description": "Use this agent for comprehensive performance testing, profiling, and optimization recommendations. This agent specializes in measuring speed, identifying bottlenecks, and providing actionable optimization strategies for applications. Examples:\\n\\n<example>\\nContext: Application speed testing",
+        "source": "./plugins/performance-benchmarker",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "planning-prd-agent",
+        "description": "'MUST BE USED PROACTIVELY when user mentions: planning, PRD, product requirements document, project plan, roadmap, specification, requirements analysis, feature breakdown, technical spec, project estimation, milestone planning, or task decomposition. Use IMMEDIATELY when user says \"create a PRD\", \"plan this feature\", \"document requirements\", \"break down this project\", \"estimate this work\", \"create a roadmap\", \"write specifications\", or references planning/documentation needs. Expert Technical Project Manager that creates comprehensive PRDs with user stories, acceptance criteria, technical architecture, task breakdowns, and separate task assignment files for sub-agent delegation.'",
+        "source": "./plugins/planning-prd-agent",
+        "author": "clouddna-au",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "prd-specialist",
+        "description": "Use this agent when you need to create comprehensive Product Requirements Documents (PRDs) that combine business strategy, technical architecture, and user research. Examples: <example>Context: The user needs to create a PRD for a new feature or product launch. user: \"I need to create a PRD for our new user authentication system that will support SSO and multi-factor authentication\" assistant: \"I'll use the prd-specialist agent to create a comprehensive PRD that covers the strategic foundation, technical requirements, and implementation blueprint for your authentication system.\"</example> <example>Context: The user is planning a major product initiative and needs strategic documentation. user: \"We're launching a mobile app for our e-commerce platform and need a detailed PRD to guide development\" assistant: \"Let me engage the prd-specialist agent to develop a thorough PRD that includes market analysis, user research integration, technical architecture, and implementation roadmap for your mobile app initiative.\"</example>",
+        "source": "./plugins/prd-specialist",
+        "author": "Jure Šunić",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "pricing-packaging-specialist",
+        "description": "Use this agent when you need to optimize B2B pricing strategies, packaging models, and revenue optimization for enterprise sales. This agent specializes in value-based pricing, usage-based billing, enterprise contract negotiations, and competitive pricing analysis for SaaS platforms. Examples:",
+        "source": "./plugins/pricing-packaging-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "problem-solver-specialist",
+        "description": "Universal expert problem-solving agent specializing in complex debugging, mysterious runtime behavior, integration issues, and multi-layered technical challenges across any technology stack or project type. Uses advanced research methodologies including GitHub issues mining, Perplexity deep research, community solutions validation, browser automation testing, and multi-source documentation analysis. Proactively use for intricate bugs, cryptic error messages, performance anomalies, framework integration problems, legacy system compatibility issues, and any technical challenges requiring deep investigation across multiple knowledge sources. Project-agnostic and universally applicable.",
+        "source": "./plugins/problem-solver-specialist",
+        "author": "Beau Lewis",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "product-sales-specialist",
+        "description": "Use this agent when you need to support B2B sales through product design, user research, project management, and creative RFP responses. This agent specializes in creating compelling product demonstrations, design-focused RFP sections, user experience narratives, and project management frameworks that win enterprise deals. Combines product expertise with sales enablement. Examples:",
+        "source": "./plugins/product-sales-specialist",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "project-curator",
+        "description": "Reorganizes project structure by cleaning root clutter, creating logical folder hierarchies, and moving files to optimal locations. Tracks dependencies and fixes broken imports/paths. Use PROACTIVELY when project structure becomes unwieldy or needs architectural cleanup.",
+        "source": "./plugins/project-curator",
+        "author": "alanKerrigan",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "project-shipper",
+        "description": "PROACTIVELY use this agent when approaching launch milestones, release deadlines, or go-to-market activities. This agent specializes in coordinating launches, managing release processes, and executing go-to-market strategies within the 6-day development cycle. Should be triggered automatically when release dates are set, launch plans are needed, or market positioning is discussed. Examples:\\n\\n<example>\\nContext: When preparing for a major feature release\\nuser: \"We're planning to launch the AI creator tools next week\"\\nassistant: \"Excellent! A major feature launch requires careful coordination. Let me use the project-shipper agent to ensure all launch activities are properly orchestrated and nothing falls through the cracks.\"\\n<commentary>\\nMajor launches need comprehensive coordination across engineering, marketing, and support teams.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: During release planning discussions\\nuser: \"We need to ship three updates this sprint\"\\nassistant: \"Managing multiple releases requires careful orchestration. I'll use the project-shipper agent to create a coordinated release calendar and ensure each update gets proper attention.\"\\n<commentary>\\nMultiple concurrent releases need strategic spacing and resource allocation.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When go-to-market strategy is needed\\nuser: \"How should we position the new viral video features?\"\\nassistant: \"Positioning is crucial for feature adoption. Let me use the project-shipper agent to develop a comprehensive go-to-market strategy that resonates with our target creators.\"\\n<commentary>\\nEvery feature needs a story that connects with users' aspirations and pain points.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Post-launch monitoring\\nuser: \"The collaboration feature launched yesterday\"\\nassistant: \"Great! The critical first 48 hours determine success. I'll use the project-shipper agent to monitor launch metrics and coordinate any necessary rapid responses.\"\\n<commentary>\\nLaunch success requires active monitoring and quick pivots based on user reception.\\n</commentary>\\n</example>",
+        "source": "./plugins/project-shipper",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "python-expert",
+        "description": "Use this agent when working with Python code that requires advanced features, performance optimization, or comprehensive refactoring. Examples: <example>Context: User needs to optimize a slow Python function that processes large datasets. user: \"This function is taking too long to process our data, can you help optimize it?\" assistant: \"I'll use the python-expert agent to analyze and optimize your Python code with advanced techniques and performance profiling.\"</example> <example>Context: User wants to implement async/await patterns in their existing synchronous Python code. user: \"I need to convert this synchronous code to use async/await for better performance\" assistant: \"Let me use the python-expert agent to refactor your code with proper async/await patterns and concurrent programming techniques.\"</example> <example>Context: User needs help implementing complex Python design patterns. user: \"I want to implement a factory pattern with decorators for my API endpoints\" assistant: \"I'll use the python-expert agent to implement advanced Python patterns with decorators and proper design principles.\"</example>",
+        "source": "./plugins/python-expert",
+        "author": "Jure Šunić",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "rapid-prototyper",
+        "description": "Use this agent when you need to quickly create a new application prototype, MVP, or proof-of-concept within the 6-day development cycle. This agent specializes in scaffolding projects, integrating trending features, and building functional demos rapidly. Examples:\\n\\n<example>\\nContext: Starting a new experiment or app idea\\nuser: \"Create a new app that helps people overcome phone anxiety\"\\nassistant: \"I'll help you create a phone anxiety app. Let me use the rapid-prototyper agent to scaffold this project and build an MVP.\"\\n<commentary>\\nWhen starting any new project or experiment, use the rapid-prototyper to quickly set up the foundation and core features.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Need to test a trending feature or viral concept\\nuser: \"I saw this TikTok trend about AI avatars, can we build something around that?\"\\nassistant: \"That's a great trending opportunity! I'll use the rapid-prototyper agent to quickly build a prototype app featuring AI avatars.\"\\n<commentary>\\nFor capitalizing on trends and viral content, the rapid-prototyper can quickly create testable prototypes.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Validating a business idea with minimal investment\\nuser: \"We need to test if people would pay for a subscription box curation app\"\\nassistant: \"Let's validate that idea with a quick prototype. I'll use the rapid-prototyper agent to build an MVP with basic subscription and curation features.\"\\n<commentary>\\nBusiness validation requires fast prototyping to test market fit before full investment.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating demo apps for stakeholder presentations\\nuser: \"We're meeting with investors next week and need to show them our vision\"\\nassistant: \"I'll help create a compelling demo. Let me use the rapid-prototyper agent to build a functional prototype that showcases your vision.\"\\n<commentary>\\nInvestor demos and stakeholder presentations benefit from working prototypes rather than just mockups.\\n</commentary>\\n</example>",
+        "source": "./plugins/rapid-prototyper",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "react-native-dev",
+        "description": "Use this agent when you need expert assistance with React Native development tasks including code analysis, component creation, debugging, performance optimization, or architectural decisions. Examples: <example>Context: User is working on a React Native app and needs help with a navigation issue. user: 'My stack navigator isn't working properly when I try to navigate between screens' assistant: 'Let me use the react-native-dev agent to analyze your navigation setup and provide a solution' <commentary>Since this is a React Native specific issue, use the react-native-dev agent to provide expert guidance on navigation problems.</commentary></example> <example>Context: User wants to create a new component that follows the existing app structure. user: 'I need to create a custom button component that matches our app's design system' assistant: 'I'll use the react-native-dev agent to create a button component that aligns with your existing codebase structure and design patterns' <commentary>The user needs React Native component development that should follow existing patterns, so use the react-native-dev agent.</commentary></example>",
+        "source": "./plugins/react-native-dev",
+        "author": "abhishek shah",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "reddit-community-builder",
+        "description": "Reddit Community Builder subagent",
+        "source": "./plugins/reddit-community-builder",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "sprint-prioritizer",
+        "description": "Use this agent when planning 6-day development cycles, prioritizing features, managing product roadmaps, or making trade-off decisions. This agent specializes in maximizing value delivery within tight timelines. Examples:\\n\\n<example>\\nContext: Planning the next sprint\\nuser: \"We have 50 feature requests but only 6 days\"\\nassistant: \"I'll help prioritize for maximum impact. Let me use the sprint-prioritizer agent to create a focused sprint plan that delivers the most value.\"\\n<commentary>\\nSprint planning requires balancing user needs, technical constraints, and business goals.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Making feature trade-offs\\nuser: \"Should we build AI chat or improve onboarding?\"\\nassistant: \"Let's analyze the impact of each option. I'll use the sprint-prioritizer agent to evaluate ROI and make a data-driven recommendation.\"\\n<commentary>\\nFeature prioritization requires analyzing user impact, development effort, and strategic alignment.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Mid-sprint scope changes\\nuser: \"The CEO wants us to add video calling to this sprint\"\\nassistant: \"I'll assess the impact on current commitments. Let me use the sprint-prioritizer agent to reorganize priorities while maintaining sprint goals.\"\\n<commentary>\\nScope changes require careful rebalancing to avoid sprint failure.\\n</commentary>\\n</example>",
+        "source": "./plugins/sprint-prioritizer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "studio-coach",
+        "description": "PROACTIVELY use this agent when complex multi-agent tasks begin, when agents seem stuck or overwhelmed, or when the team needs motivation and coordination. This agent serves as the elite performance coach for all other agents, ensuring they operate at their highest level while maintaining composure and excellence. Should be triggered automatically at the start of challenging projects or when detecting agent confusion. Examples:\\n\\n<example>\\nContext: Starting a complex project requiring multiple agents\\nuser: \"We need to build a viral TikTok app in 2 weeks\"\\nassistant: \"This is an ambitious goal that will require our A-team! Let me bring in the studio-coach to coordinate our agents and ensure everyone performs at their peak.\"\\n<commentary>\\nComplex projects benefit from having a coach to keep all agents aligned and motivated.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When an agent seems stuck or is producing subpar results\\nagent: \"I'm having trouble identifying the right trends...\"\\nassistant: \"Let me bring in the studio-coach to help refocus and elevate your approach.\"\\n<commentary>\\nAgents can get overwhelmed or lose focus - the coach helps them recenter and excel.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Before launching a major sprint or initiative\\nuser: \"Tomorrow we start the 6-day sprint for our biggest project yet\"\\nassistant: \"Time to rally the team! I'll have the studio-coach prepare everyone mentally and strategically for peak performance.\"\\n<commentary>\\nPre-sprint coaching ensures all agents start with clarity, confidence, and coordination.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When celebrating wins or learning from failures\\nuser: \"Our app just hit #1 on the App Store!\"\\nassistant: \"Incredible achievement! Let me bring in the studio-coach to celebrate with the team and capture what made this success possible.\"\\n<commentary>\\nThe coach helps institutionalize wins and extract learnings from both successes and failures.\\n</commentary>\\n</example>",
+        "source": "./plugins/studio-coach",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "studio-producer",
+        "description": "PROACTIVELY use this agent when coordinating across multiple teams, allocating resources, or optimizing studio workflows. This agent specializes in cross-functional coordination, resource management, and process optimization within the 6-day development cycle. Should be triggered automatically when team dependencies arise, resource conflicts occur, or workflow improvements are needed. Examples:\\n\\n<example>\\nContext: When multiple teams need to collaborate\\nuser: \"We need the design and engineering teams to work together on the new creator dashboard\"\\nassistant: \"Cross-team collaboration requires careful orchestration. Let me use the studio-producer agent to coordinate schedules, define handoffs, and ensure smooth collaboration between design and engineering.\"\\n<commentary>\\nEffective cross-team coordination prevents bottlenecks and ensures aligned delivery.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: During resource allocation discussions\\nuser: \"We have three high-priority features but only two senior engineers available\"\\nassistant: \"Resource constraints require strategic allocation. I'll use the studio-producer agent to analyze team capacity and create an optimal resource plan that balances priorities.\"\\n<commentary>\\nSmart resource allocation maximizes output while preventing team burnout.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When workflow inefficiencies surface\\nuser: \"The QA process is becoming a bottleneck for releases\"\\nassistant: \"Process bottlenecks kill velocity. Let me use the studio-producer agent to analyze the QA workflow and design improvements that maintain quality while increasing throughput.\"\\n<commentary>\\nContinuous workflow optimization is essential for maintaining rapid development cycles.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Sprint planning and coordination\\nuser: \"We're starting a new 6-day cycle next Monday\"\\nassistant: \"New cycles need comprehensive planning. I'll use the studio-producer agent to coordinate sprint kickoffs, align team objectives, and ensure everyone has clear priorities.\"\\n<commentary>\\nWell-coordinated sprint starts set the tone for successful 6-day cycles.\\n</commentary>\\n</example>",
+        "source": "./plugins/studio-producer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "support-responder",
+        "description": "Use this agent when handling customer support inquiries, creating support documentation, setting up automated responses, or analyzing support patterns. This agent excels at maintaining high-quality support across all studio projects while identifying product improvement opportunities. Examples:\\n\\n<example>\\nContext: Setting up support for a new app launch",
+        "source": "./plugins/support-responder",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "technical-sales-engineer",
+        "description": "Use this agent when you need to bridge technical and sales requirements for B2B enterprise deals. This agent specializes in technical demos, POC development, RFP responses, solution architecture for sales, and technical objection handling. Handles complex enterprise sales cycles with technical evaluation phases. Examples:",
+        "source": "./plugins/technical-sales-engineer",
+        "author": "Alysson Franklin",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "test-results-analyzer",
+        "description": "Use this agent for analyzing test results, synthesizing test data, identifying trends, and generating quality metrics reports. This agent specializes in turning raw test data into actionable insights that drive quality improvements. Examples:\\n\\n<example>\\nContext: Analyzing test suite results",
+        "source": "./plugins/test-results-analyzer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "test-writer-fixer",
+        "description": "Use this agent when code changes have been made and you need to write new tests, run existing tests, analyze failures, and fix them while maintaining test integrity. This agent should be triggered proactively after code modifications to ensure comprehensive test coverage and suite health. Examples:\\n\\n<example>\\nContext: The user has just implemented a new feature or modified existing code.\\nuser: \"I've updated the user authentication logic to support OAuth\"\\nassistant: \"I've successfully updated the authentication logic. Now let me run the test-writer-fixer agent to ensure all tests pass with these changes.\"\\n<commentary>\\nSince code changes were made, use the Task tool to launch the test-writer-fixer agent to run relevant tests and fix any failures.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has refactored a module or changed function signatures.\\nuser: \"Please refactor this payment processing module to use async/await\"\\nassistant: \"I've completed the refactoring to use async/await throughout the payment module.\"\\n<function call omitted for brevity>\\nassistant: \"Now I'll use the test-writer-fixer agent to run the tests and fix any issues caused by the refactoring.\"\\n<commentary>\\nAfter refactoring code, proactively use the test-writer-fixer agent to ensure tests still pass.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has fixed a bug or made a critical change.\\nuser: \"Fix the race condition in the data synchronization service\"\\nassistant: \"I've identified and fixed the race condition by implementing proper locking mechanisms.\"\\n<function call omitted for brevity>\\nassistant: \"Let me run the test-writer-fixer agent to verify the fix doesn't break existing functionality.\"\\n<commentary>\\nAfter bug fixes, use the test-writer-fixer agent to ensure the fix works and doesn't introduce regressions.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Code lacks test coverage for critical functionality.\\nuser: \"Our payment processing module has no tests\"\\nassistant: \"That's a critical gap. Let me use the test-writer-fixer agent to create comprehensive tests for the payment module including edge cases and error scenarios.\"\\n<commentary>\\nCritical modules without tests are high-risk areas that need immediate test coverage.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After implementing a new feature that needs tests.\\nuser: \"I've added the social sharing functionality\"\\nassistant: \"Great! The social sharing is implemented. Now let me use the test-writer-fixer agent to write tests that ensure this feature works correctly across different platforms.\"\\n<commentary>\\nNew features should always include comprehensive test coverage from the start.\\n</commentary>\\n</example>",
+        "source": "./plugins/test-writer-fixer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "tiktok-strategist",
+        "description": "Use this agent when you need to create TikTok marketing strategies, develop viral content ideas, plan TikTok campaigns, or optimize for TikTok's algorithm. This agent specializes in creating shareable moments and leveraging TikTok trends for app growth. Examples:\\n\\n<example>\\nContext: Launching a new app and need TikTok strategy\\nuser: \"We're launching our phone anxiety app next week. How should we approach TikTok?\"\\nassistant: \"TikTok will be crucial for your launch. Let me use the tiktok-strategist agent to create a comprehensive TikTok marketing strategy for your phone anxiety app.\"\\n<commentary>\\nNew app launches benefit from TikTok's viral potential and young user base.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating viral content for an existing app\\nuser: \"Our meditation app needs more downloads. What kind of TikTok content should we make?\"\\nassistant: \"I'll help you create viral TikTok content ideas. Let me use the tiktok-strategist agent to develop content that showcases your app in trending formats.\"\\n<commentary>\\nExisting apps can boost downloads through strategic TikTok content that fits platform culture.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Identifying TikTok influencers for partnerships\\nuser: \"Should we work with TikTok creators to promote our app?\"\\nassistant: \"Creator partnerships can be very effective. Let me use the tiktok-strategist agent to identify the right creators and collaboration strategies for your app.\"\\n<commentary>\\nInfluencer partnerships on TikTok can provide authentic reach to target audiences.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Optimizing app features for TikTok sharing\\nuser: \"How can we make our app more TikTok-friendly?\"\\nassistant: \"Making your app TikTok-native is smart. I'll use the tiktok-strategist agent to identify features and moments in your app that users would want to share on TikTok.\"\\n<commentary>\\nApps with built-in TikTok-worthy moments see higher organic growth through user-generated content.\\n</commentary>\\n</example>",
+        "source": "./plugins/tiktok-strategist",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "tool-evaluator",
+        "description": "Use this agent when evaluating new development tools, frameworks, or services for the studio. This agent specializes in rapid tool assessment, comparative analysis, and making recommendations that align with the 6-day development cycle philosophy. Examples:\\n\\n<example>\\nContext: Considering a new framework or library",
+        "source": "./plugins/tool-evaluator",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "trend-researcher",
+        "description": "Use this agent when you need to identify market opportunities, analyze trending topics, research viral content, or understand emerging user behaviors. This agent specializes in finding product opportunities from TikTok trends, App Store patterns, and social media virality. Examples:\\n\\n<example>\\nContext: Looking for new app ideas based on current trends\\nuser: \"What's trending on TikTok that we could build an app around?\"\\nassistant: \"I'll research current TikTok trends that have app potential. Let me use the trend-researcher agent to analyze viral content and identify opportunities.\"\\n<commentary>\\nWhen seeking new product ideas, the trend-researcher can identify viral trends with commercial potential.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Validating a product concept against market trends\\nuser: \"Is there market demand for an app that helps introverts network?\"\\nassistant: \"Let me validate this concept against current market trends. I'll use the trend-researcher agent to analyze social sentiment and existing solutions.\"\\n<commentary>\\nBefore building, validate ideas against real market signals and user behavior patterns.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Competitive analysis for a new feature\\nuser: \"Our competitor just added AI avatars. Should we care?\"\\nassistant: \"I'll analyze the market impact and user reception of AI avatars. Let me use the trend-researcher agent to assess this feature's traction.\"\\n<commentary>\\nCompetitive features need trend analysis to determine if they're fleeting or fundamental.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Finding viral mechanics for existing apps\\nuser: \"How can we make our habit tracker more shareable?\"\\nassistant: \"I'll research viral sharing mechanics in successful apps. Let me use the trend-researcher agent to identify patterns we can adapt.\"\\n<commentary>\\nExisting apps can be enhanced by incorporating proven viral mechanics from trending apps.\\n</commentary>\\n</example>",
+        "source": "./plugins/trend-researcher",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "twitter-engager",
+        "description": "Twitter Engager subagent",
+        "source": "./plugins/twitter-engager",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "ui-designer",
+        "description": "Use this agent when creating user interfaces, designing components, building design systems, or improving visual aesthetics. This agent specializes in creating beautiful, functional interfaces that can be implemented quickly within 6-day sprints. Examples:\\n\\n<example>\\nContext: Starting a new app or feature design",
+        "source": "./plugins/ui-designer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "unit-test-generator",
+        "description": "Expert Flutter/Dart unit test specialist that systematically improves test coverage using automated workflows with strict validation, git management, and Aurigo corporate standards. Use for comprehensive test suite creation and coverage improvement.",
+        "source": "./plugins/unit-test-generator",
+        "author": "Community",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "ux-researcher",
+        "description": "Use this agent when conducting user research, analyzing user behavior, creating journey maps, or validating design decisions through testing. This agent specializes in understanding user needs, pain points, and behaviors to inform product decisions within rapid development cycles. Examples:\\n\\n<example>\\nContext: Understanding user needs for a new feature",
+        "source": "./plugins/ux-researcher",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "vision-specialist",
+        "description": "Expert in vision models, OCR systems, barcode detection, and visual AI. Stays current with latest models (GPT-4V, Claude Vision, Mistral-OCR, etc.), optimization techniques, and specialized libraries. Use PROACTIVELY for image processing, document analysis, or visual AI tasks.",
+        "source": "./plugins/vision-specialist",
+        "author": "alanKerrigan",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "visual-storyteller",
+        "description": "Use this agent when creating visual narratives, designing infographics, building presentations, or communicating complex ideas through imagery. This agent specializes in transforming data and concepts into compelling visual stories that engage users and stakeholders. Examples:\\n\\n<example>\\nContext: Creating app onboarding illustrations",
+        "source": "./plugins/visual-storyteller",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "web-dev",
+        "description": "Use this agent for expert assistance with web development tasks using React, Next.js, NestJS, and other modern web frameworks with TypeScript and Tailwind CSS. This includes code analysis, component creation, debugging, performance optimization, and architectural decisions. Examples: <example>Context: User is building a Next.js app and encounters a routing issue. user: 'My dynamic routes in Next.js are not rendering correctly' assistant: 'Let me use the web-dev agent to analyze your Next.js routing setup and provide a solution' <commentary>This is a Next.js-specific routing issue, so the web-dev agent will provide targeted guidance.</commentary></example> <example>Context: User needs a reusable React component with Tailwind CSS. user: 'I need a card component that matches my app's Tailwind-based design system' assistant: 'I'll use the web-dev agent to create a TypeScript-based React card component styled with Tailwind CSS, following your app's design patterns' <commentary>The user requires a component that aligns with their Tailwind CSS design system, so the web-dev agent ensures compatibility.</commentary></example>",
+        "source": "./plugins/web-dev",
+        "author": "safayavatsal",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "whimsy-injector",
+        "description": "PROACTIVELY use this agent after any UI/UX changes to ensure delightful, playful elements are incorporated. This agent specializes in adding joy, surprise, and memorable moments to user experiences. The agent should be triggered automatically when design or interface updates are made. Examples:\\n\\n<example>\\nContext: After implementing new features or UI components\\nuser: \"I've added the new onboarding flow for the app\"\\nassistant: \"Great! I've implemented the onboarding flow. Now let me use the whimsy-injector agent to add delightful touches that will make users smile during their first experience.\"\\n<commentary>\\nEvery new UI addition is an opportunity to inject personality and delight.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When error states or empty states are created\\nuser: \"Set up error handling for the payment flow\"\\nassistant: \"I've implemented the error handling. Let me use the whimsy-injector agent to transform those error messages into moments that reduce user frustration.\"\\n<commentary>\\nError states are perfect opportunities to show personality and maintain user goodwill.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After creating standard UI components\\nuser: \"Build a loading spinner for the data fetch\"\\nassistant: \"I've created the basic loading functionality. Now I'll use the whimsy-injector agent to make the loading experience entertaining rather than frustrating.\"\\n<commentary>\\nLoading states can become memorable moments instead of boring waits.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When reviewing completed features\\nuser: \"The user profile page is done\"\\nassistant: \"Perfect! The profile page is complete. Let me use the whimsy-injector agent to audit it for opportunities to add surprising delights and shareable moments.\"\\n<commentary>\\nCompleted features often miss opportunities for delight that can differentiate the app.\\n</commentary>\\n</example>",
+        "source": "./plugins/whimsy-injector",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "workflow-optimizer",
+        "description": "Use this agent for optimizing human-agent collaboration workflows and analyzing workflow efficiency. This agent specializes in identifying bottlenecks, streamlining processes, and ensuring smooth handoffs between human creativity and AI assistance. Examples:\\n\\n<example>\\nContext: Improving development workflow efficiency",
+        "source": "./plugins/workflow-optimizer",
+        "author": "Michael Galpert",
+        "tags": [
+          "subagent"
+        ]
+      },
+      {
+        "name": "agent-sdk-dev",
+        "description": "Development kit for working with the Claude Agent SDK",
+        "source": "./plugins/agent-sdk-dev",
+        "tags": [
+          "development",
+          "engineering"
+        ]
+      },
+      {
+        "name": "pr-review-toolkit",
+        "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
+        "source": "./plugins/pr-review-toolkit",
+        "author": "Anthropic",
+        "tags": [
+          "code-quality",
+          "code-testing"
+        ]
+      },
+      {
+        "name": "commit-commands",
+        "description": "Commands for git commit workflows including commit, push, and PR creation",
+        "source": "./plugins/commit-commands",
+        "author": "Anthropic",
+        "tags": [
+          "git-workflow"
+        ]
+      },
+      {
+        "name": "feature-dev",
+        "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, and quality review",
+        "source": "./plugins/feature-dev",
+        "author": "Siddharth Bidasaria",
+        "tags": [
+          "development",
+          "engineering"
+        ]
+      },
+      {
+        "name": "security-guidance",
+        "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
+        "source": "./plugins/security-guidance",
+        "author": "David Dworken",
+        "tags": [
+          "security",
+          "compliance"
+        ]
+      }
+    ]
+  },
+  {
+    "slug": "plugins-for-claude-natives",
+    "name": "Plugins For Claude Natives",
+    "author": "team-attention",
+    "description": "Claude Code plugins for power users",
+    "github": "https://github.com/team-attention/plugins-for-claude-natives",
+    "stars": 809,
+    "type": "marketplace",
+    "tags": [
+      "skills",
+      "agents",
+      "commands",
+      "hooks"
+    ],
+    "contains": {
+      "plugins": 14,
+      "components": {
+        "skills": 17,
+        "hooks": 3,
+        "agents": 9,
+        "commands": 1
+      }
+    },
+    "highlights": [
+      "14 plugins in marketplace"
     ],
     "plugins_list": [
       {
-        "name": "superpowers",
-        "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-        "source": "https://github.com/obra/superpowers.git"
+        "name": "agent-council",
+        "description": "Collect and synthesize opinions from multiple AI agents (Gemini, GPT, Codex)",
+        "source": "./plugins/agent-council",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "agent-council",
+              "description": "Collect and synthesize opinions from multiple AI agents. Use when users say \"summon the council\", \"ask other AIs\", or want multiple AI perspectives on a question."
+            }
+          ]
+        }
       },
       {
-        "name": "superpowers-chrome",
-        "description": "BETA: VERY LIGHTLY TESTED - Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (17 CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
-        "source": "https://github.com/obra/superpowers-chrome.git"
+        "name": "clarify",
+        "description": "Three lenses for clarity: vague requirements to specs, strategy blind spots via Known/Unknown quadrants, and content vs form leverage analysis",
+        "source": "./plugins/clarify",
+        "components": {
+          "skills": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "metamedium",
+              "description": "This skill should be used when the user is building, planning, or strategizing and the key question is whether to optimize content (what) or change form (how/medium). Trigger on \"내용 vs 형식\", \"content vs form\", \"metamedium\", \"형식을 바꿔볼까\", \"새로운 포맷\", \"관점 전환\", \"perspective shift\", \"다른 방법 없을까\", \"같은 방식이 안 먹혀\", \"diminishing returns\". Applies Alan Kay's metamedium concept to surface form-level alternatives. For requirement clarification use vague; for strategy blind spots use unknown."
+            },
+            {
+              "name": "unknown",
+              "description": "This skill should be used when the user provides a strategy, plan, or decision document and wants to surface hidden assumptions and blind spots using the Known/Unknown 4-quadrant framework. Trigger on \"known unknown\", \"4분면 분석\", \"blind spots\", \"뭘 놓치고 있지\", \"뭘 모르는지 모르겠어\", \"전략 점검\", \"전략 분석\", \"assumption check\", \"가정 점검\", \"quadrant analysis\", \"what am I missing\". Strategy-level blind spot analysis with hypothesis-driven questioning. For requirement clarification use vague; for content-vs-form reframing use metamedium."
+            },
+            {
+              "name": "vague",
+              "description": "This skill should be used when the user's request or requirement is ambiguous and needs iterative questioning to become actionable. Trigger on \"clarify requirements\", \"refine requirements\", \"요구사항 명확히\", \"요구사항 정리\", \"뭘 원하는 건지\", \"make this clearer\", \"spec this out\", \"scope this\", \"/clarify\". Turns vague inputs into concrete specs. For strategy blind spots use unknown; for content-vs-form reframing use metamedium."
+            }
+          ]
+        }
       },
       {
-        "name": "elements-of-style",
-        "description": "Writing guidance based on William Strunk Jr.'s The Elements of Style (1918) - foundational rules for clear, concise, grammatically correct writing",
-        "source": "https://github.com/obra/the-elements-of-style.git"
+        "name": "interactive-review",
+        "description": "Interactive markdown review with web UI for visual plan/document approval",
+        "source": "./plugins/interactive-review",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "review",
+              "description": "Interactive markdown review with web UI. Use when user says \"review this\", \"check this plan\", \"피드백\", \"검토해줘\" or specifies a file path to review."
+            }
+          ]
+        }
       },
       {
-        "name": "episodic-memory",
-        "description": "Semantic search for Claude Code conversations. Remember past discussions, decisions, and patterns across sessions. Gives you memory that persists between sessions.",
-        "source": "https://github.com/obra/episodic-memory.git"
+        "name": "say-summary",
+        "description": "Speaks a short summary of Claude's response using macOS TTS (Korean/English)",
+        "source": "./plugins/say-summary",
+        "components": {
+          "hooks": 1
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
+        }
       },
       {
-        "name": "superpowers-lab",
-        "description": "Experimental skills for Superpowers: tmux automation for interactive CLIs, MCP server discovery, duplicate function detection, Slack messaging, headless Windows VM",
-        "source": "https://github.com/obra/superpowers-lab.git"
+        "name": "youtube-digest",
+        "description": "Summarize YouTube videos with transcript, insights, Korean translation, and quizzes",
+        "source": "./plugins/youtube-digest",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "youtube-digest",
+              "description": "This skill should be used when the user asks to \"유튜브 정리\", \"영상 요약\", \"transcript 번역\", \"YouTube digest\", \"영상 퀴즈\", or provides a YouTube URL for analysis. Extracts transcript, generates summary/insights/Korean translation, and tests comprehension with 9 quiz questions across 3 difficulty levels. Optional Deep Research for web-based follow-up."
+            }
+          ]
+        }
       },
       {
-        "name": "superpowers-developing-for-claude-code",
-        "description": "Skills and resources for developing Claude Code plugins, skills, MCP servers, and extensions. Includes comprehensive official documentation and self-update mechanism.",
-        "source": "https://github.com/obra/superpowers-developing-for-claude-code.git"
+        "name": "google-calendar",
+        "description": "Multi-account Google Calendar integration with parallel querying and conflict detection",
+        "source": "./plugins/google-calendar",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "google-calendar",
+              "description": "Google 캘린더 일정 조회/생성/수정/삭제. \"오늘 일정\", \"이번 주 일정\", \"미팅 추가해줘\" 요청에 사용. 여러 계정(work, personal) 통합 조회 지원."
+            }
+          ]
+        }
       },
       {
-        "name": "superpowers-dev",
-        "description": "DEV BRANCH: YOU MUST UNINSTALL OTHER VERSIONS OF SUPERPOWERS BEFORE INSTALLING THIS",
-        "source": "https://github.com/obra/superpowers.git"
+        "name": "session-wrap",
+        "description": "Session wrap-up workflow with multi-agent analysis for documentation, automation, learning, and follow-up",
+        "source": "./plugins/session-wrap",
+        "components": {
+          "skills": 3,
+          "agents": 5,
+          "commands": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "history-insight",
+              "description": "This skill should be used when user wants to access, capture, or reference Claude Code session history. Trigger when user says \"capture session\", \"save session history\", or references past/current conversation as a source - whether for saving, extracting, summarizing, or reviewing. This includes any mention of \"what we discussed\", \"today's work\", \"session history\", or when user treats the conversation itself as source material (e.g., \"from our conversation\")."
+            },
+            {
+              "name": "session-analyzer",
+              "description": "This skill should be used when the user asks to \"analyze session\", \"세션 분석\", \"evaluate skill execution\", \"스킬 실행 검증\", \"check session logs\", \"로그 분석\", provides a session ID with a skill path, or wants to verify that a skill executed correctly in a past session. Post-hoc analysis of Claude Code sessions to validate skill/agent/hook behavior against SKILL.md specifications."
+            },
+            {
+              "name": "session-wrap",
+              "description": "This skill should be used when the user asks to \"wrap up session\", \"end session\", \"session wrap\", \"/wrap\", \"document learnings\", \"what should I commit\", or wants to analyze completed work before ending a coding session."
+            }
+          ],
+          "agents": [
+            {
+              "name": "automation-scout",
+              "description": "|"
+            },
+            {
+              "name": "doc-updater",
+              "description": "|"
+            },
+            {
+              "name": "duplicate-checker",
+              "description": "|"
+            },
+            {
+              "name": "followup-suggester",
+              "description": "|"
+            },
+            {
+              "name": "learning-extractor",
+              "description": "|"
+            }
+          ],
+          "commands": [
+            {
+              "name": "wrap",
+              "description": "Session wrap-up - analyze session, suggest documentation updates, automation opportunities, and follow-up tasks"
+            }
+          ]
+        }
       },
       {
-        "name": "claude-session-driver",
-        "description": "Launch, control, and monitor other Claude Code sessions as workers via tmux",
-        "source": "https://github.com/obra/claude-session-driver.git"
+        "name": "dev",
+        "description": "Developer workflow tools: community scanning, technical decision-making",
+        "source": "./plugins/dev",
+        "components": {
+          "skills": 2,
+          "agents": 4
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "dev-scan",
+              "description": "개발 커뮤니티에서 기술 주제에 대한 다양한 의견 수집. \"개발자 반응\", \"커뮤니티 의견\", \"developer reactions\" 요청에 사용. Reddit, HN, Dev.to, Lobsters 등 종합."
+            },
+            {
+              "name": "tech-decision",
+              "description": "This skill should be used when the user asks to \"기술 의사결정\", \"뭐 쓸지 고민\", \"A vs B\", \"비교 분석\", \"라이브러리 선택\", \"아키텍처 결정\", \"어떤 걸 써야 할지\", \"트레이드오프\", \"기술 선택\", \"구현 방식 고민\", or needs deep analysis for technical decisions. Provides systematic multi-source research and synthesized recommendations."
+            }
+          ],
+          "agents": [
+            {
+              "name": "codebase-explorer",
+              "description": "Use this agent when analyzing existing codebase for technical decisions. Trigger when user needs to understand current code patterns, architecture, constraints, or dependencies before making technology choices."
+            },
+            {
+              "name": "decision-synthesizer",
+              "description": "Use this agent to generate final decision reports with clear recommendations. Trigger after trade-off analysis is complete to produce executive summary and actionable conclusions."
+            },
+            {
+              "name": "docs-researcher",
+              "description": "Use this agent to research official documentation, guides, and best practices for technologies being evaluated. Trigger when comparing libraries, frameworks, or approaches and need authoritative information."
+            },
+            {
+              "name": "tradeoff-analyzer",
+              "description": "Use this agent to synthesize research findings into structured pros/cons analysis. Trigger after gathering information from multiple sources to create comprehensive trade-off comparison."
+            }
+          ]
+        }
       },
       {
-        "name": "double-shot-latte",
-        "description": "Stop 'Would you like me to continue?' interruptions. Automatically evaluates whether Claude should continue working using Claude-judged decision making.",
-        "source": "https://github.com/obra/double-shot-latte.git"
+        "name": "kakaotalk",
+        "description": "Send and read KakaoTalk messages on macOS using Accessibility API",
+        "source": "./plugins/kakaotalk",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "kakaotalk",
+              "description": "This skill should be used when the user asks to \"카톡 보내줘\", \"카카오톡 메시지\", \"KakaoTalk message\", \"채팅 읽어줘\", \"~에게 메시지 보내줘\", or needs to send/read messages via KakaoTalk on macOS."
+            }
+          ]
+        }
+      },
+      {
+        "name": "doubt",
+        "description": "Force Claude to re-validate when you have doubts (!doubt)",
+        "source": "./plugins/doubt",
+        "components": {
+          "hooks": 2
+        },
+        "components_items": {
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            },
+            {
+              "name": "scripts",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "gmail",
+        "description": "Multi-account Gmail integration - read, search, send, and manage emails with 5-step sending workflow",
+        "source": "./plugins/gmail",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "gmail",
+              "description": "This skill should be used when the user asks to \"check email\", \"read emails\", \"send email\", \"reply to email\", \"search inbox\", or manages Gmail. Supports multi-account Gmail integration for reading, searching, sending, and label management."
+            }
+          ]
+        }
+      },
+      {
+        "name": "team-assemble",
+        "description": "Dynamically assemble expert agent teams for complex tasks using Claude Code's agent teams feature",
+        "source": "./plugins/team-assemble",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "team-assemble",
+              "description": "Analyze tasks and dynamically assemble expert agent teams using Claude Code's TeamCreate API. Scouts your codebase, designs optimal agents, and executes with validation."
+            }
+          ]
+        }
+      },
+      {
+        "name": "podcast",
+        "description": "Generate Korean podcast episodes from any source (URLs, tweets, articles) with OpenAI TTS and YouTube auto-upload",
+        "source": "./plugins/podcast",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "podcast",
+              "description": "Generate Korean podcast episodes from any source (URLs, tweets, articles, PDFs) — analyzes content, writes a script, generates audio via OpenAI TTS, converts to MP4, and auto-uploads to YouTube. Use this skill whenever the user says 'make a podcast', 'convert to podcast', 'podcast', 'create an episode', 'turn this into audio', 'YouTube podcast', 'turn this article into a podcast', 'publish as audio', or provides sources and wants them transformed into a listenable format. Supports partial execution: script-only, TTS-only, or upload-only."
+            }
+          ]
+        }
+      },
+      {
+        "name": "fetch-tweet",
+        "description": "Fetch full tweet text, author info, and engagement data from X/Twitter URLs without authentication (uses FxEmbed)",
+        "source": "./plugins/fetch-tweet",
+        "components": {
+          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "fetch-tweet",
+              "description": "This skill should be used when the user asks to \"트윗 가져와\", \"트윗 번역\", \"X 게시글 읽어줘\", \"tweet fetch\", \"트윗 내용\", \"트윗 원문\", or provides an X/Twitter URL (x.com, twitter.com) and wants to read, translate, or analyze the tweet content. Also useful when other skills need to fetch tweet text programmatically."
+            }
+          ]
+        }
       }
     ]
+  },
+  {
+    "slug": "claude-forge",
+    "name": "Claude Forge",
+    "author": "sangrokjung",
+    "description": "Supercharge Claude Code with 11 AI agents, 36 commands & 15 skills — the claude-code plugin framework inspired by oh-my-zsh. 6-layer security hooks included. 5-min install.",
+    "github": "https://github.com/sangrokjung/claude-forge",
+    "stars": 776,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "agents",
+      "commands",
+      "hooks"
+    ],
+    "contains": {},
+    "highlights": [
+      "Web UI: https://sangrokjung.github.io/claude-forge"
+    ],
+    "website": "https://sangrokjung.github.io/claude-forge"
   },
   {
     "slug": "ralph-wiggum-marketer",
@@ -9163,7 +20453,7 @@
     "author": "muratcankoylan",
     "description": "A Claude Code Plugin that provides an autonomous AI copywriter.",
     "github": "https://github.com/muratcankoylan/ralph-wiggum-marketer",
-    "stars": 706,
+    "stars": 763,
     "type": "plugin",
     "tags": [
       "skills",
@@ -9181,140 +20471,254 @@
     "website": "https://x.com/koylanai/status/2008824728824451098?s=20"
   },
   {
-    "slug": "plugins-for-claude-natives",
-    "name": "Plugins For Claude Natives",
-    "author": "team-attention",
-    "description": "Claude Code plugins for power users",
-    "github": "https://github.com/team-attention/plugins-for-claude-natives",
-    "stars": 691,
-    "type": "marketplace",
+    "slug": "claude-notifications-go",
+    "name": "Claude Notifications Go",
+    "author": "777genius",
+    "description": "🔔 Cross-platform smart notifications plugin for Claude Code. 6 types. Click-to-focus. 1 line installation. Instant. Analyze context. Zero dependencies. webhooks (ntfy, slack, telegram...). Linux, MacOS, Windows.",
+    "github": "https://github.com/777genius/claude-notifications-go",
+    "stars": 735,
+    "type": "plugin",
     "tags": [
-      "skills",
-      "agents",
       "commands",
       "hooks"
     ],
     "contains": {
-      "plugins": 13,
+      "commands": 4
+    },
+    "highlights": [
+      "Plugin declares: 4 commands"
+    ],
+    "plugin_manifest": {
+      "commands": [
+        "./commands/init.md",
+        "./commands/settings.md",
+        "./commands/notifications-init.md",
+        "./commands/notifications-settings.md"
+      ]
+    }
+  },
+  {
+    "slug": "agent-skills",
+    "name": "Agent Skills",
+    "author": "hashicorp",
+    "description": "A collection of Agent skills and Claude Code plugins for HashiCorp products.",
+    "github": "https://github.com/hashicorp/agent-skills",
+    "stars": 708,
+    "type": "marketplace",
+    "tags": [
+      "skills",
+      "mcps"
+    ],
+    "contains": {
+      "plugins": 5,
       "components": {
         "skills": 16,
-        "hooks": 3,
-        "agents": 9,
-        "commands": 1
+        "mcps": 2
       }
     },
     "highlights": [
-      "13 plugins in marketplace"
+      "Official HashiCorp release",
+      "5 plugins in marketplace"
     ],
     "plugins_list": [
       {
-        "name": "agent-council",
-        "description": "Collect and synthesize opinions from multiple AI agents (Gemini, GPT, Codex)",
-        "source": "./plugins/agent-council",
+        "name": "terraform-code-generation",
+        "description": "Terraform code generation skills including HCL generation, style guides, and testing.",
+        "source": "./terraform/code-generation",
+        "author": "HashiCorp",
+        "tags": [
+          "terraform",
+          "hcl",
+          "infrastructure",
+          "iac",
+          "testing",
+          "style-guide"
+        ],
         "components": {
-          "skills": 1
+          "skills": 4,
+          "mcps": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "azure-verified-modules",
+              "description": "Azure Verified Modules (AVM) requirements and best practices for developing certified Azure Terraform modules. Use when creating or reviewing Azure modules that need AVM certification."
+            },
+            {
+              "name": "terraform-search-import",
+              "description": "Discover existing cloud resources using Terraform Search queries and bulk import them into Terraform management. Use when bringing unmanaged infrastructure under Terraform control, auditing cloud resources, or migrating to IaC."
+            },
+            {
+              "name": "terraform-style-guide",
+              "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations."
+            },
+            {
+              "name": "terraform-test",
+              "description": "Comprehensive guide for writing and running Terraform tests. Use when creating test files (.tftest.hcl), writing test scenarios with run blocks, validating infrastructure behavior with assertions, mocking providers and data sources, testing module outputs and resource configurations, or troubleshooting Terraform test syntax and execution."
+            }
+          ],
+          "mcps": [
+            {
+              "name": "terraform",
+              "description": ""
+            }
+          ]
         }
       },
       {
-        "name": "clarify",
-        "description": "Three lenses for clarity: vague requirements to specs, strategy blind spots via Known/Unknown quadrants, and content vs form leverage analysis",
-        "source": "./plugins/clarify",
-        "components": {
-          "skills": 3
-        }
-      },
-      {
-        "name": "interactive-review",
-        "description": "Interactive markdown review with web UI for visual plan/document approval",
-        "source": "./plugins/interactive-review",
-        "components": {
-          "skills": 1
-        }
-      },
-      {
-        "name": "say-summary",
-        "description": "Speaks a short summary of Claude's response using macOS TTS (Korean/English)",
-        "source": "./plugins/say-summary",
-        "components": {
-          "hooks": 1
-        }
-      },
-      {
-        "name": "youtube-digest",
-        "description": "Summarize YouTube videos with transcript, insights, Korean translation, and quizzes",
-        "source": "./plugins/youtube-digest",
-        "components": {
-          "skills": 1
-        }
-      },
-      {
-        "name": "google-calendar",
-        "description": "Multi-account Google Calendar integration with parallel querying and conflict detection",
-        "source": "./plugins/google-calendar",
-        "components": {
-          "skills": 1
-        }
-      },
-      {
-        "name": "session-wrap",
-        "description": "Session wrap-up workflow with multi-agent analysis for documentation, automation, learning, and follow-up",
-        "source": "./plugins/session-wrap",
-        "components": {
-          "skills": 3,
-          "agents": 5,
-          "commands": 1
-        }
-      },
-      {
-        "name": "dev",
-        "description": "Developer workflow tools: community scanning, technical decision-making",
-        "source": "./plugins/dev",
+        "name": "terraform-module-generation",
+        "description": "Terraform module generation and refactoring skills including module design and Terraform Stacks.",
+        "source": "./terraform/module-generation",
+        "author": "HashiCorp",
+        "tags": [
+          "terraform",
+          "modules",
+          "infrastructure",
+          "iac",
+          "stacks",
+          "refactoring"
+        ],
         "components": {
           "skills": 2,
-          "agents": 4
+          "mcps": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "refactor-module",
+              "description": "Transform monolithic Terraform configurations into reusable, maintainable modules following HashiCorp's module design principles and community best practices."
+            },
+            {
+              "name": "terraform-stacks",
+              "description": "Comprehensive guide for working with HashiCorp Terraform Stacks. Use when creating, modifying, or validating Terraform Stack configurations (.tfcomponent.hcl, .tfdeploy.hcl files), working with stack components and deployments from local modules, public registry, or private registry sources, managing multi-region or multi-environment infrastructure, or troubleshooting Terraform Stacks syntax and structure."
+            }
+          ],
+          "mcps": [
+            {
+              "name": "terraform",
+              "description": ""
+            }
+          ]
         }
       },
       {
-        "name": "kakaotalk",
-        "description": "Send and read KakaoTalk messages on macOS using Accessibility API",
-        "source": "./plugins/kakaotalk",
+        "name": "terraform-provider-development",
+        "description": "Terraform provider development skills including resources, data sources, actions, and acceptance testing.",
+        "source": "./terraform/provider-development",
+        "author": "HashiCorp",
+        "tags": [
+          "terraform",
+          "provider",
+          "plugin-framework",
+          "resources",
+          "testing"
+        ],
+        "components": {
+          "skills": 6
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "new-terraform-provider",
+              "description": "Use this when scaffolding a new Terraform provider."
+            },
+            {
+              "name": "provider-actions",
+              "description": "Implement Terraform Provider actions using the Plugin Framework. Use when developing imperative operations that execute at lifecycle events (before/after create, update, destroy)."
+            },
+            {
+              "name": "provider-docs",
+              "description": "Create, update, and review Terraform provider documentation for Terraform Registry using HashiCorp-recommended patterns, tfplugindocs templates, and schema descriptions. Use when adding or changing provider configuration, resources, data sources, ephemeral resources, list resources, functions, or guides; when validating generated docs; and when troubleshooting missing or incorrect Registry documentation."
+            },
+            {
+              "name": "provider-resources",
+              "description": "Implement Terraform Provider resources and data sources using the Plugin Framework. Use when developing CRUD operations, schema design, state management, and acceptance testing for provider resources."
+            },
+            {
+              "name": "provider-test-patterns",
+              "description": ">-"
+            },
+            {
+              "name": "run-acceptance-tests",
+              "description": "Guide for running acceptance tests for a Terraform provider. Use this when asked to run an acceptance test or to run a test with the prefix `TestAcc`."
+            }
+          ]
+        }
+      },
+      {
+        "name": "packer-builders",
+        "description": "Packer builder skills for AWS, Azure, and Windows image creation.",
+        "source": "./packer/builders",
+        "author": "HashiCorp",
+        "tags": [
+          "packer",
+          "aws",
+          "azure",
+          "windows",
+          "ami",
+          "image",
+          "builder"
+        ],
+        "components": {
+          "skills": 3
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "aws-ami-builder",
+              "description": "Build Amazon Machine Images (AMIs) with Packer using the amazon-ebs builder. Use when creating custom AMIs for EC2 instances."
+            },
+            {
+              "name": "azure-image-builder",
+              "description": "Build Azure managed images and Azure Compute Gallery images with Packer. Use when creating custom images for Azure VMs."
+            },
+            {
+              "name": "windows-builder",
+              "description": "Build Windows images with Packer using WinRM communicator and PowerShell provisioners. Use when creating Windows AMIs, Azure images, or VMware templates."
+            }
+          ]
+        }
+      },
+      {
+        "name": "packer-hcp",
+        "description": "HCP Packer registry integration for tracking and managing image metadata.",
+        "source": "./packer/hcp",
+        "author": "HashiCorp",
+        "tags": [
+          "packer",
+          "hcp-packer",
+          "registry",
+          "metadata",
+          "image-tracking"
+        ],
         "components": {
           "skills": 1
-        }
-      },
-      {
-        "name": "doubt",
-        "description": "Force Claude to re-validate when you have doubts (!doubt)",
-        "source": "./plugins/doubt",
-        "components": {
-          "hooks": 2
-        }
-      },
-      {
-        "name": "gmail",
-        "description": "Multi-account Gmail integration - read, search, send, and manage emails with 5-step sending workflow",
-        "source": "./plugins/gmail",
-        "components": {
-          "skills": 1
-        }
-      },
-      {
-        "name": "team-assemble",
-        "description": "Dynamically assemble expert agent teams for complex tasks using Claude Code's agent teams feature",
-        "source": "./plugins/team-assemble",
-        "components": {
-          "skills": 1
-        }
-      },
-      {
-        "name": "podcast",
-        "description": "Generate Korean podcast episodes from any source (URLs, tweets, articles) with OpenAI TTS and YouTube auto-upload",
-        "source": "./plugins/podcast",
-        "components": {
-          "skills": 1
+        },
+        "components_items": {
+          "skills": [
+            {
+              "name": "push-to-registry",
+              "description": "Push Packer build metadata to HCP Packer registry for tracking and managing image lifecycle. Use when integrating Packer builds with HCP Packer for version control and governance."
+            }
+          ]
         }
       }
     ]
+  },
+  {
+    "slug": "claude-review-loop",
+    "name": "Claude Review Loop",
+    "author": "hamelsmu",
+    "description": "Claude Code plugin: automated code review loop with Codex",
+    "github": "https://github.com/hamelsmu/claude-review-loop",
+    "stars": 702,
+    "type": "plugin",
+    "tags": [
+      "commands",
+      "hooks"
+    ],
+    "contains": {},
+    "highlights": []
   },
   {
     "slug": "cc-marketplace",
@@ -9322,7 +20726,7 @@
     "author": "ananddtyagi",
     "description": "Marketplace repo for Claude Code Plugins",
     "github": "https://github.com/ananddtyagi/cc-marketplace",
-    "stars": 669,
+    "stars": 684,
     "type": "marketplace",
     "tags": [
       "agents",
@@ -9359,6 +20763,50 @@
           "agents": 3,
           "commands": 5,
           "hooks": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "quality-guardian",
+              "description": "Code quality, testing, and validation enforcement specialist"
+            },
+            {
+              "name": "sugar-orchestrator",
+              "description": "Coordinates Sugar's autonomous development workflows with strategic oversight"
+            },
+            {
+              "name": "task-planner",
+              "description": "Strategic task planning and breakdown specialist for complex development work"
+            }
+          ],
+          "commands": [
+            {
+              "name": "sugar-analyze",
+              "description": "Analyze codebase for potential work and automatically create tasks"
+            },
+            {
+              "name": "sugar-review",
+              "description": "Review and manage pending Sugar tasks interactively"
+            },
+            {
+              "name": "sugar-run",
+              "description": "Start Sugar's autonomous execution mode"
+            },
+            {
+              "name": "sugar-status",
+              "description": "View Sugar system status, task queue, and execution metrics"
+            },
+            {
+              "name": "sugar-task",
+              "description": "Create a comprehensive Sugar task with rich context and metadata"
+            }
+          ],
+          "hooks": [
+            {
+              "name": "hooks",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -9371,6 +20819,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "documentation-generator",
+              "description": "Generate comprehensive documentation for code and APIs"
+            }
+          ]
         }
       },
       {
@@ -9383,6 +20839,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "lyra",
+              "description": "Lyra - a master-level AI prompt optimization specialist."
+            }
+          ]
         }
       },
       {
@@ -9396,6 +20860,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "analyze-codebase",
+              "description": "Generate comprehensive analysis and documentation of entire codebase"
+            }
+          ]
         }
       },
       {
@@ -9408,6 +20880,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "update-claudemd",
+              "description": "Automatically update CLAUDE.md file based on recent code changes"
+            }
+          ]
         }
       },
       {
@@ -9426,6 +20906,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "ultrathink",
+              "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents—Architect, Research, Coder, and Tester—to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax."
+            }
+          ]
         }
       },
       {
@@ -9438,6 +20926,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "code-review",
+              "description": "Perform a comprehensive code review of recent changes"
+            }
+          ]
         }
       },
       {
@@ -9450,6 +20946,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "refractor",
+              "description": "Refactor code following best practices and design patterns"
+            }
+          ]
         }
       },
       {
@@ -9462,6 +20966,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "code-review-assistant",
+              "description": "Comprehensive code review with improvement suggestions"
+            }
+          ]
         }
       },
       {
@@ -9474,6 +20986,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bug-detective",
+              "description": "Systematic debugging assistant with troubleshooting steps"
+            }
+          ]
         }
       },
       {
@@ -9487,6 +21007,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "audit",
+              "description": "Perform security audit on codebase"
+            }
+          ]
         }
       },
       {
@@ -9499,6 +21027,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "plan",
+              "description": "For easy problems, start here. For harder problems, do this after Explore."
+            }
+          ]
         }
       },
       {
@@ -9511,6 +21047,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "claude-desktop-extension",
+              "description": "This command provides the context necessary for Claude Code to create the Desktop Extension or .dxt file of an MCP."
+            }
+          ]
         }
       },
       {
@@ -9523,6 +21067,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "optimize",
+              "description": "Analyze and optimize code performance"
+            }
+          ]
         }
       },
       {
@@ -9532,6 +21084,14 @@
         "author": "evmts",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "commit",
+              "description": "Creates git commits using conventional commit format with appropriate emojis, following project standards and creating descriptive messages that explain the purpose of changes."
+            }
+          ]
         }
       },
       {
@@ -9544,6 +21104,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "explore",
+              "description": "Helps Claude read a planning document and explore related files to get familiar with a topic. Asking Claude to prepare to discuss seems to work better than asking it to prepare to do specific work."
+            }
+          ]
         }
       },
       {
@@ -9556,6 +21124,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "generate-api-docs",
+              "description": "Generate API documentation for endpoints"
+            }
+          ]
         }
       },
       {
@@ -9568,6 +21144,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "debug-session",
+              "description": "Start a comprehensive debugging session"
+            }
+          ]
         }
       },
       {
@@ -9580,6 +21164,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "test-file",
+              "description": "Generate comprehensive tests for a specific file"
+            }
+          ]
         }
       },
       {
@@ -9594,6 +21186,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "double-check",
+              "description": "An easy way to force agent to think again if it's statement that the \"Job is done and production ready\" is actually done - usually it's not. Thanks to this command you don't have to check after the agent if they did their job."
+            }
+          ]
         }
       },
       {
@@ -9603,6 +21203,14 @@
         "author": "evmts",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-worktrees",
+              "description": "Creates git worktrees for all open PRs or specific branches, handling branches with slashes, cleaning up stale worktrees, and supporting custom branch creation for development."
+            }
+          ]
         }
       },
       {
@@ -9612,6 +21220,14 @@
         "author": "arkavo-org",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "pr-review",
+              "description": "Reviews pull request changes to provide feedback, check for issues, and suggest improvements before merging into the main codebase."
+            }
+          ]
         }
       },
       {
@@ -9621,6 +21237,14 @@
         "author": "giselles-ai",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "update-branch-name",
+              "description": "Updates branch names with proper prefixes and formats, enforcing naming conventions, supporting semantic prefixes, and managing remote branch updates."
+            }
+          ]
         }
       },
       {
@@ -9630,6 +21254,14 @@
         "author": "jerseycheese",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "analyze-issue",
+              "description": "Fetches GitHub issue details to create comprehensive implementation specifications, analyzing requirements and planning structured approach with clear implementation steps."
+            }
+          ]
         }
       },
       {
@@ -9642,6 +21274,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "discuss",
+              "description": "Collaborative technical discussion with proactive requirements gathering"
+            }
+          ]
         }
       },
       {
@@ -9651,6 +21291,14 @@
         "author": "danielscholl",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "bug-fix",
+              "description": "Streamlines bug fixing by creating a GitHub issue first, then a feature branch for implementing and thoroughly testing the solution before merging."
+            }
+          ]
         }
       },
       {
@@ -9665,6 +21313,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "openapi-expert",
+              "description": "|"
+            }
+          ]
         }
       },
       {
@@ -9674,6 +21330,14 @@
         "author": "toyamarinyon",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-pr",
+              "description": "Streamlines pull request creation by handling the entire workflow: creating a new branch, committing changes, formatting modified files with Biome, and submitting the PR."
+            }
+          ]
         }
       },
       {
@@ -9683,6 +21347,14 @@
         "author": "liam-hq",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "create-pull-request",
+              "description": "Provides comprehensive PR creation guidance with GitHub CLI, enforcing title conventions, following template structure, and offering concrete command examples with best practices."
+            }
+          ]
         }
       },
       {
@@ -9692,6 +21364,14 @@
         "author": "jeremymailen",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-github-issue",
+              "description": "Analyzes and fixes GitHub issues using a structured approach with GitHub CLI for issue details, implementing necessary code changes, running tests, and creating proper commit messages."
+            }
+          ]
         }
       },
       {
@@ -9701,6 +21381,14 @@
         "author": "metabase",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-issue",
+              "description": "Addresses GitHub issues by taking issue number as parameter, analyzing context, implementing solution, and testing/validating the fix for proper integration."
+            }
+          ]
         }
       },
       {
@@ -9710,6 +21398,14 @@
         "author": "metabase",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "fix-pr",
+              "description": "Fetches and fixes unresolved PR comments by automatically retrieving feedback, addressing reviewer concerns, making targeted code improvements, and streamlining the review process."
+            }
+          ]
         }
       },
       {
@@ -9719,6 +21415,14 @@
         "author": "evmts",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "husky",
+              "description": "Sets up and manages Husky Git hooks by configuring pre-commit hooks, establishing commit message standards, integrating with linting tools, and ensuring code quality on commits."
+            }
+          ]
         }
       },
       {
@@ -9728,6 +21432,14 @@
         "author": "steadycursor",
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "2-commit-fast",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -9745,6 +21457,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "pr-issue-resolve",
+              "description": "this is to analyze the PRs and solve the requested changes in them"
+            }
+          ]
         }
       },
       {
@@ -9760,6 +21480,14 @@
         ],
         "components": {
           "commands": 1
+        },
+        "components_items": {
+          "commands": [
+            {
+              "name": "github-issue-fix",
+              "description": "This is a detailed way you can analyze the GitHub issues and let Claude handle them in best possible way."
+            }
+          ]
         }
       },
       {
@@ -9772,6 +21500,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "accessibility-expert",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -9784,6 +21520,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ai-engineer",
+              "description": "Use this agent when implementing AI/ML features, integrating language models, building recommendation systems, or adding intelligent automation to applications. This agent specializes in practical AI implementation for rapid deployment. Examples:\\n\\n<example>\\nContext: Adding AI features to an app\\nuser: \"We need AI-powered content recommendations\"\\nassistant: \"I'll implement a smart recommendation engine. Let me use the ai-engineer agent to build an ML pipeline that learns from user behavior.\"\\n<commentary>\\nRecommendation systems require careful ML implementation and continuous learning capabilities.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Integrating language models\\nuser: \"Add an AI chatbot to help users navigate our app\"\\nassistant: \"I'll integrate a conversational AI assistant. Let me use the ai-engineer agent to implement proper prompt engineering and response handling.\"\\n<commentary>\\nLLM integration requires expertise in prompt design, token management, and response streaming.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing computer vision features\\nuser: \"Users should be able to search products by taking a photo\"\\nassistant: \"I'll implement visual search using computer vision. Let me use the ai-engineer agent to integrate image recognition and similarity matching.\"\\n<commentary>\\nComputer vision features require efficient processing and accurate model selection.\\n</commentary>\\n</example>"
+            }
+          ]
         }
       },
       {
@@ -9796,6 +21540,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ai-ethics-governance-specialist",
+              "description": "Use this agent when you need to implement AI ethics frameworks, governance policies, and responsible AI practices for B2B applications. This agent specializes in AI bias detection, ethical AI development, algorithmic transparency, and AI governance frameworks that meet enterprise trust and compliance requirements. Examples:"
+            }
+          ]
         }
       },
       {
@@ -9808,6 +21560,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "analytics-reporter",
+              "description": "Use this agent when analyzing metrics, generating insights from data, creating performance reports, or making data-driven recommendations. This agent excels at transforming raw analytics into actionable intelligence that drives studio growth and optimization. Examples:\\n\\n<example>\\nContext: Monthly performance review needed"
+            }
+          ]
         }
       },
       {
@@ -9820,6 +21580,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "angelos-symbo",
+              "description": "Use this agent when you need to create or convert prompts using the SYMBO (symbolic) notation system. This agent MUST be activated whenever generating SYMBO prompts or converting existing prompts to symbolic format. Examples: <example>Context: User wants to create a symbolic prompt for a task management system. user: 'Create a SYMBO prompt for a project task tracker with memory and learning capabilities' assistant: 'I'll use the angelos-symbo agent to create this symbolic prompt following SYMBO notation rules' <commentary>The user is requesting a SYMBO prompt, so the angelos-symbo agent must be used to ensure proper symbolic notation and rule compliance.</commentary></example> <example>Context: User has a natural language prompt they want converted to SYMBO format. user: 'Convert this prompt to SYMBO notation: You are an AI that helps with code reviews by analyzing code quality, suggesting improvements, and tracking common issues across projects' assistant: 'I need to convert this to SYMBO notation using the angelos-symbo agent' <commentary>Since this involves SYMBO prompt generation/conversion, the angelos-symbo agent must be activated.</commentary></example>"
+            }
+          ]
         }
       },
       {
@@ -9832,6 +21600,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-integration-specialist",
+              "description": "Use this agent when you need to design and implement internal API architecture, developer experience, and API infrastructure for B2B applications. This agent specializes in REST API design, GraphQL implementation, API documentation, SDK development, and developer portal creation. Handles API performance optimization, versioning strategies, and internal service communication. Examples:"
+            }
+          ]
         }
       },
       {
@@ -9844,6 +21620,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "api-tester",
+              "description": "Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring APIs are robust, performant, and meet specifications before deployment. Examples:\\n\\n<example>\\nContext: Testing API performance under load"
+            }
+          ]
         }
       },
       {
@@ -9856,6 +21640,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "app-store-optimizer",
+              "description": "Use this agent when preparing app store listings, researching keywords, optimizing app metadata, improving conversion rates, or analyzing app store performance. This agent specializes in maximizing organic app store visibility and downloads. Examples:\\n\\n<example>\\nContext: Preparing for app launch"
+            }
+          ]
         }
       },
       {
@@ -9868,6 +21660,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "b2b-project-shipper",
+              "description": "PROACTIVELY use this agent when approaching B2B launch milestones, enterprise release deadlines, or B2B go-to-market activities. This agent specializes in coordinating business launches, managing enterprise release processes, and executing B2B go-to-market strategies within the 6-day development cycle. Should be triggered automatically when enterprise release dates are set, B2B launch plans are needed, or business market positioning is discussed. Examples:"
+            }
+          ]
         }
       },
       {
@@ -9880,6 +21680,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "backend-architect",
+              "description": "Use this agent when designing APIs, building server-side logic, implementing databases, or architecting scalable backend systems. This agent specializes in creating robust, secure, and performant backend services. Examples:\\n\\n<example>\\nContext: Designing a new API\\nuser: \"We need an API for our social sharing feature\"\\nassistant: \"I'll design a RESTful API with proper authentication and rate limiting. Let me use the backend-architect agent to create a scalable backend architecture.\"\\n<commentary>\\nAPI design requires careful consideration of security, scalability, and maintainability.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Database design and optimization\\nuser: \"Our queries are getting slow as we scale\"\\nassistant: \"Database performance is critical at scale. I'll use the backend-architect agent to optimize queries and implement proper indexing strategies.\"\\n<commentary>\\nDatabase optimization requires deep understanding of query patterns and indexing strategies.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing authentication system\\nuser: \"Add OAuth2 login with Google and GitHub\"\\nassistant: \"I'll implement secure OAuth2 authentication. Let me use the backend-architect agent to ensure proper token handling and security measures.\"\\n<commentary>\\nAuthentication systems require careful security considerations and proper implementation.\\n</commentary>\\n</example>"
+            }
+          ]
         }
       },
       {
@@ -9892,6 +21700,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "brand-guardian",
+              "description": "Use this agent when establishing brand guidelines, ensuring visual consistency, managing brand assets, or evolving brand identity. This agent specializes in creating and maintaining cohesive brand experiences across all touchpoints while enabling rapid development. Examples:\\n\\n<example>\\nContext: Creating brand guidelines for a new app"
+            }
+          ]
         }
       },
       {
@@ -9904,6 +21720,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "ceo-quality-controller-agent",
+              "description": "Universal quality control orchestrator and final authority for any software development project. Dynamically discovers and coordinates with available sub-agents, performs comprehensive multi-dimensional quality assessment, security validation, and deployment readiness verification. Adapts to any project type, programming language, or development framework while maintaining enterprise-grade quality standards. Examples: <example>Context: Code changes ready for review across any project. user: 'Please review this code before commit' assistant: 'I'll use the 1-ceo-quality-control-agent to orchestrate comprehensive quality validation, discover available specialists, and perform final security scanning before approval.' <commentary>Universal quality control requires comprehensive validation across all dimensions regardless of project type.</commentary></example> <example>Context: Multi-agent work completion needing validation. user: 'Several agents completed their tasks, need quality review' assistant: 'Let me engage the 1-ceo-quality-control-agent to coordinate comprehensive validation across all completed work and ensure quality standards.' <commentary>Multi-agent coordination and quality validation applies to any development project.</commentary></example>"
+            }
+          ]
         }
       },
       {
@@ -9916,6 +21740,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "changelog-generator",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -9928,6 +21760,14 @@
         ],
         "components": {
           "agents": 1
+        },
+        "components_items": {
+          "agents": [
+            {
+              "name": "code-architect",
+              "description": "Use this agent when you need to design scalable architecture and folder structures for new features or projects. Examples include: when starting a new feature module, refactoring existing code organization, planning microservice boundaries, designing component hierarchies, or establishing project structure conventions. For example: user: 'I need to add a user authentication system to my app' -> assistant: 'I'll use the code-architect agent to design the architecture and folder structure for your authentication system' -> <uses agent>. Another example: user: 'How should I organize my e-commerce product catalog feature?' -> assistant: 'Let me use the code-architect agent to design a scalable structure for your product catalog' -> <uses agent>."
+            }
+          ]
         }
       },
       {
@@ -10582,1458 +22422,38 @@
     ]
   },
   {
-    "slug": "agentsys",
-    "name": "Agentsys",
-    "author": "agent-sh",
-    "description": "AI writes code. This automates everything else · 19 plugins, 47 agents, and 39 skills · for Claude Code, OpenCode, Codex, Cursor, Kiro.",
-    "github": "https://github.com/agent-sh/agentsys",
-    "stars": 658,
-    "type": "marketplace",
-    "tags": [
-      "agents",
-      "commands",
-      "hooks",
-      "mcps",
-      "skills"
-    ],
-    "contains": {
-      "plugins": 19
-    },
-    "highlights": [
-      "19 plugins in marketplace",
-      "Web UI: https://agent-sh.github.io/agentsys/"
-    ],
-    "website": "https://agent-sh.github.io/agentsys/",
-    "plugins_list": [
-      {
-        "name": "next-task",
-        "description": "Master workflow orchestrator: autonomous workflow with model optimization (opus/sonnet/haiku), two-file state management, workflow enforcement gates, 8 specialist agents",
-        "source": "https://github.com/agent-sh/next-task.git"
-      },
-      {
-        "name": "prepare-delivery",
-        "description": "Pre-ship quality gates: deslop, simplify, agnix, enhance, review loop, delivery validation, docs sync",
-        "source": "https://github.com/agent-sh/prepare-delivery.git"
-      },
-      {
-        "name": "gate-and-ship",
-        "description": "Quality gates then ship - chains /prepare-delivery then /ship in one command",
-        "source": "https://github.com/agent-sh/gate-and-ship.git"
-      },
-      {
-        "name": "ship",
-        "description": "Complete PR workflow: commit to production, skips review when called from next-task, removes task from registry on cleanup, automatic rollback",
-        "source": "https://github.com/agent-sh/ship.git"
-      },
-      {
-        "name": "deslop",
-        "description": "3-phase AI slop detection: regex patterns (HIGH), multi-pass analyzers (MEDIUM), CLI tools (LOW)",
-        "source": "https://github.com/agent-sh/deslop.git"
-      },
-      {
-        "name": "audit-project",
-        "description": "Multi-agent iterative code review until zero issues remain",
-        "source": "https://github.com/agent-sh/audit-project.git"
-      },
-      {
-        "name": "drift-detect",
-        "description": "Deep repository analysis to realign project plans with code reality - detects drift, gaps, and creates prioritized reconstruction plans",
-        "source": "https://github.com/agent-sh/drift-detect.git"
-      },
-      {
-        "name": "enhance",
-        "description": "Master enhancement orchestrator: parallel analyzer execution for plugins, agents, docs, CLAUDE.md, and prompts with unified reporting",
-        "source": "https://github.com/agent-sh/enhance.git"
-      },
-      {
-        "name": "sync-docs",
-        "description": "Standalone documentation sync: find outdated refs, update CHANGELOG, flag stale examples based on code changes",
-        "source": "https://github.com/agent-sh/sync-docs.git"
-      },
-      {
-        "name": "repo-intel",
-        "description": "Unified static analysis via agent-analyzer - git history, AST symbols, project metadata, and doc-code sync",
-        "source": "https://github.com/agent-sh/repo-intel.git"
-      },
-      {
-        "name": "perf",
-        "description": "Rigorous performance investigation workflow with baselines, profiling, hypotheses, and evidence-backed decisions",
-        "source": "https://github.com/agent-sh/perf.git"
-      },
-      {
-        "name": "learn",
-        "description": "Research topics online and create comprehensive learning guides with RAG-optimized indexes",
-        "source": "https://github.com/agent-sh/learn.git"
-      },
-      {
-        "name": "agnix",
-        "description": "Lint agent configuration files (SKILL.md, CLAUDE.md, hooks, MCP) against 342 rules across 10+ AI tools",
-        "source": "https://github.com/agent-sh/agnix.git"
-      },
-      {
-        "name": "consult",
-        "description": "Cross-tool AI consultation: get second opinions from Gemini CLI, Codex CLI, Claude Code, OpenCode, or Copilot CLI with model and thinking effort control",
-        "source": "https://github.com/agent-sh/consult.git"
-      },
-      {
-        "name": "debate",
-        "description": "Structured multi-round debate between AI tools with proposer/challenger roles and verdict",
-        "source": "https://github.com/agent-sh/debate.git"
-      },
-      {
-        "name": "web-ctl",
-        "description": "Browser automation and web testing toolkit for AI agents - headless browser control, persistent sessions, auth handoff, and prompt injection defense",
-        "source": "https://github.com/agent-sh/web-ctl.git"
-      },
-      {
-        "name": "skillers",
-        "description": "Learn from workflow patterns across sessions and suggest skills, hooks, and agents to automate repetitive work",
-        "source": "https://github.com/agent-sh/skillers.git"
-      },
-      {
-        "name": "onboard",
-        "description": "Codebase onboarding - automated data collection and interactive project orientation",
-        "source": "https://github.com/agent-sh/onboard.git"
-      },
-      {
-        "name": "can-i-help",
-        "description": "Find where to contribute to any project - matches developer skills to test gaps, stale docs, bugspots, and open issues",
-        "source": "https://github.com/agent-sh/can-i-help.git"
-      }
-    ]
-  },
-  {
-    "slug": "ccplugins-awesome-claude-code-plugins",
-    "name": "Awesome Claude Code Plugins",
-    "author": "ccplugins",
-    "description": "Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP servers, and hooks for Claude Code",
-    "github": "https://github.com/ccplugins/awesome-claude-code-plugins",
-    "stars": 649,
-    "type": "marketplace",
-    "tags": [
-      "agents",
-      "commands"
-    ],
-    "contains": {
-      "plugins": 118,
-      "components": {
-        "commands": 34,
-        "agents": 16
-      }
-    },
-    "highlights": [
-      "118 plugins in marketplace",
-      "Web UI: https://claudecodeplugins.dev"
-    ],
-    "website": "https://claudecodeplugins.dev",
-    "plugins_list": [
-      {
-        "name": "documentation-generator",
-        "description": "Create comprehensive documentation for code, APIs, and projects.",
-        "source": "./plugins/documentation-generator",
-        "author": "Anonymous",
-        "tags": [
-          "documentation"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "lyra",
-        "description": "Lyra - a master-level AI prompt optimization specialist.",
-        "source": "./plugins/lyra",
-        "author": " Anand Tyagi",
-        "tags": [
-          "workflow"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "analyze-codebase",
-        "description": "Generate comprehensive analysis and documentation of entire codebase",
-        "source": "./plugins/analyze-codebase",
-        "author": " Anand Tyagi",
-        "tags": [
-          "explore",
-          "plan"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "update-claudemd",
-        "description": "Automatically update CLAUDE.md file based on recent code changes",
-        "source": "./plugins/update-claudemd",
-        "author": " Anand Tyagi",
-        "tags": [
-          "code-review"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "ultrathink",
-        "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents—Architect, Research, Coder, and Tester—to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax.",
-        "source": "./plugins/ultrathink",
-        "author": "Jeronim Morina",
-        "tags": [
-          "plan",
-          "explore",
-          "refactoring",
-          "testing",
-          "code-review",
-          "workflow",
-          "debugging"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "code-review",
-        "description": "Perform a comprehensive code review of recent changes",
-        "source": "./plugins/code-review",
-        "author": " Anand Tyagi",
-        "tags": [
-          "code-review"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "refractor",
-        "description": "Refactor code following best practices and design patterns",
-        "source": "./plugins/refractor",
-        "author": " Anand Tyagi",
-        "tags": [
-          "refactoring"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "code-review-assistant",
-        "description": "Get comprehensive code reviews with suggestions for improvements, best practices, and potential issues.",
-        "source": "./plugins/code-review-assistant",
-        "author": "Anonymous",
-        "tags": [
-          "code-review"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "bug-detective",
-        "description": "Systematically debug issues with step-by-step troubleshooting approaches.",
-        "source": "./plugins/bug-detective",
-        "author": "Anonymous",
-        "tags": [
-          "debugging"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "audit",
-        "description": "Perform security audit on codebase",
-        "source": "./plugins/audit",
-        "author": " Anand Tyagi",
-        "tags": [
-          "code-review",
-          "security"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "plan",
-        "description": "For easy problems, start here. For harder problems, do this after Explore.",
-        "source": "./plugins/plan",
-        "author": "Galen Ward",
-        "tags": [
-          "plan"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "claude-desktop-extension",
-        "description": "This command provides the context necessary for Claude Code to create the Desktop Extension or .dxt file of an MCP.",
-        "source": "./plugins/claude-desktop-extension",
-        "author": " Anand Tyagi",
-        "tags": [
-          "workflow"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "optimize",
-        "description": "Analyze and optimize code performance",
-        "source": "./plugins/optimize",
-        "author": " Anand Tyagi",
-        "tags": [
-          "performance"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "commit",
-        "description": "Creates git commits using conventional commit format with appropriate emojis, following project standards and creating descriptive messages that explain the purpose of changes.",
-        "source": "./plugins/commit",
-        "author": "evmts",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "explore",
-        "description": "Helps Claude read a planning document and explore related files to get familiar with a topic. Asking Claude to prepare to discuss seems to work better than asking it to prepare to do specific work.\n\nThis is followed by Plan, then Execute.",
-        "source": "./plugins/explore",
-        "author": "Galen Ward",
-        "tags": [
-          "explore"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "generate-api-docs",
-        "description": "Generate API documentation for endpoints",
-        "source": "./plugins/generate-api-docs",
-        "author": " Anand Tyagi",
-        "tags": [
-          "documentation"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "debug-session",
-        "description": "Ask Claude Code to help you debug an issue",
-        "source": "./plugins/debug-session",
-        "author": " Anand Tyagi",
-        "tags": [
-          "debugging"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "test-file",
-        "description": "Generate comprehensive tests for a specific file",
-        "source": "./plugins/test-file",
-        "author": " Anand Tyagi",
-        "tags": [
-          "testing"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "double-check",
-        "description": "An easy way to force agent to think again if it's statement that the \"Job is done and production ready\" is actually done - usually it's not. Thanks to this command you don't have to check after the agent if they did their job.",
-        "source": "./plugins/double-check",
-        "author": "Robert S",
-        "tags": [
-          "plan",
-          "code-review",
-          "workflow"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "create-worktrees",
-        "description": "Creates git worktrees for all open PRs or specific branches, handling branches with slashes, cleaning up stale worktrees, and supporting custom branch creation for development.",
-        "source": "./plugins/create-worktrees",
-        "author": "evmts",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "pr-review",
-        "description": "Reviews pull request changes to provide feedback, check for issues, and suggest improvements before merging into the main codebase.",
-        "source": "./plugins/pr-review",
-        "author": "arkavo-org",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "update-branch-name",
-        "description": "Updates branch names with proper prefixes and formats, enforcing naming conventions, supporting semantic prefixes, and managing remote branch updates.",
-        "source": "./plugins/update-branch-name",
-        "author": "giselles-ai",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "analyze-issue",
-        "description": "Fetches GitHub issue details to create comprehensive implementation specifications, analyzing requirements and planning structured approach with clear implementation steps.",
-        "source": "./plugins/analyze-issue",
-        "author": "jerseycheese",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "discuss",
-        "description": "Collaborative technical discussion with proactive requirements gathering",
-        "source": "./plugins/discuss",
-        "author": "Bohdan Triapitsyn",
-        "tags": [
-          "plan"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "bug-fix",
-        "description": "Streamlines bug fixing by creating a GitHub issue first, then a feature branch for implementing and thoroughly testing the solution before merging.",
-        "source": "./plugins/bug-fix",
-        "author": "danielscholl",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "openapi-expert",
-        "description": "Use this agent to update, synchronize, or validate the OpenAPI specification (openapi.yml) against the actual REST API implementation. This includes adding new endpoints, updating request/response schemas, fixing discrepancies between the spec and code, or ensuring complete API documentation coverage.",
-        "source": "./plugins/openapi-expert",
-        "author": "Meiring de Wet",
-        "tags": [
-          "documentation",
-          "openapi",
-          "workflow"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "create-pr",
-        "description": "Streamlines pull request creation by handling the entire workflow: creating a new branch, committing changes, formatting modified files with Biome, and submitting the PR.",
-        "source": "./plugins/create-pr",
-        "author": "toyamarinyon",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "create-pull-request",
-        "description": "Provides comprehensive PR creation guidance with GitHub CLI, enforcing title conventions, following template structure, and offering concrete command examples with best practices.",
-        "source": "./plugins/create-pull-request",
-        "author": "liam-hq",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "fix-github-issue",
-        "description": "Analyzes and fixes GitHub issues using a structured approach with GitHub CLI for issue details, implementing necessary code changes, running tests, and creating proper commit messages.",
-        "source": "./plugins/fix-github-issue",
-        "author": "jeremymailen",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "fix-issue",
-        "description": "Addresses GitHub issues by taking issue number as parameter, analyzing context, implementing solution, and testing/validating the fix for proper integration.",
-        "source": "./plugins/fix-issue",
-        "author": "metabase",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "fix-pr",
-        "description": "Fetches and fixes unresolved PR comments by automatically retrieving feedback, addressing reviewer concerns, making targeted code improvements, and streamlining the review process.",
-        "source": "./plugins/fix-pr",
-        "author": "metabase",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "husky",
-        "description": "Sets up and manages Husky Git hooks by configuring pre-commit hooks, establishing commit message standards, integrating with linting tools, and ensuring code quality on commits.",
-        "source": "./plugins/husky",
-        "author": "evmts",
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "2-commit-fast",
-        "description": "Automates git commit process by selecting the first suggested message, generating structured commits with consistent formatting while skipping manual confirmation and removing Claude co-Contributorship footer",
-        "source": "./plugins/2-commit-fast",
-        "author": "steadycursor"
-      },
-      {
-        "name": "pr-issue-resolve",
-        "description": "this is to analyze the PRs and solve the requested changes in them\n",
-        "source": "./plugins/pr-issue-resolve",
-        "author": "safayavatsal",
-        "tags": [
-          "code-review",
-          "testing",
-          "refactoring",
-          "debugging",
-          "security",
-          "performance"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "github-issue-fix",
-        "description": "This is a detailed way you can analyze the GitHub issues and let Claude handle them in best possible way.",
-        "source": "./plugins/github-issue-fix",
-        "author": "safayavatsal",
-        "tags": [
-          "debugging",
-          "refactoring",
-          "testing",
-          "security"
-        ],
-        "components": {
-          "commands": 1
-        }
-      },
-      {
-        "name": "accessibility-expert",
-        "description": "Examples:",
-        "source": "./plugins/accessibility-expert",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "ai-engineer",
-        "description": "Use this agent when implementing AI/ML features, integrating language models, building recommendation systems, or adding intelligent automation to applications. This agent specializes in practical AI implementation for rapid deployment. Examples:\\n\\n<example>\\nContext: Adding AI features to an app\\nuser: \"We need AI-powered content recommendations\"\\nassistant: \"I'll implement a smart recommendation engine. Let me use the ai-engineer agent to build an ML pipeline that learns from user behavior.\"\\n<commentary>\\nRecommendation systems require careful ML implementation and continuous learning capabilities.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Integrating language models\\nuser: \"Add an AI chatbot to help users navigate our app\"\\nassistant: \"I'll integrate a conversational AI assistant. Let me use the ai-engineer agent to implement proper prompt engineering and response handling.\"\\n<commentary>\\nLLM integration requires expertise in prompt design, token management, and response streaming.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing computer vision features\\nuser: \"Users should be able to search products by taking a photo\"\\nassistant: \"I'll implement visual search using computer vision. Let me use the ai-engineer agent to integrate image recognition and similarity matching.\"\\n<commentary>\\nComputer vision features require efficient processing and accurate model selection.\\n</commentary>\\n</example>",
-        "source": "./plugins/ai-engineer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "ai-ethics-governance-specialist",
-        "description": "Use this agent when you need to implement AI ethics frameworks, governance policies, and responsible AI practices for B2B applications. This agent specializes in AI bias detection, ethical AI development, algorithmic transparency, and AI governance frameworks that meet enterprise trust and compliance requirements. Examples:",
-        "source": "./plugins/ai-ethics-governance-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "analytics-reporter",
-        "description": "Use this agent when analyzing metrics, generating insights from data, creating performance reports, or making data-driven recommendations. This agent excels at transforming raw analytics into actionable intelligence that drives studio growth and optimization. Examples:\\n\\n<example>\\nContext: Monthly performance review needed",
-        "source": "./plugins/analytics-reporter",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "angelos-symbo",
-        "description": "Use this agent when you need to create or convert prompts using the SYMBO (symbolic) notation system. This agent MUST be activated whenever generating SYMBO prompts or converting existing prompts to symbolic format. Examples: <example>Context: User wants to create a symbolic prompt for a task management system. user: 'Create a SYMBO prompt for a project task tracker with memory and learning capabilities' assistant: 'I'll use the angelos-symbo agent to create this symbolic prompt following SYMBO notation rules' <commentary>The user is requesting a SYMBO prompt, so the angelos-symbo agent must be used to ensure proper symbolic notation and rule compliance.</commentary></example> <example>Context: User has a natural language prompt they want converted to SYMBO format. user: 'Convert this prompt to SYMBO notation: You are an AI that helps with code reviews by analyzing code quality, suggesting improvements, and tracking common issues across projects' assistant: 'I need to convert this to SYMBO notation using the angelos-symbo agent' <commentary>Since this involves SYMBO prompt generation/conversion, the angelos-symbo agent must be activated.</commentary></example>",
-        "source": "./plugins/angelos-symbo",
-        "author": "normalnormie",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "api-integration-specialist",
-        "description": "Use this agent when you need to design and implement internal API architecture, developer experience, and API infrastructure for B2B applications. This agent specializes in REST API design, GraphQL implementation, API documentation, SDK development, and developer portal creation. Handles API performance optimization, versioning strategies, and internal service communication. Examples:",
-        "source": "./plugins/api-integration-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "api-tester",
-        "description": "Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring APIs are robust, performant, and meet specifications before deployment. Examples:\\n\\n<example>\\nContext: Testing API performance under load",
-        "source": "./plugins/api-tester",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "app-store-optimizer",
-        "description": "Use this agent when preparing app store listings, researching keywords, optimizing app metadata, improving conversion rates, or analyzing app store performance. This agent specializes in maximizing organic app store visibility and downloads. Examples:\\n\\n<example>\\nContext: Preparing for app launch",
-        "source": "./plugins/app-store-optimizer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "b2b-project-shipper",
-        "description": "PROACTIVELY use this agent when approaching B2B launch milestones, enterprise release deadlines, or B2B go-to-market activities. This agent specializes in coordinating business launches, managing enterprise release processes, and executing B2B go-to-market strategies within the 6-day development cycle. Should be triggered automatically when enterprise release dates are set, B2B launch plans are needed, or business market positioning is discussed. Examples:",
-        "source": "./plugins/b2b-project-shipper",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "backend-architect",
-        "description": "Use this agent when designing APIs, building server-side logic, implementing databases, or architecting scalable backend systems. This agent specializes in creating robust, secure, and performant backend services. Examples:\\n\\n<example>\\nContext: Designing a new API\\nuser: \"We need an API for our social sharing feature\"\\nassistant: \"I'll design a RESTful API with proper authentication and rate limiting. Let me use the backend-architect agent to create a scalable backend architecture.\"\\n<commentary>\\nAPI design requires careful consideration of security, scalability, and maintainability.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Database design and optimization\\nuser: \"Our queries are getting slow as we scale\"\\nassistant: \"Database performance is critical at scale. I'll use the backend-architect agent to optimize queries and implement proper indexing strategies.\"\\n<commentary>\\nDatabase optimization requires deep understanding of query patterns and indexing strategies.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing authentication system\\nuser: \"Add OAuth2 login with Google and GitHub\"\\nassistant: \"I'll implement secure OAuth2 authentication. Let me use the backend-architect agent to ensure proper token handling and security measures.\"\\n<commentary>\\nAuthentication systems require careful security considerations and proper implementation.\\n</commentary>\\n</example>",
-        "source": "./plugins/backend-architect",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "brand-guardian",
-        "description": "Use this agent when establishing brand guidelines, ensuring visual consistency, managing brand assets, or evolving brand identity. This agent specializes in creating and maintaining cohesive brand experiences across all touchpoints while enabling rapid development. Examples:\\n\\n<example>\\nContext: Creating brand guidelines for a new app",
-        "source": "./plugins/brand-guardian",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "ceo-quality-controller-agent",
-        "description": "Universal quality control orchestrator and final authority for any software development project. Dynamically discovers and coordinates with available sub-agents, performs comprehensive multi-dimensional quality assessment, security validation, and deployment readiness verification. Adapts to any project type, programming language, or development framework while maintaining enterprise-grade quality standards. Examples: <example>Context: Code changes ready for review across any project. user: 'Please review this code before commit' assistant: 'I'll use the 1-ceo-quality-control-agent to orchestrate comprehensive quality validation, discover available specialists, and perform final security scanning before approval.' <commentary>Universal quality control requires comprehensive validation across all dimensions regardless of project type.</commentary></example> <example>Context: Multi-agent work completion needing validation. user: 'Several agents completed their tasks, need quality review' assistant: 'Let me engage the 1-ceo-quality-control-agent to coordinate comprehensive validation across all completed work and ensure quality standards.' <commentary>Multi-agent coordination and quality validation applies to any development project.</commentary></example>",
-        "source": "./plugins/ceo-quality-controller-agent",
-        "author": "Beau Lewis",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "changelog-generator",
-        "description": "Changelog Generator subagent",
-        "source": "./plugins/changelog-generator",
-        "author": "Joe Heitzeberg",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "code-architect",
-        "description": "Use this agent when you need to design scalable architecture and folder structures for new features or projects. Examples include: when starting a new feature module, refactoring existing code organization, planning microservice boundaries, designing component hierarchies, or establishing project structure conventions. For example: user: 'I need to add a user authentication system to my app' -> assistant: 'I'll use the code-architect agent to design the architecture and folder structure for your authentication system' -> <uses agent>. Another example: user: 'How should I organize my e-commerce product catalog feature?' -> assistant: 'Let me use the code-architect agent to design a scalable structure for your product catalog' -> <uses agent>.",
-        "source": "./plugins/code-architect",
-        "author": "abhishek shah",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "code-reviewer",
-        "description": "Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code.",
-        "source": "./plugins/code-reviewer",
-        "author": "Anand Tyagi",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "codebase-documenter",
-        "description": "Use this agent when you need to analyze a service or codebase component and create comprehensive documentation in CLAUDE.md files. This agent should be invoked after implementing new services, major refactoring, or when documentation needs updating to reflect the current codebase structure. Examples: <example>Context: The user has just implemented a new authentication service and wants to document it properly. user: 'I just finished implementing the auth service, can you document how it works?' assistant: 'I'll use the codebase-documenter agent to analyze the authentication service and create detailed documentation in CLAUDE.md' <commentary>Since the user has completed a service implementation and needs documentation, use the Task tool to launch the codebase-documenter agent to create comprehensive CLAUDE.md documentation.</commentary></example> <example>Context: The user wants to ensure a newly added API module is properly documented for the team. user: 'We need documentation for the new payment processing API I just added' assistant: 'Let me use the codebase-documenter agent to analyze the payment processing API and create proper documentation' <commentary>The user needs documentation for a new API module, so use the codebase-documenter agent to create CLAUDE.md files with setup instructions and architectural notes.</commentary></example>",
-        "source": "./plugins/codebase-documenter",
-        "author": "Anand Tyagi",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "compliance-automation-specialist",
-        "description": "Use this agent when you need to automate compliance processes for SOC 2, ISO 27001, GDPR, HIPAA, and other enterprise regulatory requirements. This agent specializes in compliance automation, audit preparation, continuous monitoring, and regulatory framework implementation for B2B platforms. Examples:",
-        "source": "./plugins/compliance-automation-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ],
-        "components": {
-          "agents": 1
-        }
-      },
-      {
-        "name": "content-creator",
-        "description": "Content Creator subagent",
-        "source": "./plugins/content-creator",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "context7-docs-fetcher",
-        "description": "Use this agent when you need to fetch and utilize documentation from Context7 for specific libraries or frameworks. Examples: <example>Context: User is building a React application and needs documentation about hooks. user: 'I need to implement useState and useEffect in my React component' assistant: 'I'll use the context7-docs-fetcher agent to get the latest React documentation about hooks' <commentary>Since the user needs specific React documentation, use the context7-docs-fetcher agent to fetch relevant docs and provide accurate guidance.</commentary></example> <example>Context: User is working with Express.js and MongoDB and needs setup guidance. user: 'How do I create a REST API with Express and connect to MongoDB?' assistant: 'Let me use the context7-docs-fetcher agent to get the current documentation for both Express.js and MongoDB' <commentary>The user needs documentation for multiple libraries, so use the context7-docs-fetcher agent to fetch comprehensive docs.</commentary></example>",
-        "source": "./plugins/context7-docs-fetcher",
-        "author": "normalnormie",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "customer-success-manager",
-        "description": "Use this agent when you need to optimize customer success operations for B2B enterprise clients. This agent specializes in customer health monitoring, expansion revenue identification, churn prevention, enterprise account management, and customer lifecycle optimization. Handles enterprise onboarding, adoption tracking, and strategic account growth. Examples:",
-        "source": "./plugins/customer-success-manager",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "data-privacy-engineer",
-        "description": "Use this agent when you need to implement data privacy engineering, GDPR compliance, data protection frameworks, and privacy-by-design principles for B2B applications. This agent specializes in privacy engineering, data minimization, consent management, and global privacy regulation compliance for enterprise platforms. Examples:",
-        "source": "./plugins/data-privacy-engineer",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "data-scientist",
-        "description": "Data analysis expert for SQL queries, BigQuery operations, and data insights. Use proactively for data analysis tasks and queries.",
-        "source": "./plugins/data-scientist",
-        "author": "Anand Tyagi",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "database-performance-optimizer",
-        "description": "Use this agent when you need to optimize database performance for B2B applications at enterprise scale. This agent specializes in multi-tenant database optimization, query performance tuning, indexing strategies, connection pooling, and database scaling for SaaS platforms. Handles PostgreSQL, MySQL, MongoDB, and cloud database optimizations. Examples:",
-        "source": "./plugins/database-performance-optimizer",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "debugger",
-        "description": "Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.",
-        "source": "./plugins/debugger",
-        "author": "Anand Tyagi",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "deployment-engineer",
-        "description": "Use this agent when setting up CI/CD pipelines, configuring Docker containers, deploying applications to cloud platforms, setting up Kubernetes clusters, implementing infrastructure as code, or automating deployment workflows. Examples: <example>Context: User is setting up a new project and needs deployment automation. user: \"I've built a FastAPI application and need to deploy it to production with proper CI/CD\" assistant: \"I'll use the deployment-engineer agent to set up a complete deployment pipeline with Docker, GitHub Actions, and production-ready configurations.\"</example> <example>Context: User mentions containerization or deployment issues. user: \"Our deployment process is manual and error-prone. We need to automate it.\" assistant: \"Let me use the deployment-engineer agent to design an automated CI/CD pipeline that eliminates manual steps and ensures reliable deployments.\"</example>",
-        "source": "./plugins/deployment-engineer",
-        "author": "Jure Šunić",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "desktop-app-dev",
-        "description": "Desktop App Dev subagent",
-        "source": "./plugins/desktop-app-dev",
-        "author": "safayavatsal",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "devops-automator",
-        "description": "Use this agent when setting up CI/CD pipelines, configuring cloud infrastructure, implementing monitoring systems, or automating deployment processes. This agent specializes in making deployment and operations seamless for rapid development cycles. Examples:\\n\\n<example>\\nContext: Setting up automated deployments\\nuser: \"We need automatic deployments when we push to main\"\\nassistant: \"I'll set up a complete CI/CD pipeline. Let me use the devops-automator agent to configure automated testing, building, and deployment.\"\\n<commentary>\\nAutomated deployments require careful pipeline configuration and proper testing stages.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Infrastructure scaling issues\\nuser: \"Our app crashes when we get traffic spikes\"\\nassistant: \"I'll implement auto-scaling and load balancing. Let me use the devops-automator agent to ensure your infrastructure handles traffic gracefully.\"\\n<commentary>\\nScaling requires proper infrastructure setup with monitoring and automatic responses.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Monitoring and alerting setup\\nuser: \"We have no idea when things break in production\"\\nassistant: \"Observability is crucial for rapid iteration. I'll use the devops-automator agent to set up comprehensive monitoring and alerting.\"\\n<commentary>\\nProper monitoring enables fast issue detection and resolution in production.\\n</commentary>\\n</example>",
-        "source": "./plugins/devops-automator",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "enterprise-integrator-architect",
-        "description": "Use this agent when you need to design and implement complex external enterprise system integrations for B2B applications. This agent specializes in connecting your platform with Salesforce, HubSpot, Microsoft 365, Google Workspace, SAP, Oracle ERP, and other critical third-party business software. Handles external API orchestration, data synchronization with enterprise systems, webhook management for third-party services, and enterprise-grade integration patterns. Examples:",
-        "source": "./plugins/enterprise-integrator-architect",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "enterprise-onboarding-specialist",
-        "description": "Use this agent when you need to design and optimize complex enterprise customer onboarding processes involving multiple stakeholders, change management, and organizational adoption. This agent specializes in enterprise implementation strategy, stakeholder management, change management, and large-scale rollout coordination for B2B platforms. Examples:",
-        "source": "./plugins/enterprise-onboarding-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "enterprise-security-reviewer",
-        "description": "Use this agent for comprehensive B2B security assessments, enterprise compliance validation, multi-tenant security reviews, and security audit preparation. This agent specializes in SOC 2, GDPR, ISO 27001 compliance and enterprise-grade security implementations for B2B SaaS platforms. Examples:",
-        "source": "./plugins/enterprise-security-reviewer",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "experiment-tracker",
-        "description": "PROACTIVELY use this agent when experiments are started, modified, or when results need analysis. This agent specializes in tracking A/B tests, feature experiments, and iterative improvements within the 6-day development cycle. Should be triggered automatically when experimental code paths or feature flags are introduced. Examples:\\n\\n<example>\\nContext: When implementing feature flags or A/B test variants\\nuser: \"Add a feature flag to test the new onboarding flow\"\\nassistant: \"I've implemented the feature flag for the onboarding flow A/B test. Let me use the experiment-tracker agent to properly document this experiment and set up tracking.\"\\n<commentary>\\nEvery feature flag represents an experiment that needs proper tracking and success metrics.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After deploying experimental features\\nuser: \"The new viral sharing feature is now live for 10% of users\"\\nassistant: \"Great! The viral sharing feature is deployed. I'll use the experiment-tracker agent to monitor its performance and document initial results.\"\\n<commentary>\\nLive experiments need immediate tracking setup to capture valuable data from the start.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When reaching experiment milestones\\nuser: \"It's been a week since we launched the TikTok integration test\"\\nassistant: \"Perfect timing for analysis. Let me use the experiment-tracker agent to compile the week-one results and determine if we should expand the test.\"\\n<commentary>\\nRegular experiment checkpoints ensure data-driven decisions about feature rollouts.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Before making product decisions\\nuser: \"Should we keep the AI avatar feature or remove it?\"\\nassistant: \"Let me analyze the experiment data to inform this decision. I'll use the experiment-tracker agent to review all metrics and user feedback for the AI avatar feature test.\"\\n<commentary>\\nProduct decisions should be backed by experiment data, not gut feelings.\\n</commentary>\\n</example>",
-        "source": "./plugins/experiment-tracker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "feedback-synthesizer",
-        "description": "Use this agent when you need to analyze user feedback from multiple sources, identify patterns in user complaints or requests, synthesize insights from reviews, or prioritize feature development based on user input. This agent excels at turning raw feedback into actionable product insights. Examples:\\n\\n<example>\\nContext: Weekly review of user feedback",
-        "source": "./plugins/feedback-synthesizer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "finance-tracker",
-        "description": "Use this agent when managing budgets, optimizing costs, forecasting revenue, or analyzing financial performance. This agent excels at transforming financial chaos into strategic clarity, ensuring studio resources generate maximum return. Examples:\\n\\n<example>\\nContext: Planning next quarter's development budget",
-        "source": "./plugins/finance-tracker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "flutter-mobile-app-dev",
-        "description": "Use this agent when you need expert assistance with Flutter mobile development tasks, including code analysis, widget creation, debugging, performance optimization, or architectural decisions. Examples: <example>Context: User is working on a Flutter app and faces issues with navigation. user: 'My Navigator.push isn't updating the UI correctly when moving to a new screen' assistant: 'Let me use the flutter-dev agent to analyze your navigation setup and provide a solution' <commentary>Since this is a Flutter-specific navigation issue, use the flutter-dev agent to provide expert guidance on Navigator problems.</commentary></example> <example>Context: User wants to create a custom widget that aligns with their app's design system. user: 'I need to create a custom button widget that matches our app's design system' assistant: 'I'll use the flutter-dev agent to create a button widget that aligns with your existing codebase structure and design patterns' <commentary>The user needs a Flutter widget that follows existing patterns, so use the flutter-dev agent.</commentary></example>",
-        "source": "./plugins/flutter-mobile-app-dev",
-        "author": "safayavatsal",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "frontend-developer",
-        "description": "Use this agent when building user interfaces, implementing React/Vue/Angular components, handling state management, or optimizing frontend performance. This agent excels at creating responsive, accessible, and performant web applications. Examples:\\n\\n<example>\\nContext: Building a new user interface\\nuser: \"Create a dashboard for displaying user analytics\"\\nassistant: \"I'll build an analytics dashboard with interactive charts. Let me use the frontend-developer agent to create a responsive, data-rich interface.\"\\n<commentary>\\nComplex UI components require frontend expertise for proper implementation and performance.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Fixing UI/UX issues\\nuser: \"The mobile navigation is broken on small screens\"\\nassistant: \"I'll fix the responsive navigation issues. Let me use the frontend-developer agent to ensure it works perfectly across all device sizes.\"\\n<commentary>\\nResponsive design issues require deep understanding of CSS and mobile-first development.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Optimizing frontend performance\\nuser: \"Our app feels sluggish when loading large datasets\"\\nassistant: \"Performance optimization is crucial for user experience. I'll use the frontend-developer agent to implement virtualization and optimize rendering.\"\\n<commentary>\\nFrontend performance requires expertise in React rendering, memoization, and data handling.\\n</commentary>\\n</example>",
-        "source": "./plugins/frontend-developer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "growth-hacker",
-        "description": "Growth Hacker subagent",
-        "source": "./plugins/growth-hacker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "infrastructure-maintainer",
-        "description": "Use this agent when monitoring system health, optimizing performance, managing scaling, or ensuring infrastructure reliability. This agent excels at keeping studio applications running smoothly while preparing for growth and preventing disasters. Examples:\\n\\n<example>\\nContext: App experiencing slow performance",
-        "source": "./plugins/infrastructure-maintainer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "instagram-curator",
-        "description": "Instagram Curator subagent",
-        "source": "./plugins/instagram-curator",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "joker",
-        "description": "Use this agent when you need to lighten the mood, create funny content, or add humor to any situation. This agent specializes in dad jokes, programming puns, and startup humor. Examples:\\n\\n<example>\\nContext: Team needs a laugh during a stressful sprint\\nuser: \"We've been debugging for hours and everyone's frustrated\"\\nassistant: \"Time for a morale boost! Let me use the joker agent to share some programming humor.\"\\n<commentary>\\nHumor can help reset team energy during challenging moments.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating fun error messages\\nuser: \"Our 404 page is boring\"\\nassistant: \"Let's make that error page memorable! I'll use the joker agent to create some funny 404 messages.\"\\n<commentary>\\nHumorous error pages can turn frustration into delight.\\n</commentary>\\n</example>",
-        "source": "./plugins/joker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "legal-advisor",
-        "description": "Use this agent when you need legal advisory, compliance documentation, RFP response creation, and enterprise contract support for B2B applications. This agent specializes in legal document creation, regulatory analysis, enterprise procurement compliance, and RFP winning strategies. Transforms complex legal requirements into competitive advantages. Examples:",
-        "source": "./plugins/legal-advisor",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "legal-compliance-checker",
-        "description": "Use this agent when reviewing terms of service, privacy policies, ensuring regulatory compliance, or handling legal requirements. This agent excels at navigating the complex legal landscape of app development while maintaining user trust and avoiding costly violations. Examples:\\n\\n<example>\\nContext: Launching app in European markets",
-        "source": "./plugins/legal-compliance-checker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "mobile-app-builder",
-        "description": "Use this agent when developing native iOS or Android applications, implementing React Native features, or optimizing mobile performance. This agent specializes in creating smooth, native-feeling mobile experiences. Examples:\\n\\n<example>\\nContext: Building a new mobile app\\nuser: \"Create a TikTok-style video feed for our app\"\\nassistant: \"I'll build a performant video feed with smooth scrolling. Let me use the mobile-app-builder agent to implement native performance optimizations.\"\\n<commentary>\\nVideo feeds require careful mobile optimization for smooth scrolling and memory management.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Implementing mobile-specific features\\nuser: \"Add push notifications and biometric authentication\"\\nassistant: \"I'll implement native push notifications and Face ID/fingerprint auth. Let me use the mobile-app-builder agent to ensure proper platform integration.\"\\n<commentary>\\nNative features require platform-specific implementation and proper permissions handling.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Cross-platform development\\nuser: \"We need this feature on both iOS and Android\"\\nassistant: \"I'll implement it using React Native for code reuse. Let me use the mobile-app-builder agent to ensure native performance on both platforms.\"\\n<commentary>\\nCross-platform development requires balancing code reuse with platform-specific optimizations.\\n</commentary>\\n</example>",
-        "source": "./plugins/mobile-app-builder",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "mobile-ux-optimizer",
-        "description": "Use this agent when you need to optimize UI/UX components or interfaces for mobile-first experiences, analyze existing design themes, or ensure mobile usability standards are met. Examples: <example>Context: User has created a desktop-focused component and needs it optimized for mobile. user: 'I've built this navigation component but it's not working well on mobile devices' assistant: 'Let me use the mobile-ux-optimizer agent to analyze and improve this component for mobile-first experience' <commentary>The user needs mobile optimization expertise, so use the mobile-ux-optimizer agent to provide specific mobile UX improvements.</commentary></example> <example>Context: User is implementing a new feature and wants to ensure it follows the existing design theme. user: 'I'm adding a new form component to the app, can you help make sure it matches our design system?' assistant: 'I'll use the mobile-ux-optimizer agent to ensure this form component aligns with your existing theme and mobile-first principles' <commentary>Since this involves both theme consistency and mobile optimization, the mobile-ux-optimizer agent is the right choice.</commentary></example>",
-        "source": "./plugins/mobile-ux-optimizer",
-        "author": "abhishek shah",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "model-context-protocol-mcp-expert",
-        "description": "Model Context Protocol Mcp Expert subagent",
-        "source": "./plugins/model-context-protocol-mcp-expert",
-        "author": "Community",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "monitoring-observability-specialist",
-        "description": "Use this agent when you need to implement comprehensive monitoring, observability, and alerting systems for enterprise B2B applications. This agent specializes in APM, logging, metrics, distributed tracing, SLA monitoring, and proactive incident management for business-critical systems. Examples:",
-        "source": "./plugins/monitoring-observability-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "n8n-workflow-builder",
-        "description": "Use this agent when you need to design, build, or validate n8n automation workflows. This agent specializes in creating efficient n8n workflows using proper validation techniques and MCP tools integration.\\n\\nExamples:\\n- <example>\\n  Context: User wants to create a Slack notification workflow when a new GitHub issue is created.\\n  user: \"I need to create an n8n workflow that sends a Slack message whenever a new GitHub issue is opened\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to design and build this GitHub-to-Slack automation workflow with proper validation.\"\\n  <commentary>\\n  The user needs n8n workflow creation, so use the n8n-workflow-builder agent to handle the complete workflow design, validation, and deployment process.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User has an existing n8n workflow that needs debugging and optimization.\\n  user: \"My n8n workflow keeps failing at the HTTP Request node, can you help me fix it?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to analyze and debug your workflow, focusing on the HTTP Request node configuration.\"\\n  <commentary>\\n  Since this involves n8n workflow troubleshooting and validation, use the n8n-workflow-builder agent to diagnose and fix the issue.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User wants to understand n8n best practices and available nodes for a specific use case.\\n  user: \"What are the best n8n nodes for processing CSV data and sending email reports?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to explore the available nodes and recommend the best approach for CSV processing and email automation.\"\\n  <commentary>\\n  This requires n8n expertise and node discovery, so use the n8n-workflow-builder agent to provide comprehensive guidance.\\n  </commentary>\\n</example>",
-        "source": "./plugins/n8n-workflow-builder",
-        "author": "Jure Šunić",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "onomastophes",
-        "description": "Use proactively for generating creative non-olympian Greek god names with rich backstories, mythological authenticity, and modern accessibility for storytelling projects",
-        "source": "./plugins/onomastophes",
-        "author": "normalnormie",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "performance-benchmarker",
-        "description": "Use this agent for comprehensive performance testing, profiling, and optimization recommendations. This agent specializes in measuring speed, identifying bottlenecks, and providing actionable optimization strategies for applications. Examples:\\n\\n<example>\\nContext: Application speed testing",
-        "source": "./plugins/performance-benchmarker",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "planning-prd-agent",
-        "description": "'MUST BE USED PROACTIVELY when user mentions: planning, PRD, product requirements document, project plan, roadmap, specification, requirements analysis, feature breakdown, technical spec, project estimation, milestone planning, or task decomposition. Use IMMEDIATELY when user says \"create a PRD\", \"plan this feature\", \"document requirements\", \"break down this project\", \"estimate this work\", \"create a roadmap\", \"write specifications\", or references planning/documentation needs. Expert Technical Project Manager that creates comprehensive PRDs with user stories, acceptance criteria, technical architecture, task breakdowns, and separate task assignment files for sub-agent delegation.'",
-        "source": "./plugins/planning-prd-agent",
-        "author": "clouddna-au",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "prd-specialist",
-        "description": "Use this agent when you need to create comprehensive Product Requirements Documents (PRDs) that combine business strategy, technical architecture, and user research. Examples: <example>Context: The user needs to create a PRD for a new feature or product launch. user: \"I need to create a PRD for our new user authentication system that will support SSO and multi-factor authentication\" assistant: \"I'll use the prd-specialist agent to create a comprehensive PRD that covers the strategic foundation, technical requirements, and implementation blueprint for your authentication system.\"</example> <example>Context: The user is planning a major product initiative and needs strategic documentation. user: \"We're launching a mobile app for our e-commerce platform and need a detailed PRD to guide development\" assistant: \"Let me engage the prd-specialist agent to develop a thorough PRD that includes market analysis, user research integration, technical architecture, and implementation roadmap for your mobile app initiative.\"</example>",
-        "source": "./plugins/prd-specialist",
-        "author": "Jure Šunić",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "pricing-packaging-specialist",
-        "description": "Use this agent when you need to optimize B2B pricing strategies, packaging models, and revenue optimization for enterprise sales. This agent specializes in value-based pricing, usage-based billing, enterprise contract negotiations, and competitive pricing analysis for SaaS platforms. Examples:",
-        "source": "./plugins/pricing-packaging-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "problem-solver-specialist",
-        "description": "Universal expert problem-solving agent specializing in complex debugging, mysterious runtime behavior, integration issues, and multi-layered technical challenges across any technology stack or project type. Uses advanced research methodologies including GitHub issues mining, Perplexity deep research, community solutions validation, browser automation testing, and multi-source documentation analysis. Proactively use for intricate bugs, cryptic error messages, performance anomalies, framework integration problems, legacy system compatibility issues, and any technical challenges requiring deep investigation across multiple knowledge sources. Project-agnostic and universally applicable.",
-        "source": "./plugins/problem-solver-specialist",
-        "author": "Beau Lewis",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "product-sales-specialist",
-        "description": "Use this agent when you need to support B2B sales through product design, user research, project management, and creative RFP responses. This agent specializes in creating compelling product demonstrations, design-focused RFP sections, user experience narratives, and project management frameworks that win enterprise deals. Combines product expertise with sales enablement. Examples:",
-        "source": "./plugins/product-sales-specialist",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "project-curator",
-        "description": "Reorganizes project structure by cleaning root clutter, creating logical folder hierarchies, and moving files to optimal locations. Tracks dependencies and fixes broken imports/paths. Use PROACTIVELY when project structure becomes unwieldy or needs architectural cleanup.",
-        "source": "./plugins/project-curator",
-        "author": "alanKerrigan",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "project-shipper",
-        "description": "PROACTIVELY use this agent when approaching launch milestones, release deadlines, or go-to-market activities. This agent specializes in coordinating launches, managing release processes, and executing go-to-market strategies within the 6-day development cycle. Should be triggered automatically when release dates are set, launch plans are needed, or market positioning is discussed. Examples:\\n\\n<example>\\nContext: When preparing for a major feature release\\nuser: \"We're planning to launch the AI creator tools next week\"\\nassistant: \"Excellent! A major feature launch requires careful coordination. Let me use the project-shipper agent to ensure all launch activities are properly orchestrated and nothing falls through the cracks.\"\\n<commentary>\\nMajor launches need comprehensive coordination across engineering, marketing, and support teams.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: During release planning discussions\\nuser: \"We need to ship three updates this sprint\"\\nassistant: \"Managing multiple releases requires careful orchestration. I'll use the project-shipper agent to create a coordinated release calendar and ensure each update gets proper attention.\"\\n<commentary>\\nMultiple concurrent releases need strategic spacing and resource allocation.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When go-to-market strategy is needed\\nuser: \"How should we position the new viral video features?\"\\nassistant: \"Positioning is crucial for feature adoption. Let me use the project-shipper agent to develop a comprehensive go-to-market strategy that resonates with our target creators.\"\\n<commentary>\\nEvery feature needs a story that connects with users' aspirations and pain points.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Post-launch monitoring\\nuser: \"The collaboration feature launched yesterday\"\\nassistant: \"Great! The critical first 48 hours determine success. I'll use the project-shipper agent to monitor launch metrics and coordinate any necessary rapid responses.\"\\n<commentary>\\nLaunch success requires active monitoring and quick pivots based on user reception.\\n</commentary>\\n</example>",
-        "source": "./plugins/project-shipper",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "python-expert",
-        "description": "Use this agent when working with Python code that requires advanced features, performance optimization, or comprehensive refactoring. Examples: <example>Context: User needs to optimize a slow Python function that processes large datasets. user: \"This function is taking too long to process our data, can you help optimize it?\" assistant: \"I'll use the python-expert agent to analyze and optimize your Python code with advanced techniques and performance profiling.\"</example> <example>Context: User wants to implement async/await patterns in their existing synchronous Python code. user: \"I need to convert this synchronous code to use async/await for better performance\" assistant: \"Let me use the python-expert agent to refactor your code with proper async/await patterns and concurrent programming techniques.\"</example> <example>Context: User needs help implementing complex Python design patterns. user: \"I want to implement a factory pattern with decorators for my API endpoints\" assistant: \"I'll use the python-expert agent to implement advanced Python patterns with decorators and proper design principles.\"</example>",
-        "source": "./plugins/python-expert",
-        "author": "Jure Šunić",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "rapid-prototyper",
-        "description": "Use this agent when you need to quickly create a new application prototype, MVP, or proof-of-concept within the 6-day development cycle. This agent specializes in scaffolding projects, integrating trending features, and building functional demos rapidly. Examples:\\n\\n<example>\\nContext: Starting a new experiment or app idea\\nuser: \"Create a new app that helps people overcome phone anxiety\"\\nassistant: \"I'll help you create a phone anxiety app. Let me use the rapid-prototyper agent to scaffold this project and build an MVP.\"\\n<commentary>\\nWhen starting any new project or experiment, use the rapid-prototyper to quickly set up the foundation and core features.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Need to test a trending feature or viral concept\\nuser: \"I saw this TikTok trend about AI avatars, can we build something around that?\"\\nassistant: \"That's a great trending opportunity! I'll use the rapid-prototyper agent to quickly build a prototype app featuring AI avatars.\"\\n<commentary>\\nFor capitalizing on trends and viral content, the rapid-prototyper can quickly create testable prototypes.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Validating a business idea with minimal investment\\nuser: \"We need to test if people would pay for a subscription box curation app\"\\nassistant: \"Let's validate that idea with a quick prototype. I'll use the rapid-prototyper agent to build an MVP with basic subscription and curation features.\"\\n<commentary>\\nBusiness validation requires fast prototyping to test market fit before full investment.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating demo apps for stakeholder presentations\\nuser: \"We're meeting with investors next week and need to show them our vision\"\\nassistant: \"I'll help create a compelling demo. Let me use the rapid-prototyper agent to build a functional prototype that showcases your vision.\"\\n<commentary>\\nInvestor demos and stakeholder presentations benefit from working prototypes rather than just mockups.\\n</commentary>\\n</example>",
-        "source": "./plugins/rapid-prototyper",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "react-native-dev",
-        "description": "Use this agent when you need expert assistance with React Native development tasks including code analysis, component creation, debugging, performance optimization, or architectural decisions. Examples: <example>Context: User is working on a React Native app and needs help with a navigation issue. user: 'My stack navigator isn't working properly when I try to navigate between screens' assistant: 'Let me use the react-native-dev agent to analyze your navigation setup and provide a solution' <commentary>Since this is a React Native specific issue, use the react-native-dev agent to provide expert guidance on navigation problems.</commentary></example> <example>Context: User wants to create a new component that follows the existing app structure. user: 'I need to create a custom button component that matches our app's design system' assistant: 'I'll use the react-native-dev agent to create a button component that aligns with your existing codebase structure and design patterns' <commentary>The user needs React Native component development that should follow existing patterns, so use the react-native-dev agent.</commentary></example>",
-        "source": "./plugins/react-native-dev",
-        "author": "abhishek shah",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "reddit-community-builder",
-        "description": "Reddit Community Builder subagent",
-        "source": "./plugins/reddit-community-builder",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "sprint-prioritizer",
-        "description": "Use this agent when planning 6-day development cycles, prioritizing features, managing product roadmaps, or making trade-off decisions. This agent specializes in maximizing value delivery within tight timelines. Examples:\\n\\n<example>\\nContext: Planning the next sprint\\nuser: \"We have 50 feature requests but only 6 days\"\\nassistant: \"I'll help prioritize for maximum impact. Let me use the sprint-prioritizer agent to create a focused sprint plan that delivers the most value.\"\\n<commentary>\\nSprint planning requires balancing user needs, technical constraints, and business goals.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Making feature trade-offs\\nuser: \"Should we build AI chat or improve onboarding?\"\\nassistant: \"Let's analyze the impact of each option. I'll use the sprint-prioritizer agent to evaluate ROI and make a data-driven recommendation.\"\\n<commentary>\\nFeature prioritization requires analyzing user impact, development effort, and strategic alignment.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Mid-sprint scope changes\\nuser: \"The CEO wants us to add video calling to this sprint\"\\nassistant: \"I'll assess the impact on current commitments. Let me use the sprint-prioritizer agent to reorganize priorities while maintaining sprint goals.\"\\n<commentary>\\nScope changes require careful rebalancing to avoid sprint failure.\\n</commentary>\\n</example>",
-        "source": "./plugins/sprint-prioritizer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "studio-coach",
-        "description": "PROACTIVELY use this agent when complex multi-agent tasks begin, when agents seem stuck or overwhelmed, or when the team needs motivation and coordination. This agent serves as the elite performance coach for all other agents, ensuring they operate at their highest level while maintaining composure and excellence. Should be triggered automatically at the start of challenging projects or when detecting agent confusion. Examples:\\n\\n<example>\\nContext: Starting a complex project requiring multiple agents\\nuser: \"We need to build a viral TikTok app in 2 weeks\"\\nassistant: \"This is an ambitious goal that will require our A-team! Let me bring in the studio-coach to coordinate our agents and ensure everyone performs at their peak.\"\\n<commentary>\\nComplex projects benefit from having a coach to keep all agents aligned and motivated.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When an agent seems stuck or is producing subpar results\\nagent: \"I'm having trouble identifying the right trends...\"\\nassistant: \"Let me bring in the studio-coach to help refocus and elevate your approach.\"\\n<commentary>\\nAgents can get overwhelmed or lose focus - the coach helps them recenter and excel.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Before launching a major sprint or initiative\\nuser: \"Tomorrow we start the 6-day sprint for our biggest project yet\"\\nassistant: \"Time to rally the team! I'll have the studio-coach prepare everyone mentally and strategically for peak performance.\"\\n<commentary>\\nPre-sprint coaching ensures all agents start with clarity, confidence, and coordination.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When celebrating wins or learning from failures\\nuser: \"Our app just hit #1 on the App Store!\"\\nassistant: \"Incredible achievement! Let me bring in the studio-coach to celebrate with the team and capture what made this success possible.\"\\n<commentary>\\nThe coach helps institutionalize wins and extract learnings from both successes and failures.\\n</commentary>\\n</example>",
-        "source": "./plugins/studio-coach",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "studio-producer",
-        "description": "PROACTIVELY use this agent when coordinating across multiple teams, allocating resources, or optimizing studio workflows. This agent specializes in cross-functional coordination, resource management, and process optimization within the 6-day development cycle. Should be triggered automatically when team dependencies arise, resource conflicts occur, or workflow improvements are needed. Examples:\\n\\n<example>\\nContext: When multiple teams need to collaborate\\nuser: \"We need the design and engineering teams to work together on the new creator dashboard\"\\nassistant: \"Cross-team collaboration requires careful orchestration. Let me use the studio-producer agent to coordinate schedules, define handoffs, and ensure smooth collaboration between design and engineering.\"\\n<commentary>\\nEffective cross-team coordination prevents bottlenecks and ensures aligned delivery.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: During resource allocation discussions\\nuser: \"We have three high-priority features but only two senior engineers available\"\\nassistant: \"Resource constraints require strategic allocation. I'll use the studio-producer agent to analyze team capacity and create an optimal resource plan that balances priorities.\"\\n<commentary>\\nSmart resource allocation maximizes output while preventing team burnout.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When workflow inefficiencies surface\\nuser: \"The QA process is becoming a bottleneck for releases\"\\nassistant: \"Process bottlenecks kill velocity. Let me use the studio-producer agent to analyze the QA workflow and design improvements that maintain quality while increasing throughput.\"\\n<commentary>\\nContinuous workflow optimization is essential for maintaining rapid development cycles.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Sprint planning and coordination\\nuser: \"We're starting a new 6-day cycle next Monday\"\\nassistant: \"New cycles need comprehensive planning. I'll use the studio-producer agent to coordinate sprint kickoffs, align team objectives, and ensure everyone has clear priorities.\"\\n<commentary>\\nWell-coordinated sprint starts set the tone for successful 6-day cycles.\\n</commentary>\\n</example>",
-        "source": "./plugins/studio-producer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "support-responder",
-        "description": "Use this agent when handling customer support inquiries, creating support documentation, setting up automated responses, or analyzing support patterns. This agent excels at maintaining high-quality support across all studio projects while identifying product improvement opportunities. Examples:\\n\\n<example>\\nContext: Setting up support for a new app launch",
-        "source": "./plugins/support-responder",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "technical-sales-engineer",
-        "description": "Use this agent when you need to bridge technical and sales requirements for B2B enterprise deals. This agent specializes in technical demos, POC development, RFP responses, solution architecture for sales, and technical objection handling. Handles complex enterprise sales cycles with technical evaluation phases. Examples:",
-        "source": "./plugins/technical-sales-engineer",
-        "author": "Alysson Franklin",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "test-results-analyzer",
-        "description": "Use this agent for analyzing test results, synthesizing test data, identifying trends, and generating quality metrics reports. This agent specializes in turning raw test data into actionable insights that drive quality improvements. Examples:\\n\\n<example>\\nContext: Analyzing test suite results",
-        "source": "./plugins/test-results-analyzer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "test-writer-fixer",
-        "description": "Use this agent when code changes have been made and you need to write new tests, run existing tests, analyze failures, and fix them while maintaining test integrity. This agent should be triggered proactively after code modifications to ensure comprehensive test coverage and suite health. Examples:\\n\\n<example>\\nContext: The user has just implemented a new feature or modified existing code.\\nuser: \"I've updated the user authentication logic to support OAuth\"\\nassistant: \"I've successfully updated the authentication logic. Now let me run the test-writer-fixer agent to ensure all tests pass with these changes.\"\\n<commentary>\\nSince code changes were made, use the Task tool to launch the test-writer-fixer agent to run relevant tests and fix any failures.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has refactored a module or changed function signatures.\\nuser: \"Please refactor this payment processing module to use async/await\"\\nassistant: \"I've completed the refactoring to use async/await throughout the payment module.\"\\n<function call omitted for brevity>\\nassistant: \"Now I'll use the test-writer-fixer agent to run the tests and fix any issues caused by the refactoring.\"\\n<commentary>\\nAfter refactoring code, proactively use the test-writer-fixer agent to ensure tests still pass.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has fixed a bug or made a critical change.\\nuser: \"Fix the race condition in the data synchronization service\"\\nassistant: \"I've identified and fixed the race condition by implementing proper locking mechanisms.\"\\n<function call omitted for brevity>\\nassistant: \"Let me run the test-writer-fixer agent to verify the fix doesn't break existing functionality.\"\\n<commentary>\\nAfter bug fixes, use the test-writer-fixer agent to ensure the fix works and doesn't introduce regressions.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Code lacks test coverage for critical functionality.\\nuser: \"Our payment processing module has no tests\"\\nassistant: \"That's a critical gap. Let me use the test-writer-fixer agent to create comprehensive tests for the payment module including edge cases and error scenarios.\"\\n<commentary>\\nCritical modules without tests are high-risk areas that need immediate test coverage.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After implementing a new feature that needs tests.\\nuser: \"I've added the social sharing functionality\"\\nassistant: \"Great! The social sharing is implemented. Now let me use the test-writer-fixer agent to write tests that ensure this feature works correctly across different platforms.\"\\n<commentary>\\nNew features should always include comprehensive test coverage from the start.\\n</commentary>\\n</example>",
-        "source": "./plugins/test-writer-fixer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "tiktok-strategist",
-        "description": "Use this agent when you need to create TikTok marketing strategies, develop viral content ideas, plan TikTok campaigns, or optimize for TikTok's algorithm. This agent specializes in creating shareable moments and leveraging TikTok trends for app growth. Examples:\\n\\n<example>\\nContext: Launching a new app and need TikTok strategy\\nuser: \"We're launching our phone anxiety app next week. How should we approach TikTok?\"\\nassistant: \"TikTok will be crucial for your launch. Let me use the tiktok-strategist agent to create a comprehensive TikTok marketing strategy for your phone anxiety app.\"\\n<commentary>\\nNew app launches benefit from TikTok's viral potential and young user base.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Creating viral content for an existing app\\nuser: \"Our meditation app needs more downloads. What kind of TikTok content should we make?\"\\nassistant: \"I'll help you create viral TikTok content ideas. Let me use the tiktok-strategist agent to develop content that showcases your app in trending formats.\"\\n<commentary>\\nExisting apps can boost downloads through strategic TikTok content that fits platform culture.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Identifying TikTok influencers for partnerships\\nuser: \"Should we work with TikTok creators to promote our app?\"\\nassistant: \"Creator partnerships can be very effective. Let me use the tiktok-strategist agent to identify the right creators and collaboration strategies for your app.\"\\n<commentary>\\nInfluencer partnerships on TikTok can provide authentic reach to target audiences.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Optimizing app features for TikTok sharing\\nuser: \"How can we make our app more TikTok-friendly?\"\\nassistant: \"Making your app TikTok-native is smart. I'll use the tiktok-strategist agent to identify features and moments in your app that users would want to share on TikTok.\"\\n<commentary>\\nApps with built-in TikTok-worthy moments see higher organic growth through user-generated content.\\n</commentary>\\n</example>",
-        "source": "./plugins/tiktok-strategist",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "tool-evaluator",
-        "description": "Use this agent when evaluating new development tools, frameworks, or services for the studio. This agent specializes in rapid tool assessment, comparative analysis, and making recommendations that align with the 6-day development cycle philosophy. Examples:\\n\\n<example>\\nContext: Considering a new framework or library",
-        "source": "./plugins/tool-evaluator",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "trend-researcher",
-        "description": "Use this agent when you need to identify market opportunities, analyze trending topics, research viral content, or understand emerging user behaviors. This agent specializes in finding product opportunities from TikTok trends, App Store patterns, and social media virality. Examples:\\n\\n<example>\\nContext: Looking for new app ideas based on current trends\\nuser: \"What's trending on TikTok that we could build an app around?\"\\nassistant: \"I'll research current TikTok trends that have app potential. Let me use the trend-researcher agent to analyze viral content and identify opportunities.\"\\n<commentary>\\nWhen seeking new product ideas, the trend-researcher can identify viral trends with commercial potential.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Validating a product concept against market trends\\nuser: \"Is there market demand for an app that helps introverts network?\"\\nassistant: \"Let me validate this concept against current market trends. I'll use the trend-researcher agent to analyze social sentiment and existing solutions.\"\\n<commentary>\\nBefore building, validate ideas against real market signals and user behavior patterns.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Competitive analysis for a new feature\\nuser: \"Our competitor just added AI avatars. Should we care?\"\\nassistant: \"I'll analyze the market impact and user reception of AI avatars. Let me use the trend-researcher agent to assess this feature's traction.\"\\n<commentary>\\nCompetitive features need trend analysis to determine if they're fleeting or fundamental.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Finding viral mechanics for existing apps\\nuser: \"How can we make our habit tracker more shareable?\"\\nassistant: \"I'll research viral sharing mechanics in successful apps. Let me use the trend-researcher agent to identify patterns we can adapt.\"\\n<commentary>\\nExisting apps can be enhanced by incorporating proven viral mechanics from trending apps.\\n</commentary>\\n</example>",
-        "source": "./plugins/trend-researcher",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "twitter-engager",
-        "description": "Twitter Engager subagent",
-        "source": "./plugins/twitter-engager",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "ui-designer",
-        "description": "Use this agent when creating user interfaces, designing components, building design systems, or improving visual aesthetics. This agent specializes in creating beautiful, functional interfaces that can be implemented quickly within 6-day sprints. Examples:\\n\\n<example>\\nContext: Starting a new app or feature design",
-        "source": "./plugins/ui-designer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "unit-test-generator",
-        "description": "Expert Flutter/Dart unit test specialist that systematically improves test coverage using automated workflows with strict validation, git management, and Aurigo corporate standards. Use for comprehensive test suite creation and coverage improvement.",
-        "source": "./plugins/unit-test-generator",
-        "author": "Community",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "ux-researcher",
-        "description": "Use this agent when conducting user research, analyzing user behavior, creating journey maps, or validating design decisions through testing. This agent specializes in understanding user needs, pain points, and behaviors to inform product decisions within rapid development cycles. Examples:\\n\\n<example>\\nContext: Understanding user needs for a new feature",
-        "source": "./plugins/ux-researcher",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "vision-specialist",
-        "description": "Expert in vision models, OCR systems, barcode detection, and visual AI. Stays current with latest models (GPT-4V, Claude Vision, Mistral-OCR, etc.), optimization techniques, and specialized libraries. Use PROACTIVELY for image processing, document analysis, or visual AI tasks.",
-        "source": "./plugins/vision-specialist",
-        "author": "alanKerrigan",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "visual-storyteller",
-        "description": "Use this agent when creating visual narratives, designing infographics, building presentations, or communicating complex ideas through imagery. This agent specializes in transforming data and concepts into compelling visual stories that engage users and stakeholders. Examples:\\n\\n<example>\\nContext: Creating app onboarding illustrations",
-        "source": "./plugins/visual-storyteller",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "web-dev",
-        "description": "Use this agent for expert assistance with web development tasks using React, Next.js, NestJS, and other modern web frameworks with TypeScript and Tailwind CSS. This includes code analysis, component creation, debugging, performance optimization, and architectural decisions. Examples: <example>Context: User is building a Next.js app and encounters a routing issue. user: 'My dynamic routes in Next.js are not rendering correctly' assistant: 'Let me use the web-dev agent to analyze your Next.js routing setup and provide a solution' <commentary>This is a Next.js-specific routing issue, so the web-dev agent will provide targeted guidance.</commentary></example> <example>Context: User needs a reusable React component with Tailwind CSS. user: 'I need a card component that matches my app's Tailwind-based design system' assistant: 'I'll use the web-dev agent to create a TypeScript-based React card component styled with Tailwind CSS, following your app's design patterns' <commentary>The user requires a component that aligns with their Tailwind CSS design system, so the web-dev agent ensures compatibility.</commentary></example>",
-        "source": "./plugins/web-dev",
-        "author": "safayavatsal",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "whimsy-injector",
-        "description": "PROACTIVELY use this agent after any UI/UX changes to ensure delightful, playful elements are incorporated. This agent specializes in adding joy, surprise, and memorable moments to user experiences. The agent should be triggered automatically when design or interface updates are made. Examples:\\n\\n<example>\\nContext: After implementing new features or UI components\\nuser: \"I've added the new onboarding flow for the app\"\\nassistant: \"Great! I've implemented the onboarding flow. Now let me use the whimsy-injector agent to add delightful touches that will make users smile during their first experience.\"\\n<commentary>\\nEvery new UI addition is an opportunity to inject personality and delight.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When error states or empty states are created\\nuser: \"Set up error handling for the payment flow\"\\nassistant: \"I've implemented the error handling. Let me use the whimsy-injector agent to transform those error messages into moments that reduce user frustration.\"\\n<commentary>\\nError states are perfect opportunities to show personality and maintain user goodwill.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: After creating standard UI components\\nuser: \"Build a loading spinner for the data fetch\"\\nassistant: \"I've created the basic loading functionality. Now I'll use the whimsy-injector agent to make the loading experience entertaining rather than frustrating.\"\\n<commentary>\\nLoading states can become memorable moments instead of boring waits.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: When reviewing completed features\\nuser: \"The user profile page is done\"\\nassistant: \"Perfect! The profile page is complete. Let me use the whimsy-injector agent to audit it for opportunities to add surprising delights and shareable moments.\"\\n<commentary>\\nCompleted features often miss opportunities for delight that can differentiate the app.\\n</commentary>\\n</example>",
-        "source": "./plugins/whimsy-injector",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "workflow-optimizer",
-        "description": "Use this agent for optimizing human-agent collaboration workflows and analyzing workflow efficiency. This agent specializes in identifying bottlenecks, streamlining processes, and ensuring smooth handoffs between human creativity and AI assistance. Examples:\\n\\n<example>\\nContext: Improving development workflow efficiency",
-        "source": "./plugins/workflow-optimizer",
-        "author": "Michael Galpert",
-        "tags": [
-          "subagent"
-        ]
-      },
-      {
-        "name": "agent-sdk-dev",
-        "description": "Development kit for working with the Claude Agent SDK",
-        "source": "./plugins/agent-sdk-dev",
-        "tags": [
-          "development",
-          "engineering"
-        ]
-      },
-      {
-        "name": "pr-review-toolkit",
-        "description": "Comprehensive PR review agents specializing in comments, tests, error handling, type design, code quality, and code simplification",
-        "source": "./plugins/pr-review-toolkit",
-        "author": "Anthropic",
-        "tags": [
-          "code-quality",
-          "code-testing"
-        ]
-      },
-      {
-        "name": "commit-commands",
-        "description": "Commands for git commit workflows including commit, push, and PR creation",
-        "source": "./plugins/commit-commands",
-        "author": "Anthropic",
-        "tags": [
-          "git-workflow"
-        ]
-      },
-      {
-        "name": "feature-dev",
-        "description": "Comprehensive feature development workflow with specialized agents for codebase exploration, architecture design, and quality review",
-        "source": "./plugins/feature-dev",
-        "author": "Siddharth Bidasaria",
-        "tags": [
-          "development",
-          "engineering"
-        ]
-      },
-      {
-        "name": "security-guidance",
-        "description": "Security reminder hook that warns about potential security issues when editing files, including command injection, XSS, and unsafe code patterns",
-        "source": "./plugins/security-guidance",
-        "author": "David Dworken",
-        "tags": [
-          "security",
-          "compliance"
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "claude-review-loop",
-    "name": "Claude Review Loop",
-    "author": "hamelsmu",
-    "description": "Claude Code plugin: automated code review loop with Codex",
-    "github": "https://github.com/hamelsmu/claude-review-loop",
-    "stars": 619,
+    "slug": "gmickel-claude-marketplace",
+    "name": "Flow Next",
+    "author": "gmickel",
+    "description": "Repeatable agentic engineering. The workflow layer that turns AI coding agents into a disciplined factory: durable specs, fresh-context workers, adversarial cross-model reviews, receipts. Everything in your repo, zero dependencies. Claude Code · Codex · Cursor · Droid.",
+    "github": "https://github.com/gmickel/gmickel-claude-marketplace",
+    "stars": 657,
     "type": "plugin",
     "tags": [
+      "skills",
+      "agents",
       "commands",
       "hooks"
     ],
     "contains": {},
-    "highlights": []
+    "highlights": [
+      "Web UI: https://flow-next.dev"
+    ],
+    "website": "https://flow-next.dev"
   },
   {
-    "slug": "claude-forge",
-    "name": "Claude Forge",
-    "author": "sangrokjung",
-    "description": "Supercharge Claude Code with 11 AI agents, 36 commands & 15 skills — the claude-code plugin framework inspired by oh-my-zsh. 6-layer security hooks included. 5-min install.",
-    "github": "https://github.com/sangrokjung/claude-forge",
-    "stars": 612,
+    "slug": "claude-equity-research",
+    "name": "Claude Equity Research",
+    "author": "quant-sentiment-ai",
+    "description": "🔌 Claude Code Plugin for institutional-grade equity research.   Install with /plugin marketplace add. Generates professional   buy/sell recommendations with comprehensive fundamental   analysis, technical indicators, and risk assessment. Educational    use only - not financial advice.",
+    "github": "https://github.com/quant-sentiment-ai/claude-equity-research",
+    "stars": 636,
     "type": "plugin",
     "tags": [
-      "skills",
-      "agents",
-      "commands",
-      "hooks",
-      "rules"
+      "commands"
     ],
-    "contains": {
-      "skills": 1,
-      "agents": 1,
-      "commands": 1,
-      "hooks": 1,
-      "rules": 1
-    },
-    "highlights": [
-      "Web UI: https://sangrokjung.github.io/claude-forge"
-    ],
-    "website": "https://sangrokjung.github.io/claude-forge"
-  },
-  {
-    "slug": "gmickel-claude-marketplace",
-    "name": "Gmickel Claude Marketplace",
-    "author": "gmickel",
-    "description": "Claude Code plugins for reliable AI coding. Flow-Next: plan-first workflows, Ralph autonomous mode (overnight coding with fresh context), multi-model review gates via RepoPrompt/Codex, re-anchoring to prevent drift, receipt-based gating.",
-    "github": "https://github.com/gmickel/gmickel-claude-marketplace",
-    "stars": 554,
-    "type": "marketplace",
-    "tags": [
-      "skills",
-      "agents",
-      "commands",
-      "hooks"
-    ],
-    "contains": {
-      "plugins": 2,
-      "components": {
-        "skills": 23,
-        "agents": 26,
-        "commands": 2,
-        "hooks": 1
-      }
-    },
-    "highlights": [
-      "2 plugins in marketplace",
-      "Web UI: https://mickel.tech/apps/flow-next"
-    ],
-    "website": "https://mickel.tech/apps/flow-next",
-    "plugins_list": [
-      {
-        "name": "flow-next",
-        "description": "Zero-dependency planning + execution with .flow/ task tracking and Ralph autonomous mode (multi-model review gates). Worker subagent per task for context isolation. Includes 20 subagents, 11 commands, 16 skills.",
-        "source": "./plugins/flow-next",
-        "author": "Gordon Mickel",
-        "tags": [
-          "claude-code",
-          "plugin",
-          "workflow",
-          "planning",
-          "execution"
-        ],
-        "components": {
-          "skills": 16,
-          "agents": 20,
-          "commands": 1,
-          "hooks": 1
-        }
-      },
-      {
-        "name": "flow",
-        "description": "Two-step planning + execution workflow with optional Beads integration. Includes 6 subagents, 5 commands, 7 skills.",
-        "source": "./plugins/flow",
-        "author": "Gordon Mickel",
-        "tags": [
-          "claude-code",
-          "plugin",
-          "workflow",
-          "planning",
-          "execution"
-        ],
-        "components": {
-          "skills": 7,
-          "agents": 6,
-          "commands": 1
-        }
-      }
-    ]
+    "contains": {},
+    "highlights": []
   },
   {
     "slug": "cartographer",
@@ -12041,7 +22461,7 @@
     "author": "kingbootoshi",
     "description": "Claude Code plugin that maps and documents codebases of any size using parallel AI subagents",
     "github": "https://github.com/kingbootoshi/cartographer",
-    "stars": 525,
+    "stars": 604,
     "type": "plugin",
     "tags": [
       "skills"
@@ -12055,163 +22475,10 @@
     "author": "zscole",
     "description": "A Claude Code plugin that iteratively refines product specifications by debating between multiple LLMs until all models reach consensus.",
     "github": "https://github.com/zscole/adversarial-spec",
-    "stars": 516,
+    "stars": 552,
     "type": "plugin",
     "tags": [
       "skills"
-    ],
-    "contains": {},
-    "highlights": []
-  },
-  {
-    "slug": "agent-skills",
-    "name": "Agent Skills",
-    "author": "hashicorp",
-    "description": "A collection of Agent skills and Claude Code plugins for HashiCorp products.",
-    "github": "https://github.com/hashicorp/agent-skills",
-    "stars": 491,
-    "type": "marketplace",
-    "tags": [
-      "skills",
-      "mcps"
-    ],
-    "contains": {
-      "plugins": 5,
-      "components": {
-        "skills": 15,
-        "mcps": 2
-      }
-    },
-    "highlights": [
-      "Official HashiCorp release",
-      "5 plugins in marketplace"
-    ],
-    "plugins_list": [
-      {
-        "name": "terraform-code-generation",
-        "description": "Terraform code generation skills including HCL generation, style guides, and testing.",
-        "source": "./terraform/code-generation",
-        "author": "HashiCorp",
-        "tags": [
-          "terraform",
-          "hcl",
-          "infrastructure",
-          "iac",
-          "testing",
-          "style-guide"
-        ],
-        "components": {
-          "skills": 4,
-          "mcps": 1
-        }
-      },
-      {
-        "name": "terraform-module-generation",
-        "description": "Terraform module generation and refactoring skills including module design and Terraform Stacks.",
-        "source": "./terraform/module-generation",
-        "author": "HashiCorp",
-        "tags": [
-          "terraform",
-          "modules",
-          "infrastructure",
-          "iac",
-          "stacks",
-          "refactoring"
-        ],
-        "components": {
-          "skills": 2,
-          "mcps": 1
-        }
-      },
-      {
-        "name": "terraform-provider-development",
-        "description": "Terraform provider development skills including resources, data sources, actions, and acceptance testing.",
-        "source": "./terraform/provider-development",
-        "author": "HashiCorp",
-        "tags": [
-          "terraform",
-          "provider",
-          "plugin-framework",
-          "resources",
-          "testing"
-        ],
-        "components": {
-          "skills": 5
-        }
-      },
-      {
-        "name": "packer-builders",
-        "description": "Packer builder skills for AWS, Azure, and Windows image creation.",
-        "source": "./packer/builders",
-        "author": "HashiCorp",
-        "tags": [
-          "packer",
-          "aws",
-          "azure",
-          "windows",
-          "ami",
-          "image",
-          "builder"
-        ],
-        "components": {
-          "skills": 3
-        }
-      },
-      {
-        "name": "packer-hcp",
-        "description": "HCP Packer registry integration for tracking and managing image metadata.",
-        "source": "./packer/hcp",
-        "author": "HashiCorp",
-        "tags": [
-          "packer",
-          "hcp-packer",
-          "registry",
-          "metadata",
-          "image-tracking"
-        ],
-        "components": {
-          "skills": 1
-        }
-      }
-    ]
-  },
-  {
-    "slug": "claude-notifications-go",
-    "name": "Claude Notifications Go",
-    "author": "777genius",
-    "description": "🔔 Cross-platform smart notifications plugin for Claude Code. 6 types. Click-to-focus. 1 line installation. Instant. Analyze context. Zero dependencies. webhooks (ntfy, slack, telegram...). Linux, MacOS, Windows.",
-    "github": "https://github.com/777genius/claude-notifications-go",
-    "stars": 392,
-    "type": "plugin",
-    "tags": [
-      "commands",
-      "hooks"
-    ],
-    "contains": {
-      "commands": 4
-    },
-    "highlights": [
-      "Plugin declares: 4 commands"
-    ],
-    "plugin_manifest": {
-      "commands": [
-        "./commands/init.md",
-        "./commands/settings.md",
-        "./commands/notifications-init.md",
-        "./commands/notifications-settings.md"
-      ]
-    }
-  },
-  {
-    "slug": "claude-equity-research",
-    "name": "Claude Equity Research",
-    "author": "quant-sentiment-ai",
-    "description": "🔌 Claude Code Plugin for institutional-grade equity research.   Install with /plugin marketplace add. Generates professional   buy/sell recommendations with comprehensive fundamental   analysis, technical indicators, and risk assessment. Educational    use only - not financial advice.",
-    "github": "https://github.com/quant-sentiment-ai/claude-equity-research",
-    "stars": 389,
-    "type": "plugin",
-    "tags": [
-      "commands"
     ],
     "contains": {},
     "highlights": []
@@ -12222,19 +22489,19 @@
     "author": "Piebald-AI",
     "description": "Claude Code Plugin Marketplace with LSP servers",
     "github": "https://github.com/Piebald-AI/claude-code-lsps",
-    "stars": 357,
+    "stars": 493,
     "type": "marketplace",
     "tags": [
       "lsps"
     ],
     "contains": {
-      "plugins": 26,
+      "plugins": 35,
       "components": {
-        "lsps": 29
+        "lsps": 38
       }
     },
     "highlights": [
-      "26 plugins in marketplace",
+      "35 plugins in marketplace",
       "Web UI: https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it/"
     ],
     "website": "https://www.reddit.com/r/ClaudeAI/comments/1otdfo9/lsp_is_coming_to_claude_code_and_you_can_try_it/",
@@ -12253,6 +22520,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "typescript",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12266,6 +22541,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "rust",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12281,6 +22564,39 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "python",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "ty",
+        "description": "Extremely fast Python type checker by Astral",
+        "source": "./ty",
+        "author": "Piebald LLC",
+        "tags": [
+          "python",
+          "lsp",
+          "language-server",
+          "type-checking",
+          "ty",
+          "astral"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "python",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12297,6 +22613,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "python",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12312,6 +22636,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "go",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12327,6 +22659,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "java",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12345,6 +22685,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "cpp",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12359,6 +22707,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "ruby",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12375,6 +22731,22 @@
         ],
         "components": {
           "lsps": 3
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "css",
+              "description": ""
+            },
+            {
+              "name": "eslint",
+              "description": ""
+            },
+            {
+              "name": "html",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12389,6 +22761,38 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "php",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "php-lsp",
+        "description": "Full-featured PHP language server written in Rust — semantic diagnostics, code actions, refactoring, PSR-4/Composer, PHPUnit test runner",
+        "source": "./php-lsp",
+        "author": "Jorg Sowa",
+        "tags": [
+          "php",
+          "lsp",
+          "language-server",
+          "diagnostics",
+          "refactoring"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "php",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12405,6 +22809,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "csharp",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12422,6 +22834,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "powershell",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12437,6 +22857,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "kotlin",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12453,6 +22881,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "latex",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12469,6 +22905,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "bsl",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12484,6 +22928,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "julia",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12500,6 +22952,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "vue",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12516,6 +22976,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "ocaml",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12532,6 +23000,18 @@
         ],
         "components": {
           "lsps": 2
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "ada",
+              "description": ""
+            },
+            {
+              "name": "gpr",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12547,6 +23027,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "dart",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12564,6 +23052,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "solidity",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12579,6 +23075,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "scala",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12594,6 +23098,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "markdown",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12611,6 +23123,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "lean",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12628,6 +23148,14 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "lean",
+              "description": ""
+            }
+          ]
         }
       },
       {
@@ -12642,6 +23170,180 @@
         ],
         "components": {
           "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "svelte",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "haskell-language-server",
+        "description": "Haskell language server with completion, references, type info, and document symbols",
+        "source": "./haskell-language-server",
+        "author": "Micah Stubbs",
+        "tags": [
+          "haskell",
+          "lsp",
+          "language-server",
+          "hls",
+          "ghc"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "haskell",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "graphql-lsp",
+        "description": "GraphQL language server for schema and operation intelligence",
+        "source": "./graphql-lsp",
+        "author": "Dale Seo",
+        "tags": [
+          "graphql",
+          "lsp",
+          "language-server",
+          "schema"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "graphql",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "elixir-ls",
+        "description": "Elixir language server (ElixirLS) with definitions, references, hover, and symbols",
+        "source": "./elixir-ls",
+        "author": "Morgan Allen",
+        "tags": [
+          "elixir",
+          "lsp",
+          "language-server",
+          "elixir-ls",
+          "phoenix"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "elixir",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "gleam",
+        "description": "Gleam language server integration (bundled with the Gleam compiler)",
+        "source": "./gleam",
+        "author": "Piebald LLC",
+        "tags": [
+          "gleam",
+          "lsp",
+          "language-server",
+          "functional"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "gleam",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "bash-language-server",
+        "description": "Bash language server (bash-lsp) providing IDE features for shell scripts",
+        "source": "./bash-language-server",
+        "author": "Piebald LLC",
+        "tags": [
+          "bash",
+          "shell",
+          "sh",
+          "lsp",
+          "language-server"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "shellscript",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "swift-lsp",
+        "description": "Swift and Objective-C language server (sourcekit-lsp, macOS/Xcode)",
+        "source": "./swift-lsp",
+        "author": "Piebald LLC",
+        "tags": [
+          "swift",
+          "objective-c",
+          "lsp",
+          "language-server",
+          "sourcekit",
+          "xcode",
+          "macos"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "swift",
+              "description": ""
+            }
+          ]
+        }
+      },
+      {
+        "name": "perl-lsp",
+        "description": "Perl language server (perl-lsp) with type inference, cross-file navigation, and framework intelligence",
+        "source": "./perl-lsp",
+        "author": "Piebald LLC",
+        "tags": [
+          "perl",
+          "lsp",
+          "language-server"
+        ],
+        "components": {
+          "lsps": 1
+        },
+        "components_items": {
+          "lsps": [
+            {
+              "name": "perl",
+              "description": ""
+            }
+          ]
         }
       }
     ]
@@ -12652,7 +23354,7 @@
     "author": "chu2bard",
     "description": "Client SDK, Claude plugin and skill framework for the Pinion protocol. x402 micropayments on Base.",
     "github": "https://github.com/chu2bard/pinion-os",
-    "stars": 357,
+    "stars": 95,
     "type": "plugin",
     "tags": [
       "mcps"
@@ -12670,119 +23372,124 @@
     }
   },
   {
-    "slug": "airtable",
-    "name": "Airtable Skills",
+    "slug": "skills",
+    "name": "Skills",
     "author": "Airtable",
     "description": "Official Airtable plugins for AI agents.",
     "github": "https://github.com/Airtable/skills",
-    "stars": 20,
-    "type": "marketplace",
-    "tags": [
-      "skills",
-      "mcps"
-    ],
-    "contains": {
-      "plugins": 1,
-      "components": {
-        "skills": 3,
-        "mcps": 1
-      }
-    },
-    "highlights": [
-      "Official Airtable release",
-      "1 plugin in marketplace"
-    ],
-    "plugins_list": [
-      {
-        "name": "airtable",
-        "description": "Airtable is the database and operations layer for your agents — whether running product, marketing, sales, ops, HR, or a custom business app. It combines structured data with multiplayer visual surfaces (grid, kanban, calendar, gallery, timeline) humans and agents share — plus sync integrations to Jira, Salesforce, Zendesk, Google Drive, and Databricks. Makes Claude fluent in Airtable: bases and schema, records, and collaboration UI. Bundles the official Airtable MCP server.",
-        "source": "./plugins/airtable",
-        "author": "Airtable",
-        "components": {
-          "skills": 3,
-          "mcps": 1
-        }
-      }
-    ]
-  },
-  {
-    "slug": "best-claude-skills",
-    "name": "AugmentClaude Best Claude Skills",
-    "author": "Nyanbalaji28",
-    "description": "Hand-picked best Claude Code skills curated by AugmentClaude — every skill credited and linked to its original author. Full catalog of 500+ skills, bundles, and MCP servers at augmentclaude.com",
-    "github": "https://github.com/Nyanbalaji28/best-claude-skills",
-    "stars": 0,
-    "type": "marketplace",
+    "stars": 35,
+    "type": "plugin",
     "tags": [
       "skills"
     ],
+    "contains": {},
+    "highlights": []
+  },
+  {
+    "slug": "best-claude-skills",
+    "name": "Best Claude Skills",
+    "author": "Nyanbalaji28",
+    "description": "Hand-picked best Claude Code skills — curated by AugmentClaude",
+    "github": "https://github.com/Nyanbalaji28/best-claude-skills",
+    "stars": 1,
+    "type": "marketplace",
+    "tags": [
+      "commands",
+      "mcps",
+      "skills"
+    ],
     "contains": {
-      "plugins": 14,
-      "components": {
-        "skills": 14
-      }
+      "plugins": 14
     },
     "highlights": [
-      "14 hand-picked skills",
+      "14 plugins in marketplace",
       "Web UI: https://augmentclaude.com"
     ],
     "website": "https://augmentclaude.com/",
     "plugins_list": [
       {
         "name": "superpowers",
-        "description": "Jesse Vincent's complete development methodology: TDD, brainstorming-before-coding, and git worktrees — all auto-triggering."
+        "description": "Jesse Vincent's complete development methodology: TDD, brainstorming-before-coding, and git worktrees — all auto-triggering.",
+        "source": "obra/superpowers",
+        "author": "obra"
       },
       {
         "name": "gstack",
-        "description": "Garry Tan's 23-role Claude Code stack — CEO, designer, eng, QA, security, release, all as slash commands."
+        "description": "Garry Tan's 23-role Claude Code stack — CEO, designer, eng, QA, security, release, all as slash commands.",
+        "source": "garrytan/gstack",
+        "author": "garrytan"
       },
       {
         "name": "mcp-builder",
-        "description": "Anthropic's official skill for building MCP servers that connect language models to external APIs and services."
+        "description": "Anthropic's official skill for building MCP servers that connect language models to external APIs and services.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "webapp-testing",
-        "description": "Playwright-driven browser testing: verify UI behavior, debug, and capture screenshots of local web apps."
+        "description": "Playwright-driven browser testing: verify UI behavior, debug, and capture screenshots of local web apps.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "frontend-design",
-        "description": "Anthropic's official frontend-design skill — production-grade interfaces with distinctive, polished design."
+        "description": "Anthropic's official frontend-design skill — production-grade interfaces with distinctive, polished design.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "impeccable",
-        "description": "Paul Bakaus's design framework — kills generic AI design, forces deliberate taste, motion, and polish."
+        "description": "Paul Bakaus's design framework — kills generic AI design, forces deliberate taste, motion, and polish.",
+        "source": "pbakaus/impeccable",
+        "author": "pbakaus"
       },
       {
         "name": "emil-design-engineering",
-        "description": "Emil Kowalski's design engineering review — when to animate, what easing, how fast, with Before/After reviews."
+        "description": "Emil Kowalski's design engineering review — when to animate, what easing, how fast, with Before/After reviews.",
+        "source": "emilkowalski/skill",
+        "author": "emilkowalski"
       },
       {
         "name": "design-taste",
-        "description": "Three sliders (variance, motion, density) that tune Claude's UI output. Stops the generic AI look."
+        "description": "Three sliders (variance, motion, density) that tune Claude's UI output. Stops the generic AI look.",
+        "source": "Leonxlnx/taste-skill",
+        "author": "Leonxlnx"
       },
       {
         "name": "xlsx",
-        "description": "Open, edit, and create Excel and CSV files with formulas, formatting, and data cleaning."
+        "description": "Open, edit, and create Excel and CSV files with formulas, formatting, and data cleaning.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "docx",
-        "description": "Create, edit, and format Word documents with tables, images, and tracked changes."
+        "description": "Create, edit, and format Word documents with tables, images, and tracked changes.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "pptx",
-        "description": "Create, edit, read, and extract content from PowerPoint presentations."
+        "description": "Create, edit, read, and extract content from PowerPoint presentations.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "pdf",
-        "description": "Read, merge, split, rotate, watermark, encrypt, and extract text from PDF files."
+        "description": "Read, merge, split, rotate, watermark, encrypt, and extract text from PDF files.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       },
       {
         "name": "find-skills",
-        "description": "Vercel Labs' meta-skill — Claude searches the open skill ecosystem for existing solutions before improvising."
+        "description": "Vercel Labs' meta-skill — Claude searches the open skill ecosystem for existing solutions before improvising.",
+        "source": "vercel-labs/skills",
+        "author": "vercel-labs"
       },
       {
         "name": "skill-creator",
-        "description": "Anthropic's official tool for creating, editing, and benchmarking your own Claude skills."
+        "description": "Anthropic's official tool for creating, editing, and benchmarking your own Claude skills.",
+        "source": "anthropics/skills",
+        "author": "anthropics"
       }
     ]
   }

--- a/dashboard/src/components/MarketplacePluginsList.tsx
+++ b/dashboard/src/components/MarketplacePluginsList.tsx
@@ -1,0 +1,354 @@
+import { useState, useMemo, useRef, useEffect } from 'react';
+
+interface ComponentItem {
+  name: string;
+  description?: string;
+}
+
+interface MarketplacePlugin {
+  name: string;
+  description?: string;
+  source?: string;
+  source_path?: string;
+  author?: string;
+  tags?: string[];
+  components?: Record<string, number>;
+  components_items?: Record<string, ComponentItem[]>;
+}
+
+interface Props {
+  pluginsList: MarketplacePlugin[];
+  marketplaceAuthor: string;
+  marketplaceName: string;
+  tagColors: Record<string, string>;
+}
+
+function getSourceLabel(p: MarketplacePlugin): 'local' | 'github' {
+  const src = p.source ?? '';
+  if (typeof src === 'string') {
+    if (src.startsWith('./') || src.startsWith('../')) return 'local';
+    if (src.includes('github.com') || src.includes('.git')) return 'github';
+    if (src.includes('/')) return 'github';
+  }
+  return 'local';
+}
+
+export default function MarketplacePluginsList({
+  pluginsList,
+  marketplaceAuthor,
+  marketplaceName,
+  tagColors,
+}: Props) {
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<MarketplacePlugin | null>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return pluginsList;
+    const q = search.toLowerCase().trim();
+    return pluginsList.filter(
+      (p) =>
+        p.name?.toLowerCase().includes(q) ||
+        p.description?.toLowerCase().includes(q) ||
+        p.author?.toLowerCase().includes(q) ||
+        p.tags?.some((t) => t.toLowerCase().includes(q)) ||
+        Object.keys(p.components ?? {}).some((t) => t.toLowerCase().includes(q))
+    );
+  }, [pluginsList, search]);
+
+  useEffect(() => {
+    if (!selected) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setSelected(null);
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [selected]);
+
+  function handleBackdropClick(e: React.MouseEvent) {
+    if (e.target === backdropRef.current) setSelected(null);
+  }
+
+  const namedTypes = new Set(Object.keys(selected?.components_items ?? {}));
+  const countOnlyTypes = Object.entries(selected?.components ?? {}).filter(
+    ([type]) => !namedTypes.has(type)
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-4">
+        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+          Plugins ({filtered.length}
+          {filtered.length !== pluginsList.length ? ` of ${pluginsList.length}` : ''})
+        </h2>
+
+        <div className="relative w-full sm:w-72">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 pointer-events-none"
+            style={{ color: 'var(--color-text-tertiary)' }}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search plugins in this marketplace..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-8 py-2 rounded-lg text-[12.5px] outline-none transition-all duration-200"
+            style={{
+              background: 'var(--color-surface-2)',
+              border: '1px solid var(--color-border)',
+              color: 'var(--color-text-primary)',
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = 'var(--color-border-hover)';
+              e.currentTarget.style.boxShadow = '0 0 0 3px rgba(255,217,61,0.1)';
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = 'var(--color-border)';
+              e.currentTarget.style.boxShadow = 'none';
+            }}
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 rounded-full flex items-center justify-center transition-colors hover:opacity-80"
+              style={{ background: 'var(--color-surface-3)', color: 'var(--color-text-tertiary)' }}
+              aria-label="Clear search"
+            >
+              <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div
+          className="flex flex-col items-center justify-center py-14 rounded-2xl"
+          style={{ background: 'var(--color-surface-1)', border: '1px dashed var(--color-border)' }}
+        >
+          <p className="text-[13px] font-medium" style={{ color: 'var(--color-text-secondary)' }}>
+            No plugins match "{search}"
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {filtered.map((p, idx) => {
+            const sourceType = getSourceLabel(p);
+            const hasAuthor = p.author && p.author !== marketplaceAuthor;
+            const hasComponents = p.components && Object.keys(p.components).length > 0;
+            return (
+              <button
+                key={`${p.name}-${idx}`}
+                type="button"
+                onClick={() => setSelected(p)}
+                className="text-left flex flex-col p-4 rounded-xl bg-[var(--color-card-bg)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] transition-all duration-200 cursor-pointer"
+                style={{ boxShadow: 'var(--shadow-card)' }}
+              >
+                <div className="flex items-start gap-3 mb-2">
+                  <div
+                    className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 text-[12px] font-bold select-none"
+                    style={{
+                      background: 'linear-gradient(135deg, #ffd93d12 0%, #ffd93d08 100%)',
+                      border: '1px solid #ffd93d20',
+                      color: '#ffd93d99',
+                    }}
+                  >
+                    {(p.name ?? '?').charAt(0).toUpperCase()}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)] truncate">
+                        {p.name}
+                      </h3>
+                      {sourceType === 'github' && (
+                        <span className="text-[9px] font-medium px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[var(--color-text-tertiary)] border border-[var(--color-border)]">
+                          external
+                        </span>
+                      )}
+                    </div>
+                    {hasAuthor && (
+                      <p className="text-[11px] text-[var(--color-text-tertiary)]">by {p.author}</p>
+                    )}
+                  </div>
+                </div>
+
+                {p.description && (
+                  <p className="text-[12px] text-[var(--color-text-secondary)] leading-[1.5] line-clamp-2 mb-2 flex-1">
+                    {p.description}
+                  </p>
+                )}
+
+                {hasComponents && (
+                  <div className="flex items-center gap-1.5 flex-wrap mt-auto">
+                    {Object.entries(p.components!).map(([type, count]) => (
+                      <span
+                        key={type}
+                        className="text-[9px] font-semibold px-2 py-0.5 rounded-full border"
+                        style={{
+                          background: `${tagColors[type] ?? '#666'}10`,
+                          color: tagColors[type] ?? '#666',
+                          borderColor: `${tagColors[type] ?? '#666'}20`,
+                        }}
+                      >
+                        {count} {type}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {p.tags && p.tags.length > 0 && !hasComponents && (
+                  <div className="flex items-center gap-1.5 flex-wrap mt-auto">
+                    {p.tags.slice(0, 4).map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[9px] font-medium px-2 py-0.5 rounded-full bg-[var(--color-surface-3)] text-[var(--color-text-tertiary)] border border-[var(--color-border)]"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {selected && (
+        <div
+          ref={backdropRef}
+          onClick={handleBackdropClick}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        >
+          <div className="w-full max-w-xl bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-xl shadow-2xl overflow-hidden max-h-[85vh] flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)] shrink-0">
+              <div className="flex items-center gap-2.5 min-w-0">
+                <div
+                  className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 text-[13px] font-bold select-none"
+                  style={{
+                    background: 'linear-gradient(135deg, #ffd93d18 0%, #ffd93d08 100%)',
+                    border: '1.5px solid #ffd93d30',
+                    color: '#ffd93d',
+                  }}
+                >
+                  {(selected.name ?? '?').charAt(0).toUpperCase()}
+                </div>
+                <h3 className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+                  {selected.name}
+                </h3>
+              </div>
+              <button
+                onClick={() => setSelected(null)}
+                className="p-1 rounded hover:bg-white/10 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors shrink-0"
+                aria-label="Close"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="px-5 py-4 overflow-y-auto space-y-4">
+              {selected.description && (
+                <p className="text-[13px] text-[var(--color-text-secondary)] leading-relaxed">
+                  {selected.description}
+                </p>
+              )}
+
+              {selected.author && selected.author !== marketplaceAuthor && (
+                <p className="text-[12px] text-[var(--color-text-tertiary)]">by {selected.author}</p>
+              )}
+
+              {/* Components with resolved item names */}
+              {Object.entries(selected.components_items ?? {}).map(([type, items]) => (
+                <div key={type}>
+                  <div className="flex items-center gap-2 mb-2">
+                    <span
+                      className="text-[10px] font-semibold px-2.5 py-1 rounded-full border uppercase tracking-wider"
+                      style={{
+                        background: `${tagColors[type] ?? '#666'}15`,
+                        color: tagColors[type] ?? '#666',
+                        borderColor: `${tagColors[type] ?? '#666'}30`,
+                      }}
+                    >
+                      {type}
+                    </span>
+                    <span className="text-[11px] text-[var(--color-text-tertiary)]">{items.length} items</span>
+                  </div>
+                  <div className="space-y-1.5">
+                    {items.map((item) => (
+                      <div
+                        key={item.name}
+                        className="flex items-start gap-2 px-2.5 py-2 rounded-lg bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[12px]"
+                      >
+                        <span
+                          className="w-1.5 h-1.5 rounded-full shrink-0 mt-1.5"
+                          style={{ background: tagColors[type] ?? '#666' }}
+                        />
+                        <div className="min-w-0">
+                          <div className="text-[var(--color-text-primary)] font-mono text-[11.5px] font-medium">
+                            {item.name}
+                          </div>
+                          {item.description && (
+                            <p className="text-[var(--color-text-tertiary)] text-[11.5px] leading-snug mt-0.5">
+                              {item.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              {/* Component types where only a count is known (names not resolved) */}
+              {countOnlyTypes.length > 0 && (
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {countOnlyTypes.map(([type, count]) => (
+                    <span
+                      key={type}
+                      className="text-[10px] font-semibold px-2.5 py-1 rounded-full border"
+                      style={{
+                        background: `${tagColors[type] ?? '#666'}12`,
+                        color: tagColors[type] ?? '#666',
+                        borderColor: `${tagColors[type] ?? '#666'}25`,
+                      }}
+                    >
+                      {count} {type}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {!selected.components || Object.keys(selected.components).length === 0 ? (
+                <p className="text-[12px] text-[var(--color-text-tertiary)] italic">
+                  No component breakdown available for this plugin yet.
+                </p>
+              ) : null}
+
+              {/* Install command */}
+              <div>
+                <div className="text-[11px] uppercase tracking-wider text-[var(--color-text-tertiary)] mb-1.5 font-medium">
+                  Install this plugin
+                </div>
+                <pre className="p-3 rounded-lg bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[12px] text-[var(--color-text-secondary)] overflow-x-auto font-mono">
+                  <code>{`/plugin install ${selected.name}@${marketplaceName}`}</code>
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/pages/plugins/[slug].astro
+++ b/dashboard/src/pages/plugins/[slug].astro
@@ -2,6 +2,7 @@
 import DashboardLayout from '../../layouts/DashboardLayout.astro';
 import TopBar from '../../components/TopBar.astro';
 import SearchModal from '../../components/SearchModal.tsx';
+import MarketplacePluginsList from '../../components/MarketplacePluginsList.tsx';
 
 export const prerender = true;
 
@@ -50,17 +51,6 @@ const pluginCount = containsObj.plugins ?? 0;
 const repoPath = plugin.github.replace('https://github.com/', '');
 const addMarketplaceCmd = `/plugin marketplace add ${repoPath}`;
 const marketplaceName = repoPath.replace('/', '-');
-
-// Categorize marketplace plugins by source type
-function getSourceLabel(p: any): string {
-  const src = p.source ?? '';
-  if (typeof src === 'string') {
-    if (src.startsWith('./') || src.startsWith('../')) return 'local';
-    if (src.includes('github.com') || src.includes('.git')) return 'github';
-    if (src.includes('/')) return 'github';
-  }
-  return 'local';
-}
 ---
 
 <DashboardLayout
@@ -256,82 +246,13 @@ function getSourceLabel(p: any): string {
 
     <!-- Marketplace Plugins List -->
     {isMarketplace && pluginsList.length > 0 && (
-      <div>
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-lg font-bold text-[var(--color-text-primary)]">
-            Plugins ({pluginsList.length})
-          </h2>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {pluginsList.map((p: any, idx: number) => {
-            const sourceType = getSourceLabel(p);
-            const hasAuthor = p.author && p.author !== plugin.author;
-            const hasComponents = p.components && Object.keys(p.components).length > 0;
-            return (
-              <div
-                class="flex flex-col p-4 rounded-xl bg-[var(--color-card-bg)] border border-[var(--color-border)] hover:border-[var(--color-border-hover)] transition-all duration-200"
-                style="box-shadow: var(--shadow-card);"
-              >
-                <div class="flex items-start gap-3 mb-2">
-                  <div
-                    class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 text-[12px] font-bold select-none"
-                    style="background: linear-gradient(135deg, #ffd93d12 0%, #ffd93d08 100%); border: 1px solid #ffd93d20; color: #ffd93d99;"
-                  >
-                    {(p.name ?? '?').charAt(0).toUpperCase()}
-                  </div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-2 flex-wrap">
-                      <h3 class="text-[13px] font-semibold text-[var(--color-text-primary)] truncate">
-                        {p.name}
-                      </h3>
-                      {sourceType === 'github' && (
-                        <span class="text-[9px] font-medium px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[var(--color-text-tertiary)] border border-[var(--color-border)]">
-                          external
-                        </span>
-                      )}
-                    </div>
-                    {hasAuthor && (
-                      <p class="text-[11px] text-[var(--color-text-tertiary)]">by {p.author}</p>
-                    )}
-                  </div>
-                </div>
-
-                {p.description && (
-                  <p class="text-[12px] text-[var(--color-text-secondary)] leading-[1.5] line-clamp-2 mb-2 flex-1">
-                    {p.description}
-                  </p>
-                )}
-
-                {/* Component tags */}
-                {hasComponents && (
-                  <div class="flex items-center gap-1.5 flex-wrap mt-auto">
-                    {Object.entries(p.components).map(([type, count]) => (
-                      <span
-                        class="text-[9px] font-semibold px-2 py-0.5 rounded-full border"
-                        style={`background: ${TAG_COLORS[type] ?? '#666'}10; color: ${TAG_COLORS[type] ?? '#666'}; border-color: ${TAG_COLORS[type] ?? '#666'}20;`}
-                      >
-                        {count} {type}
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                {/* Plugin tags from marketplace */}
-                {p.tags && p.tags.length > 0 && !hasComponents && (
-                  <div class="flex items-center gap-1.5 flex-wrap mt-auto">
-                    {p.tags.slice(0, 4).map((tag: string) => (
-                      <span class="text-[9px] font-medium px-2 py-0.5 rounded-full bg-[var(--color-surface-3)] text-[var(--color-text-tertiary)] border border-[var(--color-border)]">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
+      <MarketplacePluginsList
+        client:load
+        pluginsList={pluginsList}
+        marketplaceAuthor={plugin.author}
+        marketplaceName={marketplaceName}
+        tagColors={TAG_COLORS}
+      />
     )}
 
     <!-- Highlights -->

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -235,33 +235,74 @@ def get_local_source_path(plugin_entry):
     return None
 
 
-def scan_plugin_dir_components(repo, dir_path):
+def _strip_component_ext(name):
+    for ext in (".md", ".json", ".js", ".ts", ".py"):
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
+def extract_frontmatter_description(content):
+    """Pull a `description:` value out of a markdown file's YAML frontmatter."""
+    if not content or not content.startswith("---"):
+        return ""
+    end = content.find("---", 3)
+    if end == -1:
+        return ""
+    frontmatter = content[3:end]
+    for line in frontmatter.split("\n"):
+        line = line.strip()
+        if line.startswith("description:"):
+            desc = line.split("description:", 1)[1].strip()
+            if len(desc) >= 2 and desc[0] == desc[-1] and desc[0] in ("'", '"'):
+                desc = desc[1:-1]
+            return desc
+    return ""
+
+
+def scan_plugin_dir_components(repo, dir_path, fetch_descriptions=True):
     """Scan a plugin directory for skills/, agents/, commands/, hooks/ subdirs
-    and count the files inside each. Returns component counts dict."""
+    and list the files inside each. Returns (counts, items) where `counts` is
+    a dict of type -> count and `items` is a dict of type -> list of
+    {"name", "description"} dicts, for types where names were resolved."""
     components = {}
+    component_items = {}
     # List the plugin's root directory
     listing = gh_dir_listing(repo, dir_path)
     if not listing:
-        return components
+        return components, component_items
 
     dir_names = {item["name"]: item["type"] for item in listing if isinstance(item, dict)}
     component_dirs = ["skills", "agents", "commands", "hooks"]
 
     for comp_dir in component_dirs:
         if comp_dir in dir_names and dir_names[comp_dir] == "dir":
-            # Count items inside this component directory
+            # List items inside this component directory
             items = gh_dir_listing(repo, f"{dir_path}/{comp_dir}")
             if items:
-                # Count files and dirs (each dir = 1 component, each .md/.json file = 1 component)
-                count = len([
-                    item for item in items
-                    if isinstance(item, dict) and (
-                        item["type"] == "dir" or
-                        item["name"].endswith((".md", ".json", ".js", ".ts", ".py"))
-                    )
-                ])
-                if count > 0:
-                    components[comp_dir] = count
+                entries = []
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    if item["type"] == "dir":
+                        item_name = item["name"]
+                        description = ""
+                        if fetch_descriptions:
+                            md = gh_file_content(repo, f"{dir_path}/{comp_dir}/{item_name}/SKILL.md")
+                            if not md:
+                                md = gh_file_content(repo, f"{dir_path}/{comp_dir}/{item_name}/{item_name}.md")
+                            description = extract_frontmatter_description(md)
+                        entries.append({"name": item_name, "description": description})
+                    elif item["name"].endswith((".md", ".json", ".js", ".ts", ".py")):
+                        item_name = _strip_component_ext(item["name"])
+                        description = ""
+                        if fetch_descriptions and item["name"].endswith(".md"):
+                            md = gh_file_content(repo, f"{dir_path}/{comp_dir}/{item['name']}")
+                            description = extract_frontmatter_description(md)
+                        entries.append({"name": item_name, "description": description})
+                if entries:
+                    components[comp_dir] = len(entries)
+                    component_items[comp_dir] = entries
 
     # Check for mcpServers in plugin.json
     plugin_json_raw = gh_file_content(repo, f"{dir_path}/.claude-plugin/plugin.json")
@@ -271,11 +312,13 @@ def scan_plugin_dir_components(repo, dir_path):
             mcps = pj.get("mcpServers")
             if isinstance(mcps, dict) and len(mcps) > 0:
                 components["mcps"] = len(mcps)
+                component_items["mcps"] = [{"name": k, "description": ""} for k in mcps.keys()]
             lsps = pj.get("lspServers")
             if isinstance(lsps, dict) and len(lsps) > 0:
                 components["lsps"] = len(lsps)
+                component_items["lsps"] = [{"name": k, "description": ""} for k in lsps.keys()]
 
-    return components
+    return components, component_items
 
 
 def extract_marketplace_plugins_detail(marketplace, repo=None, scan_local=True):
@@ -319,26 +362,56 @@ def extract_marketplace_plugins_detail(marketplace, repo=None, scan_local=True):
 
         # Inline components from marketplace.json
         components = {}
+        component_items = {}
+        can_fetch_local_desc = bool(local_path and repo and scan_local and local_scan_count < max_local_scans)
+        used_local_desc_fetch = False
         for key in ("skills", "agents", "commands"):
             val = p.get(key)
             if isinstance(val, list) and len(val) > 0:
                 components[key] = len(val)
+                entries = []
+                for v in val:
+                    if isinstance(v, str):
+                        base = v.rstrip("/").replace("\\", "/").split("/")[-1]
+                        item_name = _strip_component_ext(base)
+                        description = ""
+                        if can_fetch_local_desc and v.endswith(".md"):
+                            rel = v.lstrip("./")
+                            md = gh_file_content(repo, f"{local_path.lstrip('./')}/{rel}")
+                            description = extract_frontmatter_description(md)
+                            used_local_desc_fetch = True
+                        entries.append({"name": item_name, "description": description})
+                    elif isinstance(v, dict):
+                        n = v.get("name") or v.get("path", "")
+                        if n:
+                            item_name = _strip_component_ext(str(n).rstrip("/").split("/")[-1])
+                            entries.append({"name": item_name, "description": v.get("description", "")})
+                if entries:
+                    component_items[key] = entries
         mcps = p.get("mcpServers")
         if isinstance(mcps, dict) and len(mcps) > 0:
             components["mcps"] = len(mcps)
+            component_items["mcps"] = [{"name": k, "description": ""} for k in mcps.keys()]
         lsps = p.get("lspServers")
         if isinstance(lsps, dict) and len(lsps) > 0:
             components["lsps"] = len(lsps)
+            component_items["lsps"] = [{"name": k, "description": ""} for k in lsps.keys()]
+
+        if used_local_desc_fetch:
+            local_scan_count += 1
 
         # If no inline components and this is a local plugin, scan its directory
         if not components and local_path and repo and scan_local and local_scan_count < max_local_scans:
-            scanned = scan_plugin_dir_components(repo, local_path.lstrip("./"))
-            if scanned:
-                components = scanned
+            scanned_counts, scanned_items = scan_plugin_dir_components(repo, local_path.lstrip("./"))
+            if scanned_counts:
+                components = scanned_counts
+                component_items = scanned_items
                 local_scan_count += 1
 
         if components:
             entry["components"] = components
+        if component_items:
+            entry["components_items"] = component_items
 
         details.append(entry)
     return details


### PR DESCRIPTION
## Summary
- Clicking a plugin inside a marketplace page (e.g. `commit-commands` in `/plugins/claude-plugins-official/`) now opens a modal showing its actual commands/agents/skills — real names and descriptions, not just a count badge.
- Added a live search box above the plugin grid inside a marketplace page to filter plugins by name/author/description/tags (the top-level `/plugins` browse page already had this).
- `scripts/generate_plugins_json.py` now fetches each component file's frontmatter description (bounded by `max_local_scans = 50` locally-sourced plugins per marketplace to control GitHub API usage) and stores it in `components_items`. Documented the cap and its fallback behavior in `CLAUDE.md`.
- Regenerated `dashboard/public/plugins.json` with the new data (also picked up real growth in `claude-plugins-official`, now 255 plugins vs. the previously cached 119).

## Test plan
- [x] `cd dashboard && npm run build` — builds cleanly, all 32 plugin/marketplace pages prerender including `claude-plugins-official`
- [x] Verified in browser: clicking `commit-commands` opens a modal listing `clean_gone`, `commit-push-pr`, `commit` with real descriptions
- [x] Verified search box filters the in-marketplace plugin grid live (e.g. "commit" → 4 matches)
- [x] No console errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a plugin details modal and live search to marketplace pages in the dashboard to make it easy to inspect a plugin’s actual commands/agents/skills and find plugins faster. The plugin catalog generator now extracts component names and descriptions and the catalog was refreshed.

- Dashboard: marketplace pages now show a modal with real component names/descriptions on click; added in-page search by name/author/description/tags.
- Generator: `scripts/generate_plugins_json.py` extracts frontmatter descriptions into `components_items`; caps local scans at 50 per marketplace with graceful fallback to count-only.
- Data: regenerated `dashboard/public/plugins.json` with the new fields and latest plugin counts.
- Area: Website (dashboard/) and scripts; new UI component added `dashboard/src/components/MarketplacePluginsList.tsx`; no `docs/components.json` regeneration needed.
- Env/Secrets: no new env vars; running the generator requires `gh` CLI auth (`gh auth login`) locally.

<sup>Written for commit b2506414d408da969d8deff540c6007a23a8b43b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

