### PR TITLE
fix: align collapsed sidebar icons 

### DIFF
--- a/dashboard/src/components/Sidebar.astro
+++ b/dashboard/src/components/Sidebar.astro
@@ -144,13 +144,13 @@ function isActive(path: string): boolean {
     <a href="/trending"
       data-tooltip="Trending"
       class:list={[
-        'flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-all duration-200 group overflow-hidden',
+        'sidebar-nav-link flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-all duration-200 group overflow-hidden',
         isActive('/trending')
           ? 'bg-[var(--color-surface-3)] text-[var(--color-text-primary)] font-medium shadow-sm'
           : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm',
       ]}>
       <span class:list={[
-        'w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center transition-all duration-200',
+        'sidebar-nav-icon w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center transition-all duration-200',
         isActive('/trending') ? 'text-[var(--color-text-primary)] scale-105' : 'text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] group-hover:scale-105',
       ]}>
         <svg class="w-full h-full flex-shrink-0 block m-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -163,13 +163,13 @@ function isActive(path: string): boolean {
     <a href="/jobs"
       data-tooltip="Jobs"
       class:list={[
-        'flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-all duration-200 group overflow-hidden',
+        'sidebar-nav-link flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] transition-all duration-200 group overflow-hidden',
         isActive('/jobs')
           ? 'bg-[var(--color-surface-3)] text-[var(--color-text-primary)] font-medium shadow-sm'
           : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm',
       ]}>
       <span class:list={[
-        'w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center transition-all duration-200',
+        'sidebar-nav-icon w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center transition-all duration-200',
         isActive('/jobs') ? 'text-[var(--color-text-primary)] scale-105' : 'text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] group-hover:scale-105',
       ]}>
         <svg class="w-full h-full flex-shrink-0 block m-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -182,8 +182,8 @@ function isActive(path: string): boolean {
 
     <a href={NAV_LINKS.blog} target="_blank" rel="noopener noreferrer"
       data-tooltip="Blog"
-      class="flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-200 group overflow-hidden">
-      <span class="w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-all duration-200 group-hover:scale-105">
+      class="sidebar-nav-link flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-200 group overflow-hidden">
+      <span class="sidebar-nav-icon w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-all duration-200 group-hover:scale-105">
         <svg class="w-full h-full flex-shrink-0 block m-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M4 19.5v-15A2.5 2.5 0 016.5 2H20v20H6.5a2.5 2.5 0 010-5H20" />
         </svg>
@@ -194,8 +194,8 @@ function isActive(path: string): boolean {
 
     <a href={NAV_LINKS.docs} target="_blank" rel="noopener noreferrer"
       data-tooltip="Docs"
-      class="flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-150 group">
-      <span class="w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-transform duration-150 group-hover:scale-105">
+      class="sidebar-nav-link flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-150 group">
+      <span class="sidebar-nav-icon w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-transform duration-150 group-hover:scale-105">
         <svg class="w-full h-full flex-shrink-0 block m-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /><polyline points="10 9 9 9 8 9" />
         </svg>
@@ -206,8 +206,8 @@ function isActive(path: string): boolean {
 
     <a href={NAV_LINKS.github} target="_blank" rel="noopener noreferrer"
       data-tooltip="GitHub"
-      class="flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-200 group overflow-hidden">
-      <span class="w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-all duration-200 group-hover:scale-105">
+      class="sidebar-nav-link flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] hover:shadow-sm transition-all duration-200 group overflow-hidden">
+      <span class="sidebar-nav-icon w-[18px] h-[18px] shrink-0 inline-flex items-center justify-center text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-secondary)] transition-all duration-200 group-hover:scale-105">
         <svg class="w-full h-full flex-shrink-0 block m-auto" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
         </svg>

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -143,25 +143,29 @@ const schemaData = JSON.stringify({
         
         if (!sidebar || !mainContent || !toggleBtn) return;
 
+        function setCollapsed(collapsed: boolean) {
+          sidebar.dataset.collapsed = String(collapsed);
+          sidebar.classList.toggle('w-[72px]', collapsed);
+          sidebar.classList.toggle('w-[220px]', !collapsed);
+          mainContent.classList.toggle('md:ml-[72px]', collapsed);
+          mainContent.classList.toggle('md:ml-[220px]', !collapsed);
+          const icon = toggleBtn.querySelector('svg');
+          if (icon) icon.style.transform = collapsed ? 'rotate(180deg)' : 'rotate(0deg)';
+        }
+
         // Load saved state
         const savedState = localStorage.getItem('sidebar-collapsed');
         const isCollapsed = savedState === 'true';
-        
+
         if (isCollapsed) {
-          applySidebarState(true);
+          setCollapsed(true);
         }
 
         // Toggle handler
         toggleBtn.addEventListener('click', () => {
           const currentState = sidebar.dataset.collapsed === 'true';
           const newState = !currentState;
-          sidebar.dataset.collapsed = String(newState);
-          sidebar.classList.toggle('w-[72px]', newState);
-          sidebar.classList.toggle('w-[220px]', !newState);
-          mainContent.classList.toggle('md:ml-[72px]', newState);
-          mainContent.classList.toggle('md:ml-[220px]', !newState);
-          const icon = toggleBtn.querySelector('svg');
-          if (icon) icon.style.transform = newState ? 'rotate(180deg)' : 'rotate(0deg)';
+          setCollapsed(newState);
           localStorage.setItem('sidebar-collapsed', String(newState));
         });
 

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -155,7 +155,13 @@ const schemaData = JSON.stringify({
         toggleBtn.addEventListener('click', () => {
           const currentState = sidebar.dataset.collapsed === 'true';
           const newState = !currentState;
-          applySidebarState(newState);
+          sidebar.dataset.collapsed = String(newState);
+          sidebar.classList.toggle('w-[72px]', newState);
+          sidebar.classList.toggle('w-[220px]', !newState);
+          mainContent.classList.toggle('md:ml-[72px]', newState);
+          mainContent.classList.toggle('md:ml-[220px]', !newState);
+          const icon = toggleBtn.querySelector('svg');
+          if (icon) icon.style.transform = newState ? 'rotate(180deg)' : 'rotate(0deg)';
           localStorage.setItem('sidebar-collapsed', String(newState));
         });
 

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -168,9 +168,12 @@ body {
 
 #sidebar[data-collapsed="true"] .sidebar-text,
 #sidebar[data-collapsed="true"] .sidebar-nav-count {
-  opacity: 0;
-  width: 0;
-  overflow: hidden;
+  opacity: 0 !important;
+  width: 0 !important;
+  min-width: 0 !important;
+  padding: 0 !important;
+  border-width: 0 !important;
+  overflow: hidden !important;
 }
 
 /* Tooltip for collapsed sidebar items */
@@ -253,6 +256,11 @@ body {
    still reserve remaining flex space and shift the icon off-center. */
 #sidebar[data-collapsed="true"] .sidebar-nav-count {
   margin-left: 0 !important;
+} 
+
+/* Reset ml-auto on trailing elements (badges/icons) so icons stay centered when collapsed */
+#sidebar[data-collapsed="true"] .sidebar-text {
+   margin-left: 0 !important;
 }
 
 /* Center header content in collapsed state */


### PR DESCRIPTION
## Fixes #683

## Root cause
When the sidebar is collapsed, the `.sidebar-nav-count` badge next to each nav item was hidden via `width: 0`, but `min-width`, `padding`, and `border-width` weren't reset. Since fixed padding/border/min-width don't collapse with `width: 0`, the badge still occupied physical space and pushed several icons up to 12px off-center from their container.

Separately, the Resources section links (Trending/Jobs/Blog/Docs/GitHub) used different markup/classes than the Browse section links, and a duplicate JS-based inline-style implementation in `DashboardLayout.astro` was fighting the CSS attribute-selector approach in `global.css`, making the styling harder to maintain and more error-prone.

## Changes
- Reset `min-width`, `padding`, and `border-width` on `.sidebar-nav-count` and `.sidebar-text` in the collapsed state (`global.css`)
- Unified Resources section link markup with the same `sidebar-nav-link` / `sidebar-nav-icon` classes already used by the Browse section (`Sidebar.astro`)
- Simplified the sidebar toggle handler to rely on the CSS attribute-selector approach instead of duplicating it with inline JS styles (`DashboardLayout.astro`)

## Verification
Used `getBoundingClientRect()` to measure the offset between each nav link's center and its icon's center, before and after:

**Before:** offsets up to -12.0px on Browse section items
**After:** all offsets at 0.0px (or within a rounding pixel)

## Screenshots
<img width="106" height="782" alt="image" src="https://github.com/user-attachments/assets/2db744d5-d68f-47eb-b483-34873dc4470c" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns collapsed sidebar icons and unifies the sidebar collapse behavior on load and toggle. Fixes #683.

- CSS: Reset width/min-width/padding/border and margin-left on `.sidebar-nav-count` and `.sidebar-text` when collapsed to remove spacing and keep icons centered (`dashboard/src/styles/global.css`).
- Sidebar markup: Use `sidebar-nav-link`/`sidebar-nav-icon` across Resources and Browse links to keep icon box sizing consistent (`dashboard/src/components/Sidebar.astro`).
- Logic: Add `setCollapsed()` to apply the same class/data-attribute state on initial load and on toggle; persists via `localStorage` and rotates the toggle icon (`dashboard/src/layouts/DashboardLayout.astro`).
- Area: components (dashboard/). No new components; no catalog regen needed. No new environment variables or secrets.

<sup>Written for commit a8ca86e341ccebff7efaa2509e6022d9d1a20dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

