### PR TITLE
fix(sidebar): hide logo when sidebar is collapsed

### DIFF
--- a/dashboard/src/components/Sidebar.astro
+++ b/dashboard/src/components/Sidebar.astro
@@ -17,7 +17,8 @@ function isActive(path: string): boolean {
   <div class="px-4 py-4 border-b border-[var(--color-border)] flex items-center justify-between min-h-[65px] transition-all duration-300 bg-[var(--color-surface-0)]">
     <a href="/" class="flex items-center gap-2.5 group min-w-0 overflow-hidden transition-all duration-300">
       <span
-        class="w-8 h-8 shrink-0 rounded-md border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 flex items-center justify-center transition-all duration-200 group-hover:scale-110 group-hover:border-[var(--color-accent)]"
+        id="sidebar-logo"
+        class="w-8 h-8 shrink-0 rounded-md border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 flex items-center justify-center transition-all duration-200 group-hover:scale-100 group-hover:border-[var(--color-accent)]"
         aria-hidden="true"
       >
         <svg class="w-4 h-4 text-[var(--color-accent)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
@@ -27,12 +28,12 @@ function isActive(path: string): boolean {
       </span>
       <span class="sidebar-text text-[14px] font-bold text-[var(--color-text-primary)] tracking-tight whitespace-nowrap transition-all duration-300">AI Templates</span>
     </a>
-    <button
-      id="sidebar-toggle"
-      class="hidden md:flex shrink-0 w-8 h-8 items-center justify-center rounded-lg hover:bg-[var(--color-surface-2)] transition-all duration-200 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] active:scale-95 hover:rotate-180"
-      aria-label="Toggle sidebar"
-      title="Collapse sidebar"
-    >
+<button
+  id="sidebar-toggle"
+  class="hidden md:flex shrink-0 w-8 h-8 items-center justify-center rounded-lg hover:bg-[var(--color-surface-2)] transition-all duration-200 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] active:scale-95 hover:rotate-180"
+  aria-label="Toggle sidebar"
+  title="Collapse sidebar"
+>
       <svg class="w-4 h-4 transition-transform duration-300 ease-in-out" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
       </svg>

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -140,6 +140,7 @@ const schemaData = JSON.stringify({
         const sidebar = document.getElementById('sidebar');
         const mainContent = document.getElementById('main-content');
         const toggleBtn = document.getElementById('sidebar-toggle');
+        const sidebarLogo = document.getElementById('sidebar-logo');
         
         if (!sidebar || !mainContent || !toggleBtn) return;
 
@@ -163,6 +164,7 @@ const schemaData = JSON.stringify({
           if (!sidebar || !mainContent) return;
           
           sidebar.dataset.collapsed = String(collapsed);
+          sidebarLogo?.classList.toggle('hidden', collapsed);
           
           if (collapsed) {
             sidebar.classList.remove('w-[220px]');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide the sidebar logo when the sidebar is collapsed to keep the header clean and avoid visual clutter.

- **Bug Fixes**
  - Area: components (dashboard/src/components/Sidebar.astro, dashboard/src/layouts/DashboardLayout.astro)
  - Toggle 'hidden' on `#sidebar-logo` when collapsed; added `id="sidebar-logo"` and hooked into the existing toggle logic.
  - Minor UI tweak: removed extra hover scale to prevent jumpy animation.
  - No new components; catalog (docs/components.json) does not need regeneration.
  - No new environment variables or secrets.

<sup>Written for commit 85e05c7b7d9f9695aac99fc5ad854ef098e9ca6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

