### PR TITLE
Add operations skills category: six supply-chain analysis skills

### DIFF
--- a/cli-tool/components/skills/operations/abc-xyz-segmentation/SKILL.md
+++ b/cli-tool/components/skills/operations/abc-xyz-segmentation/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: abc-xyz-segmentation
+description: Segment a SKU portfolio on value (ABC) and demand variability (XYZ), produce the 9-box with a planning policy per cell, and reallocate planner attention accordingly. Use when the user mentions ABC analysis, inventory segmentation, SKU rationalization, stok segmentasyonu, envanter sınıflandırma, or asks which items deserve forecasting effort. Differentiator - ABC alone is treated as half an answer; policy lives in the value x variability combination.
+---
+
+# ABC-XYZ Segmentation
+
+Value tells you where the money is. Variability tells you whether forecasting, buffering or restructuring can work. Never output a classification without the policy consequences.
+
+## Required data
+
+Per-SKU demand history (`sku`, `period`, `qty`) covering 12+ periods, plus unit value (`unit_price` or cost). Without unit value, ABC degrades to a volume ranking - say so and ask for prices before presenting conclusions about money.
+
+## Workflow
+
+1. **ABC on annual value.** Rank by annual consumption value; cumulative 80% = A, next 15% = B, rest = C. Report the actual concentration found (e.g. "15 SKUs = 80%"), not the folklore 20/80.
+2. **XYZ on variability.** CV = std/mean of period demand per SKU. Defaults: X < 0.5, Y 0.5-1.0, Z >= 1.0. These are conventions - check the CV histogram for natural breaks and state the thresholds used. SKUs with structural zero periods (intermittent) belong in Z regardless of CV arithmetic; mean-based CV understates their risk.
+3. **Build the 9-box** with SKU counts AND value share per cell. Value share is what makes managers act.
+4. **Attach the policy per cell** (adapt wording to context):
+   - A-X: tight forecasting pays; low buffer, frequent review, automate replenishment
+   - A-Y: forecast + healthy buffer; investigate variability drivers
+   - A-Z: do not chase forecasts - strategic buffer, lead-time negotiation, or make-to-order
+   - B-X / C-X: min-max autopilot; withdraw planner attention
+   - B-Z: buffer or longer promise dates; check if variability is self-inflicted (promotions, batching)
+   - C-Z: rationalization shortlist - kill, consolidate, or on-demand sourcing
+5. **Name the reallocation.** The deliverable is planner-hours and buffer money moving between cells - state explicitly which cells gain and lose attention.
+6. **Validate.** Sum of cell value shares must equal 100%; spot-check two SKUs' classifications against their raw series before presenting.
+
+## Pitfalls to check explicitly
+
+- ABC computed on quantity while unit values vary 10x+ ranks the wrong items.
+- Self-inflicted variability (order batching, month-end pushes, promotions) shows up as Z; flag it as a process fix, not a demand fact.
+- Classifications rot - recommend re-running quarterly and tracking cell migrations.
+- A dominant "C-Z is 60% of SKUs" finding usually signals assortment bloat, not a planning problem.
+
+## Output format
+
+1. The 9-box (counts + value share per cell)
+2. Policy table per occupied cell
+3. Attention-reallocation paragraph (from where, to where)
+4. Rationalization shortlist (top C-Z items by holding cost or shelf age, if data allows)
+
+Worked example including a safety-stock stress test: https://github.com/gulmezeren2-byte/abc-xyz-inventory
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.

