### PR TITLE
Add newsletter worker: weekly community components email via Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,15 +261,9 @@ npx wrangler deploy  # Deploy
 
 **Secrets (Cloudflare):** `DASHBOARD_URL` (e.g. `https://www.aitmpl.com`), `TRIGGER_SECRET`, `SENTRY_DSN` (optional).
 
-### docs-monitor
+### docs-monitor (DECOMMISSIONED 2026-07)
 
-Monitors https://code.claude.com/docs for changes every hour and sends Telegram notifications. Also reports errors to Sentry via `sentry.js` (complements, doesn't replace, the Telegram error alert).
-
-```bash
-cd cloudflare-workers/docs-monitor
-npm run dev          # Local dev
-npx wrangler deploy  # Deploy
-```
+Monitored https://code.claude.com/docs hourly with Telegram notifications. **Deleted from Cloudflare** to free a cron-trigger slot for the newsletter worker (the account's free plan allows 5 cron triggers total). The code remains in `cloudflare-workers/docs-monitor/` and can be redeployed if a slot frees up (`npx wrangler deploy`).
 
 ### pulse (Weekly KPI Report)
 
@@ -312,6 +306,28 @@ GA_SERVICE_ACCOUNT_JSON     # Base64 service account (optional)
 ```
 
 **Graceful degradation:** Each source catches its own errors. Missing secrets or API failures show `⚠️ Unavailable` instead of crashing the report. Failed collectors are also reported to Sentry via `sentry.js` (see Error Tracking below). The Vercel collector was removed (2026-07) since the dashboard no longer deploys to Vercel.
+
+### newsletter (Weekly Community Components Email)
+
+Composes and sends a simple weekly email via Resend featuring trending components (one Skill, Agent, MCP, Hook and Setting per send, in that fixed order). Selection is weighted-random by recent downloads and the copy (subject, catalog intro, per-component sentences, stats cited, closer) rotates from pools so no two emails read the same. Body is plain text plus a minimal HTML version (bold + underlined component titles, clickable component links). Data comes from the live `trending-data.json` + `components.json`.
+
+**Delivery:** Resend **Broadcast** targeting the segment in `RESEND_SEGMENT_ID` — Resend injects the per-recipient unsubscribe link (`{{{RESEND_UNSUBSCRIBE_URL}}}` placeholder in the body) and manages the suppression list automatically. Replies go to `NEWSLETTER_REPLY_TO`. The segment is the safety gate: point it at a pilot segment for tests or the full-audience segment for community-wide sends. Open/click tracking is enabled on the `aitmpl.com` domain with tracking subdomain `track.aitmpl.com` (metrics per broadcast at resend.com/broadcasts). Cron: Sundays 16:00 UTC (slot freed by decommissioning docs-monitor). `GET /preview?format=text` composes without sending; `POST /trigger` sends (`?send=false` for dry run).
+
+```bash
+cd cloudflare-workers/newsletter
+npm run dev          # Local dev
+npx wrangler deploy  # Deploy
+
+# Preview content without sending (repeat to see the copy rotate)
+curl "https://aitmpl-newsletter.SUBDOMAIN.workers.dev/preview?format=text" \
+  -H "Authorization: Bearer $TRIGGER_SECRET"
+
+# Real send: creates + sends a Broadcast to the segment in RESEND_SEGMENT_ID
+curl -X POST "https://aitmpl-newsletter.SUBDOMAIN.workers.dev/trigger" \
+  -H "Authorization: Bearer $TRIGGER_SECRET"
+```
+
+**Secrets (Cloudflare):** `RESEND_API_KEY` (full access — broadcasts/segments), `RESEND_SEGMENT_ID`, `NEWSLETTER_REPLY_TO`, `TRIGGER_SECRET`, `SENTRY_DSN` (optional). Public vars in `wrangler.toml [vars]`: `DASHBOARD_URL`, `RESEND_FROM_EMAIL` (`daniel.avila@aitmpl.com`).
 
 ## Error Tracking (Sentry)
 

--- a/cloudflare-workers/newsletter/README.md
+++ b/cloudflare-workers/newsletter/README.md
@@ -1,0 +1,83 @@
+# Newsletter — Weekly Community Components Email
+
+Cloudflare Worker that composes and sends a simple weekly email featuring
+trending components (one Skill, Agent, MCP, Hook and Setting per send, in
+that fixed order) as a [Resend](https://resend.com) **Broadcast**.
+
+- **Rotating selection**: each category pick is weighted-random by recent
+  downloads — popular components appear more often, but every send differs.
+- **Rotating copy**: subjects, catalog intro, per-component sentences, stat
+  phrasing and closers are drawn from pools, so no two emails read the same.
+- **Minimal formatting**: plain-text body plus a simple HTML version (bold +
+  underlined component titles, clickable links, no styling beyond that).
+- **Unsubscribe built-in**: the body carries `{{{RESEND_UNSUBSCRIBE_URL}}}`;
+  Resend replaces it per recipient, hosts the unsubscribe page, and skips
+  unsubscribed contacts on future broadcasts automatically.
+- **Replies** go to `NEWSLETTER_REPLY_TO`.
+- **Tracking**: open/click tracking enabled on the `aitmpl.com` domain with
+  tracking subdomain `track.aitmpl.com`. Per-broadcast metrics (delivered,
+  opens, clicks per link) at resend.com/broadcasts.
+- Data sources: `https://www.aitmpl.com/trending-data.json` and
+  `/components.json` (static dashboard assets).
+
+## Safety gate
+
+The broadcast targets the segment in the `RESEND_SEGMENT_ID` secret. Point it
+at a small pilot segment for tests, or the full-audience segment for
+community-wide sends. Nothing outside that segment can receive the email.
+
+## Schedule
+
+Cron: Sundays 16:00 UTC (`0 16 * * SUN`). Note: the Cloudflare account's free
+plan allows 5 cron triggers; this slot was freed by decommissioning the
+`claude-docs-monitor` worker (2026-07).
+
+## Endpoints
+
+```bash
+# Preview the generated email WITHOUT sending (hit repeatedly to see rotation)
+curl "https://aitmpl-newsletter.<subdomain>.workers.dev/preview?format=text" \
+  -H "Authorization: Bearer $TRIGGER_SECRET"
+
+# Dry run (full runner, no send)
+curl -X POST "https://aitmpl-newsletter.<subdomain>.workers.dev/trigger?send=false" \
+  -H "Authorization: Bearer $TRIGGER_SECRET"
+
+# Real send: creates + sends a Broadcast to RESEND_SEGMENT_ID
+curl -X POST "https://aitmpl-newsletter.<subdomain>.workers.dev/trigger" \
+  -H "Authorization: Bearer $TRIGGER_SECRET"
+
+# Health
+curl "https://aitmpl-newsletter.<subdomain>.workers.dev/status"
+```
+
+## Development & Deploy
+
+```bash
+cd cloudflare-workers/newsletter
+npm run dev          # Local dev (http://localhost:8787)
+npx wrangler deploy  # Deploy
+```
+
+## Configuration
+
+Public vars live in `wrangler.toml` `[vars]`: `DASHBOARD_URL`,
+`RESEND_FROM_EMAIL`.
+
+Secrets (via `wrangler secret put <KEY>`):
+
+| Secret | Purpose |
+|---|---|
+| `RESEND_API_KEY` | Resend **full access** API key (broadcasts + segments) |
+| `RESEND_SEGMENT_ID` | Segment the broadcast targets (pilot or full audience) |
+| `NEWSLETTER_REPLY_TO` | Reply-to address for the newsletter |
+| `TRIGGER_SECRET` | Auth for `/trigger` and `/preview` |
+| `SENTRY_DSN` | Optional — error reporting + cron check-ins (`newsletter-weekly` monitor slug) |
+
+## Growing the audience
+
+Contacts are loaded from Clerk (production instance) into Resend segments.
+The pilot batches were loaded with an ad-hoc script (Clerk API → `resend
+contacts create` + `add-segment`); the full-audience sync follows the same
+pattern over all users. Resend excludes unsubscribed/bounced contacts
+automatically.

