### PR TITLE
Add skill: mac-storage-cleaner (safe macOS disk cleanup)

### DIFF
--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: mac-storage-cleaner
+description: Safely reclaim disk space on a Mac — the trustworthy, transparent, reversible alternative to CleanMyMac and similar tools. Use whenever the user says their Mac disk or storage is full or nearly full, gets a "startup disk almost full" / low-storage warning, asks to free up space, clean/clear caches, remove junk, delete leftover files from apps they uninstalled, or find what's eating their disk — in any language (e.g. English "my mac is out of space", "free up disk", "clear caches", "what's taking up my storage"; Georgian "ქეში გაასუფთავე", "მეხსიერება გადამევსო", "ადგილი აღარ მაქვს"). Surveys usage first, auto-clears only pure caches, moves anything riskier to the Trash (restorable), asks before anything expensive, logs every deletion, and reports what was freed. Do NOT use for cloud storage, RAM/memory-pressure, or a single named app's own in-app cache button.
+---
+
+# Mac Storage Cleaner
+
+Free disk space the way a careful engineer would, and earn the trust one-click
+cleaners lose: **measure first, delete only what provably regenerates, make
+anything riskier reversible, ask before anything expensive, log every action,
+and report honestly.** The differentiator over CleanMyMac-style tools is
+judgment and transparency — the user sees what will go and why, and can undo it.
+
+Scripts live in `scripts/`; the full tiered inventory, exact reclaim commands,
+and gotchas are in `references/cache-catalog.md`. Read the catalog whenever you
+hit something a script didn't classify or you need the precise command.
+
+## Core principles
+
+- **Safe tier → delete outright** (space back immediately). These are pure
+  caches; the only cost is a slower next build/install.
+- **Everything else → Trash, not `rm`.** Ask-tier items, app leftovers, big
+  files — move them to the Trash with `trash-items.sh` so the user can restore
+  them. Reversibility is the whole point; never hard-delete a user's data.
+- **When unsure, demote a tier.** A slower rebuild is trivial; deleting a
+  license, an unpushable Xcode archive, or someone's only local backup is not.
+- **Every destructive run is logged** to `~/Library/Logs/mac-storage-cleaner/operations.log`.
+
+## Workflow
+
+**Locating the scripts.** The commands below resolve `$D` to this skill's own
+directory so they work whether the skill was installed as a plugin
+(`$CLAUDE_PLUGIN_ROOT` is set) or as a standalone skill (`~/.claude/skills/…`).
+Shell state doesn't persist between commands, so each block re-resolves `$D`.
+
+### 1. Survey — caches (always first, read-only)
+
+```bash
+D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+bash "$D/scripts/survey.sh"
+```
+
+Prints free space and sizes every cache that exists on *this* machine, grouped
+**safe / ask / never / app-data**. Never skip it — locations and sizes differ on
+every Mac. Note current free space for the before/after report.
+
+### 2. Clear the safe tier (no per-item permission needed)
+
+Tell the user briefly what the safe tier removes and roughly how much it frees,
+then:
+
+```bash
+D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+bash "$D/scripts/clean-safe.sh"
+```
+
+Removes only the vetted safe allowlist (nothing else — the survey's "other large
+caches" list is for the user to review, not for auto-deletion), handles read-only
+files, skips anything macOS protects (reporting rather than failing), runs
+`brew cleanup -s --prune=all` and removes unavailable simulators, logs each
+deletion, and prints what it reclaimed. If the user only wanted specific items,
+delete those directly instead.
+
+**Browser & Electron app caches** (Chrome/Arc/Slack/VS Code/…) are safe but live
+inside app-data folders — clear only the `Cache`/`Code Cache`/`GPUCache`
+subfolders the survey lists, ideally with the app quit, and **never** the whole
+app folder. Exact paths: `references/cache-catalog.md`.
+
+### 3. Surface the "ask" tier — recommend, don't delete
+
+Big but not free caches (Docker images, ML models, simulator devices, Xcode
+Archives, module stores). List each with size + a specific recommendation; let
+the user choose. Use the tool-native command, and prefer Trash for file
+deletions. Key ones (full detail in the catalog):
+
+- **Docker** — `docker system prune -a`, never `rm` the VM disk.
+- **ML models** (HuggingFace/Ollama) — often duplicated variants; offer to remove unused ones.
+- **Simulators** — only `xcrun simctl delete unavailable` is safe; deleting active devices wipes state.
+- **Xcode Archives** — warn: holds dSYMs for crash symbolication and shippable builds.
+
+### 4. Go beyond caches — the space the cleaners miss (read-only scan)
+
+```bash
+D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+bash "$D/scripts/find-extras.sh"
+```
+
+Surfaces the real hogs a cache sweep ignores: **leftover data from uninstalled
+apps**, **big files (>500MB)**, **stale installers** (.dmg/.pkg), and **old
+Downloads**. Everything here is ask-tier — present candidates, let the user pick,
+then remove reversibly:
+
+```bash
+D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+bash "$D/scripts/trash-items.sh" "/path/one" "/path/two"
+```
+
+**If trashing reports "could NOT trash (permissions/TCC?)"** for every item, the
+controlling app hasn't been granted Automation control of Finder — a normal
+first-run state. Tell the user to allow it in System Settings › Privacy &
+Security › Automation (enable Finder for the terminal/app), then re-run; or move
+the item to the Trash manually in Finder. Don't report space as freed when items
+logged `trash-failed` — nothing was actually removed.
+
+**App leftovers need verification.** The scan lists containers whose owning app a
+quick check couldn't confirm is installed — but Spotlight misses un-indexed apps,
+so some candidates *are* still installed. Before proposing to remove any leftover,
+**confirm the app is really gone** (check `/Applications`, `mdfind`, or just ask
+the user "do you still use X?"), and always Trash it, never `rm`. To also clear a
+confirmed-uninstalled app's *other* leftovers (Preferences, Application Support,
+Logs, Saved State, etc.), see the leftover-location list in the catalog.
+
+### 5. Report
+
+In the user's language: before → after free space
+(`df -h /System/Volumes/Data`), a short list of what was cleared/trashed with
+sizes, a one-line note that the first build/install afterward will be slower, the
+still-large "ask" items each with a recommendation, and the log path.
+
+If free space rose less than the reclaimed size suggests, explain **APFS
+purgeable space**: macOS may hold freed space as purgeable (often behind Time
+Machine local snapshots) and release it on demand — the space is genuinely
+recovered. Don't chase it with `sudo`.
+
+## Safety rules
+
+Read `references/cache-catalog.md` for the full tiered inventory and gotchas. The essentials:
+
+- **Never delete** user data that looks like storage: iOS backups
+  (`~/Library/Application Support/MobileSync/Backup`), Photos library, Mail/Messages
+  data, whole app-support folders, `~/.ssh`/`~/.aws`/keychains, Time Machine
+  snapshots. Report their size so the user knows, but don't touch them.
+- **Messaging-app media is user data, not cache.** Telegram/WhatsApp/Slack store
+  downloaded photos/videos in their caches. Don't bulk-delete these; point the
+  user to the app's own "Clear Cache" (e.g. Telegram › Settings › Data and
+  Storage › Storage Usage) so they choose what to drop.
+- **Never `sudo`** into `/System`, `/Library/Caches`, `/private/var/folders`, or
+  SIP-protected areas — that's macOS's job.
+- **Watch mixed directories**: `~/.cargo` (has installed binaries — only clear
+  `registry/`), `~/.m2` (has `settings.xml` — only clear `repository/`), `~/.gradle`
+  (only `caches/`). `~/.npm` is pure cache so it's fine whole.
+- **Continue past errors and verify** with `du`; `rm -rf` on multiple paths keeps
+  going after a failure, so never assume total success or total failure.

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/references/cache-catalog.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/references/cache-catalog.md
@@ -1,0 +1,163 @@
+# macOS cache catalog
+
+The full, tiered inventory the skill reasons from. `survey.sh` sizes the common
+roots automatically; consult this when you hit something the survey didn't cover,
+need the exact reclaim command, or must judge a borderline location.
+
+## Tiers
+
+- **safe** — a pure cache. Deleting it can only make the next build/install/run
+  slower. Zero risk to data the user or an app cannot regenerate. Auto-delete OK.
+- **ask** — large but *not* a free cache: expensive to restore (multi-GB
+  re-download, long rebuild), or a directory that mixes cache with things the user
+  may want (models, VM disks, simulator state). Always confirm first.
+- **never** — user data or app state that does not regenerate. The scripts never
+  touch these; they appear only so you can *warn* the user when something big
+  (an old iPhone backup, a full Trash) is masquerading as "storage to clean."
+
+Golden rule: **when unsure, demote.** A slower rebuild is a shrug; deleting a
+license file, an unpushable archive, or someone's only local backup is not.
+
+## Safe tier
+
+| Location | What | Reclaim | Regenerates on |
+|---|---|---|---|
+| `~/Library/Developer/Xcode/DerivedData` | Xcode build products, indexes | `rm -rf` | next Xcode / `xcodebuild` |
+| `~/Library/Developer/Xcode/{iOS,watchOS,tvOS} DeviceSupport` | symbols copied from attached devices | `rm -rf` | re-copies when a device on that OS build is re-attached (note: an OS build you no longer have a device for won't regenerate — minor, only affects symbolicating that old build) |
+| `~/Library/Developer/CoreSimulator/Caches` | simulator runtime caches | `rm -rf` | automatically |
+| `~/Library/Caches/com.apple.dt.Xcode` | misc Xcode cache | `rm -rf` | automatically |
+| `~/Library/Caches/org.swift.swiftpm` | SwiftPM download cache | `rm -rf` | next resolve |
+| `~/Library/Caches/CocoaPods` | pod spec/download cache | `rm -rf` or `pod cache clean --all` | next `pod install` |
+| `~/.gradle/caches` | Gradle dependency + build cache | `rm -rf` | next Gradle build |
+| `~/.npm` | npm download cache | `rm -rf` or `npm cache clean --force` | next `npm i` |
+| `~/.bun/install/cache` | Bun install cache | `rm -rf` | next `bun i` |
+| `~/Library/Caches/Yarn` | Yarn classic cache | `rm -rf` or `yarn cache clean` | next `yarn` |
+| `~/Library/Caches/{node-gyp,typescript,electron,electron-builder}` | tool download/build caches | `rm -rf` | next use |
+| `~/.cache/uv`, `~/Library/Caches/uv` | uv wheel/source cache | `uv cache clean` or `rm -rf` | next `uv` |
+| `~/.cache/pip`, `~/Library/Caches/pip` | pip wheel cache | `pip cache purge` or `rm -rf` | next `pip install` |
+| `~/Library/Caches/go-build` | Go compile cache | `go clean -cache` or `rm -rf` | next `go build` |
+| `~/Library/Caches/Homebrew` + downloads | brew bottle/download cache | `brew cleanup -s --prune=all` | next `brew install` |
+| `/private/tmp/{metro-*,haste-map-*,react-*}` | Metro/RN temp | `rm -rf` | next Metro start |
+| `~/Library/Caches/<app>` (generic, NOT on the list above) | most per-app caches | prefer `trash-items.sh` (reversible); `rm -rf` only once you've confirmed it's a pure cache | usually automatic — but some apps keep the only local copy of downloaded content or a token here, so verify before deleting |
+
+**Browser & Electron app caches (safe, but quit the app first):** delete only the
+cache *subfolders* — never the whole app-support folder, which holds real data.
+- Electron apps (Slack, Discord, VS Code, Cursor, Windsurf, Teams, Notion, …):
+  `~/Library/Application Support/<App>/{Cache,Code Cache,GPUCache,DawnWebGPUCache}`.
+- Chromium browsers (Chrome, Arc, Brave, Edge, Vivaldi):
+  `~/Library/Application Support/<Browser>/<Profile>/{Cache,Code Cache,Service Worker/CacheStorage}`.
+  Clearing `Service Worker/CacheStorage` drops sites' offline data (minor).
+- Spotify: `~/Library/Caches/com.spotify.client` and `.../Application Support/Spotify/PersistentCache`.
+- Also safe: `~/Library/Caches/ms-playwright*`, `~/.cache/puppeteer`, `~/Library/Caches/Cypress`,
+  `~/Library/Caches/JetBrains` — but these force a browser re-download or IDE reindex,
+  so they sit in **ask** for auto-runs; recommend them, don't delete silently.
+
+## Ask tier
+
+| Location | Why not auto | Right move |
+|---|---|---|
+| `~/Library/Containers/com.docker.docker` (`Docker.raw`) | VM disk with images/volumes — not a cache | Start Docker, run `docker system prune -a` (and `docker volume prune`). Never `rm` the .raw. |
+| `~/.cache/huggingface`, `~/.ollama/models`, `~/.cache/torch`, `~/.lmstudio` | multi-GB model re-downloads | Confirm; if duplicate variants of one model exist (e.g. whisper in faster-whisper + MLX + turbo), point it out and delete the unused ones. |
+| `~/Library/Developer/CoreSimulator/Devices` | simulator state + installed apps | `xcrun simctl delete unavailable` is safe (orphans only). Deleting active devices wipes their state — ask. |
+| `~/Library/Developer/Xcode/Archives` | contains dSYMs + shippable builds | **Warn:** deleting loses crash symbolication and re-upload ability. Ask. |
+| `~/Library/pnpm/store`, `~/.pnpm-store` | content store all projects hardlink from | `pnpm store prune` removes only unreferenced; safer than `rm -rf`. |
+| `~/go/pkg/mod` | module cache, files are read-only | `go clean -modcache` (plain `rm -rf` fails on perms). Re-downloads. |
+| `~/.cargo/registry` (`cache/`, `src/`) | crate cache | `rm -rf ~/.cargo/registry/{cache,src}` only. **Never** `~/.cargo` — holds `bin/` (installed binaries) and `config.toml`. |
+| `~/Library/Caches/deno`, `~/.cache/deno` | modules fetched from arbitrary URLs (unlike npm, a source can 404 permanently) | `deno clean` or `rm -rf`; ask, since a raw-URL import that vanished can't be re-fetched. |
+| `~/.gradle/wrapper/dists` | downloaded Gradle distributions | re-download; ask. |
+| `~/.m2/repository` | Maven local repo | cache-like but large; **never** `~/.m2` itself — `settings.xml` lives at its root. |
+| `~/Library/Caches/JetBrains`, `~/Library/Application Support/JetBrains/*/caches` | IDE indexes | forces full reindex; recommend, don't auto. |
+| project `node_modules` / `target/` / `build/` | per-project, huge in aggregate | see stale-project sweep below. |
+
+## Never tier (warn only)
+
+- `~/Library/Application Support/MobileSync/Backup` — local iOS device backups. User data.
+- `~/Library/Application Support/CallHistoryDB`, `AddressBook`, Messages `chat.db`, Mail `V*/` — app data.
+- `~/Pictures/Photos Library.photoslibrary` — the photo library itself.
+- `~/.Trash` — emptying is fine but it's the user's decision; offer, don't assume.
+- `~/Library/Application Support/<app>` (whole folder), `~/Library/Preferences`,
+  `~/Library/Keychains`, anything under `~/.ssh`, `~/.aws`, `~/.config` credentials — never.
+- Time Machine **local snapshots** (`tmutil listlocalsnapshots /`) — these are backups.
+  They hold "purgeable" space macOS reclaims on demand; only thin them if the disk is
+  genuinely wedged: `tmutil thinlocalsnapshots / 999999999999 4`.
+- `/System`, `/Library/Caches`, `/private/var/folders`, dyld shared cache — system-owned
+  or SIP-protected. Leave them to macOS; don't reach for `sudo` to force it.
+
+## App leftovers (uninstalled apps)
+
+Dragging an app to the Trash leaves its data scattered across the library. For an
+app you've **confirmed is uninstalled**, its leftovers live in these locations —
+match by bundle id (e.g. `com.foo.Bar`) or app name. `find-extras.sh` flags the
+sandbox-container ones; the rest need a name/id match. Always Trash, never `rm`,
+and verify the app is truly gone first (a live app here means data loss).
+
+- `~/Library/Containers/<bundle id>` — sandboxed app data (biggest usually)
+- `~/Library/Group Containers/<group id>` — shared between an app and its extensions
+- `~/Library/Application Support/<app or id>`
+- `~/Library/Caches/<id>` and `~/Library/Caches/<id>.ShipIt`
+- `~/Library/Preferences/<id>.plist`
+- `~/Library/HTTPStorages/<id>`
+- `~/Library/WebKit/<id>`
+- `~/Library/Saved Application State/<id>.savedState`
+- `~/Library/Logs/<app>`
+- `~/Library/Cookies/<id>.binarycookies`
+- `~/Library/LaunchAgents/<id>.plist` (and `/Library/LaunchAgents`, `/Library/LaunchDaemons` — need admin)
+
+Verify installed-state with more than one signal before deleting: `mdfind
+"kMDItemCFBundleIdentifier == '<id>'"`, a look in `/Applications` and
+`~/Applications`, or simply ask the user. Dedicated apps (Pearcleaner, AppCleaner)
+exist for this; the skill's job is to surface the space and let the user decide,
+not to compete on completeness.
+
+## In-app / manual tier (don't delete for the user)
+
+Some large "caches" are really user content the app manages itself. Deleting the
+files can lose downloaded media or force a re-login. Point the user to the app's
+own control instead:
+
+- **Telegram** — Settings › Data and Storage › Storage Usage › Clear Cache.
+- **WhatsApp / Signal** — in-app storage management; the cache holds received media.
+- **Slack / Discord / Teams** — the `Cache`/`Code Cache`/`GPUCache` subfolders are
+  safe (see safe tier); the rest of their Application Support is real state — leave it.
+- **Spotify** — Settings › Storage, or delete `.../Application Support/Spotify/PersistentCache` (safe).
+- **Photos / Music** — "Optimize Mac Storage" in the app/System Settings, never manual deletion.
+
+## Reversible deletion
+
+Prefer `trash-items.sh` (moves to Trash via Finder) for anything outside the pure
+safe tier. Trade-off: trashed items still occupy disk until the Trash is emptied,
+so for pure caches a direct `rm` (clean-safe.sh) is better — space returns now and
+reversibility is pointless for a cache. Rule of thumb: **cache → rm; anything a
+human might miss → Trash.** Every action is appended to
+`~/Library/Logs/mac-storage-cleaner/operations.log` (timestamp, action, size, path).
+
+## Optional: stale-project sweep
+
+Old projects' `node_modules`/`target`/`build` dirs often dwarf every cache combined.
+This is **ask** tier — list candidates, let the user pick; deleting is safe (they
+rebuild via install/build) but can be surprising. List, sorted by size, without touching:
+
+```bash
+find ~/Desktop ~/Documents ~/Developer ~/Projects ~/code -type d \
+  \( -name node_modules -o -name target -o -name .next -o -name build -o -name Pods \) \
+  -prune 2>/dev/null | while read -r d; do du -sh "$d"; done | sort -rh | head -30
+```
+
+`npx npkill` is the interactive equivalent if the user prefers a picker.
+
+## Gotchas
+
+- **TCC / App Management.** `.app` bundles cached under `~/Library/Caches` (some dev
+  tools, e.g. dotslash-managed apps) are protected; `rm`/`chmod` return "Operation not
+  permitted" even without the sandbox. Skip them and say so — Finder can delete them.
+- **Read-only cache files.** Go and some SwiftPM caches are read-only; run
+  `chmod -R u+w <dir>` before `rm -rf` (clean-safe.sh already does this).
+- **Running apps.** Clearing a live browser/Electron cache can glitch it; prefer the
+  app quit. Never delete a database an app has open.
+- **`rm -rf a b c` continues past errors** — a failure on one path doesn't imply the
+  others failed. Verify with `du`, don't assume.
+- **APFS purgeable space.** After large deletions `df` "Avail" may not move: the space
+  becomes "purgeable" (freed on demand), especially when Time Machine local snapshots
+  reference the deleted files. Report reclaimed *size measured before deletion* rather
+  than trusting the df delta, and explain purgeable space if the user expects a bigger jump.
+- **Per-user temp** (`/var/folders/.../C`) is usually small and macOS-managed — leave it.

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# mac-storage-cleaner CLEAN — removes ONLY the vetted safe tier (pure caches).
+# Never touches the ask/never tiers, browser/app data, models, VMs, or backups.
+# Handles read-only files (chmod) and reports anything blocked by macOS App
+# Management/TCC instead of failing. Run survey.sh first and show the user.
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/lib.sh"
+
+total_kb=0
+skipped=0
+echo "Clearing safe caches (pure caches only)..."
+collect "${SAFE_PATHS[@]}"
+# bash 3.2 (macOS default) throws "unbound variable" on "${FOUND[@]}" when the
+# array is empty under `set -u` — which happens on a fresh Mac with no dev
+# caches. Guard the loop so a clean machine reports "nothing to do" instead of crashing.
+[ "${#FOUND[@]}" -gt 0 ] && for p in "${FOUND[@]}"; do
+  kb=$(size_kb "$p")
+  if ! rm -rf "$p" 2>/dev/null; then
+    chmod -R u+w "$p" 2>/dev/null   # read-only files (e.g. Go/SwiftPM caches)
+    rm -rf "$p" 2>/dev/null
+  fi
+  if [ -e "$p" ]; then
+    echo "  skipped (macOS App Management/TCC-protected or in use): $p"
+    log_op skipped "$(human_kb "${kb:-0}")" "$p"
+    skipped=$((skipped + 1))
+  else
+    echo "  removed $(human_kb "${kb:-0}")  $p"
+    log_op removed "$(human_kb "${kb:-0}")" "$p"
+    total_kb=$((total_kb + ${kb:-0}))
+  fi
+done
+
+# Tool-native cleanups that are unambiguously safe (freed space is separate from
+# the rm total above; both are logged for the audit trail).
+if command -v brew >/dev/null 2>&1; then
+  echo "  brew cleanup (brew cleanup -s --prune=all)..."
+  brew cleanup -s --prune=all >/dev/null 2>&1 && { echo "  done: brew cleanup"; log_op cleaned "brew cache" "brew cleanup -s --prune=all"; }
+fi
+# Gate simctl on a REAL developer install. /usr/bin/xcrun is a stub present on
+# every Mac, so `command -v xcrun` passes even with no Xcode/CLT — and calling it
+# then pops the macOS "install command line developer tools" dialog, which would
+# ambush a non-developer just trying to free space. xcode-select -p only succeeds
+# when a toolchain is actually selected.
+if xcode-select -p >/dev/null 2>&1 && command -v xcrun >/dev/null 2>&1; then
+  xcrun simctl delete unavailable >/dev/null 2>&1 && { echo "  done: removed unavailable simulators"; log_op cleaned "unavailable simulators" "simctl delete unavailable"; }
+fi
+
+echo
+echo "Approx. reclaimed from cache deletions: $(human_kb "$total_kb") (brew/simulator cleanup above frees more, not counted here)"
+[ "$skipped" -gt 0 ] && echo "($skipped path(s) skipped — delete via Finder if you need them gone.)"
+echo
+echo "Free space now:"
+if [ -d /System/Volumes/Data ]; then df -h /System/Volumes/Data 2>/dev/null | sed -n '1p;$p'; else df -h /; fi
+echo "(APFS may report freed space as 'purgeable'; df 'Avail' can lag behind.)"
+echo "Log: $LOG_DIR/operations.log"

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -9,6 +9,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 total_kb=0
 skipped=0
+log_writable || echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — cleanup will proceed, but this run will NOT be recorded."
 echo "Clearing safe caches (pure caches only)..."
 collect "${SAFE_PATHS[@]}"
 # bash 3.2 (macOS default) throws "unbound variable" on "${FOUND[@]}" when the

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
@@ -41,9 +41,10 @@ echo "  (if empty: nothing over 5MB looked unmatched)"
 echo
 echo "Review by hand (folder names aren't bundle IDs, so not auto-classified):"
 echo "  - large ~/Library/Application Support entries:"
-du -sh "$HOME/Library/Application Support/"* 2>/dev/null | sort -rh | head -6
+for d in "$HOME/Library/Application Support/"*; do [ -e "$d" ] || continue; du -sh "$d" 2>/dev/null; done | sort -rh | head -6
 echo "  - UUID-named containers (group/anonymous — check what owns them):"
 for d in "$HOME/Library/Containers/"*; do
+  [ -e "$d" ] || continue   # unmatched glob stays literal on an empty dir; skip it
   name=$(basename "$d")
   case "$name" in [0-9A-Fa-f]*-[0-9A-Fa-f]*-[0-9A-Fa-f]*-*) du -sh "$d" 2>/dev/null ;; esac
 done | sort -rh | head -5

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# mac-storage-cleaner EXTRAS — read-only discovery BEYOND caches. Finds the space
+# hogs the cache survey misses: leftovers of uninstalled apps, big/old files,
+# and stale installers. Deletes nothing. Everything here is ask-tier: present
+# candidates, let the user choose, then remove via trash-items.sh (reversible).
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/lib.sh"
+
+line () { printf '%s\n' "--------------------------------------------------------------"; }
+
+echo "============== mac-storage-cleaner extras (read-only) =============="
+echo
+
+echo "===== App data whose owner a quick check could NOT confirm installed ====="
+echo "CANDIDATES ONLY (>=5MB). A quick check + Spotlight didn't find the owning"
+echo "app — but Spotlight misses un-indexed apps, so some of these ARE still"
+echo "installed. The skill must confirm each app is really gone before removing,"
+echo "and remove via the Trash (reversible), never rm."
+if ! mdutil -s / 2>/dev/null | grep -qi 'indexing enabled'; then
+  echo "  ⚠ Spotlight indexing looks OFF on this Mac — the install check is UNRELIABLE"
+  echo "    here and may list apps that are actually installed. Treat as informational"
+  echo "    only and confirm every app by hand before removing anything."
+fi
+export IDS="$(installed_bundle_ids | sort -u)"
+for d in "$HOME/Library/Containers/"*; do
+  [ -d "$d" ] || continue
+  name=$(basename "$d")
+  case "$name" in
+    com.apple.*) continue ;;
+    # UUID-named group/anonymous containers aren't bundle IDs — reviewed separately.
+    [0-9A-Fa-f]*-[0-9A-Fa-f]*-[0-9A-Fa-f]*-*) continue ;;
+  esac
+  kb=$(size_kb "$d"); [ "${kb:-0}" -ge 5120 ] || continue   # cheap size gate first (skip <5MB noise)
+  container_is_orphan "$name" || continue                    # expensive Spotlight lookup only for big ones
+  printf '%s\t%s\n' "${kb:-0}" "$d"
+done | sort -rn | head -15 | while IFS="$(printf '\t')" read -r kb d; do
+  printf '  %s\t%s\n' "$(human_kb "$kb")" "$d"
+done
+echo "  (if empty: nothing over 5MB looked unmatched)"
+echo
+echo "Review by hand (folder names aren't bundle IDs, so not auto-classified):"
+echo "  - large ~/Library/Application Support entries:"
+du -sh "$HOME/Library/Application Support/"* 2>/dev/null | sort -rh | head -6
+echo "  - UUID-named containers (group/anonymous — check what owns them):"
+for d in "$HOME/Library/Containers/"*; do
+  name=$(basename "$d")
+  case "$name" in [0-9A-Fa-f]*-[0-9A-Fa-f]*-[0-9A-Fa-f]*-*) du -sh "$d" 2>/dev/null ;; esac
+done | sort -rh | head -5
+echo
+
+echo "===== Stale installers (.dmg/.pkg/.iso in Downloads & Desktop) ====="
+find "$HOME/Downloads" "$HOME/Desktop" -maxdepth 2 -type f \
+  \( -iname '*.dmg' -o -iname '*.pkg' -o -iname '*.iso' -o -iname '*.msi' \) 2>/dev/null \
+  -exec du -sh {} + 2>/dev/null | sort -rh | head -20
+echo
+
+echo "===== Biggest files in your home (>500MB, non-Library) ====="
+find "$HOME/Downloads" "$HOME/Desktop" "$HOME/Documents" "$HOME/Movies" \
+  -type f -size +500M 2>/dev/null \
+  -exec du -sh {} + 2>/dev/null | sort -rh | head -20
+echo
+
+echo "===== Old Downloads (not modified in 90+ days) ====="
+old=$(find "$HOME/Downloads" -maxdepth 1 -mtime +90 2>/dev/null | wc -l | tr -d ' ')
+if [ "${old:-0}" -gt 0 ]; then
+  echo "  $old item(s), totaling:"
+  find "$HOME/Downloads" -maxdepth 1 -mtime +90 -exec du -sk {} + 2>/dev/null \
+    | awk '{s+=$1} END{printf "  %.1f GB\n", s/1024/1024}'
+else
+  echo "  (none)"
+fi
+echo
+line
+echo "To remove any of these reversibly (into the Trash, restorable):"
+echo "  bash $DIR/trash-items.sh \"/path/one\" \"/path/two\" ..."

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -106,9 +106,14 @@ human_kb () {
 # Every destructive action appends here, so a run is auditable and the user can
 # see exactly what was removed (mirrors what the trustworthy CLIs do).
 LOG_DIR="$HOME/Library/Logs/mac-storage-cleaner"
-log_op () {  # log_op <action> <size> <path>
+log_op () {  # log_op <action> <size> <path> — best-effort; suppresses its own errors
   mkdir -p "$LOG_DIR" 2>/dev/null
-  printf '%s\t%s\t%s\t%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" "$2" "$3" >> "$LOG_DIR/operations.log"
+  printf '%s\t%s\t%s\t%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" "$2" "$3" >> "$LOG_DIR/operations.log" 2>/dev/null
+}
+# True only if the audit log can actually be written. Callers warn the user when
+# it can't, so a run is never silently unlogged while we claim to log every deletion.
+log_writable () {
+  mkdir -p "$LOG_DIR" 2>/dev/null && : >> "$LOG_DIR/operations.log" 2>/dev/null
 }
 
 # --- Reversible delete ----------------------------------------------------

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Shared definitions for mac-storage-cleaner. Sourced by survey.sh and clean-safe.sh.
+# bash 3.2 compatible (macOS ships bash 3.2). No side effects on source.
+
+# --- SAFE tier ------------------------------------------------------------
+# Pure caches. Deleting one can ONLY make the next build/install/run slower;
+# it can never lose data an app or the user cannot regenerate on its own.
+# Globs are allowed. $HOME is expanded here (double-quoted), glob chars are not.
+SAFE_PATHS=(
+  # Apple / Xcode
+  "$HOME/Library/Developer/Xcode/DerivedData"
+  "$HOME/Library/Developer/Xcode/iOS DeviceSupport"
+  "$HOME/Library/Developer/Xcode/watchOS DeviceSupport"
+  "$HOME/Library/Developer/Xcode/tvOS DeviceSupport"
+  "$HOME/Library/Developer/CoreSimulator/Caches"
+  "$HOME/Library/Caches/org.swift.swiftpm"
+  "$HOME/Library/Caches/com.apple.dt.Xcode"
+  "$HOME/Library/Caches/CocoaPods"
+  # JS / Node
+  "$HOME/.npm"
+  "$HOME/.bun/install/cache"
+  "$HOME/Library/Caches/Yarn"
+  "$HOME/Library/Caches/node-gyp"
+  "$HOME/Library/Caches/typescript"
+  "$HOME/Library/Caches/electron"
+  "$HOME/Library/Caches/electron-builder"
+  # Python
+  "$HOME/.cache/uv"
+  "$HOME/Library/Caches/uv"
+  "$HOME/.cache/pip"
+  "$HOME/Library/Caches/pip"
+  # JVM / Android build artifacts (see notes: caches/ only, never all of ~/.gradle)
+  "$HOME/.gradle/caches"
+  # Other
+  "$HOME/Library/Caches/Homebrew"
+  "$HOME/Library/Caches/go-build"
+  # Namespaced RN/Metro temp caches only — NOT bare "react-*", which would match
+  # a user's own /private/tmp/react-native-fork clone or scratch dir and rm it.
+  "/private/tmp/metro-*"
+  "/private/tmp/haste-map-*"
+  "/private/tmp/react-native-packager-cache-*"
+  "/private/tmp/react-packager-cache-*"
+)
+
+# --- ASK tier -------------------------------------------------------------
+# Large but either not a pure cache, or expensive to restore (multi-GB
+# re-download / long rebuild), or a directory that mixes cache with content
+# the user may want. Report with sizes; NEVER delete without an explicit yes.
+ASK_PATHS=(
+  "$HOME/Library/Containers/com.docker.docker"      # VM disk + images, not cache
+  "$HOME/.cache/huggingface"                          # ML models, multi-GB redownload
+  "$HOME/.ollama/models"                              # local LLM weights
+  "$HOME/Library/Developer/CoreSimulator/Devices"     # simulator state + installed apps
+  "$HOME/Library/Developer/Xcode/Archives"            # ships dSYMs for crash symbolication
+  "$HOME/Library/pnpm/store"                           # pnpm content store (all projects re-fetch)
+  "$HOME/.pnpm-store"
+  "$HOME/go/pkg/mod"                                   # read-only; use: go clean -modcache
+  "$HOME/.cargo/registry"                              # re-download/re-extract crates
+  "$HOME/.gradle/wrapper/dists"                        # downloaded Gradle distributions
+  "$HOME/Library/Caches/JetBrains"                     # IDE indexes; forces reindex
+  "$HOME/Library/Caches/ms-playwright"                 # test browsers, redownload
+  "$HOME/Library/Caches/ms-playwright-go"
+  "$HOME/.cache/puppeteer"
+  "$HOME/Library/Caches/Cypress"
+  "$HOME/Library/Caches/deno"                          # modules from arbitrary URLs; a source can 404 permanently
+  "$HOME/.cache/deno"
+)
+
+# --- NEVER tier -----------------------------------------------------------
+# NOT caches. User data / state that does not come back. Only reported so the
+# user is warned when something big sits here; the scripts never touch these.
+NEVER_PATHS=(
+  "$HOME/Library/Application Support/MobileSync/Backup"  # local iPhone/iPad backups
+  "$HOME/.Trash"                                          # emptying is the user's call
+)
+
+# collect PATTERNS... -> fills global array FOUND with existing matches.
+# Handles globs (word-split, no spaces in our glob patterns) and plain paths
+# with spaces (quoted -e test). Resets FOUND on each call.
+collect () {
+  FOUND=()
+  local pat m
+  for pat in "$@"; do
+    case "$pat" in
+      *'*'*|*'?'*|*'['*)
+        for m in $pat; do [ -e "$m" ] && FOUND+=("$m"); done ;;
+      *)
+        [ -e "$pat" ] && FOUND+=("$pat") ;;
+    esac
+  done
+}
+
+# du -sk of a path in kilobytes (0 if missing), for arithmetic.
+size_kb () { du -sk "$1" 2>/dev/null | awk '{print $1}'; }
+
+# Pretty-print a kilobyte total as human units.
+human_kb () {
+  awk -v k="$1" 'BEGIN{
+    split("K M G T",u); s=k; i=1;
+    while (s>=1024 && i<4){ s/=1024; i++ }
+    printf("%.1f%s", s, u[i]);
+  }'
+}
+
+# --- Operation log --------------------------------------------------------
+# Every destructive action appends here, so a run is auditable and the user can
+# see exactly what was removed (mirrors what the trustworthy CLIs do).
+LOG_DIR="$HOME/Library/Logs/mac-storage-cleaner"
+log_op () {  # log_op <action> <size> <path>
+  mkdir -p "$LOG_DIR" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" "$2" "$3" >> "$LOG_DIR/operations.log"
+}
+
+# --- Reversible delete ----------------------------------------------------
+# Move a path to the Trash via Finder instead of rm, so the user can restore it.
+# Used for anything riskier than a pure cache (ask-tier items, app leftovers,
+# big files). Returns non-zero if it could not be trashed.
+# NOTE: trashed items still occupy disk until the Trash is emptied — for pure
+# caches we prefer a direct rm (see clean-safe.sh) so space is freed immediately.
+trash_path () {
+  local p="$1"
+  [ -e "$p" ] || return 0
+  # Pass the path as an argv value, NOT interpolated into the script text — a
+  # filename containing " or \ would otherwise break (or, pathologically, inject)
+  # the AppleScript. argv is data, so any legal filename trashes correctly.
+  osascript - "$p" >/dev/null 2>&1 <<'APPLESCRIPT'
+on run argv
+  tell application "Finder" to delete (POSIX file (item 1 of argv) as alias)
+end run
+APPLESCRIPT
+}
+
+# --- Installed apps -> bundle identifiers ---------------------------------
+# Fast prefilter for orphan detection. Not authoritative on its own (apps can
+# live outside these dirs), so container_is_orphan double-checks with Spotlight.
+installed_bundle_ids () {
+  local base app id
+  for base in /Applications "$HOME/Applications" /System/Applications /System/Applications/Utilities; do
+    [ -d "$base" ] || continue
+    for app in "$base"/*.app "$base"/*/*.app; do
+      [ -d "$app" ] || continue
+      id=$(defaults read "$app/Contents/Info" CFBundleIdentifier 2>/dev/null)
+      [ -n "$id" ] && printf '%s\n' "$id"
+    done
+  done
+}
+
+# Decide whether a sandbox-container bundle id belongs to NO installed app.
+# Conservative on purpose: a false "orphan" that deletes a live app's data would
+# wreck trust, so we clear a container as live on ANY of:
+#   - exact match to an installed id
+#   - it is an extension of an installed app  (id.SomeExtension)
+#   - an installed id is an extension of it   (rare, helper bundles)
+#   - Spotlight finds an app bundle anywhere carrying this id or its 3-part root
+# $IDS (newline list from installed_bundle_ids) must be set by the caller.
+# Returns 0 if the container looks orphaned, 1 if it belongs to a live app.
+container_is_orphan () {
+  local n="$1" id root
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    case "$n" in "$id"|"$id".*) return 1 ;; esac
+    case "$id" in "$n".*) return 1 ;; esac
+  done <<EOF
+${IDS:-}
+EOF
+  if mdfind "kMDItemContentTypeTree == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '$n'" 2>/dev/null | grep -q .; then
+    return 1
+  fi
+  root=$(printf '%s' "$n" | awk -F. 'NF>=3{printf "%s.%s.%s",$1,$2,$3; next} {print}')
+  if [ "$root" != "$n" ] && \
+     mdfind "kMDItemContentTypeTree == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '$root'" 2>/dev/null | grep -q .; then
+    return 1
+  fi
+  return 0
+}

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# mac-storage-cleaner SURVEY — 100% read-only. Discovers and sizes caches across
+# every common ecosystem, showing only what actually exists on this Mac.
+# Deletes nothing. Safe to run anytime.
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/lib.sh"
+
+line () { printf '%s\n' "--------------------------------------------------------------"; }
+
+echo "================= mac-storage-cleaner survey (read-only) ================="
+echo
+echo "Free space:"
+if [ -d /System/Volumes/Data ]; then df -h /System/Volumes/Data 2>/dev/null | sed -n '1p;$p'; else df -h /; fi
+echo
+
+echo "===== SAFE caches — auto-clearable (only cost: slower next build) ====="
+collect "${SAFE_PATHS[@]}"
+if [ "${#FOUND[@]}" -gt 0 ]; then
+  du -sh "${FOUND[@]}" 2>/dev/null | sort -rh
+  line
+  du -sch "${FOUND[@]}" 2>/dev/null | tail -1 | awk '{print "reclaimable in safe tier: "$1}'
+else
+  echo "  (none present)"
+fi
+echo
+
+echo "===== Other large ~/Library/Caches entries (usually safe — verify, Trash if unsure) ====="
+echo "Only the vetted safe list above is auto-deleted; these are for you to review."
+du -sh "$HOME/Library/Caches/"* 2>/dev/null | sort -rh | head -12
+echo
+
+echo "===== App caches — Electron & browsers (safe; quit the app first) ====="
+# Electron-style cache subfolders (depth<=2) + known browser profile caches.
+{
+  find "$HOME/Library/Application Support" -maxdepth 2 -type d \
+    \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null
+  for b in \
+    "Google/Chrome" "BraveSoftware/Brave-Browser" "Microsoft Edge" \
+    "Arc" "Vivaldi" "Chromium" "com.operasoftware.Opera"; do
+    for sub in "Default/Cache" "Default/Code Cache" "Default/Service Worker/CacheStorage"; do
+      d="$HOME/Library/Application Support/$b/$sub"
+      [ -d "$d" ] && printf '%s\n' "$d"
+    done
+  done
+} | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
+[ -z "$(find "$HOME/Library/Application Support" -maxdepth 2 -type d -name Cache 2>/dev/null | head -1)" ] && echo "  (scan found little; some may be TCC-protected)"
+echo
+
+echo "===== ASK first — big, but expensive to restore or not a cache ====="
+collect "${ASK_PATHS[@]}"
+if [ "${#FOUND[@]}" -gt 0 ]; then
+  du -sh "${FOUND[@]}" 2>/dev/null | sort -rh
+else
+  echo "  (none present)"
+fi
+d="$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw"
+[ -f "$d" ] && stat -f '  Docker.raw last modified: %Sm' "$d" 2>/dev/null
+echo
+
+echo "===== NEVER auto-delete — user data (reported for awareness only) ====="
+collect "${NEVER_PATHS[@]}"
+if [ "${#FOUND[@]}" -gt 0 ]; then
+  du -sh "${FOUND[@]}" 2>/dev/null | sort -rh
+else
+  echo "  (none present)"
+fi
+snap=$(tmutil listlocalsnapshots / 2>/dev/null | grep -c 'com.apple.TimeMachine')
+[ "${snap:-0}" -gt 0 ] && echo "  Time Machine local snapshots: $snap (backups — hold 'purgeable' space; macOS thins them automatically)"
+echo
+
+echo "===== Top ~/Library/Application Support (app DATA, not cache) ====="
+du -sh "$HOME/Library/Application Support/"* 2>/dev/null | sort -rh | head -8
+echo
+line
+echo "NOTE: After deleting, macOS may mark freed space 'purgeable' (esp. if Time"
+echo "Machine local snapshots reference it), so df 'Avail' can lag. It frees on"
+echo "demand; to force snapshot thinning: tmutil thinlocalsnapshots / 999999999999 4"

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
@@ -44,7 +44,7 @@ echo "===== App caches — Electron & browsers (safe; quit the app first) ====="
     done
   done
 } | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