--- a/cli-tool/components/skills/operations/forecast-accuracy-review/SKILL.md
+++ b/cli-tool/components/skills/operations/forecast-accuracy-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: forecast-accuracy-review
+description: Evaluate demand-forecast quality honestly - WMAPE, bias and Forecast Value Added against a naive benchmark over a rolling-origin backtest. Use when the user mentions forecast accuracy, MAPE, demand planning performance, tahmin doğruluğu, talep tahmini, or asks whether a forecasting process or tool is worth it. Differentiator - judges the process (value added vs doing nothing), not just the model.
+---
+
+# Forecast Accuracy Review
+
+A forecast is only worth what it adds over the free alternative: shipping last period's number. Every review must answer "how many points does this process add over naive?" before any model discussion.
+
+## Required data
+
+Per-SKU demand history at the planning bucket (usually monthly): `sku`, `period`, `qty`. If evaluating an existing forecast, also the forecast values with their creation dates (to avoid hindsight leakage). 18+ periods per SKU for a meaningful backtest; flag SKUs with less.
+
+## Workflow
+
+1. **Profile the demand first.** Per SKU compute mean, CV and zero-period share; classify smooth / erratic / intermittent / lumpy (defaults: CV 0.5 and 1.0 boundaries, intermittency at >25% zero periods - state them, adjust to natural breaks). Accuracy expectations differ by class; never report one blended number alone.
+2. **Set the benchmarks.** Naive (last period) always; seasonal naive when 2+ full seasons exist. These are non-negotiable controls.
+3. **Backtest rolling-origin.** One-step-ahead forecasts for each of the last 6+ periods, expanding window, using only data before each origin. A single train/test split is one lucky draw - do not accept it.
+4. **Score with honest metrics:**
+   - **WMAPE** = sum(|error|) / sum(actual) - the volume-weighted headline
+   - **Bias** = sum(error) / sum(actual) - direction; a fine WMAPE with persistent bias is quietly building excess stock or stockouts
+   - MAPE only as a footnote, and always disclose how many zero-actual periods it dropped
+5. **Deliver the FVA verdict.** FVA = WMAPE(naive) - WMAPE(candidate), per segment and overall. Negative FVA means the process destroys value - say it plainly.
+6. **Validate.** Recompute WMAPE for one model directly from the raw backtest rows and confirm it matches the table before presenting.
+
+## Pitfalls to check explicitly
+
+- **MAPE with zeros**: undefined on zero-actual periods; silently dropping them fakes precision on intermittent SKUs.
+- **MAPE asymmetry** rewards under-forecasting (errors capped at 100% below, unbounded above).
+- **Aggregation mix**: a good total can hide terrible A-item accuracy; always show the value-weighted cut.
+- **Lumpy segments**: if WMAPE > ~100%, the honest recommendation is an inventory-policy answer (buffers, MTO), not a better model.
+- **Hindsight leakage**: forecasts must predate actuals; check timestamps when auditing an existing process.
+
+## Output format
+
+1. Scoreboard table: model x (WMAPE, bias, MAPE-footnote), sorted by WMAPE
+2. FVA statement: "the process adds/destroys X points vs naive" - overall and per segment
+3. Segment table (pattern x best approach)
+4. Two or three recommendation sentences tied to segments, not globals
+
+Worked example with five baseline models and charts: https://github.com/gulmezeren2-byte/forecast-accuracy-lab
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.

--- a/cli-tool/components/skills/operations/otif-analysis/SKILL.md
+++ b/cli-tool/components/skills/operations/otif-analysis/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: otif-analysis
+description: Audit delivery performance from order-level data - compute the OTIF metric ladder (tolerant to strict), find where lateness concentrates, and quantify the gap between the reported KPI and what customers experience. Use when the user mentions OTIF, on-time delivery, delivery performance, late orders, teslimat performansı, zamanında teslimat, or asks why customers complain despite a high on-time score. Differentiator - exposes measurement choices before optimizing operations.
+---
+
+# OTIF Analysis
+
+Most "delivery problems" are measurement problems first. Before recommending any operational fix, establish what the honest number is and which definition choices inflate the reported one.
+
+## Required data
+
+Order-level rows with: `order_id`, `requested_delivery_date` (what the customer asked for), `promised_delivery_date` (what was confirmed), `actual_delivery_date`, completeness info (lines ordered vs delivered, or qty ordered vs delivered), and a status/cancelled flag. Useful cuts: carrier, region, customer, product family.
+
+If `requested_delivery_date` is missing, say so explicitly: only the promised-date rungs are computable, and the analysis cannot see sales-padding. Recommend capturing the requested date going forward.
+
+## Workflow
+
+1. **Validate before computing.** Count duplicated order rows; flag impossible dates (actual before order date); count cancelled orders and state how they will be treated. Report these counts in the output - an audit that silently cleans data is not an audit.
+2. **Compute the metric ladder** on the same population, strictest last:
+   - L1: on-time vs promised date, with the tolerance window currently in use (ask what it is; if unknown, show +3 days and label it)
+   - L2: on-time vs promised, zero tolerance
+   - L3: on-time vs *requested*, zero tolerance
+   - L4: **OTIF** = on-time vs requested AND order complete (all lines / full qty). In-full is judged at order level - a 9-of-10-lines delivery is not 90% on-time, it is one incomplete order
+   - L5: OTIF with cancelled orders kept in the denominator
+   Present the ladder as a table with the delta and the cause of each drop (tolerance, padding, partials, cancellations).
+3. **Decompose the gap.** For the dimension with the largest spread (try carrier, region, month, customer, product family), show OTIF per segment. Name the concentrated driver, not just the average.
+4. **Analyze the tail, not the mean.** Average lateness hides the distribution. Report the share of orders 4+ days late and the worst decile - those are the orders customers remember.
+5. **Reconcile before reporting.** Recompute the headline OTIF once more directly from raw rows (single pass, no intermediate tables) and confirm it matches. If it does not, stop and find out why.
+
+## Pitfalls to check explicitly
+
+- **Anchor choice**: promised-date metrics hide sales padding. Compute average (promised - requested) days; if > 0.5, quantify its KPI effect.
+- **Tolerance windows** are policy, not truth. Show the tolerance-sensitivity curve if the tolerance is contested.
+- **Cancelled orders** quietly leaving the denominator flatter the metric.
+- **Line-level averaging** overstates performance versus order-level in-full.
+
+## Output format
+
+1. The ladder table (definition, result %, delta, cause)
+2. Three finding sentences, each: what moved / where it concentrates / what decision it needs
+3. A definitions footnote stating anchor date, tolerance, in-full rule and cancellation treatment - so the number cannot be misread
+
+Worked example with charts and synthetic data: https://github.com/gulmezeren2-byte/otif-analytics
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.

