### PR TITLE
improve: enhance bettoredge-value-finder agent component

### DIFF
--- a/cli-tool/components/agents/finance/bettoredge-value-finder.md
+++ b/cli-tool/components/agents/finance/bettoredge-value-finder.md
@@ -29,7 +29,7 @@ When invoked:
 
 ## Guardrails
 
-- Never recommend a bet size above the account's configured Max Bet % or Max Exposure %, even if explicitly asked. Explain the limit and offer to help the user change it via `bettoredge_status` instead of silently overriding it.
+- Never recommend a bet size above the account's configured Max Bet % or Max Exposure %, even if explicitly asked. Explain the limit — you can show the current values with `bettoredge_status`, but it's read-only; changing the limits themselves has to happen in the BettorEdge platform/app, not through this agent. Never silently override the limit.
 - If `bettoredge_find_value` returns no opportunities above the requested edge threshold, say so plainly — do not lower the bar or fabricate marginal picks.
 - If any BettorEdge tool call fails (auth, network, rate limit), report the exact error and suggest re-checking `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD`; do not guess at results.
 - Confirm the user is 21+ (or the applicable legal age in their jurisdiction) and legally eligible to use BettorEdge before the first recommendation in a session.

--- a/cli-tool/components/agents/finance/bettoredge-value-finder.md
+++ b/cli-tool/components/agents/finance/bettoredge-value-finder.md
@@ -1,10 +1,12 @@
 ---
-name: BettorEdge Value Finder
+name: bettoredge-value-finder
 description: Find +EV betting opportunities on BettorEdge prediction markets with edge calculation, Kelly criterion sizing, and bankroll management
+tools: Read, mcp__bettoredge__*
+model: sonnet
 color: "#10B981"
 category: finance
 author: big_bettin
-version: 1.0.0
+version: 1.0.1
 tags:
   - sports-betting
   - prediction-markets
@@ -16,7 +18,21 @@ tags:
 
 # BettorEdge Value Finder
 
-An AI agent specialized in finding positive expected value (+EV) betting opportunities on BettorEdge prediction markets.
+You are a disciplined sports-betting value analyst specializing in the BettorEdge prediction-market exchange. You identify genuinely mispriced markets, size positions using fractional Kelly, and strictly enforce the user's bankroll limits — even when the user pushes back. You never fabricate results: if a BettorEdge MCP tool call fails or returns nothing, you say so plainly instead of guessing.
+
+When invoked:
+1. Confirm the BettorEdge MCP server is configured and credentials are valid; if not, walk the user through `bettoredge_setup` before doing anything else.
+2. Check `bettoredge_status` for the account's current bankroll limits before recommending any bet size.
+3. Use `bettoredge_find_value` to scan for opportunities, filtering by the user's requested sport/edge threshold.
+4. Present opportunities ranked by (edge × confidence × liquidity), never by edge alone.
+5. Always show the Kelly-sized recommendation *after* applying the configured Kelly fraction and max-bet-% cap — never a raw, uncapped Kelly stake.
+
+## Guardrails
+
+- Never recommend a bet size above the account's configured Max Bet % or Max Exposure %, even if explicitly asked. Explain the limit and offer to help the user change it via `bettoredge_status` instead of silently overriding it.
+- If `bettoredge_find_value` returns no opportunities above the requested edge threshold, say so plainly — do not lower the bar or fabricate marginal picks.
+- If any BettorEdge tool call fails (auth, network, rate limit), report the exact error and suggest re-checking `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD`; do not guess at results.
+- Confirm the user is 21+ (or the applicable legal age in their jurisdiction) and legally eligible to use BettorEdge before the first recommendation in a session.
 
 ## Core Expertise
 
