### PR TITLE
fix: honor CLAUDE_CONFIG_DIR for user data

### DIFF
--- a/cli-tool/src/analytics.js
+++ b/cli-tool/src/analytics.js
@@ -21,6 +21,7 @@ const NotificationManager = require('./analytics/notifications/NotificationManag
 const PerformanceMonitor = require('./analytics/utils/PerformanceMonitor');
 const ConsoleBridge = require('./console-bridge');
 const ClaudeAPIProxy = require('./claude-api-proxy');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class ClaudeAnalytics {
   constructor(options = {}) {
@@ -85,7 +86,7 @@ class ClaudeAnalytics {
 
   async initialize() {
     const homeDir = os.homedir();
-    this.claudeDir = path.join(homeDir, '.claude');
+    this.claudeDir = getClaudeConfigDir(homeDir);
     this.claudeDesktopDir = path.join(homeDir, 'Library', 'Application Support', 'Claude');
     this.claudeStatsigDir = path.join(this.claudeDir, 'statsig');
 
@@ -1651,7 +1652,7 @@ class ClaudeAnalytics {
     const homeDir = os.homedir();
     
     // Define agent paths (user level and project level)
-    const userAgentsDir = path.join(homeDir, '.claude', 'agents');
+    const userAgentsDir = path.join(getClaudeConfigDir(homeDir), 'agents');
     const projectAgentsDirs = [];
     
     try {

--- a/cli-tool/src/analytics/core/YearInReview2025.js
+++ b/cli-tool/src/analytics/core/YearInReview2025.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
-const os = require('os');
+const { getClaudeConfigDir } = require('../../claude-paths');
 
 /**
  * Year in Review 2025 Analyzer
@@ -573,7 +573,7 @@ class YearInReview2025 {
     const path = require('path');
 
     try {
-      const claudeDir = path.join(os.homedir(), '.claude');
+      const claudeDir = getClaudeConfigDir();
       const localDir = path.join(claudeDir, 'local');
 
       // Check if local directory exists
@@ -657,7 +657,7 @@ class YearInReview2025 {
     const path = require('path');
 
     try {
-      const historyPath = path.join(os.homedir(), '.claude', 'history.jsonl');
+      const historyPath = path.join(getClaudeConfigDir(), 'history.jsonl');
       if (!await fs.pathExists(historyPath)) {
         return { commands: [], total: 0, events: [] };
       }
@@ -720,7 +720,7 @@ class YearInReview2025 {
     const path = require('path');
 
     try {
-      const skillsPath = path.join(os.homedir(), '.claude', 'skills');
+      const skillsPath = path.join(getClaudeConfigDir(), 'skills');
       if (!await fs.pathExists(skillsPath)) {
         return { skills: [], total: 0, events: [] };
       }
@@ -770,7 +770,7 @@ class YearInReview2025 {
     const path = require('path');
 
     try {
-      const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+      const settingsPath = path.join(getClaudeConfigDir(), 'settings.json');
       if (!await fs.pathExists(settingsPath)) {
         return { mcps: [], total: 0, events: [] };
       }

--- a/cli-tool/src/analytics/core/YearInReview2025.js
+++ b/cli-tool/src/analytics/core/YearInReview2025.js
@@ -568,7 +568,6 @@ class YearInReview2025 {
    */
   async detectInstalledComponents() {
     const components = [];
-    const os = require('os');
     const fs = require('fs-extra');
     const path = require('path');
 
@@ -653,7 +652,6 @@ class YearInReview2025 {
    */
   async analyzeCommands() {
     const fs = require('fs-extra');
-    const os = require('os');
     const path = require('path');
 
     try {
@@ -716,7 +714,6 @@ class YearInReview2025 {
    */
   async analyzeSkills() {
     const fs = require('fs-extra');
-    const os = require('os');
     const path = require('path');
 
     try {
@@ -766,7 +763,6 @@ class YearInReview2025 {
    */
   async analyzeMCPs() {
     const fs = require('fs-extra');
-    const os = require('os');
     const path = require('path');
 
     try {

--- a/cli-tool/src/chats-mobile.js
+++ b/cli-tool/src/chats-mobile.js
@@ -12,6 +12,7 @@ const DataCache = require('./analytics/data/DataCache');
 const AgentAnalyzer = require('./analytics/core/AgentAnalyzer');
 const WebSocketServer = require('./analytics/notifications/WebSocketServer');
 const SessionSharing = require('./session-sharing');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class ChatsMobile {
   constructor(options = {}) {
@@ -28,7 +29,7 @@ class ChatsMobile {
     
     // Initialize ConversationAnalyzer with proper parameters
     const homeDir = os.homedir();
-    const claudeDir = path.join(homeDir, '.claude');
+    const claudeDir = getClaudeConfigDir(homeDir);
     this.conversationAnalyzer = new ConversationAnalyzer(claudeDir, this.dataCache);
 
     // Initialize SessionSharing for export/import functionality
@@ -821,7 +822,7 @@ class ChatsMobile {
   async setupFileWatching() {
     try {
       const homeDir = os.homedir();
-      const claudeDir = path.join(homeDir, '.claude');
+      const claudeDir = getClaudeConfigDir(homeDir);
       
       this.fileWatcher.setupFileWatchers(
         claudeDir,
@@ -1004,7 +1005,7 @@ class ChatsMobile {
   async loadInitialData() {
     try {
       const homeDir = os.homedir();
-      const claudeDataDir = path.join(homeDir, '.claude');
+      const claudeDataDir = getClaudeConfigDir(homeDir);
       
       if (await fs.pathExists(claudeDataDir)) {
         // Use ConversationAnalyzer to load conversations

--- a/cli-tool/src/claude-api-proxy.js
+++ b/cli-tool/src/claude-api-proxy.js
@@ -1,15 +1,15 @@
 const express = require('express');
 const fs = require('fs-extra');
 const path = require('path');
-const os = require('os');
 const { v4: uuidv4 } = require('uuid');
 const chalk = require('chalk');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class ClaudeAPIProxy {
   constructor() {
     this.app = express();
     this.port = 3335;
-    this.claudeDir = path.join(os.homedir(), '.claude');
+    this.claudeDir = getClaudeConfigDir();
     
     // Store active sessions and conversation contexts
     this.activeSessions = new Map();

--- a/cli-tool/src/claude-paths.js
+++ b/cli-tool/src/claude-paths.js
@@ -1,6 +1,11 @@
 const os = require('os');
 const path = require('path');
 
+/**
+ * Resolve Claude Code's user-data directory.
+ * CLAUDE_CONFIG_DIR takes precedence over homeDir and relative values resolve
+ * from the current working directory, matching Node's normal path semantics.
+ */
 function getClaudeConfigDir(homeDir = os.homedir(), env = process.env) {
   const configuredDir = env.CLAUDE_CONFIG_DIR?.trim();
   return configuredDir ? path.resolve(configuredDir) : path.join(homeDir, '.claude');

--- a/cli-tool/src/claude-paths.js
+++ b/cli-tool/src/claude-paths.js
@@ -1,0 +1,9 @@
+const os = require('os');
+const path = require('path');
+
+function getClaudeConfigDir(homeDir = os.homedir(), env = process.env) {
+  const configuredDir = env.CLAUDE_CONFIG_DIR?.trim();
+  return configuredDir ? path.resolve(configuredDir) : path.join(homeDir, '.claude');
+}
+
+module.exports = { getClaudeConfigDir };

--- a/cli-tool/src/health-check.js
+++ b/cli-tool/src/health-check.js
@@ -5,6 +5,7 @@ const os = require('os');
 const { execSync } = require('child_process');
 const ora = require('ora');
 const boxen = require('boxen');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 /**
  * Health Check module for Claude Code CLI
@@ -538,7 +539,7 @@ class HealthChecker {
 
   checkPermissions() {
     const homeDir = os.homedir();
-    const claudeDir = path.join(homeDir, '.claude');
+    const claudeDir = getClaudeConfigDir(homeDir);
     
     try {
       if (fs.existsSync(claudeDir)) {
@@ -747,7 +748,7 @@ class HealthChecker {
 
   checkPersonalCommands() {
     const homeDir = os.homedir();
-    const commandsDir = path.join(homeDir, '.claude', 'commands');
+    const commandsDir = path.join(getClaudeConfigDir(homeDir), 'commands');
     
     if (fs.existsSync(commandsDir)) {
       const commands = fs.readdirSync(commandsDir).filter(file => file.endsWith('.md'));
@@ -820,7 +821,7 @@ class HealthChecker {
 
   checkPersonalAgents() {
     const homeDir = os.homedir();
-    const agentsDir = path.join(homeDir, '.claude', 'agents');
+    const agentsDir = path.join(getClaudeConfigDir(homeDir), 'agents');
     
     if (fs.existsSync(agentsDir)) {
       const agents = this.countAgentsRecursively(agentsDir);
@@ -925,7 +926,7 @@ class HealthChecker {
 
   checkUserHooks() {
     const homeDir = os.homedir();
-    const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+    const settingsPath = path.join(getClaudeConfigDir(homeDir), 'settings.json');
     
     if (fs.existsSync(settingsPath)) {
       try {
@@ -1003,7 +1004,7 @@ class HealthChecker {
 
   checkHookCommands() {
     const hookSettingsFiles = [
-      path.join(os.homedir(), '.claude', 'settings.json'),
+      path.join(getClaudeConfigDir(), 'settings.json'),
       path.join(process.cwd(), '.claude', 'settings.json'),
       path.join(process.cwd(), '.claude', 'settings.local.json')
     ];
@@ -1109,7 +1110,7 @@ class HealthChecker {
 
   checkUserSettings() {
     const homeDir = os.homedir();
-    const userSettingsPath = path.join(homeDir, '.claude', 'settings.json');
+    const userSettingsPath = path.join(getClaudeConfigDir(homeDir), 'settings.json');
     
     if (!fs.existsSync(userSettingsPath)) {
       return {

--- a/cli-tool/src/index.js
+++ b/cli-tool/src/index.js
@@ -23,6 +23,7 @@ const { trackingService } = require('./tracking-service');
 const { createGlobalAgent, listGlobalAgents, removeGlobalAgent, updateGlobalAgent } = require('./sdk/global-agent-manager');
 const SessionSharing = require('./session-sharing');
 const ConversationAnalyzer = require('./analytics/core/ConversationAnalyzer');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 /**
  * Get platform-appropriate Python command candidates
@@ -276,7 +277,7 @@ async function createClaudeConfig(options = {}) {
     try {
       const os = require('os');
       const homeDir = os.homedir();
-      const claudeDir = path.join(homeDir, '.claude');
+      const claudeDir = getClaudeConfigDir(homeDir);
 
       // Initialize ConversationAnalyzer and SessionSharing
       const conversationAnalyzer = new ConversationAnalyzer(claudeDir);

--- a/cli-tool/src/plugin-dashboard.js
+++ b/cli-tool/src/plugin-dashboard.js
@@ -4,6 +4,7 @@ const path = require('path');
 const express = require('express');
 const open = require('open');
 const os = require('os');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class PluginDashboard {
   constructor(options = {}) {
@@ -12,7 +13,7 @@ class PluginDashboard {
     this.port = 3336;
     this.httpServer = null;
     this.homeDir = os.homedir();
-    this.claudeDir = path.join(this.homeDir, '.claude');
+    this.claudeDir = getClaudeConfigDir(this.homeDir);
     this.settingsFile = path.join(this.claudeDir, 'settings.json');
   }
 

--- a/cli-tool/src/session-sharing.js
+++ b/cli-tool/src/session-sharing.js
@@ -6,6 +6,7 @@ const { exec } = require('child_process');
 const { promisify } = require('util');
 const execAsync = promisify(exec);
 const QRCode = require('qrcode');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 /**
  * SessionSharing - Handles exporting Claude Code sessions as downloadable context
@@ -355,7 +356,7 @@ class SessionSharing {
    */
   async installSession(sessionData, options = {}) {
     const homeDir = os.homedir();
-    const claudeDir = path.join(homeDir, '.claude');
+    const claudeDir = getClaudeConfigDir(homeDir);
 
     // Determine project directory
     const projectName = sessionData.conversation.project || 'shared-session';

--- a/cli-tool/src/skill-dashboard.js
+++ b/cli-tool/src/skill-dashboard.js
@@ -5,6 +5,7 @@ const express = require('express');
 const open = require('open');
 const os = require('os');
 const yaml = require('js-yaml');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class SkillDashboard {
   constructor(options = {}) {
@@ -13,7 +14,7 @@ class SkillDashboard {
     this.port = 3337;
     this.httpServer = null;
     this.homeDir = os.homedir();
-    this.claudeDir = path.join(this.homeDir, '.claude');
+    this.claudeDir = getClaudeConfigDir(this.homeDir);
     this.personalSkillsDir = path.join(this.claudeDir, 'skills');
   }
 

--- a/cli-tool/src/teams-dashboard.js
+++ b/cli-tool/src/teams-dashboard.js
@@ -5,6 +5,7 @@ const express = require('express');
 const open = require('open');
 const os = require('os');
 const readline = require('readline');
+const { getClaudeConfigDir } = require('./claude-paths');
 
 class TeamsDashboard {
   constructor(options = {}) {
@@ -13,7 +14,7 @@ class TeamsDashboard {
     this.port = 3338;
     this.httpServer = null;
     this.homeDir = os.homedir();
-    this.claudeDir = path.join(this.homeDir, '.claude');
+    this.claudeDir = getClaudeConfigDir(this.homeDir);
     this.projectsDir = path.join(this.claudeDir, 'projects');
     this.sessionCache = new Map();
   }

--- a/cli-tool/tests/unit/claude-paths.test.js
+++ b/cli-tool/tests/unit/claude-paths.test.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const { getClaudeConfigDir } = require('../../src/claude-paths');
+
+describe('getClaudeConfigDir', () => {
+  test('defaults to the Claude directory in the user home', () => {
+    expect(getClaudeConfigDir('/home/tester', {})).toBe(path.join('/home/tester', '.claude'));
+  });
+
+  test('uses CLAUDE_CONFIG_DIR when configured', () => {
+    expect(getClaudeConfigDir('/home/tester', {
+      CLAUDE_CONFIG_DIR: '/profiles/claude-enterprise'
+    })).toBe(path.resolve('/profiles/claude-enterprise'));
+  });
+
+  test('ignores an empty CLAUDE_CONFIG_DIR', () => {
+    expect(getClaudeConfigDir('/home/tester', { CLAUDE_CONFIG_DIR: '  ' }))
+      .toBe(path.join('/home/tester', '.claude'));
+  });
+});
+
+describe('Claude data consumers', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  test.each([
+    ['API proxy', () => new (require('../../src/claude-api-proxy'))()],
+    ['plugin dashboard', () => new (require('../../src/plugin-dashboard').PluginDashboard)()],
+    ['skill dashboard', () => new (require('../../src/skill-dashboard').SkillDashboard)()],
+    ['teams dashboard', () => new (require('../../src/teams-dashboard').TeamsDashboard)()],
+    ['mobile chats', () => new (require('../../src/chats-mobile').ChatsMobile)()]
+  ])('%s reads from the configured directory', (_name, createConsumer) => {
+    process.env.CLAUDE_CONFIG_DIR = '/profiles/claude-enterprise';
+    const consumer = createConsumer();
+
+    expect(consumer.claudeDir ?? consumer.conversationAnalyzer.claudeDir)
+      .toBe(path.resolve('/profiles/claude-enterprise'));
+    consumer.dataCache?.cleanup();
+  });
+});

--- a/cli-tool/tests/unit/claude-paths.test.js
+++ b/cli-tool/tests/unit/claude-paths.test.js
@@ -12,6 +12,11 @@ describe('getClaudeConfigDir', () => {
     })).toBe(path.resolve('/profiles/claude-enterprise'));
   });
 
+  test('resolves a relative CLAUDE_CONFIG_DIR from the working directory', () => {
+    expect(getClaudeConfigDir('/home/tester', { CLAUDE_CONFIG_DIR: 'custom-dir' }))
+      .toBe(path.resolve('custom-dir'));
+  });
+
   test('ignores an empty CLAUDE_CONFIG_DIR', () => {
     expect(getClaudeConfigDir('/home/tester', { CLAUDE_CONFIG_DIR: '  ' }))
       .toBe(path.join('/home/tester', '.claude'));


### PR DESCRIPTION
## Summary

- centralize resolution of Claude's user-data directory
- honor `CLAUDE_CONFIG_DIR` across analytics, chats, session sharing, health checks, and the plugin/skill/team dashboards
- keep project-local `.claude` directories unchanged

Closes #631.

## Validation

- `npx jest tests/unit/claude-paths.test.js --runInBand --coverage=false` (8 tests)
- `node --check` for every changed JavaScript file
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `CLAUDE_CONFIG_DIR` across the CLI so user data reads/writes from the configured directory. Fixes #631 while keeping project-local `.claude` behavior unchanged.

- **Bug Fixes**
  - Area: CLI (`cli-tool/src/`); centralized path resolution in `cli-tool/src/claude-paths.js`, removed stale imports, and added `cli-tool/tests/unit/claude-paths.test.js` to document precedence and relative path resolution.
  - All tools now respect `CLAUDE_CONFIG_DIR`: analytics (incl. YearInReview2025), chats-mobile, API proxy, health-check, session sharing, and plugin/skill/teams dashboards.
  - Defaults to `~/.claude` when unset or blank; relative values resolve from the current working directory.
  - No new components; no catalog regen; env: optional `CLAUDE_CONFIG_DIR` only.

<sup>Written for commit 23dc01815baa34841ff0326aa5a73c0050dacec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