--- a/cli-tool/components/skills/operations/root-cause-pareto/SKILL.md
+++ b/cli-tool/components/skills/operations/root-cause-pareto/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: root-cause-pareto
+description: Build a decision-grade Pareto for downtime, defects, complaints or delays - with unit-of-measure discipline, category hygiene, exposure normalization and a follow-up metric. Use when the user mentions pareto analysis, kök neden, duruş analizi, downtime, arıza analizi, defect ranking, şikayet analizi, 80/20 analysis. Differentiator - treats the Pareto as the start of a causal investigation, not a bar chart deliverable.
+---
+
+# Root-Cause Pareto
+
+A Pareto chart is easy; a Pareto that survives challenge in a management meeting is not. The difference is four disciplines applied before the chart exists.
+
+## Workflow
+
+1. **Pick the unit of measure deliberately.** Occurrences, minutes, or money - choose the one closest to the pain being managed and say why. Ranking breakdowns by *count* when one category costs 10x more *minutes* per event points the team at the wrong problem. When in doubt, show count and impact side by side.
+2. **Enforce category hygiene before counting:**
+   - Categories must sit at one granularity level (no "Mechanical failure" next to "Sensor S-114 misaligned")
+   - "Other/Miscellaneous" must stay under ~15% of the total; if it is bigger, the categorization failed - split it before proceeding
+   - Merge synonyms and near-duplicates (free-text logs always contain them; list the merges made)
+3. **Normalize by exposure before comparing.** Line A with 3 shifts will "lead" any raw ranking against Line B with 1 shift. Divide by machine-hours, orders, or units produced when comparing across lines, shifts, or periods - state the exposure base used.
+4. **Check stability.** A Pareto from one bad week is an anecdote. Compare the ranking across at least two comparable periods; only categories that stay on top deserve investment. Note rank changes.
+5. **Rank, plot, and go one level deeper on the #1 category.** Break the top category into its own sub-Pareto or apply 5-why prompts to its most frequent instances. The actionable cause is usually one level below the headline category.
+6. **Define the counter-metric.** Before recommending an action, state which number should move, by roughly how much, and when to re-measure. A Pareto without a follow-up measurement is decoration.
+
+## Pitfalls to check explicitly
+
+- Unit mismatch (count vs duration vs cost) silently reordering priorities
+- Unnormalized cross-line comparisons
+- "Other" as the tallest bar
+- Categories mixing symptoms ("stopped") with causes ("no material")
+- Acting on unstable rankings from short windows
+
+## Output format
+
+1. One sentence: unit of measure, exposure base, period, and total impact covered
+2. The ranked table (category, impact, share, cumulative) - chart optional, table mandatory
+3. Sub-analysis of the top category with candidate root causes
+4. Recommended action + counter-metric + re-measure date
+5. Data notes: merges performed, rows excluded, Other%
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.

