### PR TITLE
fix(analytics): skip inaccessible transcript entries

### DIFF
--- a/cli-tool/src/analytics/core/ConversationAnalyzer.js
+++ b/cli-tool/src/analytics/core/ConversationAnalyzer.js
@@ -103,10 +103,11 @@ class ConversationAnalyzer {
       
 
       for (const filePath of jsonlFiles) {
-        const stats = await this.getFileStats(filePath);
         const filename = path.basename(filePath);
 
         try {
+          const stats = await this.getFileStats(filePath);
+
           // Extract project name from path
           const projectFromPath = await this.extractProjectFromPath(filePath);
 

--- a/cli-tool/src/analytics/core/ConversationAnalyzer.js
+++ b/cli-tool/src/analytics/core/ConversationAnalyzer.js
@@ -78,7 +78,13 @@ class ConversationAnalyzer {
 
         for (const item of items) {
           const itemPath = path.join(dir, item);
-          const stats = await fs.stat(itemPath);
+          let stats;
+          try {
+            stats = await fs.stat(itemPath);
+          } catch (error) {
+            console.warn(chalk.yellow(`Warning: Could not inspect ${itemPath}:`, error.message));
+            continue;
+          }
 
           if (stats.isDirectory()) {
             // Recursively search subdirectories

--- a/cli-tool/tests/integration/analytics-system.test.js
+++ b/cli-tool/tests/integration/analytics-system.test.js
@@ -93,6 +93,26 @@ describe('Analytics System Integration', () => {
       }
     });
 
+    it('should skip transcripts that disappear after discovery', async () => {
+      const StateCalculator = require('../../src/analytics/core/StateCalculator');
+      const ConversationAnalyzer = require('../../src/analytics/core/ConversationAnalyzer');
+      const analyzer = new ConversationAnalyzer(testDataDir);
+      const originalGetFileStats = analyzer.getFileStats.bind(analyzer);
+
+      jest.spyOn(analyzer, 'getFileStats').mockImplementation(async (filePath) => {
+        if (path.basename(filePath) === 'conversation_1.jsonl') {
+          const error = new Error('file disappeared');
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return originalGetFileStats(filePath);
+      });
+
+      const conversations = await analyzer.loadConversations(new StateCalculator());
+
+      expect(conversations).toHaveLength(2);
+    });
+
     it('should cache data efficiently', async () => {
       const DataCache = require('../../src/analytics/data/DataCache');
       

--- a/cli-tool/tests/integration/analytics-system.test.js
+++ b/cli-tool/tests/integration/analytics-system.test.js
@@ -66,6 +66,33 @@ describe('Analytics System Integration', () => {
       });
     });
 
+    it('should skip inaccessible entries while discovering conversations', async () => {
+      const StateCalculator = require('../../src/analytics/core/StateCalculator');
+      const ConversationAnalyzer = require('../../src/analytics/core/ConversationAnalyzer');
+      const inaccessiblePath = path.join(testDataDir, 'broken-symlink');
+      await fs.writeFile(inaccessiblePath, 'placeholder');
+
+      const originalStat = fs.stat.bind(fs);
+      const statSpy = jest.spyOn(fs, 'stat').mockImplementation(async (itemPath) => {
+        if (itemPath === inaccessiblePath) {
+          const error = new Error('broken symbolic link');
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return originalStat(itemPath);
+      });
+
+      try {
+        const analyzer = new ConversationAnalyzer(testDataDir);
+        const conversations = await analyzer.loadConversations(new StateCalculator());
+
+        expect(conversations.length).toBeGreaterThan(0);
+      } finally {
+        statSpy.mockRestore();
+        await fs.remove(inaccessiblePath);
+      }
+    });
+
     it('should cache data efficiently', async () => {
       const DataCache = require('../../src/analytics/data/DataCache');
       

--- a/cli-tool/tests/integration/analytics-system.test.js
+++ b/cli-tool/tests/integration/analytics-system.test.js
@@ -81,13 +81,18 @@ describe('Analytics System Integration', () => {
         }
         return originalStat(itemPath);
       });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       try {
         const analyzer = new ConversationAnalyzer(testDataDir);
         const conversations = await analyzer.loadConversations(new StateCalculator());
 
         expect(conversations.length).toBeGreaterThan(0);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toEqual(expect.stringContaining(inaccessiblePath));
+        expect(warnSpy.mock.calls[0][0]).toEqual(expect.stringContaining('broken symbolic link'));
       } finally {
+        warnSpy.mockRestore();
         statSpy.mockRestore();
         await fs.remove(inaccessiblePath);
       }


### PR DESCRIPTION
## Summary

- keep recursively discovering Claude conversation transcripts when one filesystem entry cannot be inspected
- add a Windows-relevant regression for a broken/inaccessible symlink alongside valid JSONL files

## Problem

Closes #621.

`ConversationAnalyzer.findJsonlFiles()` previously let any `fs.stat()` failure escape the recursive walker. The outer `loadConversations()` catch then returned an empty array, so one broken symlink or inaccessible entry could make thousands of valid transcripts appear as zero conversations.

Paths containing spaces are already handled by `path.join`; the all-or-nothing error boundary was the failure mode.

## Changes

- catch inspection failures per directory entry
- log the skipped entry and continue walking sibling files/directories
- verify valid transcripts remain discoverable when one entry returns `ENOENT`

## Validation

- `node --check src/analytics/core/ConversationAnalyzer.js`
- `node --check tests/integration/analytics-system.test.js`
- `npx jest tests/integration/analytics-system.test.js --runInBand --testNamePattern "skip inaccessible entries" --coverage=false` (passed)

The full legacy analytics integration file starts server/WebSocket lifecycle cases and did not finish within the local one-minute execution window; the isolated backend regression completes in under two seconds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents analytics from aborting transcript discovery when a file/symlink can’t be inspected or when a transcript disappears after discovery. The scan now logs a warning and skips problematic entries so valid conversations still load on Windows, fixing #621.

- **Bug Fixes**
  - Skip directory entries that throw in fs.stat; warn and continue recursion.
  - Skip transcripts that error in getFileStats during load (e.g., deleted after discovery).
  - Add integration tests for broken symlink (ENOENT) and disappearing transcript; verify warning is emitted for inaccessible entries.
  - Area: CLI (cli-tool/src/analytics/*, tests). No new components; no catalog regen. No new env vars or secrets.

<sup>Written for commit aff9f49fc76ec7413ae50c542f3ede73975c9881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

