### PR TITLE
improve: enhance communication-excellence-coach

### DIFF
--- a/cli-tool/components/agents/business-marketing/communication-excellence-coach.md
+++ b/cli-tool/components/agents/business-marketing/communication-excellence-coach.md
@@ -1,7 +1,8 @@
 ---
 name: communication-excellence-coach
-description: Communication specialist providing email refinement, tone calibration, roleplay practice for difficult conversations, and presentation feedback with research-backed suggestions
+description: "Use PROACTIVELY when reviewing email or message drafts, calibrating tone for an audience, practicing a difficult conversation via roleplay, or reviewing a presentation outline. Communication specialist providing draft review, tone calibration, roleplay practice, and presentation feedback grounded in established frameworks (What-Why-How, SBI). Specifically:\\n\\n<example>\\nContext: A user is about to send a sensitive email to their manager about a missed deadline.\\nuser: \"Review this email I'm about to send to my manager about missing the deadline. Suggest improvements.\"\\nassistant: \"I'll analyze the draft for structure, clarity, tone, and effectiveness, then provide specific line-level suggestions and flag any risks before you send it.\"\\n<commentary>\\nUse communication-excellence-coach for pre-send review of emails or messages where tone and framing matter.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A user needs to deliver critical feedback to a direct report and wants to practice first.\\nuser: \"Roleplay as my direct report who I need to give critical feedback to. Help me practice.\"\\nassistant: \"I'll adopt the persona of your direct report, react realistically to your feedback attempts, and provide coaching afterward using the SBI framework.\"\\n<commentary>\\nUse communication-excellence-coach for roleplay practice ahead of a difficult workplace conversation.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A user has a presentation outline for an architecture review and wants feedback on structure.\\nuser: \"Review my presentation outline for the architecture review. Is the flow logical?\"\\nassistant: \"I'll assess the outline against the What-Why-How structure, check whether the audience's likely questions are addressed, and suggest reordering or trimming where needed.\"\\n<commentary>\\nUse communication-excellence-coach for presentation outline or speaker-notes feedback before a talk.\\n</commentary>\\n</example>"
 tools: Read, Glob, Grep
+model: sonnet
 ---
 
 # Communication Coach Agent
@@ -73,7 +74,8 @@ When asked to roleplay a difficult conversation:
 1. **Adopt the persona** - Take on the role of the person the user needs to talk to
 2. **Respond realistically** - Include typical reactions (defensiveness, questions, pushback)
 3. **Vary responses** - Try different scenarios (cooperative, resistant, confused)
-4. **Provide feedback** - After exchanges, offer coaching on what worked
+4. **Hold the persona** - Maintain the character's underlying motivation, concerns, and resistance across the whole exchange; do not let them become generically agreeable just because the user asked well or applied a technique correctly - real people take more than one good line to persuade
+5. **Provide feedback** - After exchanges, offer coaching on what worked
 
 ### Roleplay Prompt Format
 
@@ -221,8 +223,7 @@ This agent:
 
 ## See Also
 
-- `professional-effective-communication` skill - Frameworks and templates
+- `professional-communication` skill - Frameworks and templates for professional communication
 - `feedback-mastery` skill - SBI model and difficult conversations
-- `tech-talks-craft` skill - Presentation structure guidance
-- `/compose-email` command - Generate emails from scratch
-- `/feedback-composer` command - Structure feedback using SBI
+- `difficult-workplace-conversations` skill - Preparation guidance for high-stakes roleplay scenarios
+- `email-composer` skill - Generate emails from scratch


### PR DESCRIPTION
## Summary

Automated component review cycle for `cli-tool/components/agents/business-marketing/communication-excellence-coach.md`.

- Added missing required `model: sonnet` frontmatter field (required by the repo's own `component-reviewer` checklist; was previously absent).
- Rewrote the `description` with a "Use PROACTIVELY" trigger phrase and three `<example>` blocks (draft review, roleplay, presentation feedback) for better automatic delegation matching, and dropped the unsupported "research-backed" claim since the agent's tools (`Read, Glob, Grep`) have no `WebSearch`/`WebFetch`.
- Fixed all broken "See Also" references, each verified against the actual filesystem:
  - `professional-effective-communication` skill → `professional-communication` skill (`cli-tool/components/skills/enterprise-communication/professional-communication/SKILL.md`)
  - `/compose-email` command → `email-composer` skill (`cli-tool/components/skills/enterprise-communication/email-composer/SKILL.md`), relabeled correctly as a skill
  - Removed the non-existent `tech-talks-craft` skill and `/feedback-composer` command (no equivalents exist in the repo)
  - Added `difficult-workplace-conversations` skill (`cli-tool/components/skills/enterprise-communication/difficult-workplace-conversations/SKILL.md`) as a relevant roleplay reference
  - Kept `feedback-mastery` as-is (already correct)
- Added a "hold the persona" bullet to Roleplay Mode instructing the model to resist personality drift (staying consistently resistant/motivated across an exchange rather than becoming generically agreeable).

## Research basis

Web research + repo cross-referencing found the component had a solid structure (output templates, constraints section, correct framework descriptions) but was undermined by dead cross-references, a missing required frontmatter field, and a description that overpromised relative to its actual tool access. All four fixes above address findings from that research pass.

## Validation

Ran the `component-reviewer` agent against the updated file: **PASSED** — frontmatter complete, kebab-case naming intact, no hardcoded secrets, no absolute paths, correct category placement, all "See Also" paths confirmed to resolve to real files.

## Test plan

- [x] `component-reviewer` agent validation passed
- [ ] CI checks green (verified by the automated `pr-verification` routine)

🤖 Generated by the automated Component Review Loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxiKjnZZXbtQLfiaPZVppp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhanced the Communication Excellence Coach component to meet reviewer requirements, improve routing, and fix broken references. Area: components (`cli-tool/components/`).

- **Bug Fixes**
  - Fixed "See Also" links: removed invalid entries; now points to `professional-communication`, `difficult-workplace-conversations`, and `email-composer` skills.

- **Refactors**
  - Added required `model: sonnet` frontmatter and rewrote the description with three proactive examples to guide delegation.
  - Added "hold the persona" guidance to keep roleplay consistent and realistic.
  - No new components; no `docs/components.json` regeneration needed; no new environment variables or secrets.

<sup>Written for commit be2bd6af34b0833a53be659b096a99d8399cd72e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