--- a/cli-tool/components/skills/operations/safety-stock-review/SKILL.md
+++ b/cli-tool/components/skills/operations/safety-stock-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: safety-stock-review
+description: Size or audit safety stock with assumption checks - the z*sigma*sqrt(LT) formula plus an empirical stress test of what it actually delivers (cycle service vs fill rate) per variability class. Use when the user mentions safety stock, emniyet stoku, emniyet stoğu, reorder point, service level, stok seviyesi belirleme. Differentiator - refuses to hand back a number without validating the demand-distribution assumptions behind it.
+---
+
+# Safety Stock Review
+
+The textbook formula assumes roughly normal demand. Real portfolios contain SKUs where that assumption fails badly - the skill's job is to compute the number AND say where it can be trusted.
+
+## Required data
+
+Per-SKU demand history (`sku`, `period`, `qty`, 12+ periods), lead time (with variability if available), and the service target. Clarify early **which service the target means**: cycle service (probability of no stockout per cycle) or fill rate (share of units served) - contracts usually mean fill rate, formulas usually compute cycle service.
+
+## Workflow
+
+1. **Classify first.** Compute CV and zero-period share per SKU. For CV >= 1.0 or intermittent demand, state up front that the normal-formula result will be optimistic.
+2. **Compute the formula result:** SS = z * sigma_d * sqrt(LT), ROP = mu_d * LT + SS (demand-period units consistent with LT). If lead time varies, use the extended form with the sigma_LT term - ignoring lead-time variance is the most common silent understatement.
+3. **Stress-test empirically.** Set stock at mu + SS and replay the actual history: report both achieved cycle service (share of periods fully covered) and achieved fill rate (units served / units demanded). Zero-demand periods pass cycle service for free - fill rate is the honest one on intermittent items.
+4. **Show the cost of nines.** SS at 90/95/98/99% targets for the SKUs in question - service targets are pricing decisions, and the curve makes that visible.
+5. **Recommend per class**, not globally: formula fine for X-class; formula + empirical check for Y; for Z-class recommend empirical/quantile-based sizing or a policy change (MTO, lead-time reduction) instead of a bigger z.
+6. **Validate.** Reconcile the stress-test denominator (total units demanded) against the raw data sum before presenting.
+
+## Pitfalls to check explicitly
+
+- Cycle service quoted where the contract says fill rate - a penalty clause waiting to be found.
+- Normal formula on lumpy demand understates risk precisely on the items that hurt most.
+- sigma computed over a period mixing trend or seasonality inflates SS everywhere; deseasonalize or use forecast-error sigma when a forecast exists.
+- One global service target across the whole portfolio - targets should follow item criticality and margin.
+
+## Output format
+
+1. Per-SKU (or per-class) table: mu, sigma, CV, class, SS, ROP, achieved cycle service, achieved fill rate
+2. Trust statement per class ("formula reliable here / optimistic here, use X instead")
+3. Cost-of-nines table for the discussed target range
+4. Assumption footnote: service definition, lead-time treatment, sigma source
+
+Worked stress test with charts: https://github.com/gulmezeren2-byte/abc-xyz-inventory
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.

