### PR TITLE
fix(commands,docs): quote argument-hint YAML values across 275 files (closes #708)

### DIFF
--- a/.claude/agents/component-reviewer.md
+++ b/.claude/agents/component-reviewer.md
@@ -78,7 +78,7 @@ You are a frontend developer specializing in modern React applications...
 ```markdown
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
-argument-hint: [message] | --no-verify | --amend
+argument-hint: "[message] | --no-verify | --amend"
 description: Create well-formatted commits with conventional commit format
 ---
 

--- a/.claude/commands/cleanup-cache.md
+++ b/.claude/commands/cleanup-cache.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(df:*), Bash(du:*), Bash(npm cache clean:*), Bash(brew cleanup:*), Bash(rm:*), Bash(find:*), Bash(docker system prune:*)
-argument-hint: [--aggressive] | [--maximum]
+argument-hint: "[--aggressive] | [--maximum]"
 description: Clean system caches (npm, Homebrew, Yarn, browsers, Python/ML) to free disk space
 ---
 

--- a/cli-tool/components/commands/automation/act.md
+++ b/cli-tool/components/commands/automation/act.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [workflow-name]
+argument-hint: "[workflow-name]"
 description: Execute GitHub Actions locally using act
 ---
 

--- a/cli-tool/components/commands/automation/ci-pipeline.md
+++ b/cli-tool/components/commands/automation/ci-pipeline.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [pipeline-name] | setup | status | fix
+argument-hint: "[pipeline-name] | setup | status | fix"
 description: Manage and automate CI/CD pipeline configuration with GitHub Actions, multi-environment support, and deployment strategies
 ---
 

--- a/cli-tool/components/commands/automation/husky.md
+++ b/cli-tool/components/commands/automation/husky.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read
-argument-hint: [--skip-install] | [--only-lint] | [--skip-tests]
+argument-hint: "[--skip-install] | [--only-lint] | [--skip-tests]"
 description: Run comprehensive CI checks and fix issues until repository is in working state
 ---
 

--- a/cli-tool/components/commands/automation/workflow-orchestrator.md
+++ b/cli-tool/components/commands/automation/workflow-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [workflow-name] | create | run | schedule | monitor
+argument-hint: "[workflow-name] | create | run | schedule | monitor"
 description: Orchestrate complex automation workflows with task dependencies, scheduling, and cross-platform execution
 ---
 

--- a/cli-tool/components/commands/database/supabase-backup-manager.md
+++ b/cli-tool/components/commands/database/supabase-backup-manager.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [operation] | --backup | --restore | --schedule | --validate | --cleanup
+argument-hint: "[operation] | --backup | --restore | --schedule | --validate | --cleanup"
 description: Manage Supabase database backups with automated scheduling and recovery procedures
 ---
 

--- a/cli-tool/components/commands/database/supabase-data-explorer.md
+++ b/cli-tool/components/commands/database/supabase-data-explorer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [table-name] | --query [sql] | --export | --inspect
+argument-hint: "[table-name] | --query [sql] | --export | --inspect"
 description: Explore and analyze Supabase database data with intelligent querying and visualization
 ---
 

--- a/cli-tool/components/commands/database/supabase-migration-assistant.md
+++ b/cli-tool/components/commands/database/supabase-migration-assistant.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-type] | --create | --alter | --seed | --rollback
+argument-hint: "[migration-type] | --create | --alter | --seed | --rollback"
 description: Generate and manage Supabase database migrations with automated testing and validation
 ---
 

--- a/cli-tool/components/commands/database/supabase-performance-optimizer.md
+++ b/cli-tool/components/commands/database/supabase-performance-optimizer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [optimization-type] | --queries | --indexes | --storage | --rls | --functions
+argument-hint: "[optimization-type] | --queries | --indexes | --storage | --rls | --functions"
 description: Optimize Supabase database performance with intelligent analysis and recommendations
 ---
 

--- a/cli-tool/components/commands/database/supabase-realtime-monitor.md
+++ b/cli-tool/components/commands/database/supabase-realtime-monitor.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [monitoring-type] | --connections | --subscriptions | --performance | --debug | --analytics
+argument-hint: "[monitoring-type] | --connections | --subscriptions | --performance | --debug | --analytics"
 description: Monitor and optimize Supabase realtime connections with performance analysis and debugging
 ---
 

--- a/cli-tool/components/commands/database/supabase-schema-sync.md
+++ b/cli-tool/components/commands/database/supabase-schema-sync.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [action] | --pull | --push | --diff | --validate
+argument-hint: "[action] | --pull | --push | --diff | --validate"
 description: Synchronize database schema with Supabase using MCP integration
 ---
 

--- a/cli-tool/components/commands/database/supabase-security-audit.md
+++ b/cli-tool/components/commands/database/supabase-security-audit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [audit-scope] | --rls | --permissions | --auth | --api-keys | --comprehensive
+argument-hint: "[audit-scope] | --rls | --permissions | --auth | --api-keys | --comprehensive"
 description: Conduct comprehensive Supabase security audit with RLS analysis and vulnerability assessment
 ---
 

--- a/cli-tool/components/commands/database/supabase-type-generator.md
+++ b/cli-tool/components/commands/database/supabase-type-generator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [generation-scope] | --all-tables | --specific-table | --functions | --enums | --views
+argument-hint: "[generation-scope] | --all-tables | --specific-table | --functions | --enums | --views"
 description: Generate TypeScript types from Supabase schema with automatic synchronization and validation
 ---
 

--- a/cli-tool/components/commands/deployment/add-changelog.md
+++ b/cli-tool/components/commands/deployment/add-changelog.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Write, Bash
-argument-hint: [version] | [entry-type] [description]
+argument-hint: "[version] | [entry-type] [description]"
 description: Generate and maintain project changelog with Keep a Changelog format
 ---
 

--- a/cli-tool/components/commands/deployment/blue-green-deployment.md
+++ b/cli-tool/components/commands/deployment/blue-green-deployment.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [strategy] | setup | deploy | switch | rollback | status
+argument-hint: "[strategy] | setup | deploy | switch | rollback | status"
 description: Implement blue-green deployment strategy with zero-downtime switching, health validation, and automatic rollback
 ---
 

--- a/cli-tool/components/commands/deployment/changelog-demo-command.md
+++ b/cli-tool/components/commands/deployment/changelog-demo-command.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [format] | --generate | --validate | --demo
+argument-hint: "[format] | --generate | --validate | --demo"
 description: Demonstrate changelog automation features with real examples and validation
 ---
 

--- a/cli-tool/components/commands/deployment/ci-setup.md
+++ b/cli-tool/components/commands/deployment/ci-setup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [platform] | --github-actions | --gitlab-ci | --jenkins | --full-setup
+argument-hint: "[platform] | --github-actions | --gitlab-ci | --jenkins | --full-setup"
 description: Setup comprehensive CI/CD pipeline with automated testing, building, and deployment
 ---
 

--- a/cli-tool/components/commands/deployment/containerize-application.md
+++ b/cli-tool/components/commands/deployment/containerize-application.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [application-type] | --node | --python | --java | --go | --multi-stage
+argument-hint: "[application-type] | --node | --python | --java | --go | --multi-stage"
 description: Containerize application with optimized Docker configuration, security, and multi-stage builds
 ---
 

--- a/cli-tool/components/commands/deployment/deployment-monitoring.md
+++ b/cli-tool/components/commands/deployment/deployment-monitoring.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [monitoring-type] | setup | dashboard | alerts | metrics | health | performance
+argument-hint: "[monitoring-type] | setup | dashboard | alerts | metrics | health | performance"
 description: Comprehensive deployment monitoring with observability, alerting, health checks, and performance tracking
 ---
 

--- a/cli-tool/components/commands/deployment/hotfix-deploy.md
+++ b/cli-tool/components/commands/deployment/hotfix-deploy.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [hotfix-type] | --security | --critical | --rollback-ready | --emergency
+argument-hint: "[hotfix-type] | --security | --critical | --rollback-ready | --emergency"
 description: Deploy critical hotfixes with emergency procedures, validation, and rollback capabilities
 ---
 

--- a/cli-tool/components/commands/deployment/prepare-release.md
+++ b/cli-tool/components/commands/deployment/prepare-release.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [version-type] | patch | minor | major | --pre-release | --hotfix
+argument-hint: "[version-type] | patch | minor | major | --pre-release | --hotfix"
 description: Prepare and validate release packages with comprehensive testing, documentation, and automation
 ---
 

--- a/cli-tool/components/commands/deployment/rollback-deploy.md
+++ b/cli-tool/components/commands/deployment/rollback-deploy.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [target-version] | --previous | --emergency | --validate-first | --with-db
+argument-hint: "[target-version] | --previous | --emergency | --validate-first | --with-db"
 description: Rollback deployment to previous version with safety checks, database considerations, and monitoring
 ---
 

--- a/cli-tool/components/commands/deployment/setup-automated-releases.md
+++ b/cli-tool/components/commands/deployment/setup-automated-releases.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [release-type] | --semantic | --conventional-commits | --github-actions | --full-automation
+argument-hint: "[release-type] | --semantic | --conventional-commits | --github-actions | --full-automation"
 description: Setup automated release workflows with semantic versioning, conventional commits, and comprehensive automation
 ---
 

--- a/cli-tool/components/commands/deployment/setup-kubernetes-deployment.md
+++ b/cli-tool/components/commands/deployment/setup-kubernetes-deployment.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [deployment-type] | --microservices | --monolith | --stateful | --full-stack | --production-ready
+argument-hint: "[deployment-type] | --microservices | --monolith | --stateful | --full-stack | --production-ready"
 description: Configure comprehensive Kubernetes deployment with manifests, security, scaling, and production best practices
 ---
 

--- a/cli-tool/components/commands/documentation/create-onboarding-guide.md
+++ b/cli-tool/components/commands/documentation/create-onboarding-guide.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [role-type] | --developer | --designer | --devops | --comprehensive | --interactive
+argument-hint: "[role-type] | --developer | --designer | --devops | --comprehensive | --interactive"
 description: Create comprehensive developer onboarding guide with environment setup, workflows, and interactive tutorials
 ---
 

--- a/cli-tool/components/commands/documentation/doc-api.md
+++ b/cli-tool/components/commands/documentation/doc-api.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [api-type] | --openapi | --graphql | --rest | --grpc | --interactive
+argument-hint: "[api-type] | --openapi | --graphql | --rest | --grpc | --interactive"
 description: Generate comprehensive API documentation from code with interactive examples and testing capabilities
 ---
 

--- a/cli-tool/components/commands/documentation/docs-maintenance.md
+++ b/cli-tool/components/commands/documentation/docs-maintenance.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash, Grep
-argument-hint: [maintenance-type] | --audit | --update | --validate | --optimize | --comprehensive
+argument-hint: "[maintenance-type] | --audit | --update | --validate | --optimize | --comprehensive"
 description: Use PROACTIVELY to implement comprehensive documentation maintenance systems with quality assurance, validation, and automated updates
 ---
 

--- a/cli-tool/components/commands/documentation/generate-api-documentation.md
+++ b/cli-tool/components/commands/documentation/generate-api-documentation.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [output-format] | --swagger-ui | --redoc | --postman | --insomnia | --multi-format
+argument-hint: "[output-format] | --swagger-ui | --redoc | --postman | --insomnia | --multi-format"
 description: Auto-generate API reference documentation with multiple output formats and automated deployment
 ---
 

--- a/cli-tool/components/commands/documentation/interactive-documentation.md
+++ b/cli-tool/components/commands/documentation/interactive-documentation.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [platform] | --docusaurus | --gitbook | --notion | --storybook | --jupyter | --comprehensive
+argument-hint: "[platform] | --docusaurus | --gitbook | --notion | --storybook | --jupyter | --comprehensive"
 description: Use PROACTIVELY to create interactive documentation platforms with live examples, code playgrounds, and user engagement features
 ---
 

--- a/cli-tool/components/commands/documentation/load-llms-txt.md
+++ b/cli-tool/components/commands/documentation/load-llms-txt.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, WebFetch
-argument-hint: [data-source] | --xatu | --custom-url | --validate
+argument-hint: "[data-source] | --xatu | --custom-url | --validate"
 description: Load and process external documentation context from llms.txt files or custom sources
 ---
 

--- a/cli-tool/components/commands/documentation/migration-guide.md
+++ b/cli-tool/components/commands/documentation/migration-guide.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-type] | framework | database | cloud | architecture | --version-upgrade
+argument-hint: "[migration-type] | framework | database | cloud | architecture | --version-upgrade"
 description: Create comprehensive migration guides with step-by-step procedures, validation, and rollback strategies
 ---
 

--- a/cli-tool/components/commands/documentation/troubleshooting-guide.md
+++ b/cli-tool/components/commands/documentation/troubleshooting-guide.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [system-component] | --application | --database | --network | --deployment | --comprehensive
+argument-hint: "[system-component] | --application | --database | --network | --deployment | --comprehensive"
 description: Generate systematic troubleshooting documentation with diagnostic procedures, common issues, and automated solutions
 ---
 

--- a/cli-tool/components/commands/documentation/update-docs.md
+++ b/cli-tool/components/commands/documentation/update-docs.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [doc-type] | --implementation | --api | --architecture | --sync | --validate
+argument-hint: "[doc-type] | --implementation | --api | --architecture | --sync | --validate"
 description: Systematically update project documentation with implementation status, API changes, and synchronized content
 ---
 

--- a/cli-tool/components/commands/game-development/game-analytics-integration.md
+++ b/cli-tool/components/commands/game-development/game-analytics-integration.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [analytics-type] | --player-behavior | --performance | --monetization | --retention | --comprehensive
+argument-hint: "[analytics-type] | --player-behavior | --performance | --monetization | --retention | --comprehensive"
 description: Use PROACTIVELY to implement game analytics systems with player behavior tracking, performance monitoring, and business intelligence integration
 ---
 

--- a/cli-tool/components/commands/game-development/game-asset-pipeline.md
+++ b/cli-tool/components/commands/game-development/game-asset-pipeline.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [pipeline-type] | --art | --audio | --models | --textures | --comprehensive
+argument-hint: "[pipeline-type] | --art | --audio | --models | --textures | --comprehensive"
 description: Use PROACTIVELY to build automated game asset processing pipelines with optimization, validation, and multi-platform delivery systems
 ---
 

--- a/cli-tool/components/commands/game-development/game-performance-profiler.md
+++ b/cli-tool/components/commands/game-development/game-performance-profiler.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [profile-type] | --fps | --memory | --rendering | --comprehensive
+argument-hint: "[profile-type] | --fps | --memory | --rendering | --comprehensive"
 description: Use PROACTIVELY to analyze game performance bottlenecks and generate optimization recommendations across multiple platforms
 ---
 

--- a/cli-tool/components/commands/game-development/game-testing-framework.md
+++ b/cli-tool/components/commands/game-development/game-testing-framework.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [test-type] | --unit | --integration | --performance | --automation | --comprehensive
+argument-hint: "[test-type] | --unit | --integration | --performance | --automation | --comprehensive"
 description: Use PROACTIVELY to implement comprehensive game testing frameworks with automated validation, performance testing, and multi-platform verification
 ---
 

--- a/cli-tool/components/commands/game-development/unity-project-setup.md
+++ b/cli-tool/components/commands/game-development/unity-project-setup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [project-name] | --2d | --3d | --mobile | --vr | --console
+argument-hint: "[project-name] | --2d | --3d | --mobile | --vr | --console"
 description: Use PROACTIVELY to set up professional Unity game development projects with industry-standard structure, essential packages, and platform-optimized configurations
 ---
 

--- a/cli-tool/components/commands/git-workflow/branch-cleanup.md
+++ b/cli-tool/components/commands/git-workflow/branch-cleanup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git branch:*), Bash(git checkout:*), Bash(git push:*), Bash(git merge:*), Bash(gh:*), Read, Grep
-argument-hint: [--dry-run] | [--force] | [--remote-only] | [--local-only]
+argument-hint: "[--dry-run] | [--force] | [--remote-only] | [--local-only]"
 description: Use PROACTIVELY to clean up merged branches, stale remotes, and organize branch structure
 ---
 

--- a/cli-tool/components/commands/git-workflow/commit.md
+++ b/cli-tool/components/commands/git-workflow/commit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git log:*)
-argument-hint: [message] | --no-verify | --amend
+argument-hint: "[message] | --no-verify | --amend"
 description: Create well-formatted commits with conventional commit format and emoji
 ---
 

--- a/cli-tool/components/commands/git-workflow/gemini-review.md
+++ b/cli-tool/components/commands/git-workflow/gemini-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(gh:*), Read, Grep, TodoWrite, Edit, MultiEdit
-argument-hint: [pr-number] | --analyze-only | --preview | --priority high|medium|low
+argument-hint: "[pr-number] | --analyze-only | --preview | --priority high|medium|low"
 description: Transform Gemini Code Assist PR reviews into prioritized TodoLists with automated execution
 model: claude-sonnet-4-5-20250929
 ---

--- a/cli-tool/components/commands/git-workflow/git-bisect-helper.md
+++ b/cli-tool/components/commands/git-workflow/git-bisect-helper.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git bisect:*), Bash(git log:*), Bash(git show:*), Bash(git checkout:*), Bash(npm:*), Bash(yarn:*), Bash(pnpm:*), Read, Edit, Grep
-argument-hint: [good-commit] [bad-commit] | --auto [test-command] | --reset | --continue
+argument-hint: "[good-commit] [bad-commit] | --auto [test-command] | --reset | --continue"
 description: Use PROACTIVELY to guide automated git bisect sessions for finding regression commits with smart test execution
 ---
 

--- a/cli-tool/components/commands/git/finish.md
+++ b/cli-tool/components/commands/git/finish.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git:*), Read, Edit
-argument-hint: [--no-delete] [--no-tag]
+argument-hint: "[--no-delete] [--no-tag]"
 description: Complete and merge current Git Flow branch (feature/release/hotfix) with proper cleanup and tagging
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-admin-reports.md
+++ b/cli-tool/components/commands/google-workspace/gws-admin-reports.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Admin SDK: Audit logs and usage reports.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-admin.md
+++ b/cli-tool/components/commands/google-workspace/gws-admin.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Admin SDK: Manage users, groups, and devices.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-alertcenter.md
+++ b/cli-tool/components/commands/google-workspace/gws-alertcenter.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Alert Center: Manage Workspace security alerts.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-apps-script-push.md
+++ b/cli-tool/components/commands/google-workspace/gws-apps-script-push.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Apps Script: Upload local files to an Apps Script project.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-apps-script.md
+++ b/cli-tool/components/commands/google-workspace/gws-apps-script.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Apps Script: Manage and execute Apps Script projects.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-calendar-agenda.md
+++ b/cli-tool/components/commands/google-workspace/gws-calendar-agenda.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Calendar: Show upcoming events across all calendars.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-calendar-insert.md
+++ b/cli-tool/components/commands/google-workspace/gws-calendar-insert.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Calendar: Create a new event.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-calendar.md
+++ b/cli-tool/components/commands/google-workspace/gws-calendar.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Calendar: Manage calendars and events.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-chat-send.md
+++ b/cli-tool/components/commands/google-workspace/gws-chat-send.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Chat: Send a message to a space.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-chat.md
+++ b/cli-tool/components/commands/google-workspace/gws-chat.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Chat: Manage Chat spaces and messages.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-classroom.md
+++ b/cli-tool/components/commands/google-workspace/gws-classroom.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Classroom: Manage classes, rosters, and coursework.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-cloudidentity.md
+++ b/cli-tool/components/commands/google-workspace/gws-cloudidentity.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Cloud Identity: Manage identity groups and memberships.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-docs-write.md
+++ b/cli-tool/components/commands/google-workspace/gws-docs-write.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Docs: Append text to a document.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-docs.md
+++ b/cli-tool/components/commands/google-workspace/gws-docs.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Read and write Google Docs.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-drive-upload.md
+++ b/cli-tool/components/commands/google-workspace/gws-drive-upload.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Drive: Upload a file with automatic metadata.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-drive.md
+++ b/cli-tool/components/commands/google-workspace/gws-drive.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Drive: Manage files, folders, and shared drives.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-events-renew.md
+++ b/cli-tool/components/commands/google-workspace/gws-events-renew.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Events: Renew/reactivate Workspace Events subscriptions.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-events-subscribe.md
+++ b/cli-tool/components/commands/google-workspace/gws-events-subscribe.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Events: Subscribe to Workspace events and stream them as NDJSON.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-events.md
+++ b/cli-tool/components/commands/google-workspace/gws-events.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Subscribe to Google Workspace events.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-forms.md
+++ b/cli-tool/components/commands/google-workspace/gws-forms.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Read and write Google Forms.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-gmail-send.md
+++ b/cli-tool/components/commands/google-workspace/gws-gmail-send.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Gmail: Send an email.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-gmail-triage.md
+++ b/cli-tool/components/commands/google-workspace/gws-gmail-triage.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Gmail: Show unread inbox summary (sender, subject, date).
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-gmail-watch.md
+++ b/cli-tool/components/commands/google-workspace/gws-gmail-watch.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Gmail: Watch for new emails and stream them as NDJSON.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-gmail.md
+++ b/cli-tool/components/commands/google-workspace/gws-gmail.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Gmail: Send, read, and manage email.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-groupssettings.md
+++ b/cli-tool/components/commands/google-workspace/gws-groupssettings.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Manage Google Groups settings.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-keep.md
+++ b/cli-tool/components/commands/google-workspace/gws-keep.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Manage Google Keep notes.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-licensing.md
+++ b/cli-tool/components/commands/google-workspace/gws-licensing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Enterprise License Manager: Manage product licenses.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-meet.md
+++ b/cli-tool/components/commands/google-workspace/gws-meet.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Manage Google Meet conferences.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-modelarmor-create-template.md
+++ b/cli-tool/components/commands/google-workspace/gws-modelarmor-create-template.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Model Armor: Create a new Model Armor template.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-modelarmor-sanitize-prompt.md
+++ b/cli-tool/components/commands/google-workspace/gws-modelarmor-sanitize-prompt.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Model Armor: Sanitize a user prompt through a Model Armor template.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-modelarmor-sanitize-response.md
+++ b/cli-tool/components/commands/google-workspace/gws-modelarmor-sanitize-response.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Model Armor: Sanitize a model response through a Model Armor template.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-modelarmor.md
+++ b/cli-tool/components/commands/google-workspace/gws-modelarmor.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Model Armor: Filter user-generated content for safety.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-people.md
+++ b/cli-tool/components/commands/google-workspace/gws-people.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google People: Manage contacts and profiles.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-reseller.md
+++ b/cli-tool/components/commands/google-workspace/gws-reseller.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workspace Reseller: Manage Workspace subscriptions.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-shared.md
+++ b/cli-tool/components/commands/google-workspace/gws-shared.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: gws CLI: Shared patterns for authentication, global flags, and output formatting.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-sheets-append.md
+++ b/cli-tool/components/commands/google-workspace/gws-sheets-append.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Sheets: Append a row to a spreadsheet.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-sheets-read.md
+++ b/cli-tool/components/commands/google-workspace/gws-sheets-read.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Sheets: Read values from a spreadsheet.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-sheets.md
+++ b/cli-tool/components/commands/google-workspace/gws-sheets.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Sheets: Read and write spreadsheets.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-slides.md
+++ b/cli-tool/components/commands/google-workspace/gws-slides.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Slides: Read and write presentations.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-tasks.md
+++ b/cli-tool/components/commands/google-workspace/gws-tasks.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Tasks: Manage task lists and tasks.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-vault.md
+++ b/cli-tool/components/commands/google-workspace/gws-vault.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Vault: Manage eDiscovery holds and exports.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow-email-to-task.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow-email-to-task.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Convert a Gmail message into a Google Tasks entry.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow-file-announce.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow-file-announce.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Announce a Drive file in a Chat space.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow-meeting-prep.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow-meeting-prep.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Prepare for your next meeting: agenda, attendees, and linked docs.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow-standup-report.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow-standup-report.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Today's meetings + open tasks as a standup summary.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow-weekly-digest.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow-weekly-digest.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Weekly summary: this week's meetings + unread email count.
 ---
 

--- a/cli-tool/components/commands/google-workspace/gws-workflow.md
+++ b/cli-tool/components/commands/google-workspace/gws-workflow.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [resource] [method] [flags]
+argument-hint: "[resource] [method] [flags]"
 description: Google Workflow: Cross-service productivity workflows.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-content-creator.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-content-creator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Create, organize, and distribute content across Workspace.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-customer-support.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-customer-support.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Manage customer support — track tickets, respond, escalate issues.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-event-coordinator.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-event-coordinator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Plan and manage events — scheduling, invitations, and logistics.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-exec-assistant.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-exec-assistant.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Manage an executive's schedule, inbox, and communications.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-hr-coordinator.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-hr-coordinator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Handle HR workflows — onboarding, announcements, and employee comms.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-it-admin.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-it-admin.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Administer IT — manage users, monitor security, configure Workspace.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-project-manager.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-project-manager.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Coordinate projects — track tasks, schedule meetings, and share docs.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-researcher.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-researcher.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Organize research — manage references, notes, and collaboration.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-sales-ops.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-sales-ops.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Manage sales workflows — track deals, schedule calls, client comms.
 ---
 

--- a/cli-tool/components/commands/google-workspace/personas/persona-team-lead.md
+++ b/cli-tool/components/commands/google-workspace/personas/persona-team-lead.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 description: Lead a team — run standups, coordinate tasks, and communicate.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-audit-external-sharing.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-audit-external-sharing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find and review Google Drive files shared outside the organization.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-backup-sheet-as-csv.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-backup-sheet-as-csv.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Export a Google Sheets spreadsheet as a CSV file for local backup or processing.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-batch-invite-to-event.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-batch-invite-to-event.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Add a list of attendees to an existing Google Calendar event and send notifications.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-batch-rename-files.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-batch-rename-files.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Rename multiple Google Drive files matching a pattern to follow a consistent naming convention.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-batch-reply-to-emails.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-batch-reply-to-emails.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find Gmail messages matching a query and send a standard reply to each one.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-block-focus-time.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-block-focus-time.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create recurring focus time blocks on Google Calendar to protect deep work hours.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-bulk-download-folder.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-bulk-download-folder.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: List and download all files from a Google Drive folder.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-cancel-and-notify.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-cancel-and-notify.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Delete a Google Calendar event and send a cancellation email via Gmail.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-collect-form-responses.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-collect-form-responses.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Retrieve and review responses from a Google Form.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-compare-sheet-tabs.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-compare-sheet-tabs.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Read data from two tabs in a Google Sheet to compare and identify differences.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-copy-sheet-for-new-month.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-copy-sheet-for-new-month.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Duplicate a Google Sheets template tab for a new month of tracking.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-classroom-course.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-classroom-course.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Classroom course and invite students.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-doc-from-template.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-doc-from-template.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Copy a Google Docs template, fill in content, and share with collaborators.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-events-from-sheet.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-events-from-sheet.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Read event data from a Google Sheets spreadsheet and create Google Calendar entries for each row.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-expense-tracker.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-expense-tracker.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Set up a Google Sheets spreadsheet for tracking expenses with headers and initial entries.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-feedback-form.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-feedback-form.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Form for feedback and share it via Gmail.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-gmail-filter.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-gmail-filter.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Gmail filter to automatically label, star, or categorize incoming messages.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-meet-space.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-meet-space.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Meet meeting space and share the join link.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-presentation.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-presentation.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a new Google Slides presentation and add initial slides.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-shared-drive.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-shared-drive.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Shared Drive and add members with appropriate roles.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-task-list.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-task-list.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Set up a new Google Tasks list with initial tasks.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-create-vacation-responder.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-create-vacation-responder.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Enable a Gmail out-of-office auto-reply with a custom message and date range.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-deploy-apps-script.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-deploy-apps-script.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Push local files to a Google Apps Script project.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-draft-email-from-doc.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-draft-email-from-doc.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Read content from a Google Doc and use it as the body of a Gmail message.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-email-drive-link.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-email-drive-link.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Share a Google Drive file and email the link with a message to recipients.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-find-free-time.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-find-free-time.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Query Google Calendar free/busy status for multiple users to find a meeting slot.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-find-large-files.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-find-large-files.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Identify large Google Drive files consuming storage quota.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-forward-labeled-emails.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-forward-labeled-emails.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find Gmail messages with a specific label and forward them to another address.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-generate-report-from-sheet.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-generate-report-from-sheet.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Read data from a Google Sheet and create a formatted Google Docs report.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-label-and-archive-emails.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-label-and-archive-emails.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Apply Gmail labels to matching messages and archive them to keep your inbox clean.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-log-deal-update.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-log-deal-update.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Append a deal status update to a Google Sheets sales tracking spreadsheet.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-organize-drive-folder.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-organize-drive-folder.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Drive folder structure and move files into the right locations.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-plan-weekly-schedule.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-plan-weekly-schedule.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Review your Google Calendar week, identify gaps, and add events to fill them.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-post-mortem-setup.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-post-mortem-setup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a Google Docs post-mortem, schedule a Google Calendar review, and notify via Chat.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-reschedule-meeting.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-reschedule-meeting.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Move a Google Calendar event to a new time and automatically notify all attendees.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-review-meet-participants.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-review-meet-participants.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Review who attended a Google Meet conference and for how long.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-review-overdue-tasks.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-review-overdue-tasks.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find Google Tasks that are past due and need attention.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-save-email-attachments.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-save-email-attachments.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find Gmail messages with attachments and save them to a Google Drive folder.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-save-email-to-doc.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-save-email-to-doc.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Save a Gmail message body into a Google Doc for archival or reference.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-schedule-recurring-event.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-schedule-recurring-event.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Create a recurring Google Calendar event with attendees.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-search-and-export-emails.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-search-and-export-emails.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Find Gmail messages matching a query and export them for review.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-send-personalized-emails.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-send-personalized-emails.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Read recipient data from Google Sheets and send personalized Gmail messages to each row.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-send-team-announcement.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-send-team-announcement.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Send a team announcement via both Gmail and a Google Chat space.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-share-doc-and-notify.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-share-doc-and-notify.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Share a Google Docs document with edit access and email collaborators the link.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-share-event-materials.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-share-event-materials.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Share Google Drive files with all attendees of a Google Calendar event.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-share-folder-with-team.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-share-folder-with-team.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Share a Google Drive folder and all its contents with a list of collaborators.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-sync-contacts-to-sheet.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-sync-contacts-to-sheet.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Export Google Contacts directory to a Google Sheets spreadsheet.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-transfer-file-ownership.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-transfer-file-ownership.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Transfer ownership of Google Drive files from one user to another.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-triage-security-alerts.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-triage-security-alerts.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: List and review Google Workspace security alerts from Alert Center.
 ---
 

--- a/cli-tool/components/commands/google-workspace/recipes/recipe-watch-drive-changes.md
+++ b/cli-tool/components/commands/google-workspace/recipes/recipe-watch-drive-changes.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Write, Edit
-argument-hint: [task-parameters]
+argument-hint: "[task-parameters]"
 description: Subscribe to change notifications on a Google Drive file or folder.
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-api-tester.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-api-tester.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [route-path] [--method=GET] [--data='{}'] [--headers='{}']
+argument-hint: "[route-path] [--method=GET] [--data='{}'] [--headers='{}']"
 description: Test and validate Next.js API routes with comprehensive test scenarios
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-bundle-analyzer.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-bundle-analyzer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [--build] [--analyze] [--report]
+argument-hint: "[--build] [--analyze] [--report]"
 description: Analyze and optimize Next.js bundle size with detailed recommendations
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-component-generator.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-component-generator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit
-argument-hint: [component-name] [--client] [--server] [--page] [--layout]
+argument-hint: "[component-name] [--client] [--server] [--page] [--layout]"
 description: Generate optimized React components for Next.js with TypeScript and best practices
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-middleware-creator.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-middleware-creator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit
-argument-hint: [middleware-type] [--auth] [--rate-limit] [--redirect] [--rewrite]
+argument-hint: "[middleware-type] [--auth] [--rate-limit] [--redirect] [--rewrite]"
 description: Create optimized Next.js middleware with authentication, rate limiting, and routing logic
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-migration-helper.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-migration-helper.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
-argument-hint: [--pages-to-app] [--js-to-ts] [--class-to-hooks] [--analyze]
+argument-hint: "[--pages-to-app] [--js-to-ts] [--class-to-hooks] [--analyze]"
 description: Comprehensive Next.js migration assistant for Pages Router to App Router, JavaScript to TypeScript, and modern patterns
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-performance-audit.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-performance-audit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [--lighthouse] [--bundle] [--runtime] [--all]
+argument-hint: "[--lighthouse] [--bundle] [--runtime] [--all]"
 description: Comprehensive Next.js performance audit with actionable optimization recommendations
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/nextjs-scaffold.md
+++ b/cli-tool/components/commands/nextjs-vercel/nextjs-scaffold.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [project-name] [--typescript] [--tailwind] [--app-router]
+argument-hint: "[project-name] [--typescript] [--tailwind] [--app-router]"
 description: Create a new Next.js application with best practices and optimal configuration
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/vercel-deploy-optimize.md
+++ b/cli-tool/components/commands/nextjs-vercel/vercel-deploy-optimize.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [environment] [--analyze] [--preview]
+argument-hint: "[environment] [--analyze] [--preview]"
 description: Optimize and deploy Next.js application to Vercel with performance monitoring
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/vercel-edge-function.md
+++ b/cli-tool/components/commands/nextjs-vercel/vercel-edge-function.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit
-argument-hint: [function-name] [--auth] [--geo] [--transform] [--proxy]
+argument-hint: "[function-name] [--auth] [--geo] [--transform] [--proxy]"
 description: Generate optimized Vercel Edge Functions with geolocation, authentication, and data transformation
 ---
 

--- a/cli-tool/components/commands/nextjs-vercel/vercel-env-sync.md
+++ b/cli-tool/components/commands/nextjs-vercel/vercel-env-sync.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [--pull] [--push] [--validate] [--backup]
+argument-hint: "[--pull] [--push] [--validate] [--backup]"
 description: Synchronize environment variables between local development and Vercel deployments
 ---
 

--- a/cli-tool/components/commands/performance/add-performance-monitoring.md
+++ b/cli-tool/components/commands/performance/add-performance-monitoring.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [monitoring-type] | --apm | --rum | --custom
+argument-hint: "[monitoring-type] | --apm | --rum | --custom"
 description: Setup comprehensive application performance monitoring with metrics, alerting, and observability
 ---
 

--- a/cli-tool/components/commands/performance/implement-caching-strategy.md
+++ b/cli-tool/components/commands/performance/implement-caching-strategy.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [cache-type] | --browser | --application | --database
+argument-hint: "[cache-type] | --browser | --application | --database"
 description: Design and implement comprehensive caching solutions for improved performance and scalability
 ---
 

--- a/cli-tool/components/commands/performance/optimize-api-performance.md
+++ b/cli-tool/components/commands/performance/optimize-api-performance.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [api-type] | --rest | --graphql | --grpc
+argument-hint: "[api-type] | --rest | --graphql | --grpc"
 description: Comprehensive API performance optimization with response time reduction, throughput improvement, and scalability enhancements
 ---
 

--- a/cli-tool/components/commands/performance/optimize-bundle-size.md
+++ b/cli-tool/components/commands/performance/optimize-bundle-size.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [build-tool] | --webpack | --vite | --rollup
+argument-hint: "[build-tool] | --webpack | --vite | --rollup"
 description: Reduce and optimize bundle sizes through analysis, configuration, and code splitting strategies
 ---
 

--- a/cli-tool/components/commands/performance/optimize-database-performance.md
+++ b/cli-tool/components/commands/performance/optimize-database-performance.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [database-type] | --postgresql | --mysql | --mongodb
+argument-hint: "[database-type] | --postgresql | --mysql | --mongodb"
 description: Optimize database queries, indexing, and performance for improved response times and scalability
 ---
 

--- a/cli-tool/components/commands/performance/optimize-memory-usage.md
+++ b/cli-tool/components/commands/performance/optimize-memory-usage.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [target-area] | --frontend | --backend | --database
+argument-hint: "[target-area] | --frontend | --backend | --database"
 description: Comprehensive memory usage optimization with leak detection, garbage collection tuning, and memory profiling
 ---
 

--- a/cli-tool/components/commands/performance/performance-audit.md
+++ b/cli-tool/components/commands/performance/performance-audit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [target-area] | --frontend | --backend | --full
+argument-hint: "[target-area] | --frontend | --backend | --full"
 description: Comprehensive performance audit with metrics, bottleneck identification, and optimization recommendations
 ---
 

--- a/cli-tool/components/commands/performance/setup-cdn-optimization.md
+++ b/cli-tool/components/commands/performance/setup-cdn-optimization.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [cdn-provider] | --cloudflare | --aws | --fastly
+argument-hint: "[cdn-provider] | --cloudflare | --aws | --fastly"
 description: Configure CDN for optimal content delivery, caching, and global performance optimization
 ---
 

--- a/cli-tool/components/commands/project-management/add-package.md
+++ b/cli-tool/components/commands/project-management/add-package.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash, Glob
-argument-hint: [package-name] [package-type] | --library | --application | --tool
+argument-hint: "[package-name] [package-type] | --library | --application | --tool"
 description: Add and configure new package to workspace with proper structure and dependencies
 ---
 

--- a/cli-tool/components/commands/project-management/add-to-changelog.md
+++ b/cli-tool/components/commands/project-management/add-to-changelog.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [version] [change-type] [message] | --added | --changed | --fixed
+argument-hint: "[version] [change-type] [message] | --added | --changed | --fixed"
 description: Add entry to project changelog following Keep a Changelog format
 ---
 

--- a/cli-tool/components/commands/project-management/create-feature.md
+++ b/cli-tool/components/commands/project-management/create-feature.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [feature-name] | [feature-type] [name]
+argument-hint: "[feature-name] | [feature-type] [name]"
 description: Scaffold new feature with boilerplate code, tests, and documentation
 ---
 

--- a/cli-tool/components/commands/project-management/create-jtbd.md
+++ b/cli-tool/components/commands/project-management/create-jtbd.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Grep, Glob
-argument-hint: [feature-name] | --template | --interactive
+argument-hint: "[feature-name] | --template | --interactive"
 description: Create Jobs-to-be-Done (JTBD) analysis for product features
 ---
 

--- a/cli-tool/components/commands/project-management/create-prd.md
+++ b/cli-tool/components/commands/project-management/create-prd.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Grep, Glob
-argument-hint: [feature-name] | --template | --interactive
+argument-hint: "[feature-name] | --template | --interactive"
 description: Create Product Requirements Document (PRD) for new features
 ---
 

--- a/cli-tool/components/commands/project-management/create-prp.md
+++ b/cli-tool/components/commands/project-management/create-prp.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch, Grep, Glob
-argument-hint: [feature-description] | --research | --template | --validate
+argument-hint: "[feature-description] | --research | --template | --validate"
 description: Create comprehensive Product Requirement Prompt (PRP) with research and validation
 ---
 

--- a/cli-tool/components/commands/project-management/init-project.md
+++ b/cli-tool/components/commands/project-management/init-project.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash, Glob
-argument-hint: [project-type] [framework] | --react | --vue | --api | --cli
+argument-hint: "[project-type] [framework] | --react | --vue | --api | --cli"
 description: Initialize new project with essential structure, configuration, and development environment setup
 ---
 

--- a/cli-tool/components/commands/project-management/milestone-tracker.md
+++ b/cli-tool/components/commands/project-management/milestone-tracker.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash, Read, Grep, Glob
-argument-hint: [time-period] | --sprint | --quarter | --all
+argument-hint: "[time-period] | --sprint | --quarter | --all"
 description: Track and analyze project milestone progress with predictive analytics
 ---
 

--- a/cli-tool/components/commands/project-management/pac-configure.md
+++ b/cli-tool/components/commands/project-management/pac-configure.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [project-name] | --minimal | --epic-name | --owner
+argument-hint: "[project-name] | --minimal | --epic-name | --owner"
 description: Initialize Product as Code (PAC) project structure with templates and configuration
 ---
 

--- a/cli-tool/components/commands/project-management/pac-create-epic.md
+++ b/cli-tool/components/commands/project-management/pac-create-epic.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [epic-name] | --name | --description | --owner
+argument-hint: "[epic-name] | --name | --description | --owner"
 description: Create new PAC epic following Product as Code specification
 ---
 

--- a/cli-tool/components/commands/project-management/pac-create-ticket.md
+++ b/cli-tool/components/commands/project-management/pac-create-ticket.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [ticket-name] | --epic | --type | --assignee | --priority
+argument-hint: "[ticket-name] | --epic | --type | --assignee | --priority"
 description: Create new PAC ticket within an epic following Product as Code specification
 ---
 

--- a/cli-tool/components/commands/project-management/pac-update-status.md
+++ b/cli-tool/components/commands/project-management/pac-update-status.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [ticket-id] | --status | --assignee | --comment
+argument-hint: "[ticket-id] | --status | --assignee | --comment"
 description: Update PAC ticket status and track progress in Product as Code workflow
 ---
 

--- a/cli-tool/components/commands/project-management/pac-validate.md
+++ b/cli-tool/components/commands/project-management/pac-validate.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash
-argument-hint: [scope] | --file | --epic | --fix | --pre-commit
+argument-hint: "[scope] | --file | --epic | --fix | --pre-commit"
 description: Validate Product as Code project structure and files for PAC specification compliance
 ---
 

--- a/cli-tool/components/commands/project-management/project-health-check.md
+++ b/cli-tool/components/commands/project-management/project-health-check.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [evaluation-period] | --30-days | --sprint | --quarter
+argument-hint: "[evaluation-period] | --30-days | --sprint | --quarter"
 description: Analyze overall project health and generate comprehensive metrics report
 ---
 

--- a/cli-tool/components/commands/project-management/project-timeline-simulator.md
+++ b/cli-tool/components/commands/project-management/project-timeline-simulator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [project-type] | --duration | --team-size | --risk-level
+argument-hint: "[project-type] | --duration | --team-size | --risk-level"
 description: Simulate project outcomes with variable modeling, risk assessment, and resource optimization
 ---
 

--- a/cli-tool/components/commands/project-management/project-to-linear.md
+++ b/cli-tool/components/commands/project-management/project-to-linear.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [project-description] | --team-id | --create-new | --epic-name
+argument-hint: "[project-description] | --team-id | --create-new | --epic-name"
 description: Sync project structure and requirements to Linear workspace with comprehensive task breakdown
 ---
 

--- a/cli-tool/components/commands/project-management/release.md
+++ b/cli-tool/components/commands/project-management/release.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [version-type] | --patch | --minor | --major | --prerelease
+argument-hint: "[version-type] | --patch | --minor | --major | --prerelease"
 description: Prepare and execute project release with version management and changelog updates
 ---
 

--- a/cli-tool/components/commands/project-management/todo.md
+++ b/cli-tool/components/commands/project-management/todo.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit
-argument-hint: [action] [task-description] | add | complete | remove | list
+argument-hint: "[action] [task-description] | add | complete | remove | list"
 description: Manage project todos in todos.md file
 ---
 

--- a/cli-tool/components/commands/security/add-authentication-system.md
+++ b/cli-tool/components/commands/security/add-authentication-system.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [auth-method] | --oauth | --jwt | --mfa | --passwordless
+argument-hint: "[auth-method] | --oauth | --jwt | --mfa | --passwordless"
 description: Implement secure user authentication system with chosen method and security best practices
 ---
 

--- a/cli-tool/components/commands/security/dependency-audit.md
+++ b/cli-tool/components/commands/security/dependency-audit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep
-argument-hint: [scope] | --security | --licenses | --updates | --all
+argument-hint: "[scope] | --security | --licenses | --updates | --all"
 description: Audit dependencies for security vulnerabilities, license compliance, and update recommendations
 ---
 

--- a/cli-tool/components/commands/security/penetration-test.md
+++ b/cli-tool/components/commands/security/penetration-test.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [target] | --web-app | --api | --auth | --full-scan
+argument-hint: "[target] | --web-app | --api | --auth | --full-scan"
 description: Perform penetration testing and vulnerability assessment on application
 ---
 

--- a/cli-tool/components/commands/security/secrets-scanner.md
+++ b/cli-tool/components/commands/security/secrets-scanner.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [scope] | --api-keys | --passwords | --certificates | --fix
+argument-hint: "[scope] | --api-keys | --passwords | --certificates | --fix"
 description: Scan codebase for exposed secrets, credentials, and sensitive information
 ---
 

--- a/cli-tool/components/commands/security/security-audit.md
+++ b/cli-tool/components/commands/security/security-audit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [focus-area] | --full
+argument-hint: "[focus-area] | --full"
 description: Perform comprehensive security assessment and vulnerability analysis
 ---
 

--- a/cli-tool/components/commands/security/security-hardening.md
+++ b/cli-tool/components/commands/security/security-hardening.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [focus-area] | --headers | --auth | --encryption | --infrastructure
+argument-hint: "[focus-area] | --headers | --auth | --encryption | --infrastructure"
 description: Harden application security configuration with comprehensive security controls
 ---
 

--- a/cli-tool/components/commands/setup/create-database-migrations.md
+++ b/cli-tool/components/commands/setup/create-database-migrations.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-name] | --create-table | --add-column | --alter-table
+argument-hint: "[migration-name] | --create-table | --add-column | --alter-table"
 description: Create and manage database migrations with proper versioning and rollback support
 ---
 

--- a/cli-tool/components/commands/setup/design-database-schema.md
+++ b/cli-tool/components/commands/setup/design-database-schema.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [schema-type] | --relational | --nosql | --hybrid | --normalize
+argument-hint: "[schema-type] | --relational | --nosql | --hybrid | --normalize"
 description: Design optimized database schemas with proper relationships, constraints, and performance considerations
 ---
 

--- a/cli-tool/components/commands/setup/design-rest-api.md
+++ b/cli-tool/components/commands/setup/design-rest-api.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [api-version] | --v1 | --v2 | --graphql-hybrid | --openapi
+argument-hint: "[api-version] | --v1 | --v2 | --graphql-hybrid | --openapi"
 description: Design RESTful API architecture with comprehensive endpoints, authentication, and documentation
 ---
 

--- a/cli-tool/components/commands/setup/implement-graphql-api.md
+++ b/cli-tool/components/commands/setup/implement-graphql-api.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [schema-approach] | --schema-first | --code-first | --federation
+argument-hint: "[schema-approach] | --schema-first | --code-first | --federation"
 description: Implement GraphQL API with comprehensive schema, resolvers, and real-time subscriptions
 ---
 

--- a/cli-tool/components/commands/setup/migrate-to-typescript.md
+++ b/cli-tool/components/commands/setup/migrate-to-typescript.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-strategy] | --gradual | --complete | --strict | --incremental
+argument-hint: "[migration-strategy] | --gradual | --complete | --strict | --incremental"
 description: Migrate JavaScript project to TypeScript with proper typing and tooling setup
 ---
 

--- a/cli-tool/components/commands/setup/setup-ci-cd-pipeline.md
+++ b/cli-tool/components/commands/setup/setup-ci-cd-pipeline.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [platform] | --github-actions | --gitlab-ci | --azure-pipelines | --jenkins
+argument-hint: "[platform] | --github-actions | --gitlab-ci | --azure-pipelines | --jenkins"
 description: Setup comprehensive CI/CD pipeline with automated testing, deployment, and monitoring
 ---
 

--- a/cli-tool/components/commands/setup/setup-development-environment.md
+++ b/cli-tool/components/commands/setup/setup-development-environment.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [environment-type] | --local | --docker | --cloud | --full-stack
+argument-hint: "[environment-type] | --local | --docker | --cloud | --full-stack"
 description: Setup comprehensive development environment with tools, configurations, and workflows
 ---
 

--- a/cli-tool/components/commands/setup/setup-docker-containers.md
+++ b/cli-tool/components/commands/setup/setup-docker-containers.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [environment-type] | --development | --production | --microservices | --compose
+argument-hint: "[environment-type] | --development | --production | --microservices | --compose"
 description: Setup Docker containerization with multi-stage builds and development workflows
 ---
 

--- a/cli-tool/components/commands/setup/setup-formatting.md
+++ b/cli-tool/components/commands/setup/setup-formatting.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [language] | --javascript | --typescript | --python | --multi-language
+argument-hint: "[language] | --javascript | --typescript | --python | --multi-language"
 description: Configure comprehensive code formatting tools with consistent style enforcement
 ---
 

--- a/cli-tool/components/commands/setup/setup-linting.md
+++ b/cli-tool/components/commands/setup/setup-linting.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [language] | --javascript | --typescript | --python | --multi-language
+argument-hint: "[language] | --javascript | --typescript | --python | --multi-language"
 description: Configure comprehensive code linting and quality analysis tools with automated enforcement
 ---
 

--- a/cli-tool/components/commands/setup/setup-monitoring-observability.md
+++ b/cli-tool/components/commands/setup/setup-monitoring-observability.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [monitoring-type] | --metrics | --logging | --tracing | --full-stack
+argument-hint: "[monitoring-type] | --metrics | --logging | --tracing | --full-stack"
 description: Setup comprehensive monitoring and observability with metrics, logging, tracing, and alerting
 ---
 

--- a/cli-tool/components/commands/setup/setup-monorepo.md
+++ b/cli-tool/components/commands/setup/setup-monorepo.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [monorepo-tool] | --nx | --lerna | --rush | --turborepo | --yarn-workspaces
+argument-hint: "[monorepo-tool] | --nx | --lerna | --rush | --turborepo | --yarn-workspaces"
 description: Configure monorepo project structure with comprehensive workspace management and build orchestration
 ---
 

--- a/cli-tool/components/commands/setup/setup-rate-limiting.md
+++ b/cli-tool/components/commands/setup/setup-rate-limiting.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [rate-limit-type] | --api | --authentication | --file-upload | --database
+argument-hint: "[rate-limit-type] | --api | --authentication | --file-upload | --database"
 description: Implement comprehensive API rate limiting with advanced algorithms and user-specific policies
 ---
 

--- a/cli-tool/components/commands/setup/update-dependencies.md
+++ b/cli-tool/components/commands/setup/update-dependencies.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [update-strategy] | --patch | --minor | --major | --security-only
+argument-hint: "[update-strategy] | --patch | --minor | --major | --security-only"
 description: Update and modernize project dependencies with comprehensive testing and compatibility checks
 ---
 

--- a/cli-tool/components/commands/simulation/business-scenario-explorer.md
+++ b/cli-tool/components/commands/simulation/business-scenario-explorer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [business-context] | --market-expansion | --product-launch | --funding-scenarios
+argument-hint: "[business-context] | --market-expansion | --product-launch | --funding-scenarios"
 description: Explore multiple business timeline scenarios with comprehensive risk analysis and strategic optimization
 ---
 

--- a/cli-tool/components/commands/simulation/constraint-modeler.md
+++ b/cli-tool/components/commands/simulation/constraint-modeler.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [constraint-domain] | --business | --technical | --regulatory | --resource
+argument-hint: "[constraint-domain] | --business | --technical | --regulatory | --resource"
 description: Model system constraints with validation, dependency mapping, and optimization strategies
 ---
 

--- a/cli-tool/components/commands/simulation/decision-tree-explorer.md
+++ b/cli-tool/components/commands/simulation/decision-tree-explorer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [decision-context] | --strategic | --investment | --operational | --crisis-response
+argument-hint: "[decision-context] | --strategic | --investment | --operational | --crisis-response"
 description: Explore complex decision branches with probability analysis, expected value calculation, and optimization
 ---
 

--- a/cli-tool/components/commands/simulation/digital-twin-creator.md
+++ b/cli-tool/components/commands/simulation/digital-twin-creator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [twin-subject] | --manufacturing | --business-process | --customer-journey | --system-performance
+argument-hint: "[twin-subject] | --manufacturing | --business-process | --customer-journey | --system-performance"
 description: Create calibrated digital twins with real-world validation, scenario testing, and decision optimization
 ---
 

--- a/cli-tool/components/commands/simulation/future-scenario-generator.md
+++ b/cli-tool/components/commands/simulation/future-scenario-generator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [time-horizon] | --near-term | --medium-term | --long-term | --disruption-focus
+argument-hint: "[time-horizon] | --near-term | --medium-term | --long-term | --disruption-focus"
 description: Generate comprehensive future scenarios with plausibility scoring, trend integration, and strategic implications
 ---
 

--- a/cli-tool/components/commands/simulation/market-response-modeler.md
+++ b/cli-tool/components/commands/simulation/market-response-modeler.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [market-trigger] | --product-launch | --pricing-change | --marketing-campaign | --competitive-response
+argument-hint: "[market-trigger] | --product-launch | --pricing-change | --marketing-campaign | --competitive-response"
 description: Model comprehensive market and customer responses with segment analysis, behavioral prediction, and optimization
 ---
 

--- a/cli-tool/components/commands/simulation/monte-carlo-simulator.md
+++ b/cli-tool/components/commands/simulation/monte-carlo-simulator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [simulation-target] | --financial-projections | --project-timelines | --market-scenarios | --risk-assessment
+argument-hint: "[simulation-target] | --financial-projections | --project-timelines | --market-scenarios | --risk-assessment"
 description: Run Monte Carlo simulations with probability distributions, confidence intervals, and statistical analysis
 ---
 

--- a/cli-tool/components/commands/simulation/simulation-calibrator.md
+++ b/cli-tool/components/commands/simulation/simulation-calibrator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [simulation-type] | --business | --technical | --behavioral | --strategic
+argument-hint: "[simulation-type] | --business | --technical | --behavioral | --strategic"
 description: Calibrate simulation accuracy with systematic validation, bias detection, and continuous improvement
 ---
 

--- a/cli-tool/components/commands/simulation/system-dynamics-modeler.md
+++ b/cli-tool/components/commands/simulation/system-dynamics-modeler.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [system-type] | --business-ecosystem | --organizational-dynamics | --market-evolution | --feedback-loops
+argument-hint: "[system-type] | --business-ecosystem | --organizational-dynamics | --market-evolution | --feedback-loops"
 description: Model complex system dynamics with feedback loops, delays, and emergent behavior analysis
 ---
 

--- a/cli-tool/components/commands/simulation/timeline-compressor.md
+++ b/cli-tool/components/commands/simulation/timeline-compressor.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, WebSearch
-argument-hint: [timeline-type] | --product-development | --market-adoption | --business-transformation | --competitive-response
+argument-hint: "[timeline-type] | --product-development | --market-adoption | --business-transformation | --competitive-response"
 description: Compress real-world timelines into rapid simulation cycles with accelerated learning and decision optimization
 ---
 

--- a/cli-tool/components/commands/svelte/svelte-component.md
+++ b/cli-tool/components/commands/svelte/svelte-component.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit
-argument-hint: [component-name] [--typescript] [--story]
+argument-hint: "[component-name] [--typescript] [--story]"
 description: Create new Svelte components with best practices, TypeScript support, and testing
 ---
 

--- a/cli-tool/components/commands/sync/bidirectional-sync.md
+++ b/cli-tool/components/commands/sync/bidirectional-sync.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [sync-mode] | --full | --incremental | --dry-run | --conflict-strategy
+argument-hint: "[sync-mode] | --full | --incremental | --dry-run | --conflict-strategy"
 description: Enable comprehensive bidirectional GitHub-Linear synchronization with conflict resolution
 ---
 

--- a/cli-tool/components/commands/sync/bulk-import-issues.md
+++ b/cli-tool/components/commands/sync/bulk-import-issues.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [import-scope] | --state | --label | --milestone | --batch-size
+argument-hint: "[import-scope] | --state | --label | --milestone | --batch-size"
 description: Bulk import GitHub issues to Linear with comprehensive progress tracking and error handling
 ---
 

--- a/cli-tool/components/commands/sync/cross-reference-manager.md
+++ b/cli-tool/components/commands/sync/cross-reference-manager.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [action] | audit | repair | map | validate | export
+argument-hint: "[action] | audit | repair | map | validate | export"
 description: Manage cross-platform reference links between GitHub and Linear with integrity checking
 ---
 

--- a/cli-tool/components/commands/sync/issue-to-linear-task.md
+++ b/cli-tool/components/commands/sync/issue-to-linear-task.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [issue-number] | --team | --project | --close-github | --skip-comments
+argument-hint: "[issue-number] | --team | --project | --close-github | --skip-comments"
 description: Convert individual GitHub issues to Linear tasks with comprehensive data preservation
 ---
 

--- a/cli-tool/components/commands/sync/linear-task-to-issue.md
+++ b/cli-tool/components/commands/sync/linear-task-to-issue.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [task-id] | --repo | --milestone | --close-linear | --skip-attachments
+argument-hint: "[task-id] | --repo | --milestone | --close-linear | --skip-attachments"
 description: Convert Linear tasks to GitHub issues with relationship preservation and metadata mapping
 ---
 

--- a/cli-tool/components/commands/sync/sync-automation-setup.md
+++ b/cli-tool/components/commands/sync/sync-automation-setup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [setup-mode] | --full | --webhooks-only | --monitoring | --deploy-target
+argument-hint: "[setup-mode] | --full | --webhooks-only | --monitoring | --deploy-target"
 description: Setup comprehensive automated synchronization workflows with monitoring and CI/CD integration
 ---
 

--- a/cli-tool/components/commands/sync/sync-conflict-resolver.md
+++ b/cli-tool/components/commands/sync/sync-conflict-resolver.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [action] | detect | resolve | analyze | configure | report
+argument-hint: "[action] | detect | resolve | analyze | configure | report"
 description: Resolve synchronization conflicts with intelligent strategies and automated resolution
 ---
 

--- a/cli-tool/components/commands/sync/sync-health-monitor.md
+++ b/cli-tool/components/commands/sync/sync-health-monitor.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [scope] | --github | --linear | --webhooks | --performance | --report
+argument-hint: "[scope] | --github | --linear | --webhooks | --performance | --report"
 description: Monitor and diagnose GitHub-Linear sync health with performance analytics and automated troubleshooting
 ---
 

--- a/cli-tool/components/commands/sync/sync-issues-to-linear.md
+++ b/cli-tool/components/commands/sync/sync-issues-to-linear.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [sync-scope] | --state | --label | --assignee | --milestone
+argument-hint: "[sync-scope] | --state | --label | --assignee | --milestone"
 description: Sync GitHub issues to Linear workspace with comprehensive field mapping and rate limit management
 ---
 

--- a/cli-tool/components/commands/sync/sync-linear-to-issues.md
+++ b/cli-tool/components/commands/sync/sync-linear-to-issues.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [sync-scope] | --team | --project | --priority | --states
+argument-hint: "[sync-scope] | --team | --project | --priority | --states"
 description: Sync Linear tasks to GitHub issues with state mapping and attachment handling
 ---
 

--- a/cli-tool/components/commands/sync/sync-migration-assistant.md
+++ b/cli-tool/components/commands/sync/sync-migration-assistant.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-type] | --github-to-linear | --linear-to-github | --bidirectional | --validate
+argument-hint: "[migration-type] | --github-to-linear | --linear-to-github | --bidirectional | --validate"
 description: Comprehensive migration assistant for large-scale GitHub-Linear data transitions with validation and rollback
 ---
 

--- a/cli-tool/components/commands/sync/sync-pr-to-task.md
+++ b/cli-tool/components/commands/sync/sync-pr-to-task.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [pr-number] | --task | --auto-detect | --enable-auto | --update-state
+argument-hint: "[pr-number] | --task | --auto-detect | --enable-auto | --update-state"
 description: Link GitHub pull requests to Linear tasks with automated state synchronization and workflow integration
 ---
 

--- a/cli-tool/components/commands/sync/sync-status.md
+++ b/cli-tool/components/commands/sync/sync-status.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash
-argument-hint: [--detailed] | [--health-check] | [--diagnostics]
+argument-hint: "[--detailed] | [--health-check] | [--diagnostics]"
 description: Monitor GitHub-Linear sync health status with performance metrics and diagnostics
 ---
 

--- a/cli-tool/components/commands/sync/task-from-pr.md
+++ b/cli-tool/components/commands/sync/task-from-pr.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [pr-number] | --team | --estimate | --batch-process | --auto-create
+argument-hint: "[pr-number] | --team | --estimate | --batch-process | --auto-create"
 description: Create Linear tasks from GitHub pull requests with intelligent content extraction and task sizing
 ---
 

--- a/cli-tool/components/commands/team/architecture-review.md
+++ b/cli-tool/components/commands/team/architecture-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Glob, Grep, Bash
-argument-hint: [scope] | --modules | --patterns | --dependencies | --security
+argument-hint: "[scope] | --modules | --patterns | --dependencies | --security"
 description: Comprehensive architecture review with design patterns analysis and improvement recommendations
 ---
 

--- a/cli-tool/components/commands/team/decision-quality-analyzer.md
+++ b/cli-tool/components/commands/team/decision-quality-analyzer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [analysis-type] | --bias-detection | --scenario-testing | --process-optimization | --outcome-tracking
+argument-hint: "[analysis-type] | --bias-detection | --scenario-testing | --process-optimization | --outcome-tracking"
 description: Analyze team decision quality with bias detection, scenario testing, and process improvement recommendations
 ---
 

--- a/cli-tool/components/commands/team/dependency-mapper.md
+++ b/cli-tool/components/commands/team/dependency-mapper.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Glob, Grep, Bash
-argument-hint: [scope] | --tasks | --code | --circular | --critical-path
+argument-hint: "[scope] | --tasks | --code | --circular | --critical-path"
 description: Map project and task dependencies with critical path analysis and circular dependency detection
 ---
 

--- a/cli-tool/components/commands/team/estimate-assistant.md
+++ b/cli-tool/components/commands/team/estimate-assistant.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Glob, Grep
-argument-hint: [task-description] | --historical | --complexity-analysis | --team-velocity | --confidence-intervals
+argument-hint: "[task-description] | --historical | --complexity-analysis | --team-velocity | --confidence-intervals"
 description: Generate accurate task estimates using historical data, complexity analysis, and team velocity metrics
 ---
 

--- a/cli-tool/components/commands/team/issue-triage.md
+++ b/cli-tool/components/commands/team/issue-triage.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Bash
-argument-hint: [scope] | --github-issues | --linear-tasks | --priority-analysis | --team-assignment
+argument-hint: "[scope] | --github-issues | --linear-tasks | --priority-analysis | --team-assignment"
 description: Intelligent issue triage with automatic categorization, prioritization, and team assignment
 ---
 

--- a/cli-tool/components/commands/team/memory-spring-cleaning.md
+++ b/cli-tool/components/commands/team/memory-spring-cleaning.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Glob
-argument-hint: [scope] | --claude-md | --documentation | --outdated-patterns | --implementation-sync
+argument-hint: "[scope] | --claude-md | --documentation | --outdated-patterns | --implementation-sync"
 description: Clean and organize project memory files with implementation synchronization and pattern updates
 ---
 

--- a/cli-tool/components/commands/team/migration-assistant.md
+++ b/cli-tool/components/commands/team/migration-assistant.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [action] | --plan | --analyze | --migrate | --verify | --rollback
+argument-hint: "[action] | --plan | --analyze | --migrate | --verify | --rollback"
 description: Comprehensive system migration assistance with planning, analysis, execution, and rollback capabilities
 ---
 

--- a/cli-tool/components/commands/team/retrospective-analyzer.md
+++ b/cli-tool/components/commands/team/retrospective-analyzer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Bash, Glob
-argument-hint: [sprint-identifier] | --metrics | --insights | --action-items | --trends
+argument-hint: "[sprint-identifier] | --metrics | --insights | --action-items | --trends"
 description: Analyze team retrospectives with quantitative metrics and actionable insights generation
 ---
 

--- a/cli-tool/components/commands/team/session-learning-capture.md
+++ b/cli-tool/components/commands/team/session-learning-capture.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Glob
-argument-hint: [capture-type] | --project-learnings | --implementation-corrections | --structure-insights | --workflow-improvements
+argument-hint: "[capture-type] | --project-learnings | --implementation-corrections | --structure-insights | --workflow-improvements"
 description: Capture and document session learnings with automatic knowledge integration and memory updates
 ---
 

--- a/cli-tool/components/commands/team/sprint-planning.md
+++ b/cli-tool/components/commands/team/sprint-planning.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, WebSearch
-argument-hint: [sprint-duration] | [start-date] [duration]
+argument-hint: "[sprint-duration] | [start-date] [duration]"
 description: Plan and organize sprint workflows with Linear integration and capacity analysis
 ---
 

--- a/cli-tool/components/commands/team/standup-report.md
+++ b/cli-tool/components/commands/team/standup-report.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Glob, Grep
-argument-hint: [time-range] | --yesterday | --last-24h | --since-friday | --custom-range
+argument-hint: "[time-range] | --yesterday | --last-24h | --since-friday | --custom-range"
 description: Generate comprehensive daily standup reports with team activity analysis and progress tracking
 ---
 

--- a/cli-tool/components/commands/team/team-knowledge-mapper.md
+++ b/cli-tool/components/commands/team/team-knowledge-mapper.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Glob, Grep
-argument-hint: [mapping-type] | --skill-matrix | --knowledge-gaps | --expertise-areas | --learning-paths
+argument-hint: "[mapping-type] | --skill-matrix | --knowledge-gaps | --expertise-areas | --learning-paths"
 description: Map team knowledge and expertise with skill gap analysis and learning path recommendations
 ---
 

--- a/cli-tool/components/commands/team/team-velocity-tracker.md
+++ b/cli-tool/components/commands/team/team-velocity-tracker.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Glob, Grep
-argument-hint: [analysis-period] | --sprint | --monthly | --quarterly | --trend-analysis
+argument-hint: "[analysis-period] | --sprint | --monthly | --quarterly | --trend-analysis"
 description: Track and analyze team velocity with predictive forecasting and performance optimization recommendations
 ---
 

--- a/cli-tool/components/commands/team/team-workload-balancer.md
+++ b/cli-tool/components/commands/team/team-workload-balancer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [analysis-type] | --current-workload | --skill-matching | --capacity-planning | --assignment-optimization
+argument-hint: "[analysis-type] | --current-workload | --skill-matching | --capacity-planning | --assignment-optimization"
 description: Analyze and optimize team workload distribution with skill matching and capacity planning
 ---
 

--- a/cli-tool/components/commands/testing/add-mutation-testing.md
+++ b/cli-tool/components/commands/testing/add-mutation-testing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [language] | --javascript | --java | --python | --rust | --go | --csharp
+argument-hint: "[language] | --javascript | --java | --python | --rust | --go | --csharp"
 description: Setup comprehensive mutation testing with framework selection and CI integration
 ---
 

--- a/cli-tool/components/commands/testing/add-property-based-testing.md
+++ b/cli-tool/components/commands/testing/add-property-based-testing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [language] | --javascript | --python | --java | --haskell | --rust | --clojure
+argument-hint: "[language] | --javascript | --python | --java | --haskell | --rust | --clojure"
 description: Implement property-based testing with framework selection and invariant identification
 ---
 

--- a/cli-tool/components/commands/testing/e2e-setup.md
+++ b/cli-tool/components/commands/testing/e2e-setup.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [framework] | --cypress | --playwright | --webdriver | --puppeteer | --mobile
+argument-hint: "[framework] | --cypress | --playwright | --webdriver | --puppeteer | --mobile"
 description: Configure comprehensive end-to-end testing suite with framework selection and CI integration
 ---
 

--- a/cli-tool/components/commands/testing/generate-test-cases.md
+++ b/cli-tool/components/commands/testing/generate-test-cases.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [target] | [scope] | --unit | --integration | --edge-cases | --automatic
+argument-hint: "[target] | [scope] | --unit | --integration | --edge-cases | --automatic"
 description: Generate comprehensive test cases with automatic analysis and coverage optimization
 ---
 

--- a/cli-tool/components/commands/testing/generate-tests.md
+++ b/cli-tool/components/commands/testing/generate-tests.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [file-path] | [component-name]
+argument-hint: "[file-path] | [component-name]"
 description: Generate a complete test file for a specified source file or component. Use when the user explicitly asks to write, create, or generate tests for a specific file.
 ---
 

--- a/cli-tool/components/commands/testing/setup-comprehensive-testing.md
+++ b/cli-tool/components/commands/testing/setup-comprehensive-testing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [scope] | --unit | --integration | --e2e | --visual | --performance | --full-stack
+argument-hint: "[scope] | --unit | --integration | --e2e | --visual | --performance | --full-stack"
 description: Setup complete testing infrastructure with framework configuration and CI integration
 ---
 

--- a/cli-tool/components/commands/testing/setup-load-testing.md
+++ b/cli-tool/components/commands/testing/setup-load-testing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [testing-type] | --capacity | --stress | --spike | --endurance | --volume
+argument-hint: "[testing-type] | --capacity | --stress | --spike | --endurance | --volume"
 description: Configure comprehensive load testing with performance metrics and bottleneck identification
 ---
 

--- a/cli-tool/components/commands/testing/setup-visual-testing.md
+++ b/cli-tool/components/commands/testing/setup-visual-testing.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [testing-scope] | --components | --pages | --responsive | --cross-browser | --accessibility
+argument-hint: "[testing-scope] | --components | --pages | --responsive | --cross-browser | --accessibility"
 description: Setup comprehensive visual regression testing with cross-browser and responsive testing
 ---
 

--- a/cli-tool/components/commands/testing/test-automation-orchestrator.md
+++ b/cli-tool/components/commands/testing/test-automation-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [orchestration-type] | --parallel | --sequential | --conditional | --pipeline-optimization
+argument-hint: "[orchestration-type] | --parallel | --sequential | --conditional | --pipeline-optimization"
 description: Orchestrate comprehensive test automation with intelligent execution and optimization
 ---
 

--- a/cli-tool/components/commands/testing/test-changelog-automation.md
+++ b/cli-tool/components/commands/testing/test-changelog-automation.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [automation-type] | --changelog | --workflow-demo | --ci-integration | --validation
+argument-hint: "[automation-type] | --changelog | --workflow-demo | --ci-integration | --validation"
 description: Automate changelog testing workflow with CI integration and validation
 ---
 

--- a/cli-tool/components/commands/testing/test-coverage.md
+++ b/cli-tool/components/commands/testing/test-coverage.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [coverage-type] | --line | --branch | --function | --statement | --report
+argument-hint: "[coverage-type] | --line | --branch | --function | --statement | --report"
 description: Analyze and improve test coverage with comprehensive reporting and gap identification
 ---
 

--- a/cli-tool/components/commands/testing/test-quality-analyzer.md
+++ b/cli-tool/components/commands/testing/test-quality-analyzer.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [analysis-type] | --coverage-quality | --test-effectiveness | --maintainability | --performance-analysis
+argument-hint: "[analysis-type] | --coverage-quality | --test-effectiveness | --maintainability | --performance-analysis"
 description: Analyze test suite quality with comprehensive metrics and improvement recommendations
 ---
 

--- a/cli-tool/components/commands/testing/testing_plan_integration.md
+++ b/cli-tool/components/commands/testing/testing_plan_integration.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [target-code] | [test-type] | --rust | --inline | --refactoring-suggestions
+argument-hint: "[target-code] | [test-type] | --rust | --inline | --refactoring-suggestions"
 description: Create comprehensive integration testing plan with inline tests and refactoring recommendations
 ---
 

--- a/cli-tool/components/commands/testing/write-tests.md
+++ b/cli-tool/components/commands/testing/write-tests.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [target-file] | [test-type] | --unit | --integration | --e2e | --component
+argument-hint: "[target-file] | [test-type] | --unit | --integration | --e2e | --component"
 description: Write comprehensive unit and integration tests with proper mocking and coverage
 ---
 

--- a/cli-tool/components/commands/utilities/cleanup-cache.md
+++ b/cli-tool/components/commands/utilities/cleanup-cache.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(df:*), Bash(du:*), Bash(npm cache clean:*), Bash(brew cleanup:*), Bash(rm:*), Bash(find:*), Bash(docker system prune:*)
-argument-hint: [--aggressive] | [--maximum]
+argument-hint: "[--aggressive] | [--maximum]"
 description: Clean system caches (npm, Homebrew, Yarn, browsers, Python/ML) to free disk space
 ---
 

--- a/cli-tool/components/commands/utilities/code-review.md
+++ b/cli-tool/components/commands/utilities/code-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Read, Bash, Grep, Glob
-argument-hint: [file-path] | [commit-hash] | --full
+argument-hint: "[file-path] | [commit-hash] | --full"
 description: Comprehensive code quality review with security, performance, and architecture analysis
 ---
 

--- a/cli-tool/components/commands/utilities/ultra-think.md
+++ b/cli-tool/components/commands/utilities/ultra-think.md
@@ -1,6 +1,6 @@
 ---
 description: Multi-framework structured analysis: surfaces hidden assumptions, generates competing solutions, stress-tests each with adversarial reasoning, and delivers confidence-calibrated recommendations
-argument-hint: [problem or question to analyze]
+argument-hint: "[problem or question to analyze]"
 ---
 
 # Deep Analysis and Problem Solving Mode

--- a/cli-tool/components/skills/development/command-creator/README.md
+++ b/cli-tool/components/skills/development/command-creator/README.md
@@ -425,10 +425,11 @@ This skill includes three comprehensive reference files in the `references/` dir
 
 - Use `<angle-brackets>` for **required** arguments
 - Use `[square-brackets]` for **optional** arguments
+- **Always wrap the value in double quotes** — bare `[...]` is a YAML flow sequence (an array), and downstream slash-command loaders (e.g. GitHub Copilot CLI ≥1.0.65) validate `argument-hint` as a string and silently reject the skill otherwise
 - Examples:
-  - `argument-hint: <file-path>` (required)
-  - `argument-hint: [base-branch]` (optional)
-  - `argument-hint: <command> [args...]` (mixed)
+  - `argument-hint: "<file-path>"` (required)
+  - `argument-hint: "[base-branch]"` (optional)
+  - `argument-hint: "<command> [args...]"` (mixed)
 
 ### Agent-Optimized Instructions
 

--- a/cli-tool/components/skills/development/command-creator/README.md
+++ b/cli-tool/components/skills/development/command-creator/README.md
@@ -61,7 +61,7 @@ Slash commands are markdown files stored in `.claude/commands/` (project-level) 
 ```markdown
 ---
 description: Brief description shown in /help (required)
-argument-hint: <placeholder> (optional, if command takes arguments)
+argument-hint: "<placeholder>"  # optional — include only if command takes arguments
 ---
 
 # Command Title

--- a/cli-tool/components/skills/development/command-creator/SKILL.md
+++ b/cli-tool/components/skills/development/command-creator/SKILL.md
@@ -43,7 +43,7 @@ Every slash command is a markdown file with:
 ```markdown
 ---
 description: Brief description shown in /help (required)
-argument-hint: <placeholder> (optional, if command takes arguments)
+argument-hint: "<placeholder>"  # optional — include only if command takes arguments
 ---
 
 # Command Title
@@ -107,7 +107,7 @@ Ask:
 
 If command takes arguments:
 
-- Add `argument-hint: <placeholder>` to frontmatter
+- Add `argument-hint: "<placeholder>"` to frontmatter (always wrap the value in double quotes — bare `[...]` is a YAML flow sequence, which Copilot CLI ≥1.0.65 rejects)
 - Use `<angle-brackets>` for required arguments
 - Use `[square-brackets]` for optional arguments
 

--- a/cli-tool/components/skills/development/command-creator/references/best-practices.md
+++ b/cli-tool/components/skills/development/command-creator/references/best-practices.md
@@ -85,7 +85,7 @@ Use this template structure for comprehensive commands:
 ```markdown
 ---
 description: [One-line description for /help output]
-argument-hint: [<required>] or [[optional]] (omit if no arguments)
+argument-hint: "[<required>] or [[optional]] (omit if no arguments)"
 ---
 
 # [Command Title]

--- a/cli-tool/components/skills/development/command-creator/references/examples.md
+++ b/cli-tool/components/skills/development/command-creator/references/examples.md
@@ -458,7 +458,7 @@ The goal is to create a comprehensive implementation plan that will be saved as 
 ```markdown
 ---
 description: Perform a local code review using repository standards and best practices
-argument-hint: [base-branch]
+argument-hint: "[base-branch]"
 ---
 
 # Codex Review

--- a/cli-tool/components/skills/development/command-creator/references/examples.md
+++ b/cli-tool/components/skills/development/command-creator/references/examples.md
@@ -11,7 +11,7 @@ This document provides complete, real-world examples of slash commands from the 
 ```markdown
 ---
 description: Create git commit and submit stack with Graphite
-argument-hint: <description>
+argument-hint: "<description>"
 ---
 
 # Submit Stack

--- a/cli-tool/components/skills/development/command-development/README.md
+++ b/cli-tool/components/skills/development/command-development/README.md
@@ -117,7 +117,7 @@ Claude loads references and examples as needed based on task.
 ```markdown
 ---
 description: Brief description
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 allowed-tools: Read, Bash(git:*)
 ---
 
@@ -172,7 +172,7 @@ Review this code for quality and potential bugs.
 ```markdown
 ---
 description: Deploy to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Deploy to $1 environment using version $2
@@ -183,7 +183,7 @@ Deploy to $1 environment using version $2
 ```markdown
 ---
 description: Document file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Generate documentation for @$1

--- a/cli-tool/components/skills/development/command-development/SKILL.md
+++ b/cli-tool/components/skills/development/command-development/SKILL.md
@@ -169,7 +169,7 @@ model: haiku
 
 ```yaml
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 ```
 
@@ -201,7 +201,7 @@ Capture all arguments as single string:
 ```markdown
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$ARGUMENTS following our coding standards and best practices.
@@ -226,7 +226,7 @@ Capture individual arguments with `$1`, `$2`, `$3`, etc.:
 ```markdown
 ---
 description: Review PR with priority and assignee
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 ---
 
 Review pull request #$1 with priority level $2.
@@ -271,7 +271,7 @@ Include file contents in command:
 ```markdown
 ---
 description: Review specific file
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Review @$1 for:
@@ -386,7 +386,7 @@ Organize commands in subdirectories:
 
 ```markdown
 ---
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 $IF($1,
@@ -419,7 +419,7 @@ $IF($1,
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 <!--
@@ -457,7 +457,7 @@ Provide specific feedback for each file.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*)
 ---
 
@@ -471,7 +471,7 @@ Analyze results and suggest fixes for failures.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1 including:
@@ -487,7 +487,7 @@ Generate comprehensive documentation for @$1 including:
 ```markdown
 ---
 description: Complete PR workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read
 ---
 
@@ -604,7 +604,7 @@ plugin-name/
 ```markdown
 ---
 description: Deploy using plugin configuration
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -619,7 +619,7 @@ Monitor deployment and report status.
 ```markdown
 ---
 description: Generate docs from template
-argument-hint: [component]
+argument-hint: "[component]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/docs.md
@@ -655,7 +655,7 @@ Launch plugin agents for complex tasks:
 ```markdown
 ---
 description: Deep code review
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate comprehensive review of @$1 using the code-reviewer agent.
@@ -684,7 +684,7 @@ Leverage plugin skills for specialized knowledge:
 ```markdown
 ---
 description: Document API with standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document API in @$1 following plugin standards.
@@ -721,7 +721,7 @@ Combine agents, skills, and scripts:
 ```markdown
 ---
 description: Comprehensive review workflow
-argument-hint: [file]
+argument-hint: "[file]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -757,7 +757,7 @@ Commands should validate inputs and resources before processing.
 ```markdown
 ---
 description: Deploy with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -774,7 +774,7 @@ Otherwise:
 ```markdown
 ---
 description: Process configuration
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file exists: !`test -f $1 && echo "EXISTS" || echo "MISSING"`

--- a/cli-tool/components/skills/development/command-development/examples/plugin-commands.md
+++ b/cli-tool/components/skills/development/command-development/examples/plugin-commands.md
@@ -26,7 +26,7 @@ Practical examples of commands designed for Claude Code plugins, demonstrating p
 ```markdown
 ---
 description: Analyze code quality using plugin tools
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -57,7 +57,7 @@ Review the analysis output and provide:
 ```markdown
 ---
 description: Complete code audit using plugin suite
-argument-hint: [directory]
+argument-hint: "[directory]"
 allowed-tools: Bash(*)
 model: sonnet
 ---
@@ -97,7 +97,7 @@ Analyze all results and create comprehensive report including:
 ```markdown
 ---
 description: Generate API documentation from template
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Template structure: @${CLAUDE_PLUGIN_ROOT}/templates/api-documentation.md
@@ -134,7 +134,7 @@ Format output as markdown suitable for README or docs site.
 ```markdown
 ---
 description: Execute complete release workflow
-argument-hint: [version]
+argument-hint: "[version]"
 allowed-tools: Bash(*), Read
 ---
 
@@ -177,7 +177,7 @@ Review all step outputs and report:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Read, Bash(*)
 ---
 
@@ -218,7 +218,7 @@ Report deployment status and any issues encountered.
 ```markdown
 ---
 description: Deep code review using plugin agent
-argument-hint: [file-or-directory]
+argument-hint: "[file-or-directory]"
 ---
 
 Initiate comprehensive code review of @$1 using the code-reviewer agent.
@@ -255,7 +255,7 @@ Note: This uses the Task tool to launch the plugin's code-reviewer agent for tho
 ```markdown
 ---
 description: Document API following plugin standards
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 API source code: @$1
@@ -295,7 +295,7 @@ Generate production-ready API documentation.
 ```markdown
 ---
 description: Comprehensive review using all plugin components
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 allowed-tools: Bash(node:*), Read
 ---
 
@@ -352,7 +352,7 @@ Include specific file locations and suggested changes for each item.
 ```markdown
 ---
 description: Build for specific environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*)
 ---
 
@@ -397,7 +397,7 @@ If validations fail:
 ```markdown
 ---
 description: Run environment-appropriate checks
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(*), Read
 ---
 

--- a/cli-tool/components/skills/development/command-development/examples/simple-commands.md
+++ b/cli-tool/components/skills/development/command-development/examples/simple-commands.md
@@ -91,7 +91,7 @@ Prioritize issues by severity.
 ```markdown
 ---
 description: Run tests for specific file
-argument-hint: [test-file]
+argument-hint: "[test-file]"
 allowed-tools: Bash(npm:*), Bash(jest:*)
 ---
 
@@ -122,7 +122,7 @@ If failures found, suggest fixes based on error messages.
 ```markdown
 ---
 description: Generate documentation for file
-argument-hint: [source-file]
+argument-hint: "[source-file]"
 ---
 
 Generate comprehensive documentation for @$1
@@ -200,7 +200,7 @@ Provide:
 ```markdown
 ---
 description: Deploy to specified environment
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 allowed-tools: Bash(kubectl:*), Read
 ---
 
@@ -238,7 +238,7 @@ Proceed with deployment? (yes/no)
 ```markdown
 ---
 description: Compare two files
-argument-hint: [file1] [file2]
+argument-hint: "[file1] [file2]"
 ---
 
 Compare @$1 with @$2
@@ -283,7 +283,7 @@ Present as structured comparison report.
 ```markdown
 ---
 description: Quick fix for common issues
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 model: haiku
 ---
 
@@ -319,7 +319,7 @@ Provide code changes with file paths and line numbers.
 ```markdown
 ---
 description: Research best practices for topic
-argument-hint: [topic]
+argument-hint: "[topic]"
 model: sonnet
 ---
 
@@ -364,7 +364,7 @@ Provide actionable guidance based on research.
 ```markdown
 ---
 description: Explain how code works
-argument-hint: [file-or-function]
+argument-hint: "[file-or-function]"
 ---
 
 Explain @$1 in detail
@@ -438,7 +438,7 @@ Analyze and suggest...
 
 ```markdown
 ---
-argument-hint: [target]
+argument-hint: "[target]"
 ---
 
 Process $1...
@@ -450,7 +450,7 @@ Process $1...
 
 ```markdown
 ---
-argument-hint: [source] [target] [options]
+argument-hint: "[source] [target] [options]"
 ---
 
 Process $1 to $2 with $3...

--- a/cli-tool/components/skills/development/command-development/references/advanced-workflows.md
+++ b/cli-tool/components/skills/development/command-development/references/advanced-workflows.md
@@ -15,7 +15,7 @@ Commands that guide users through multi-step processes:
 ```markdown
 ---
 description: Complete PR review workflow
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 allowed-tools: Bash(gh:*), Read, Grep
 ---
 
@@ -132,7 +132,7 @@ Commands that adapt based on conditions:
 ```markdown
 ---
 description: Smart deployment workflow
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Bash(git:*), Bash(npm:*), Read
 ---
 
@@ -454,7 +454,7 @@ Ready for next deployment.
 ```markdown
 ---
 description: Deploy with optional version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Environment: ${1:-staging}
@@ -472,7 +472,7 @@ Note: Using defaults for missing arguments:
 ```markdown
 ---
 description: Deploy to validated environment
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Environment: $1
@@ -494,7 +494,7 @@ Environment validated. Proceeding...
 ```markdown
 ---
 description: Deploy with shorthand
-argument-hint: [env-shorthand]
+argument-hint: "[env-shorthand]"
 ---
 
 Input: $1
@@ -641,7 +641,7 @@ If any step fails, resume with:
 ```markdown
 ---
 description: Initialize deployment
-argument-hint: [environment]
+argument-hint: "[environment]"
 allowed-tools: Write, Bash(git:*)
 ---
 

--- a/cli-tool/components/skills/development/command-development/references/documentation-patterns.md
+++ b/cli-tool/components/skills/development/command-development/references/documentation-patterns.md
@@ -13,7 +13,7 @@ Well-documented commands are easier to use, maintain, and distribute. Documentat
 ```markdown
 ---
 description: Clear, actionable description under 60 chars
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 allowed-tools: Read, Bash(git:*)
 model: sonnet
 ---
@@ -233,7 +233,7 @@ Create a help subcommand for complex commands:
 ```markdown
 ---
 description: Main command with help
-argument-hint: [subcommand] [args]
+argument-hint: "[subcommand] [args]"
 ---
 
 # Command Processor
@@ -273,7 +273,7 @@ Provide help based on context:
 ```markdown
 ---
 description: Context-aware command
-argument-hint: [operation] [target]
+argument-hint: "[operation] [target]"
 ---
 
 # Context-Aware Operation

--- a/cli-tool/components/skills/development/command-development/references/frontmatter-reference.md
+++ b/cli-tool/components/skills/development/command-development/references/frontmatter-reference.md
@@ -11,7 +11,7 @@ YAML frontmatter is optional metadata at the start of command files:
 description: Brief description
 allowed-tools: Read, Write
 model: sonnet
-argument-hint: [arg1] [arg2]
+argument-hint: "[arg1] [arg2]"
 ---
 
 Command prompt content here...
@@ -203,29 +203,29 @@ model: opus
 
 **Format:**
 ```yaml
-argument-hint: [arg1] [arg2] [optional-arg]
+argument-hint: "[arg1] [arg2] [optional-arg]"
 ```
 
 **Examples:**
 
 **Single argument:**
 ```yaml
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ```
 
 **Multiple required arguments:**
 ```yaml
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ```
 
 **Optional arguments:**
 ```yaml
-argument-hint: [file-path] [options]
+argument-hint: "[file-path] [options]"
 ```
 
 **Descriptive names:**
 ```yaml
-argument-hint: [source-branch] [target-branch] [commit-message]
+argument-hint: "[source-branch] [target-branch] [commit-message]"
 ```
 
 **Best practices:**
@@ -241,7 +241,7 @@ argument-hint: [source-branch] [target-branch] [commit-message]
 ```yaml
 ---
 description: Fix issue by number
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 ---
 
 Fix issue #$1...
@@ -251,7 +251,7 @@ Fix issue #$1...
 ```yaml
 ---
 description: Deploy to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 ---
 
 Deploy $1 to $2 using version $3...
@@ -261,7 +261,7 @@ Deploy $1 to $2 using version $3...
 ```yaml
 ---
 description: Run tests with options
-argument-hint: [test-pattern] [options]
+argument-hint: "[test-pattern] [options]"
 ---
 
 Run tests matching $1 with options: $2
@@ -368,7 +368,7 @@ All common fields:
 ```markdown
 ---
 description: Deploy application to environment
-argument-hint: [app-name] [environment] [version]
+argument-hint: "[app-name] [environment] [version]"
 allowed-tools: Bash(kubectl:*), Bash(helm:*), Read
 model: sonnet
 ---
@@ -390,7 +390,7 @@ Restricted invocation:
 ```markdown
 ---
 description: Approve production deployment
-argument-hint: [deployment-id]
+argument-hint: "[deployment-id]"
 disable-model-invocation: true
 allowed-tools: Bash(gh:*)
 ---

--- a/cli-tool/components/skills/development/command-development/references/interactive-commands.md
+++ b/cli-tool/components/skills/development/command-development/references/interactive-commands.md
@@ -875,7 +875,7 @@ Options:
 **Arguments for known values:**
 ```markdown
 ---
-argument-hint: [project-name]
+argument-hint: "[project-name]"
 allowed-tools: AskUserQuestion, Write
 ---
 

--- a/cli-tool/components/skills/development/command-development/references/plugin-features-reference.md
+++ b/cli-tool/components/skills/development/command-development/references/plugin-features-reference.md
@@ -249,7 +249,7 @@ Commands that use plugin templates:
 ```markdown
 ---
 description: Generate documentation from template
-argument-hint: [component-name]
+argument-hint: "[component-name]"
 ---
 
 Template: @${CLAUDE_PLUGIN_ROOT}/templates/component-docs.md
@@ -294,7 +294,7 @@ Commands that adapt to environment:
 ```markdown
 ---
 description: Deploy based on environment
-argument-hint: [dev|staging|prod]
+argument-hint: "[dev|staging|prod]"
 ---
 
 Environment config: @${CLAUDE_PLUGIN_ROOT}/config/$1.json
@@ -336,7 +336,7 @@ Commands can trigger plugin agents using the Task tool:
 ```markdown
 ---
 description: Deep analysis using plugin agent
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Initiate deep code analysis of @$1 using the code-analyzer agent.
@@ -362,7 +362,7 @@ Commands can reference plugin skills for specialized knowledge:
 ```markdown
 ---
 description: API documentation with best practices
-argument-hint: [api-file]
+argument-hint: "[api-file]"
 ---
 
 Document the API in @$1 following our API documentation standards.
@@ -412,7 +412,7 @@ Commands that coordinate multiple plugin components:
 ```markdown
 ---
 description: Comprehensive code review workflow
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 File to review: @$1
@@ -445,7 +445,7 @@ Commands should validate inputs before processing:
 ```markdown
 ---
 description: Deploy to environment with validation
-argument-hint: [environment]
+argument-hint: "[environment]"
 ---
 
 Validate environment: !`echo "$1" | grep -E "^(dev|staging|prod)$" || echo "INVALID"`
@@ -468,7 +468,7 @@ Verify required files exist:
 ```markdown
 ---
 description: Process configuration file
-argument-hint: [config-file]
+argument-hint: "[config-file]"
 ---
 
 Check file: !`test -f $1 && echo "EXISTS" || echo "MISSING"`
@@ -488,7 +488,7 @@ Validate required arguments provided:
 ```markdown
 ---
 description: Create deployment with version
-argument-hint: [environment] [version]
+argument-hint: "[environment] [version]"
 ---
 
 Validate inputs: !`test -n "$1" -a -n "$2" && echo "OK" || echo "MISSING"`
@@ -545,7 +545,7 @@ Handle errors gracefully with helpful messages:
 ```markdown
 ---
 description: Process file with error handling
-argument-hint: [file-path]
+argument-hint: "[file-path]"
 ---
 
 Try processing: !`node ${CLAUDE_PLUGIN_ROOT}/scripts/process.js $1 2>&1 || echo "ERROR: $?"`

--- a/cli-tool/docs_to_claude/COMMANDS_GUIDE.md
+++ b/cli-tool/docs_to_claude/COMMANDS_GUIDE.md
@@ -45,7 +45,7 @@ Each command is defined in a Markdown file with this structure:
 ```markdown
 ---
 allowed-tools: Read, Edit, Bash
-argument-hint: [optional-arg]
+argument-hint: "[optional-arg]"
 description: Brief description of the command
 model: sonnet
 ---
@@ -107,8 +107,8 @@ allowed-tools: Read, Edit, Bash(git add:*), Bash(git status:*)
 Provides autocomplete guidance for command arguments:
 ```yaml
 argument-hint: add [tagId] | remove [tagId] | list
-argument-hint: [issue-number]
-argument-hint: [component-name] [directory]
+argument-hint: "[issue-number]"
+argument-hint: "[component-name] [directory]"
 ```
 
 ### `description` (Optional)
@@ -147,7 +147,7 @@ Capture all arguments passed to the command:
 
 ```markdown
 ---
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 description: Fix GitHub issue following coding standards
 ---
 
@@ -166,7 +166,7 @@ Access specific arguments individually (similar to shell scripts):
 
 ```markdown
 ---
-argument-hint: [pr-number] [priority] [assignee]
+argument-hint: "[pr-number] [priority] [assignee]"
 description: Review pull request with specific priority and assignee
 ---
 
@@ -259,7 +259,7 @@ Analyze the architectural implications of @src/config/architecture.md and provid
 ```markdown
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*)
-argument-hint: [optional-commit-message]
+argument-hint: "[optional-commit-message]"
 description: Create a well-formatted git commit
 model: claude-3-5-sonnet-20241022
 ---
@@ -293,7 +293,7 @@ Commit message should be:
 ```markdown
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [component-name] [directory]
+argument-hint: "[component-name] [directory]"
 description: Generate React component with TypeScript and tests
 model: claude-3-5-sonnet-20241022
 ---
@@ -348,7 +348,7 @@ Follow the existing code patterns from: @src/components/
 ```markdown
 ---
 allowed-tools: Read, Edit, Bash, WebFetch
-argument-hint: [endpoint-path]
+argument-hint: "[endpoint-path]"
 description: Generate comprehensive API tests
 model: claude-3-5-sonnet-20241022
 ---
@@ -546,7 +546,7 @@ model: claude-3-5-sonnet-20241022
 ```markdown
 ---
 allowed-tools: Read, Write, Edit, Bash
-argument-hint: [migration-name]
+argument-hint: "[migration-name]"
 description: Create database migration with rollback
 model: claude-3-5-sonnet-20241022
 ---
@@ -803,10 +803,10 @@ allowed-tools: Read, Write, Edit, Bash, WebFetch, WebSearch, Grep, Glob
 ### 4. Argument Design
 ```yaml
 # ✅ Clear argument guidance
-argument-hint: [component-name] [directory] [--typescript]
+argument-hint: "[component-name] [directory] [--typescript]"
 
 # ❌ Vague guidance  
-argument-hint: [options]
+argument-hint: "[options]"
 ```
 
 ### 5. Command Testing


### PR DESCRIPTION
Closes #708. Extends the same fix pattern the maintainer already accepted in #147, to every remaining file.

## What & why

275 files declared `argument-hint` in YAML **flow-sequence** (bare-bracket) syntax:

```yaml
---
argument-hint: [feature-name] | --template | --interactive
---
```

That value is parsed by YAML as an **array of strings**, not a string. GitHub Copilot CLI ≥ 1.0.65 validates `argument-hint` as a string and **silently drops the whole SKILL** when the type check fails — the slash command disappears from the CLI menu. Claude Code currently renders the concatenated array (works, "incorrectly typed"), but the [analogous latent bug](https://github.com/anthropics/claude-code/issues/22161) is one colon away from becoming an unrecoverable TUI hang. All 275 here are the safer bare-bracket form; none use `[foo: bar]`.

## What changed

Purely mechanical single-character transform, applied to 275 files, 344 lines:

```diff
- argument-hint: [feature-name] | --template | --interactive
+ argument-hint: "[feature-name] | --template | --interactive"
```

### By category

| Directory | Files |
|---|---|
| `cli-tool/components/commands/google-workspace` | 107 |
| `cli-tool/components/commands/project-management` | 18 |
| `cli-tool/components/commands/testing` | 14 |
| `cli-tool/components/commands/team` | 14 |
| `cli-tool/components/commands/sync` | 14 |
| `cli-tool/components/commands/setup` | 14 |
| `cli-tool/components/commands/deployment` | 11 |
| `cli-tool/components/commands/simulation` | 10 |
| `cli-tool/components/commands/nextjs-vercel` | 10 |
| `cli-tool/components/commands/documentation` | 9 |
| `cli-tool/components/commands/performance` | 8 |
| `cli-tool/components/commands/database` | 8 |
| `cli-tool/components/commands/security` | 6 |
| `cli-tool/components/commands/game-development` | 5 |
| `cli-tool/components/commands/git-workflow` | 4 |
| `cli-tool/components/commands/automation` | 4 |
| `cli-tool/components/commands/utilities` | 3 |
| `cli-tool/components/commands/svelte`, `.../git` | 1 each |
| **Total command SKILLs** | **266** |
| Documentation/reference files also demonstrating the vulnerable shape in code blocks (`COMMANDS_GUIDE.md` + files under `cli-tool/components/skills/development/command-development/`) | **9** (69 example lines) |

Doc files were included because they were teaching the vulnerable shape to future contributors — anyone reading them and copying the example into a new command would reintroduce the bug.

## Safety

**Pre-fix check:** no vulnerable value contains `"` or `\`, so bare double-quote wrapping is always safe:

```bash
$ rg '^argument-hint:\s*\[.*"' | wc -l
0
```

**Post-fix check:**

```bash
$ rg '^argument-hint:\s*\[' | wc -l
0
```

Ran `yaml.safe_load` on every command file's frontmatter: `argument-hint` parses as `str` in every case where the surrounding YAML parses.

### Pre-existing YAML issue found — flagged for a follow-up

A separate class of unquoted-special-character bug exists in `description:` fields on 42 command files (mostly `google-workspace/gws-*.md`), e.g.:

```yaml
description: Google Chat: Manage Chat spaces and messages.
```

That colon after `Google Chat` breaks YAML parsing of the whole frontmatter, so those files' entire frontmatter is unusable to a strict loader today — a **more severe** version of the same class of bug. It is intentionally **out of scope** for this PR (which matches Issue #708's stated scope of `argument-hint`), but I'm happy to open a follow-up Issue + PR quoting those `description:` values if you'd like.

## Sources

- Your merged PR #147 — same fix, one file.
- [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) — the analogous colon-inside-brackets Ink/React #31 TUI-hang variant.
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — `argument-hint` documented as a string.
- [Claude Code slash-command frontmatter reference](https://code.claude.com/docs/en/slash-commands) — example values shown as strings.
- [Agent Skills base specification](https://agentskills.io/specification) — does not define `argument-hint`; spec-conformant loaders ignore unknown fields, so the type change is inert for platforms outside Claude Code / Copilot CLI.

## Test plan

- [x] `rg '^argument-hint:\s*\[' | wc -l` → 0 in the branch
- [x] `python3 -c "import yaml; yaml.safe_load(open('...').read().split('---')[1])"` on a sample of fixed files reports `str` for `argument-hint`
- [ ] Maintainer: install any command from this branch via `npx claude-code-templates@latest --command <path>` on Copilot CLI 1.0.65+ and verify the slash command appears in `copilot skill list`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quoted all `argument-hint` YAML values and updated all command-creator templates and examples to the quoted form so Copilot CLI ≥1.0.65 treats them as strings and loads every skill. Closes #708.

- **Bug Fixes**
  - Area: components (`cli-tool/components/`), website (`docs/`)
  - Scope: 275 files; wrapped values after `argument-hint:` in quotes; fixed remaining command-creator SKILL/README/examples to show quoted form
  - Impact: `argument-hint` parses as a string; previously hidden commands reappear in Copilot CLI
  - New components: none; catalog `docs/components.json` regen not needed; env/secrets: none

<sup>Written for commit 7305400a6b52b2e2a8d33a8a8018865b6fca1cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