-[ -z "$(find "$HOME/Library/Application Support" -maxdepth 2 -type d -name Cache 2>/dev/null | head -1)" ] && echo "  (scan found little; some may be TCC-protected)"
+[ -z "$(find "$HOME/Library/Application Support" -maxdepth 2 -type d \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null | head -1)" ] && echo "  (scan found little; some may be TCC-protected)"
 echo
 
 echo "===== ASK first — big, but expensive to restore or not a cache ====="

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -9,6 +9,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 
 [ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]"; exit 1; }
 
+log_writable || echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — items will still be trashed, but this run will NOT be recorded."
 moved=0
 for p in "$@"; do
   if [ ! -e "$p" ]; then

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# mac-storage-cleaner TRASH — move given paths to the Trash (reversible), not rm.
+# Use for anything riskier than a pure cache: ask-tier items, app leftovers,
+# big/old files. The user can restore from Trash until it's emptied. Every
+# action is logged. Usage: trash-items.sh <path> [<path> ...]
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$DIR/lib.sh"
+
+[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]"; exit 1; }
+
+moved=0
+for p in "$@"; do
+  if [ ! -e "$p" ]; then
+    echo "  not found: $p"
+    continue
+  fi
+  sz=$(human_kb "$(size_kb "$p")")
+  if trash_path "$p"; then
+    echo "  trashed $sz  $p"
+    log_op trashed "$sz" "$p"
+    moved=$((moved + 1))
+  else
+    echo "  could NOT trash (permissions/TCC?): $p"
+    log_op trash-failed "$sz" "$p"
+  fi
+done
+
+echo
+echo "$moved item(s) moved to Trash — restorable until you empty it."
+echo "Space is reclaimed when the Trash is emptied (Finder > Empty Trash)."
+echo "Log: $LOG_DIR/operations.log"