--- a/cli-tool/components/skills/operations/weekly-ops-report/SKILL.md
+++ b/cli-tool/components/skills/operations/weekly-ops-report/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: weekly-ops-report
+description: Turn raw operational data into a weekly management report that answers exactly three questions - what changed, where is it concentrated, what needs a decision. Use when the user mentions weekly report, haftalık rapor, yönetim raporu, ops review, KPI summary, or asks to summarize operational data for managers. Differentiator - contract-first reporting with plain-language findings and driver decomposition, never a chart dump.
+---
+
+# Weekly Ops Report
+
+A weekly report is a contract: *what changed, where is it concentrated, what needs a decision.* Anything that does not serve one of those three questions is decoration and gets cut.
+
+## Workflow
+
+1. **Data-quality gate first.** Before any KPI: duplicated rows, missing calendar days, impossible values (negative quantities, dates out of range). Fix what is safe to fix, and report every finding in a footer - an unattended report must audit its own inputs.
+2. **Compute the KPI set** agreed for the audience (typical core: revenue/volume, service level, stock cover; keep it under ~6). For each: this week, vs last week, and vs the trailing 8-week average. The baseline comparison prevents one unusual prior week from faking a trend.
+3. **Apply movement thresholds.** Only movements beyond agreed thresholds (state defaults, e.g. |revenue| >= 5%, |service| >= 1.5 pts) become findings. Reporting every wiggle trains readers to ignore the report.
+4. **Decompose every finding.** A movement without its driver is not a finding. Break the moved metric by its main dimension (region, carrier, category...) and name the concentrated segment with its share of the move.
+5. **Write findings as sentences**, one line each, using: *METRIC moved X (vs baseline) - DRIVER is the main contributor (Y, ~Z% of the move) - SUGGESTED NEXT STEP.* Tag each finding positive / negative / warning. Maximum five findings; if more qualify, keep the five largest by impact.
+6. **Assemble in fixed order:** headline KPI cards, findings list, trend view (13 weeks), attention lists (e.g. low-cover SKUs), data-quality footer. Same structure every week - familiarity is what makes deltas visible.
+7. **Validate before delivering.** Recompute one headline KPI directly from raw rows and match it against the report value. If automation is involved, this check runs inside the pipeline, not in someone's head.
+
+## Pitfalls to check explicitly
+
+- Week-over-week only (no baseline) - manufactures fake trends
+- Unstated metric definitions - pair every service/on-time figure with its definition footnote
+- Commentary drift - keep generated findings rule-based and auditable; human judgment belongs in a clearly separated commentary block, not mixed into computed statements
+- Silent denominator changes (cancelled orders, excluded lines) between weeks
+
+## Output format
+
+The report skeleton in order: title + period + generation stamp; 4-6 KPI cards with deltas; "What changed and where to look" findings (max 5, tagged); 13-week trends; attention table; data-quality footer listing every issue found.
+
+Worked implementation (scheduled pipeline, rule-based insight engine): https://github.com/gulmezeren2-byte/auto-report-pipeline
+
+---
+
+Source: [industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) by Eren Gulmez (MIT). The full method pack - entry skill, role agents, data-hygiene rules and artifact templates - lives there.


### PR DESCRIPTION
## What

Adds a new `operations/` category under `cli-tool/components/skills/` with six skills for supply-chain and operations data analysis:

- `otif-analysis` — delivery performance: the OTIF metric ladder (tolerant → strict), driver decomposition, tail analysis
- `forecast-accuracy-review` — WMAPE + bias + Forecast Value Added vs a naive benchmark, rolling-origin backtests
- `abc-xyz-segmentation` — value × variability 9-box with a planning policy per cell
- `safety-stock-review` — the z·σ·√LT formula plus an empirical stress test (cycle service vs fill rate)
- `root-cause-pareto` — Pareto discipline: unit choice, category hygiene, exposure normalization
- `weekly-ops-report` — a reporting contract: what changed / where it concentrates / what needs a decision

## Why

The catalog covers analytics, science and business well, but has nothing for manufacturing/supply-chain practitioners. These skills encode the measurement pitfalls of that domain (MAPE silently dropping zero-demand months, tolerance windows inflating on-time KPIs, cycle-service vs fill-rate confusion), not just the steps.

## Source and license

Maintained at [gulmezeren2-byte/industrial-engineering-ai-skills](https://github.com/gulmezeren2-byte/industrial-engineering-ai-skills) (MIT). Each SKILL.md carries a source line; happy to be listed in the README attribution section if that's the convention.

## Testing notes

All six follow the agentskills.io format used by existing skills (frontmatter parses, `name` matches folder). The change is markdown-only under `components/`; `npm test` produces identical results on this branch and on `main` in my environment (the failing suites are pre-existing and unrelated). The methodology behind each skill is demonstrated with reproducible numbers in the linked repo.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Operations skills category with six supply‑chain analysis skills to the components catalog. This expands coverage for manufacturing and operations users.

- Area: components (`cli-tool/components/skills/operations/`) — added `otif-analysis`, `forecast-accuracy-review`, `abc-xyz-segmentation`, `safety-stock-review`, `root-cause-pareto`, `weekly-ops-report`.
- Why: fills gaps in OTIF auditing, forecast accuracy, inventory segmentation, safety stock sizing, root‑cause Pareto, and weekly ops reporting.
- Catalog: New components added; regenerate `docs/components.json`.
- No code or infra changes; markdown-only. No new environment variables or secrets.

<sup>Written for commit 3d0673e74f56a14a259f3c5c650e91d43360490b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

