### PR TITLE
feat(dashboard): hide Loops from navigation menu

### DIFF
--- a/dashboard/src/components/Sidebar.astro
+++ b/dashboard/src/components/Sidebar.astro
@@ -67,7 +67,7 @@ function isActive(path: string): boolean {
       <span class="sidebar-text font-ui-mono text-[10px] font-semibold text-[var(--color-text-tertiary)] uppercase tracking-[0.1em] select-none transition-all duration-300 block">Browse</span>
     </div>
 
-    {Object.entries(TYPE_CONFIG).map(([type, config]) => (
+    {Object.entries(TYPE_CONFIG).filter(([, config]) => !config.hidden).map(([type, config]) => (
       <a
         href={`/${type}`}
         data-nav-type={type}

--- a/dashboard/src/components/TypeTabs.astro
+++ b/dashboard/src/components/TypeTabs.astro
@@ -10,7 +10,7 @@ const { activeType, counts = {} } = Astro.props;
 ---
 
 <nav class="flex items-center gap-1 px-6 py-2 border-b border-[var(--color-border)] overflow-x-auto">
-  {Object.entries(TYPE_CONFIG).map(([type, config]) => {
+  {Object.entries(TYPE_CONFIG).filter(([, config]) => !config.hidden).map(([type, config]) => {
     const isActive = type === activeType;
     const count = counts[type] ?? 0;
     return (

--- a/dashboard/src/lib/icons.ts
+++ b/dashboard/src/lib/icons.ts
@@ -12,14 +12,14 @@ export const ICONS: Record<string, string> = {
 // Compact inline SVG for React (as string)
 export const ICON_SVGS = ICONS;
 
-export const TYPE_CONFIG: Record<string, { icon: string; label: string; singular: string; color: string; flag: string }> = {
+export const TYPE_CONFIG: Record<string, { icon: string; label: string; singular: string; color: string; flag: string; hidden?: boolean }> = {
   skills:   { icon: 'skills',   label: 'Skills',   singular: 'skill',   color: '#f59e0b', flag: '--skill' },
   agents:   { icon: 'agents',   label: 'Agents',   singular: 'agent',   color: '#3b82f6', flag: '--agent' },
   commands: { icon: 'commands', label: 'Commands', singular: 'command', color: '#10b981', flag: '--command' },
   settings: { icon: 'settings', label: 'Settings', singular: 'setting', color: '#8b5cf6', flag: '--setting' },
   hooks:    { icon: 'hooks',    label: 'Hooks',    singular: 'hook',    color: '#f97316', flag: '--hook' },
   mcps:     { icon: 'mcps',     label: 'MCPs',     singular: 'mcp',     color: '#06b6d4', flag: '--mcp' },
-  loops:    { icon: 'loops',    label: 'Loops',    singular: 'loop',    color: '#ec4899', flag: '--loop' },
+  loops:    { icon: 'loops',    label: 'Loops',    singular: 'loop',    color: '#ec4899', flag: '--loop', hidden: true },
 };
 
 export const VALID_TYPES = Object.keys(TYPE_CONFIG);


### PR DESCRIPTION
## Summary
- Add an optional `hidden` flag to `TYPE_CONFIG` in `dashboard/src/lib/icons.ts` and mark `loops` as hidden
- Filter hidden types out of the sidebar Browse section (`Sidebar.astro`) and the type tabs (`TypeTabs.astro`)
- `/loops` pages remain accessible via direct URL; only the menu entries are removed

## Test plan
- Verified locally with `astro dev`: Loops no longer appears in the sidebar or type tabs, and `/loops` still loads by direct URL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Loops from the dashboard navigation and type tabs by adding a `hidden` flag to `TYPE_CONFIG`. Loops pages still work via direct URL.

- Area: dashboard/ (navigation UI)
- Added optional `hidden` flag to `TYPE_CONFIG` in `dashboard/src/lib/icons.ts`; set `loops` to hidden
- Filtered hidden types in `dashboard/src/components/Sidebar.astro` and `dashboard/src/components/TypeTabs.astro`
- No new components; no `docs/components.json` regeneration
- No new environment variables or secrets

<sup>Written for commit 2f1f3b8e654d2286f925c49d82c6696f41b0f944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