### PR DESCRIPTION
Adds `mac-storage-cleaner` under **productivity** — a safe, transparent, reversible macOS disk-space cleaner.

- Surveys usage first (read-only); auto-clears **only** a vetted allowlist of pure caches.
- Anything riskier goes to the **Trash** (reversible), never `rm`; asks before anything expensive (Docker/ML models/simulators).
- Finds leftovers from uninstalled apps + big files; **logs every deletion**.
- MIT, bash-only (macOS bash 3.2-safe), no SaaS/no server. Adversarially reviewed before release.

Upstream repo: https://github.com/JubaKitiashvili/mac-storage-cleaner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `mac-storage-cleaner` to safely free macOS disk space with a survey-first flow, reversible Trash moves, and an audit log. This update also adds guardrails: improved app-cache detection, safer glob handling, and a warning when the audit log isn’t writable.

- **New Features**
  - Adds `cli-tool/components/skills/productivity/mac-storage-cleaner` with `survey.sh`, `clean-safe.sh`, `find-extras.sh`, `trash-items.sh`, `lib.sh`, `SKILL.md`, and a cache catalog; all bash, no `sudo`.
  - Logs to `~/Library/Logs/mac-storage-cleaner/operations.log`; asks before Docker/ML/simulators/Xcode archives and moves risky items to Trash.
  - Robustness: fixes the Electron/browser app-cache emptiness check, guards `*` globs on empty dirs, and surfaces a warning if the audit log can’t be written.

- **Migration**
  - Area: components (`cli-tool/components/`). New component added — regenerate the catalog (`docs/components.json`).
  - No new environment variables or secrets required (respects optional `CLAUDE_PLUGIN_ROOT`).

<sup>Written for commit 04c4415a111c0313478534b7840f6a76c01416d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

