### PR TITLE
fix: add missing 'item' field to breadcrumb structured data

### DIFF
--- a/dashboard/src/pages/component/[type]/[...slug].astro
+++ b/dashboard/src/pages/component/[type]/[...slug].astro
@@ -211,7 +211,12 @@ const componentSchema = component
               name: config?.label ?? typePlural,
               item: `https://www.aitmpl.com/${typePlural}`,
             },
-            { '@type': 'ListItem', position: 3, name: title },
+            {
+              '@type': 'ListItem',
+              position: 3,
+              name: title,
+              item: `https://www.aitmpl.com${canonicalPath}`,
+            },
           ],
         },
       ],


### PR DESCRIPTION
## What

1. Adds the missing `item` field to the last `ListItem` (position 3) of the `BreadcrumbList` JSON-LD schema on component detail pages (`/component/{type}/{slug}`), using the page's canonical URL (`https://www.aitmpl.com${canonicalPath}`).
2. Removes legacy root files: `vercel.json`, `.vercelignore` (obsolete since the Vercel → Cloudflare Pages migration) and `NEON_INTEGRATION_PLAN.md` (Neon integration already implemented — featured page + skill are live).

## Why

Google Search Console flagged a critical Breadcrumbs structured-data issue on aitmpl.com: **Missing field "item" (in "itemListElement")**. Critical issues prevent the breadcrumb rich result from appearing in Google Search. This was the only `BreadcrumbList` in the repo, so a one-file change resolves the report.

The removed files are dead weight: nothing in the build, CI, or deploy pipeline references them anymore.

## Notes for reviewers

- Verified locally on the dev server: the rendered JSON-LD at `/component/agents/development-team/frontend-developer` now includes `item` on all three breadcrumb entries.
- After this deploys (auto via GitHub Actions on merge to `main`), use "Validate fix" in the Search Console Breadcrumbs report to trigger re-crawl.