### PR TITLE
fix(plugins): register krasserm/ml-plugins in generator REPOS so ml-research survives regeneration

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -23386,6 +23386,26 @@
     "highlights": []
   },
   {
+    "slug": "ml-plugins",
+    "name": "ML Research",
+    "author": "krasserm",
+    "description": "Native Claude Code port of Hugging Face's ml-intern: autonomous ML engineering on the Hugging Face ecosystem, with research-first fine-tuning (SFT/DPO/GRPO/LoRA) on HF Jobs, dataset/repo/paper tooling, and an optional budget-bounded autonomous experiment loop.",
+    "github": "https://github.com/krasserm/ml-plugins",
+    "stars": 2,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "agents",
+      "hooks"
+    ],
+    "contains": {
+      "skills": 2,
+      "agents": 2,
+      "hooks": 1
+    },
+    "highlights": []
+  },
+  {
     "slug": "best-claude-skills",
     "name": "Best Claude Skills",
     "author": "Nyanbalaji28",

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -60,6 +60,7 @@ REPOS = [
     ("Piebald-AI/claude-code-lsps", None),
     ("chu2bard/pinion-os", None),
     ("Airtable/skills", None),
+    ("krasserm/ml-plugins", None),
 ]
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")
@@ -507,6 +508,8 @@ def process_repo(repo_full, website_override=None):
             contains["components"] = marketplace_component_totals
     else:
         contains = single_components if single_components else {}
+        if not contains and plugins_detail:
+            contains = dict(plugins_detail[0].get("components", {}))
 
     # 8. Build tags
     all_components = {**marketplace_component_totals, **single_components}
@@ -540,8 +543,11 @@ def process_repo(repo_full, website_override=None):
     repo_display = repo_info.get("name", name)
     mp_name = marketplace.get("name", "")
     plugin_name = plugin_json.get("name", "") if plugin_json else ""
+    plugin_display = plugin_json.get("displayName", "") if plugin_json else ""
     # Use marketplace/plugin name only if it looks human-readable (has spaces or capitals)
-    if mp_name and (mp_name != mp_name.lower().replace(" ", "-") or " " in mp_name):
+    if plugin_display:
+        display_name = plugin_display
+    elif mp_name and (mp_name != mp_name.lower().replace(" ", "-") or " " in mp_name):
         display_name = mp_name
     elif plugin_name and (plugin_name != plugin_name.lower().replace(" ", "-") or " " in plugin_name):
         display_name = plugin_name


### PR DESCRIPTION
## Problem

#613 added the ml-research plugin (krasserm/ml-plugins) by editing `dashboard/public/plugins.json` directly. That file is a generated artifact of `scripts/generate_plugins_json.py`, rebuilt from its hardcoded `REPOS` list, and the repo was never added to that list.

When #697 regenerated `plugins.json`, the entry was silently dropped. It is currently missing from the plugins directory.

## Fix

- Add `("krasserm/ml-plugins", None)` to `REPOS` in `scripts/generate_plugins_json.py`
- Restore the entry in `dashboard/public/plugins.json` as produced by the generator's own `process_repo()`, inserted in stars-descending order (a full regeneration was skipped to avoid refreshing volatile star counts on all 32 other entries)
- Generator: prefer plugin.json `displayName` (the official human-readable-name field) when choosing an entry's display name
- Generator: for single-plugin repos, fall back to the locally scanned component counts already collected in `plugins_detail` when plugin.json declares no component lists, so `contains` isn't empty

This makes the listing durable: future regenerations will now include it, with faithful metadata.

## Verification

- Entry matches generator output exactly (built via `process_repo()` after the generator changes), so the next full regeneration reproduces it modulo star counts
- `plugins.json` parses as valid JSON; 33 entries, sorted by stars descending
- Restored entry: name "ML Research", type plugin, `contains: {"skills": 2, "agents": 2, "hooks": 1}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the ML Research plugin (`krasserm/ml-plugins`) to the marketplace and updates the generator so future regenerations keep it with correct metadata.

- **Bug Fixes**
  - Adds `krasserm/ml-plugins` to generator `REPOS` and restores its entry in `dashboard/public/plugins.json` (sorted by stars).
  - Generator now prefers plugin.json `displayName`; fills `contains` for single-plugin repos by falling back to scanned component counts.
  - Area: website (dashboard marketplace).
  - No new components; no `docs/components.json` regeneration needed.
  - No new environment variables or secrets.

<sup>Written for commit e560749dafe55ada259f7e4958342459e4d5aed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