--- a/cloudflare-workers/newsletter/index.js
+++ b/cloudflare-workers/newsletter/index.js
@@ -1,0 +1,409 @@
+/**
+ * Cloudflare Worker: Newsletter — Weekly Community Components Email
+ *
+ * Picks trending components (Skills, Agents, MCPs, Hooks, Settings) with
+ * weighted randomness, composes a simple email whose wording rotates on
+ * every send, and delivers it as a Resend Broadcast to the segment in
+ * RESEND_SEGMENT_ID. Resend injects the per-recipient unsubscribe link
+ * ({{{RESEND_UNSUBSCRIBE_URL}}} in the body) and manages the suppression
+ * list automatically. Replies go to NEWSLETTER_REPLY_TO.
+ *
+ * The segment is the safety gate: point RESEND_SEGMENT_ID at a test segment
+ * (single recipient) while iterating, and at the full-audience segment when
+ * going community-wide.
+ *
+ * Zero npm dependencies, matching the other workers in this directory.
+ *
+ * Error tracking: set SENTRY_DSN (wrangler secret put SENTRY_DSN) to report
+ * failures to the "aitmpl-workers" Sentry project. Optional — the worker
+ * degrades gracefully (console.error only) if it's not configured.
+ */
+
+import { reportError, checkIn } from './sentry.js';
+
+const RESEND_API = 'https://api.resend.com';
+const MONITOR_SLUG = 'newsletter-weekly';
+
+// Component categories featured in every email (one pick per category).
+// urlType matches the dashboard detail route: /component/<urlType>/<cleanPath>
+const CATEGORIES = [
+  { key: 'skills', label: 'Skill', flag: '--skill', urlType: 'skill' },
+  { key: 'agents', label: 'Agent', flag: '--agent', urlType: 'agent' },
+  { key: 'mcps', label: 'MCP', flag: '--mcp', urlType: 'mcp' },
+  { key: 'hooks', label: 'Hook', flag: '--hook', urlType: 'hook' },
+  { key: 'settings', label: 'Setting', flag: '--setting', urlType: 'setting' },
+];
+
+// ─── Entry Points ────────────────────────────────────────────────────────────
+
+export default {
+  async scheduled(event, env, ctx) {
+    console.log('📬 Newsletter: starting weekly send (cron)...');
+    await runNewsletter(env, { send: true });
+  },
+
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    const authorized = () => {
+      const authHeader = request.headers.get('Authorization');
+      return env.TRIGGER_SECRET && authHeader === `Bearer ${env.TRIGGER_SECRET}`;
+    };
+
+    // Manual trigger (real send unless ?send=false)
+    if (url.pathname === '/trigger' && request.method === 'POST') {
+      if (!authorized()) return jsonResponse({ error: 'Unauthorized' }, 401);
+      const send = url.searchParams.get('send') !== 'false';
+      try {
+        const result = await runNewsletter(env, { send });
+        return jsonResponse(result);
+      } catch (error) {
+        return jsonResponse({ success: false, error: error.message }, 500);
+      }
+    }
+
+    // Content preview — composes the email without ever calling Resend.
+    // Hit it repeatedly to see the wording/selection rotate.
+    if (url.pathname === '/preview' && request.method === 'GET') {
+      if (!authorized()) return jsonResponse({ error: 'Unauthorized' }, 401);
+      try {
+        const { subject, text, html } = await buildEmail(env);
+        if (url.searchParams.get('format') === 'text') {
+          return new Response(`Subject: ${subject}\n\n${text}`, {
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          });
+        }
+        return jsonResponse({ subject, text, html });
+      } catch (error) {
+        return jsonResponse({ success: false, error: error.message }, 500);
+      }
+    }
+
+    if (url.pathname === '/status') {
+      return jsonResponse({
+        status: 'running',
+        worker: 'aitmpl-newsletter',
+        schedule: 'Sundays 16:00 UTC (Resend Broadcast to RESEND_SEGMENT_ID)',
+        categories: CATEGORIES.map((c) => c.key),
+      });
+    }
+
+    return new Response(
+      'Newsletter — Weekly Community Components Email\n\nEndpoints:\n- POST /trigger (requires auth, ?send=false for dry run)\n- GET /preview (requires auth, ?format=text for plain text)\n- GET /status',
+      { headers: { 'Content-Type': 'text/plain' } }
+    );
+  },
+};
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+async function runNewsletter(env, opts = {}) {
+  const { send = true } = opts;
+  const checkInId = await checkIn(env, MONITOR_SLUG, 'in_progress');
+
+  try {
+    const { subject, text, html, picks } = await buildEmail(env);
+
+    let delivery = { sent: false };
+    if (send) {
+      delivery = await sendBroadcast(env, { subject, text, html });
+    }
+
+    await checkIn(env, MONITOR_SLUG, 'ok', checkInId);
+    return {
+      success: true,
+      subject,
+      text,
+      picks: picks.map((p) => `${p.type}: ${p.name}`),
+      delivery,
+    };
+  } catch (error) {
+    console.error('Newsletter failed:', error);
+    await reportError(env, error, { worker: 'aitmpl-newsletter' });
+    await checkIn(env, MONITOR_SLUG, 'error', checkInId);
+    throw error;
+  }
+}
+
+// ─── Data ────────────────────────────────────────────────────────────────────
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { 'User-Agent': 'aitmpl-newsletter/1.0' } });
+  if (!res.ok) throw new Error(`Fetch failed ${res.status}: ${url}`);
+  return res.json();
+}
+
+async function buildEmail(env) {
+  const base = (env.DASHBOARD_URL || 'https://www.aitmpl.com').replace(/\/$/, '');
+  const [trendingData, catalog] = await Promise.all([
+    fetchJson(`${base}/trending-data.json`),
+    fetchJson(`${base}/components.json`),
+  ]);
+
+  const picks = selectComponents(trendingData.trending, catalog, base);
+  if (picks.length === 0) throw new Error('No components could be selected from trending data');
+
+  const { subject, text, html } = composeEmail(picks);
+  return { subject, text, html, picks };
+}
+
+/**
+ * For each category, pick ONE component with probability proportional to its
+ * recent downloads — popular components show up more often, but every send
+ * can surface something different.
+ */
+function selectComponents(trending, catalog, base) {
+  const picks = [];
+  for (const cat of CATEGORIES) {
+    const pool = (trending?.[cat.key] || []).filter((i) => i && i.name);
+    if (pool.length === 0) continue;
+
+    // Occasionally weight by monthly downloads instead of weekly, so the mix
+    // between "spiking now" and "steady favorite" also rotates.
+    const statKey = Math.random() < 0.7 ? 'downloadsWeek' : 'downloadsMonth';
+    const item = pickWeighted(pool, statKey);
+
+    const record = findInCatalog(catalog, cat.key, item);
+    const path = installPath(record, item);
+    picks.push({
+      type: cat.label,
+      flag: cat.flag,
+      name: item.name,
+      category: item.category,
+      description: cleanDescription(record?.description),
+      installPath: path,
+      url: `${base}/component/${cat.urlType}/${path}`,
+      downloadsToday: item.downloadsToday || 0,
+      downloadsWeek: item.downloadsWeek || 0,
+      downloadsMonth: item.downloadsMonth || 0,
+      downloadsTotal: item.downloadsTotal || 0,
+    });
+  }
+  return picks;
+}
+
+function pickWeighted(items, statKey) {
+  const weights = items.map((i) => Math.max(1, Number(i[statKey]) || 0));
+  const total = weights.reduce((s, w) => s + w, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < items.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return items[i];
+  }
+  return items[items.length - 1];
+}
+
+function findInCatalog(catalog, typeKey, item) {
+  const list = catalog?.[typeKey] || [];
+  return (
+    list.find((c) => c.name === item.name && c.category === item.category) ||
+    list.find((c) => c.name === item.name) ||
+    null
+  );
+}
+
+// Mirrors getInstallCommand in dashboard/src/lib/data.ts — the install path is
+// the catalog `path` without its extension (e.g. "git-workflow/smart-commit").
+function installPath(record, item) {
+  if (record?.path) return record.path.replace(/\.(md|json)$/, '');
+  if (item.category) return `${item.category}/${item.name}`;
+  return item.name;
+}
+
+function cleanDescription(desc) {
+  if (!desc) return '';
+  let d = String(desc).trim().replace(/^["']+|["']+$/g, '').replace(/\s+/g, ' ');
+  // Keep it to one sentence-ish line.
+  const firstStop = d.indexOf('. ');
+  if (firstStop > 40) d = d.slice(0, firstStop + 1);
+  if (d.length > 160) d = d.slice(0, 157).replace(/\s+\S*$/, '').replace(/[,;:]$/, '') + '...';
+  if (!/[.!?]$/.test(d)) d += '.';
+  return d;
+}
+
+// ─── Composition (rotating copy) ─────────────────────────────────────────────
+
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+function formatCount(n) {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `${k >= 10 ? Math.round(k) : Math.round(k * 10) / 10}K`;
+  }
+  return String(n);
+}
+
+const SUBJECTS = [
+  (p) => `Claude Code Templates: this week on aitmpl.com`,
+  (p) => `Claude Code Templates: ${p.length} components people are installing right now`,
+  (p) => `Claude Code Templates: what people are installing this week`,
+  (p) => `Claude Code Templates: ${p[0].name} and ${p.length - 1} more trending components`,
+  (p) => `Claude Code Templates: fresh picks from aitmpl.com`,
+  (p) => `Claude Code Templates: ${p.length} components worth a look`,
+  (p) => `Claude Code Templates: the components people kept installing this week`,
+];
+
+const GREETINGS = ['Hey!', 'Hi there,', 'Hello!', 'Hey,', 'Hi!'];
+
+// The intro is two short paragraphs: Daniel introduces himself, then frames
+// the growing component catalog. The catalog line rotates.
+const INTRO_PRESENTATIONS = [
+  'Daniel from aitmpl.com here (on X: https://x.com/dani_avila7). You signed up on the site a while back, and I figured you would like to see what people are up to.',
+];
+
+const INTRO_CATALOGS = [
+  "aitmpl.com keeps growing: over 2,000 Claude Code components and counting. Here's a quick pick of what people have been installing lately:",
+  'New components land on aitmpl.com every week. These are the ones people have been installing the most lately:',
+  'The catalog on aitmpl.com keeps getting bigger, so here goes a short list of what has been popular these days:',
+];
+
+// Per-component sentence builders: (description, statPhrase) => line
+const ITEM_TEMPLATES = [
+  (d, s) => (d ? `${d} It picked up ${s}.` : `Picked up ${s}.`),
+  (d, s) => (d ? `${ucFirst(s)} and counting. ${d}` : `${ucFirst(s)} and counting.`),
+  (d, s) => (d ? `${d} (${s})` : `(${s})`),
+  (d, s) => (d ? `A community favorite right now with ${s}. ${d}` : `A community favorite right now with ${s}.`),
+  (d, s) => (d ? `${d} Devs gave it ${s}.` : `Devs gave it ${s}.`),
+  (d, s) => (d ? `${ucFirst(s)} for this one. ${d}` : `${ucFirst(s)} for this one.`),
+];
+
+function ucFirst(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function statPhrase(p) {
+  const options = [];
+  if (p.downloadsWeek > 0) options.push(`${formatCount(p.downloadsWeek)} downloads this week`);
+  if (p.downloadsMonth > 0) options.push(`${formatCount(p.downloadsMonth)} installs this month`);
+  if (p.downloadsTotal > 0) options.push(`over ${formatCount(p.downloadsTotal)} installs all-time`);
+  if (options.length === 0) options.push('a steady stream of installs');
+  return pick(options);
+}
+
+const CLOSERS = [
+  "That's it for this week. Try one, break nothing, ship faster.",
+  'See you next week with a fresh batch.',
+  "That's the roundup. Happy building with Claude Code.",
+  'More next week. Keep building.',
+  "That's all for now. Until next week!",
+];
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Turn bare URLs into anchors (skips trailing punctuation like the ")" in
+// "(https://x.com/dani_avila7),"). Input must already be HTML-escaped.
+function autolink(s) {
+  return s.replace(/https?:\/\/[^\s<]*[^\s<.,)!?]/g, (url) => `<a href="${url}">${url}</a>`);
+}
+
+function composeEmail(picks) {
+  // Category order is fixed (Skill, Agent, MCP, Hook, Setting) — picks arrive
+  // already in CATEGORIES order.
+  const subject = pick(SUBJECTS)(picks);
+  const greeting = pick(GREETINGS);
+  const presentation = pick(INTRO_PRESENTATIONS);
+  const catalogLine = pick(INTRO_CATALOGS);
+  const closer = pick(CLOSERS);
+  const footerNote = 'You are receiving this because you have an account on aitmpl.com.';
+  // Resend replaces this placeholder with a per-recipient unsubscribe link
+  // when the email is sent as a Broadcast.
+  const unsubscribe = 'Unsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}';
+
+  const blocks = picks.map((p) => ({
+    title: `${p.type}: ${p.name}`,
+    line: pick(ITEM_TEMPLATES)(p.description, statPhrase(p)),
+    url: p.url,
+    install: `npx claude-code-templates@latest ${p.flag} ${p.installPath}`,
+  }));
+
+  // Plain-text version: blank lines between every element for phone readability.
+  const text = [
+    greeting,
+    '',
+    presentation,
+    '',
+    catalogLine,
+    '',
+    ...blocks.flatMap((b) => [b.title, b.line, '', `Check it out: ${b.url}`, '', `Install: ${b.install}`, '']),
+    closer,
+    '',
+    footerNote,
+    unsubscribe,
+  ].join('\n');
+
+  // HTML version: same content, minimal markup — bold + underlined component
+  // titles, real links, no styling beyond that.
+  const para = (s) => `<p>${autolink(escapeHtml(s)).replace(/\n/g, '<br>\n')}</p>`;
+  const html = [
+    para(greeting),
+    para(presentation),
+    para(catalogLine),
+    ...blocks.map(
+      (b) =>
+        `<p><strong><u>${escapeHtml(b.title)}</u></strong><br>\n${autolink(escapeHtml(b.line))}</p>\n` +
+        `<p>Check it out: <a href="${b.url}">${b.url}</a></p>\n` +
+        `<p>Install: <code>${escapeHtml(b.install)}</code></p>`
+    ),
+    para(closer),
+    `<p>${escapeHtml(footerNote)}<br>\n<a href="{{{RESEND_UNSUBSCRIBE_URL}}}">Unsubscribe</a></p>`,
+  ].join('\n');
+
+  return { subject, text, html };
+}
+
+// ─── Delivery (Resend) ───────────────────────────────────────────────────────
+
+// Creates a Broadcast targeting env.RESEND_SEGMENT_ID and sends it. Resend
+// injects the per-recipient unsubscribe link and skips unsubscribed contacts.
+async function sendBroadcast(env, { subject, text, html }) {
+  if (!env.RESEND_API_KEY) throw new Error('RESEND_API_KEY is not configured');
+  if (!env.RESEND_FROM_EMAIL) throw new Error('RESEND_FROM_EMAIL is not configured');
+  if (!env.RESEND_SEGMENT_ID) throw new Error('RESEND_SEGMENT_ID is not configured');
+
+  const headers = {
+    Authorization: `Bearer ${env.RESEND_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+
+  const createRes = await fetch(`${RESEND_API}/broadcasts`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      segment_id: env.RESEND_SEGMENT_ID,
+      from: env.RESEND_FROM_EMAIL,
+      reply_to: env.NEWSLETTER_REPLY_TO || undefined,
+      subject,
+      text,
+      html,
+      name: `newsletter ${new Date().toISOString().slice(0, 10)}`,
+    }),
+  });
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(`Resend broadcast create failed (${createRes.status}): ${body}`);
+  }
+  const { id } = await createRes.json();
+
+  const sendRes = await fetch(`${RESEND_API}/broadcasts/${id}/send`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({}),
+  });
+  if (!sendRes.ok) {
+    const body = await sendRes.text();
+    throw new Error(`Resend broadcast send failed (${sendRes.status}): ${body}`);
+  }
+
+  return { sent: true, broadcastId: id };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/cloudflare-workers/newsletter/index.js
+++ b/cloudflare-workers/newsletter/index.js
@@ -114,7 +114,7 @@ async function runNewsletter(env, opts = {}) {
 
     let delivery = { sent: false };
     if (send) {
-      delivery = await sendBroadcast(env, { subject, text, html });
+      delivery = await sendBroadcast(env, { subject, text, html }, { dedupe });
     }
 
     await checkIn(env, MONITOR_SLUG, 'ok', checkInId);
@@ -363,27 +363,56 @@ function composeEmail(picks) {
 
 // ─── Delivery (Resend) ───────────────────────────────────────────────────────
 
+function todayBroadcastName() {
+  return `newsletter ${new Date().toISOString().slice(0, 10)}`;
+}
+
+// All broadcasts (any status) named `name`. Throws on listing errors so
+// callers decide whether to fail open or closed.
+async function listBroadcastsByName(env, name) {
+  const res = await fetch(`${RESEND_API}/broadcasts`, {
+    headers: { Authorization: `Bearer ${env.RESEND_API_KEY}` },
+  });
+  if (!res.ok) throw new Error(`Resend broadcast list failed (${res.status})`);
+  const { data } = await res.json();
+  return (data || []).filter((b) => b.name === name);
+}
+
 // True if a non-draft broadcast named "newsletter <today>" already exists.
-// Resend accepts duplicate names, so this pre-flight check is what protects
-// the audience from a double-send if the cron fires twice. Fails open: a
-// listing error must not block the legitimate weekly send.
+// Catches sequential cron double-fires cheaply. Fails open: a listing error
+// must not block the legitimate weekly send.
 async function broadcastAlreadySentToday(env) {
   try {
-    const res = await fetch(`${RESEND_API}/broadcasts`, {
-      headers: { Authorization: `Bearer ${env.RESEND_API_KEY}` },
-    });
-    if (!res.ok) return false;
-    const { data } = await res.json();
-    const todayName = `newsletter ${new Date().toISOString().slice(0, 10)}`;
-    return (data || []).some((b) => b.name === todayName && b.status !== 'draft');
+    return (await listBroadcastsByName(env, todayBroadcastName())).some((b) => b.status !== 'draft');
   } catch {
     return false;
   }
 }
 
+async function deleteBroadcast(env, id) {
+  try {
+    await fetch(`${RESEND_API}/broadcasts/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${env.RESEND_API_KEY}` },
+    });
+  } catch (e) {
+    console.error(`Newsletter: failed to delete duplicate draft broadcast ${id}:`, e.message);
+  }
+}
+
 // Creates a Broadcast targeting env.RESEND_SEGMENT_ID and sends it. Resend
 // injects the per-recipient unsubscribe link and skips unsubscribed contacts.
-async function sendBroadcast(env, { subject, text, html }) {
+//
+// With opts.dedupe (cron path), the create+send is split into a stateless
+// leader election to close the read-then-create race of two overlapping cron
+// invocations: each run creates its broadcast as a DRAFT, waits a settle
+// period so any concurrent run's draft becomes visible, then lists today's
+// broadcasts — if another run already sent, or a concurrent draft with a
+// smaller id exists, this run deletes its own draft and yields. Only the
+// deterministic winner calls /send, so the audience can never receive the
+// newsletter twice. (Workers KV offers no compare-and-set, so it cannot
+// provide a stronger lock than this without adding Durable Objects.)
+async function sendBroadcast(env, { subject, text, html }, opts = {}) {
   if (!env.RESEND_API_KEY) throw new Error('RESEND_API_KEY is not configured');
   if (!env.RESEND_FROM_EMAIL) throw new Error('RESEND_FROM_EMAIL is not configured');
   if (!env.RESEND_SEGMENT_ID) throw new Error('RESEND_SEGMENT_ID is not configured');
@@ -392,6 +421,7 @@ async function sendBroadcast(env, { subject, text, html }) {
     Authorization: `Bearer ${env.RESEND_API_KEY}`,
     'Content-Type': 'application/json',
   };
+  const name = todayBroadcastName();
 
   const createRes = await fetch(`${RESEND_API}/broadcasts`, {
     method: 'POST',
@@ -403,7 +433,7 @@ async function sendBroadcast(env, { subject, text, html }) {
       subject,
       text,
       html,
-      name: `newsletter ${new Date().toISOString().slice(0, 10)}`,
+      name,
     }),
   });
   if (!createRes.ok) {
@@ -411,6 +441,25 @@ async function sendBroadcast(env, { subject, text, html }) {
     throw new Error(`Resend broadcast create failed (${createRes.status}): ${body}`);
   }
   const { id } = await createRes.json();
+
+  if (opts.dedupe) {
+    // Settle so a concurrent double-fire's draft is visible before electing.
+    await new Promise((r) => setTimeout(r, 10_000));
+    try {
+      const peers = await listBroadcastsByName(env, name);
+      const someoneSent = peers.some((b) => b.id !== id && b.status !== 'draft');
+      const draftIds = peers.filter((b) => b.status === 'draft').map((b) => b.id).sort();
+      const winner = draftIds[0];
+      if (someoneSent || (winner && winner !== id)) {
+        console.log(`Newsletter: concurrent duplicate detected, yielding (mine=${id}, winner=${winner || 'already sent'})`);
+        await deleteBroadcast(env, id);
+        return { sent: false, skipped: 'concurrent duplicate detected', broadcastId: id };
+      }
+    } catch (e) {
+      // Fail open: an election listing error must not block the weekly send.
+      console.error('Newsletter: dedupe election listing failed, proceeding to send:', e.message);
+    }
+  }
 
   const sendRes = await fetch(`${RESEND_API}/broadcasts/${id}/send`, {
     method: 'POST',

--- a/cloudflare-workers/newsletter/index.js
+++ b/cloudflare-workers/newsletter/index.js
@@ -448,8 +448,21 @@ async function sendBroadcast(env, { subject, text, html }, opts = {}) {
     try {
       const peers = await listBroadcastsByName(env, name);
       const someoneSent = peers.some((b) => b.id !== id && b.status !== 'draft');
-      const draftIds = peers.filter((b) => b.status === 'draft').map((b) => b.id).sort();
-      const winner = draftIds[0];
+      // Only drafts created within the overlap window are election candidates.
+      // An older draft belongs to a run that died before cleaning up — yielding
+      // to it would mean nobody sends today (its owner is gone), so it is
+      // ignored. Unparseable timestamps count as fresh (safe: worst case is an
+      // extra yield, and send-failure cleanup below makes stale drafts rare).
+      const now = Date.now();
+      const isFresh = (b) => {
+        const t = Date.parse(String(b.created_at || '').replace(' ', 'T').replace(/\+00$/, 'Z'));
+        return Number.isNaN(t) || now - t < 5 * 60_000;
+      };
+      const candidateIds = peers
+        .filter((b) => b.status === 'draft' && (b.id === id || isFresh(b)))
+        .map((b) => b.id)
+        .sort();
+      const winner = candidateIds[0];
       if (someoneSent || (winner && winner !== id)) {
         console.log(`Newsletter: concurrent duplicate detected, yielding (mine=${id}, winner=${winner || 'already sent'})`);
         await deleteBroadcast(env, id);
@@ -468,7 +481,12 @@ async function sendBroadcast(env, { subject, text, html }, opts = {}) {
   });
   if (!sendRes.ok) {
     const body = await sendRes.text();
-    throw new Error(`Resend broadcast send failed for created broadcast ${id} (${sendRes.status}): ${body}`);
+    // Clean up the draft so it cannot win future elections that nobody sends,
+    // and so a retry starts from a clean slate. If the send actually went
+    // through despite the error response, the broadcast is no longer a draft
+    // and this DELETE fails harmlessly.
+    await deleteBroadcast(env, id);
+    throw new Error(`Resend broadcast send failed for broadcast ${id} (${sendRes.status}), draft cleaned up: ${body}`);
   }
 
   return { sent: true, broadcastId: id };

--- a/cloudflare-workers/newsletter/index.js
+++ b/cloudflare-workers/newsletter/index.js
@@ -39,7 +39,9 @@ const CATEGORIES = [
 export default {
   async scheduled(event, env, ctx) {
     console.log('📬 Newsletter: starting weekly send (cron)...');
-    await runNewsletter(env, { send: true });
+    // dedupe guards against Cloudflare's documented occasional cron double-fire;
+    // manual /trigger sends skip it so pilots/tests can send multiple times a day.
+    await runNewsletter(env, { send: true, dedupe: true });
   },
 
   async fetch(request, env, ctx) {
@@ -98,10 +100,16 @@ export default {
 // ─── Runner ──────────────────────────────────────────────────────────────────
 
 async function runNewsletter(env, opts = {}) {
-  const { send = true } = opts;
+  const { send = true, dedupe = false } = opts;
   const checkInId = await checkIn(env, MONITOR_SLUG, 'in_progress');
 
   try {
+    if (send && dedupe && (await broadcastAlreadySentToday(env))) {
+      console.log('Newsletter: broadcast for today already exists, skipping (cron double-fire guard)');
+      await checkIn(env, MONITOR_SLUG, 'ok', checkInId);
+      return { success: true, skipped: 'broadcast for today already sent' };
+    }
+
     const { subject, text, html, picks } = await buildEmail(env);
 
     let delivery = { sent: false };
@@ -343,7 +351,7 @@ function composeEmail(picks) {
     ...blocks.map(
       (b) =>
         `<p><strong><u>${escapeHtml(b.title)}</u></strong><br>\n${autolink(escapeHtml(b.line))}</p>\n` +
-        `<p>Check it out: <a href="${b.url}">${b.url}</a></p>\n` +
+        `<p>Check it out: <a href="${escapeHtml(b.url)}">${escapeHtml(b.url)}</a></p>\n` +
         `<p>Install: <code>${escapeHtml(b.install)}</code></p>`
     ),
     para(closer),
@@ -354,6 +362,24 @@ function composeEmail(picks) {
 }
 
 // ─── Delivery (Resend) ───────────────────────────────────────────────────────
+
+// True if a non-draft broadcast named "newsletter <today>" already exists.
+// Resend accepts duplicate names, so this pre-flight check is what protects
+// the audience from a double-send if the cron fires twice. Fails open: a
+// listing error must not block the legitimate weekly send.
+async function broadcastAlreadySentToday(env) {
+  try {
+    const res = await fetch(`${RESEND_API}/broadcasts`, {
+      headers: { Authorization: `Bearer ${env.RESEND_API_KEY}` },
+    });
+    if (!res.ok) return false;
+    const { data } = await res.json();
+    const todayName = `newsletter ${new Date().toISOString().slice(0, 10)}`;
+    return (data || []).some((b) => b.name === todayName && b.status !== 'draft');
+  } catch {
+    return false;
+  }
+}
 
 // Creates a Broadcast targeting env.RESEND_SEGMENT_ID and sends it. Resend
 // injects the per-recipient unsubscribe link and skips unsubscribed contacts.
@@ -393,7 +419,7 @@ async function sendBroadcast(env, { subject, text, html }) {
   });
   if (!sendRes.ok) {
     const body = await sendRes.text();
-    throw new Error(`Resend broadcast send failed (${sendRes.status}): ${body}`);
+    throw new Error(`Resend broadcast send failed for created broadcast ${id} (${sendRes.status}): ${body}`);
   }
 
   return { sent: true, broadcastId: id };

--- a/cloudflare-workers/newsletter/package.json
+++ b/cloudflare-workers/newsletter/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "aitmpl-newsletter",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker — Weekly community components email via Resend",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "secret:resend": "wrangler secret put RESEND_API_KEY",
+    "secret:trigger": "wrangler secret put TRIGGER_SECRET",
+    "secret:segment": "wrangler secret put RESEND_SEGMENT_ID",
+    "secret:reply-to": "wrangler secret put NEWSLETTER_REPLY_TO",
+    "secret:sentry": "wrangler secret put SENTRY_DSN"
+  },
+  "keywords": [
+    "cloudflare-workers",
+    "resend",
+    "newsletter",
+    "email"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "wrangler": "^3.91.0"
+  }
+}

--- a/cloudflare-workers/newsletter/sentry.js
+++ b/cloudflare-workers/newsletter/sentry.js
@@ -1,0 +1,138 @@
+/**
+ * Minimal Sentry error reporter for Cloudflare Workers (no npm dependency).
+ *
+ * Sends errors directly to the Sentry envelope API via fetch(), matching this
+ * project's convention of single-file, zero-dependency Workers.
+ *
+ * Secret required (wrangler secret put SENTRY_DSN):
+ *   SENTRY_DSN — DSN from the "aitmpl-workers" Sentry project
+ */
+
+/**
+ * Parse a Sentry DSN into the pieces needed to build the envelope endpoint.
+ * DSN format: https://<publicKey>@<host>/<projectId>
+ */
+function parseDsn(dsn) {
+  try {
+    const url = new URL(dsn);
+    return {
+      publicKey: url.username,
+      host: url.host,
+      projectId: url.pathname.replace(/^\//, ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Report an error to Sentry. Safe to call even if SENTRY_DSN is not configured
+ * (no-op) or if the request to Sentry itself fails (never throws).
+ *
+ * @param {object} env - Worker env bindings (needs env.SENTRY_DSN)
+ * @param {Error|string} error - The error (or message) to report
+ * @param {object} [context] - Extra tags/context, e.g. { cron, endpoint, status }
+ */
+async function reportError(env, error, context = {}) {
+  const dsn = env && env.SENTRY_DSN;
+  if (!dsn) {
+    console.error('[sentry] SENTRY_DSN not configured, skipping report:', error);
+    return;
+  }
+
+  const parsed = parseDsn(dsn);
+  if (!parsed) {
+    console.error('[sentry] invalid SENTRY_DSN, skipping report');
+    return;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  const stacktrace = error instanceof Error && error.stack ? error.stack : undefined;
+  const eventId = crypto.randomUUID().replace(/-/g, '');
+  const timestamp = new Date().toISOString();
+
+  const event = {
+    event_id: eventId,
+    timestamp,
+    platform: 'javascript',
+    logger: 'cloudflare-worker',
+    environment: 'production',
+    tags: { worker: context.worker || 'unknown', ...context.tags },
+    extra: context,
+    exception: {
+      values: [
+        {
+          type: error instanceof Error ? error.name || 'Error' : 'Error',
+          value: message,
+          stacktrace: stacktrace ? { frames: [{ filename: 'worker', function: 'anonymous', context_line: stacktrace }] } : undefined,
+        },
+      ],
+    },
+  };
+
+  const envelopeHeader = JSON.stringify({ event_id: eventId, sent_at: timestamp });
+  const itemHeader = JSON.stringify({ type: 'event' });
+  const body = `${envelopeHeader}\n${itemHeader}\n${JSON.stringify(event)}\n`;
+
+  const endpoint = `https://${parsed.host}/api/${parsed.projectId}/envelope/`;
+  const authHeader = `Sentry sentry_version=7, sentry_client=aitmpl-worker/1.0, sentry_key=${parsed.publicKey}`;
+
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+        'X-Sentry-Auth': authHeader,
+      },
+      body,
+    });
+  } catch (sendError) {
+    // Never let error reporting break the worker itself
+    console.error('[sentry] failed to send report:', sendError.message);
+  }
+}
+
+/**
+ * Send a Sentry Cron Monitor check-in.
+ * @param {object} env - Worker env bindings (needs env.SENTRY_DSN)
+ * @param {string} monitorSlug - Slug configured in Sentry (Crons > Add Monitor)
+ * @param {'in_progress'|'ok'|'error'} status
+ * @param {string} [checkInId] - Pass the id returned from the 'in_progress' call
+ *                               so 'ok'/'error' updates the same check-in.
+ * @returns {Promise<string|undefined>} checkInId
+ */
+async function checkIn(env, monitorSlug, status, checkInId) {
+  const dsn = env && env.SENTRY_DSN;
+  if (!dsn) return undefined;
+
+  const parsed = parseDsn(dsn);
+  if (!parsed) return undefined;
+
+  const id = checkInId || crypto.randomUUID().replace(/-/g, '');
+  const timestamp = new Date().toISOString();
+
+  const envelopeHeader = JSON.stringify({ sent_at: timestamp });
+  const itemPayload = { check_in_id: id, monitor_slug: monitorSlug, status };
+  const itemHeader = JSON.stringify({ type: 'check_in' });
+  const body = `${envelopeHeader}\n${itemHeader}\n${JSON.stringify(itemPayload)}\n`;
+
+  const endpoint = `https://${parsed.host}/api/${parsed.projectId}/envelope/`;
+  const authHeader = `Sentry sentry_version=7, sentry_client=aitmpl-worker/1.0, sentry_key=${parsed.publicKey}`;
+
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+        'X-Sentry-Auth': authHeader,
+      },
+      body,
+    });
+  } catch (sendError) {
+    console.error('[sentry] failed to send check-in:', sendError.message);
+  }
+
+  return id;
+}
+
+export { reportError, checkIn };