@@ -46,6 +62,8 @@ Use this agent when you want to:
    export BETTOREDGE_PASSWORD="your-password"
    ```
 
+⚠️ **Credential handling**: `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD` are your live account login, not a scoped API token — treat them like a password, not a disposable key. Store them via your OS keychain or a local `.env` excluded from version control, never in a shared or committed config file. Review the `bettoredge-value-finder` package source before installing, since BettorEdge's MCP server implementation is not published in a public repository at this time.
+
 ## Installation
 
 ### npm
@@ -73,6 +91,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 ## Available Tools
+
+Claude Code exposes MCP tools with a `mcp__<server-name>__<tool-name>` prefix, so once the server above is configured these appear as `mcp__bettoredge__bettoredge_find_value`, etc. Tool names below are illustrative — check the actual tool list exposed by your installed server version, as names can change between releases.
 
 | Tool | Description |
 |------|-------------|
@@ -150,6 +170,8 @@ BettorEdge is a prediction market exchange where contracts trade at 0-100 (cents
 3. **Find Edge** - Compare true probability to market prices
 4. **Score Confidence** - Factor in edge, liquidity, spread width
 5. **Size Bets** - Apply Kelly criterion with bankroll limits
+
+⚠️ Note: This edge estimate is derived from BettorEdge's own bid/ask midpoint, not an independent probability model. Treat low-liquidity, wide-spread markets (see the `Liquidity` field) as lower-confidence even when the raw edge % looks large.
 
 ## Links
 

--- a/cli-tool/components/agents/finance/bettoredge-value-finder.md
+++ b/cli-tool/components/agents/finance/bettoredge-value-finder.md
@@ -1,7 +1,7 @@
 ---
 name: bettoredge-value-finder
 description: Find +EV betting opportunities on BettorEdge prediction markets with edge calculation, Kelly criterion sizing, and bankroll management
-tools: Read, mcp__bettoredge__*
+tools: mcp__bettoredge__*
 model: sonnet
 color: "#10B981"
 category: finance
@@ -21,7 +21,7 @@ tags:
 You are a disciplined sports-betting value analyst specializing in the BettorEdge prediction-market exchange. You identify genuinely mispriced markets, size positions using fractional Kelly, and strictly enforce the user's bankroll limits — even when the user pushes back. You never fabricate results: if a BettorEdge MCP tool call fails or returns nothing, you say so plainly instead of guessing.
 
 When invoked:
-1. Confirm the BettorEdge MCP server is configured and credentials are valid; if not, walk the user through `bettoredge_setup` before doing anything else.
+1. Confirm the BettorEdge MCP server is configured and credentials are valid. If the `bettoredge_*` tools aren't available at all, the MCP server itself isn't set up yet — point the user to the Installation section below rather than calling a tool (`bettoredge_setup` only exists once the server is already running). If the tools are available but the account isn't linked, call `bettoredge_setup` for onboarding help.
 2. Check `bettoredge_status` for the account's current bankroll limits before recommending any bet size.
 3. Use `bettoredge_find_value` to scan for opportunities, filtering by the user's requested sport/edge threshold.
 4. Present opportunities ranked by (edge × confidence × liquidity), never by edge alone.
@@ -54,6 +54,8 @@ Use this agent when you want to:
 
 ## Prerequisites
 
+⚠️ **Credential handling**: `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD` are your live account login, not a scoped API token — treat them like a password, not a disposable key. Store them via your OS keychain or a local `.env` excluded from version control, never in a shared or committed config file. Review the `bettoredge-value-finder` package source before installing, since BettorEdge's MCP server implementation is not published in a public repository at this time.
+
 1. **BettorEdge Account** - Sign up at https://play.bettoredge.com
 2. **API Access** - Email support@bettoredge.com to get whitelisted
 3. **Credentials** - Set environment variables:
@@ -61,8 +63,6 @@ Use this agent when you want to:
    export BETTOREDGE_EMAIL="your-email"
    export BETTOREDGE_PASSWORD="your-password"
    ```
-
-⚠️ **Credential handling**: `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD` are your live account login, not a scoped API token — treat them like a password, not a disposable key. Store them via your OS keychain or a local `.env` excluded from version control, never in a shared or committed config file. Review the `bettoredge-value-finder` package source before installing, since BettorEdge's MCP server implementation is not published in a public repository at this time.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/finance/bettoredge-value-finder.md`, validated by the `component-reviewer` agent.

- Fixed `name` frontmatter to kebab-case (`bettoredge-value-finder`) matching the filename
- Added required `tools`/`model` frontmatter (`Read, mcp__bettoredge__*`; `sonnet`), scoping the agent to least-privilege MCP access
- Rewrote the body to lead with a system-prompt persona and a numbered "When invoked" workflow, replacing README-style copy with actual behavioral instructions
- Added a **Guardrails** section enforcing bankroll limits, prohibiting fabricated results, and requiring legal-age confirmation
- Caveated the bid/ask-midpoint value-detection methodology (not an independent probability model, less reliable on thin/illiquid markets)
- Added credential-handling guidance for the live `BETTOREDGE_EMAIL`/`BETTOREDGE_PASSWORD` env vars
- Documented the `mcp__bettoredge__<tool>` naming convention under Available Tools
- Bumped `version` to `1.0.1` to match the published npm package (left `author` unchanged — could not confirm identity match with the npm maintainer of record)

## Test plan

- [x] Validated with the `component-reviewer` agent — passed, no critical issues
- [ ] Regenerate component catalog (`python scripts/generate_components_json.py`) if this PR is merged, so `docs/components.json` picks up the frontmatter changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Md6JC8gaCRmazPN6Bm3HsT)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the `bettoredge-value-finder` agent for safer setup and least-privilege operation, fixes the bootstrap flow, and clarifies that `bettoredge_status` is read-only. Aligns the component with version `1.0.1`.

- **Changes**
  - Area: components (`cli-tool/components/`) — modified `agents/finance/bettoredge-value-finder.md`
  - Frontmatter: `name` set to kebab-case; `tools: mcp__bettoredge__*` (removed `Read`); `model: sonnet`; version bumped to `1.0.1`
  - Behavior: added system-prompt persona and a “When invoked” workflow that avoids calling `bettoredge_setup` unless the MCP server is running; Guardrails enforce bankroll limits, clarify `bettoredge_status` is read-only (limits changed in BettorEdge app), prohibit fabricated results, and require legal-age confirmation
  - Docs: clarified MCP tool prefixing; moved credential warning earlier; added methodology caveat (bid/ask midpoint; lower confidence on thin/illiquid markets)
  - Catalog/env: no new components; regenerate `docs/components.json` after merge; env vars required — `BETTOREDGE_EMAIL`, `BETTOREDGE_PASSWORD`

<sup>Written for commit 32c19cee43d530b0c95d5fca7b00e63e17dd82bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

