### PR TITLE
Add erp-report-engine MCP server (read-only ERP database access)

### DIFF
--- a/cli-tool/components/mcps/database/erp-report-engine.json
+++ b/cli-tool/components/mcps/database/erp-report-engine.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "erp-report-engine": {
-      "description": "Read-only MCP over the SQL database behind an ERP (Logo Tiger, Netsis, Mikro). The agent queries canonical entities through a statement-checking read-only guard measured by a public 28-attack benchmark; never raw ERP tables, never writes.",
+      "description": "Read-only SQL access to an ERP's database (Logo Tiger, Netsis, Mikro): canonical entities through a statement-checking guard.",
       "command": "uvx",
       "args": [
         "--from",

--- a/cli-tool/components/mcps/database/erp-report-engine.json
+++ b/cli-tool/components/mcps/database/erp-report-engine.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "erp-report-engine": {
+      "description": "Read-only MCP over the SQL database behind an ERP (Logo Tiger, Netsis, Mikro). The agent queries canonical entities through a statement-checking read-only guard measured by a public 28-attack benchmark; never raw ERP tables, never writes.",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "erp-report-engine[mcp]",
+        "erp-report-engine",
+        "mcp",
+        "-c",
+        "<path-to-your-erp-config.yaml>"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds **erp-report-engine** to `mcps/database/` — a read-only MCP server over the SQL database behind an ERP.

The agent queries **canonical entities** (`orders`, `order_lines`, `inventory`, `receivables`), never the raw ERP tables, through a four-layer read-only guard that checks the **statement itself** — refusing writes, second statements, and side-effecting functions (`pg_read_file`, `xp_cmdshell`, `dblink`, …) that a shape-only check waves through. Bundled profiles for Logo Tiger, Netsis, and Mikro (all SQL Server).

The read-only claim is measured, not asserted: a public **28-attack benchmark** (`erp-report-engine trust-benchmark`) and an in-browser [playground](https://gulmezeren2-byte.github.io/erp-report-engine/playground.html) that runs the real guard via Pyodide.

- Follows the existing `mcps/database/*.json` format (single `mcpServers` entry).
- Launches via `uvx` (no manual install); the user points `-c` at their own `erp-config.yaml`.
- On [PyPI](https://pypi.org/project/erp-report-engine/) and the official MCP registry (`io.github.gulmezeren2-byte/erp-report-engine`). Repo: https://github.com/gulmezeren2-byte/erp-report-engine

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `erp-report-engine` MCP server for safe, read-only ERP SQL access via canonical entities. Also shortens its component description to match peer length.

- Area: components (`cli-tool/components/`).
- New component: `mcps/database/erp-report-engine.json`; regenerate `docs/components.json`.
- Run: `uvx --from erp-report-engine[mcp] erp-report-engine mcp -c <path-to-your-erp-config.yaml>`; no new env vars; needs DB creds in `erp-config.yaml`.
- Supports Logo Tiger, Netsis, and Mikro; published on PyPI and MCP registry `io.github.gulmezeren2-byte/erp-report-engine`.

<sup>Written for commit 502b18c06fdf15a829d16340e54e579aabfb3b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