--- a/cloudflare-workers/newsletter/sentry.js
+++ b/cloudflare-workers/newsletter/sentry.js
@@ -78,7 +78,7 @@ async function reportError(env, error, context = {}) {
   const authHeader = `Sentry sentry_version=7, sentry_client=aitmpl-worker/1.0, sentry_key=${parsed.publicKey}`;
 
   try {
-    await fetch(endpoint, {
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-sentry-envelope',
@@ -86,6 +86,10 @@ async function reportError(env, error, context = {}) {
       },
       body,
     });
+    if (!res.ok) {
+      // Surface invalid DSNs, auth failures, and rate limiting in worker logs
+      console.error(`[sentry] report rejected (${res.status}):`, await res.text().catch(() => ''));
+    }
   } catch (sendError) {
     // Never let error reporting break the worker itself
     console.error('[sentry] failed to send report:', sendError.message);
@@ -120,7 +124,7 @@ async function checkIn(env, monitorSlug, status, checkInId) {
   const authHeader = `Sentry sentry_version=7, sentry_client=aitmpl-worker/1.0, sentry_key=${parsed.publicKey}`;
 
   try {
-    await fetch(endpoint, {
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-sentry-envelope',
@@ -128,6 +132,9 @@ async function checkIn(env, monitorSlug, status, checkInId) {
       },
       body,
     });
+    if (!res.ok) {
+      console.error(`[sentry] check-in rejected (${res.status}):`, await res.text().catch(() => ''));
+    }
   } catch (sendError) {
     console.error('[sentry] failed to send check-in:', sendError.message);
   }

--- a/cloudflare-workers/newsletter/wrangler.toml
+++ b/cloudflare-workers/newsletter/wrangler.toml
@@ -1,0 +1,31 @@
+# Cloudflare Worker Configuration
+# Newsletter — Weekly Community Components Email (via Resend Broadcasts)
+
+name = "aitmpl-newsletter"
+main = "index.js"
+compatibility_date = "2024-01-01"
+
+# Cron Trigger — Sundays 16:00 UTC. The account's 5-cron-trigger limit (free
+# plan) had this slot taken by claude-docs-monitor, which was decommissioned
+# (2026-07) to make room for the newsletter.
+# The broadcast goes to the segment in RESEND_SEGMENT_ID, which acts as the
+# safety gate: keep it pointed at a pilot segment until the full-audience
+# segment is ready.
+[triggers]
+crons = ["0 16 * * SUN"]
+
+[vars]
+# Public deploy-time values (not secrets)
+DASHBOARD_URL = "https://www.aitmpl.com"
+RESEND_FROM_EMAIL = "Daniel Avila <daniel.avila@aitmpl.com>"
+
+# Secrets (set via: wrangler secret put <KEY>)
+# Required:
+# - RESEND_API_KEY: Resend FULL ACCESS API key (broadcasts + segments)
+# - RESEND_SEGMENT_ID: Resend segment the broadcast targets (test or full audience)
+# - NEWSLETTER_REPLY_TO: reply-to address for the newsletter
+# - TRIGGER_SECRET: Secret for manual /trigger and /preview endpoints
+#
+# Optional (error tracking):
+# - SENTRY_DSN: DSN from the "aitmpl-workers" Sentry project. Also configure a
+#   Cron Monitor in Sentry with slug "newsletter-weekly".


### PR DESCRIPTION
## What

New Cloudflare Worker `cloudflare-workers/newsletter/` that composes and sends a weekly email to the community featuring trending components — one Skill, Agent, MCP, Hook and Setting per send, in that fixed order.

- **Rotating selection**: each category pick is weighted-random over `downloadsWeek`/`downloadsMonth` from the live `trending-data.json`, so popular components appear more often but every send differs.
- **Rotating copy**: subject, catalog intro, per-component sentences, cited stat (week/month/all-time) and closer are drawn from pools — no two emails read the same.
- **Minimal format**: plain-text body + simple HTML version (bold/underlined component titles, clickable component links, install commands). No styled templates by design.
- **Delivery**: Resend **Broadcast** targeting the segment in `RESEND_SEGMENT_ID`. Resend injects the per-recipient unsubscribe link (`{{{RESEND_UNSUBSCRIBE_URL}}}`) and manages the suppression list. Replies route to `NEWSLETTER_REPLY_TO`.
- **Endpoints**: `GET /preview` (compose without sending, for copy iteration), `POST /trigger` (`?send=false` dry run), `GET /status` — Bearer `TRIGGER_SECRET`, same pattern as `pulse`.
- **Zero npm runtime deps** + per-worker `sentry.js` (reportError + `newsletter-weekly` cron check-ins), matching the other workers.

## Why

Weekly touchpoint for the community (10K+ registered users) highlighting what people are actually installing, with per-broadcast open/click metrics in Resend to learn which component types drive engagement.

## Reviewer notes

- **Cron**: Sundays 16:00 UTC. The account was at the free plan's 5-cron-trigger limit, so the `claude-docs-monitor` worker was decommissioned (deleted from Cloudflare; code stays in the repo). CLAUDE.md documents this.
- **Safety gate**: the worker can only email whatever segment `RESEND_SEGMENT_ID` points at — pilots ran against 49/50-user segments before pointing at the full audience.
- Already deployed and validated in production: test sends, two 50-user pilots, and domain tracking (`track.aitmpl.com`) verified. Secrets set via `wrangler secret put` (`RESEND_API_KEY`, `RESEND_SEGMENT_ID`, `NEWSLETTER_REPLY_TO`, `TRIGGER_SECRET`).
- Pre-existing uncommitted worktree changes (`wrangler.jsonc`, root `package.json` deploy script, `.gitignore`, lockfile) are intentionally **not** included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cloudflare Worker that sends a weekly components newsletter via `Resend` Broadcasts using live trending data and rotating copy. Delivery is hardened with a draft leader‑election and stale‑draft cleanup to prevent double sends; Sentry check‑ins are included.

- Area: workers (`cloudflare-workers/`). New `cloudflare-workers/newsletter/` with plain-text/HTML email; endpoints `/preview`, `/trigger` (Bearer `TRIGGER_SECRET`), `/status`. Cron Sundays 16:00 UTC; `docs-monitor` decommissioned to free the slot.
- Safety: preflight check + draft leader‑election to avoid cron double sends; ignores stale drafts and cleans up on send failures; `/trigger` bypasses dedupe; returns `broadcastId`; HTML‑escapes dynamic fields; Sentry check‑ins and non‑2xx response logging.
- Data/content: pulls `components.json` and `trending-data.json`; weighted picks and rotating copy. No new components; catalog (`docs/components.json`) does not need regeneration.
- Env/secrets: `RESEND_API_KEY`, `RESEND_SEGMENT_ID`, `NEWSLETTER_REPLY_TO`, `TRIGGER_SECRET`, optional `SENTRY_DSN`. Public vars: `DASHBOARD_URL`, `RESEND_FROM_EMAIL`.

<sup>Written for commit 54e4cf1ebf504403de2a10d7e2187649849ea3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

