### PR TITLE
docs: clarify embedded timekeeping boundaries

### DIFF
--- a/cli-tool/components/agents/programming-languages/embedded-systems.md
+++ b/cli-tool/components/agents/programming-languages/embedded-systems.md
@@ -73,6 +73,31 @@ Power management:
 - Voltage scaling
 - Peripheral control
 
+### Timekeeping and power-loss boundary
+
+Before designing a scheduled action, time-limited credential, data logger, or
+RTC-driven wakeup, establish what time source the hardware actually has.
+
+- A crystal or RC oscillator is only a clock source; it does not retain
+  calendar time by itself.
+- A low-power timer can schedule a wakeup while its power domain is alive; do
+  not describe it as a real-time clock unless it has calendar state and a
+  documented backup-power path.
+- Treat full power loss, brownout, reset, and deep sleep as different states.
+  Verify which state clears the timer and calendar registers for the exact MCU
+  and board.
+- If an action must remain valid across full power loss, require a
+  battery-backed RTC domain or an explicit resynchronization path. Until time
+  is trustworthy again, fail closed for time-based access or safety decisions.
+
+Capture this evidence before implementation:
+
+1. Exact MCU/RTC part number and datasheet section.
+2. Clock source, reset behavior, backup supply, and expected retention window.
+3. The wake source and accuracy budget for the required interval.
+4. A power-cycle test that proves the intended retained state, or a documented
+   fail-closed/resync behavior when retention is unavailable.
+
 Real-time systems:
 - FreeRTOS
 - Zephyr


### PR DESCRIPTION
## What changed

Adds a focused timekeeping and power-loss decision gate to the existing
`embedded-systems` agent.

The agent now distinguishes a clock source, a low-power wake timer, and a
battery-backed RTC; it also requires reset/backup-power evidence and a
power-cycle test or fail-closed resynchronization behavior before relying on
time across full power loss.

## Why

Embedded workflows can otherwise incorrectly infer persistent calendar time
from a crystal or deep-sleep timer. That is particularly risky for scheduled
actions, time-limited credentials, data logging, and safety decisions.

## Validation

- `git diff --check`
- Target file has valid frontmatter, is 11 KB, has seven sections, and does
  not contain the audit's dangerous-instruction or URL patterns.
- `npm run security-audit -- --file components/agents/programming-languages/embedded-systems.md --ci --verbose`
  was run. The current audit command ignored its file filter and reported the
  pre-existing repository baseline: all 764 components fail, largely because
  existing files lack frontmatter. This change does not introduce that failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies timekeeping boundaries in the `embedded-systems` agent doc by adding guidance for distinguishing clock sources, low‑power timers, and battery-backed RTCs. Sets evidence and fail-closed/resync requirements before relying on time across power loss.

- Area: components (`cli-tool/components/`); updated `agents/programming-languages/embedded-systems.md`.
- Adds a "Timekeeping and power-loss boundary" subsection to prevent misuse of oscillators/LP timers as RTC.
- No new components; no `docs/components.json` regeneration needed.
- No new environment variables or secrets.

<sup>Written for commit dd4b4a62db0f71dbf4b14af25fc60e3c40c294a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

