### PR TITLE
docs: fix template navigation links

### DIFF
--- a/cli-tool/docs_to_claude/DOWNLOAD_TRACKING.md
+++ b/cli-tool/docs_to_claude/DOWNLOAD_TRACKING.md
@@ -282,7 +282,7 @@ console.log(JSON.stringify(payload, null, 2))
 
 ## Licencia
 
-MIT License - Ver [LICENSE](LICENSE) para detalles.
+MIT License - Ver [LICENSE](../../LICENSE) para detalles.
 
 ## Contacto
 

--- a/cli-tool/templates/javascript-typescript/README.md
+++ b/cli-tool/templates/javascript-typescript/README.md
@@ -213,10 +213,10 @@ The template adapts to your specific framework needs automatically.
 
 ## 📖 Learn More
 
-- **Main Project**: [Claude Code Templates](../README.md)
+- **Main Project**: [Claude Code Templates](../../../README.md)
 - **Common Templates**: [Universal patterns](../common/README.md)
-- **Python Templates**: [Python development](../python/README.md)
-- **CLI Tool**: [Automated installer](../cli-tool/README.md)
+- **Python Templates**: [Python development](../python/CLAUDE.md)
+- **CLI Tool**: [Automated installer](../../README.md)
 
 ## 💡 Why Use This Template?
 


### PR DESCRIPTION
## Summary

- Fix the JavaScript/TypeScript template's links to the repository README, Python template entrypoint, and CLI installer documentation.
- Fix the Spanish download-tracking document's license link.

## Root cause

These links were resolved relative to their Markdown files, but several targets were written as if they were resolved from a parent directory. They therefore led to paths that do not exist in the repository.

## Validation

- Resolved every modified relative link against the current checkout and confirmed the target exists.
- Ran `git diff --check`.

## Impact

Readers can navigate from the JavaScript/TypeScript template and download-tracking guide to the intended project documents without landing on 404 pages.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect relative links in the JavaScript/TypeScript template README and the Spanish download‑tracking guide so readers land on the right docs instead of 404s.

- Fixed JS/TS template links to the repo README, Python entrypoint, and CLI installer.
- Fixed LICENSE link in `cli-tool/docs_to_claude/DOWNLOAD_TRACKING.md` (Spanish).
- Area: website (docs/) content under `cli-tool/templates/` and `cli-tool/docs_to_claude/`.
- No new components; no catalog (`docs/components.json`) regeneration needed.
- No new environment variables or secrets.

<sup>Written for commit 695651cbcb5e87fdd573e3e0bdcebaede773dba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

