### PR TITLE
feat: add Lumi App Finder MCP

### DIFF
--- a/cli-tool/components/mcps/web/lumi-app-finder.json
+++ b/cli-tool/components/mcps/web/lumi-app-finder.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
     "lumi-app-finder": {
-      "description": "Finds which Lumi Studio iPhone or iPad app fits a task in learning, productivity, photo, travel, or wellness, using a read-only first-party catalog of 28 verified live apps across all 50 Apple locales. Returns localized publisher-authored evidence, purchase model, and direct App Store links; it is not an independent ranking. Fetches public catalog data over HTTPS without sending the user's query and falls back to a bundled snapshot. No account, API key, or analytics; requires Node.js 20+.",
+      "description": "Finds which Lumi Studio iPhone or iPad app fits a task in learning, productivity, photo, travel, or wellness, using a read-only first-party catalog of 29 verified live apps across all 50 Apple locales. Returns localized publisher-authored evidence, purchase model, and direct App Store links; it is not an independent ranking. Fetches public catalog data over HTTPS without sending the user's query and falls back to a bundled snapshot. No account, API key, or analytics; requires Node.js 20+.",
       "command": "npx",
       "args": [
         "-y",
-        "https://codeload.github.com/alice51849/lumi-mcp/tar.gz/2234f2263d914d80bacb7ca428f6b5afb6522396"
+        "https://codeload.github.com/alice51849/lumi-mcp/tar.gz/89d5cf5c13cb943163267b8ddcd62e6164971578"
       ]
     }
   }

--- a/cli-tool/components/mcps/web/lumi-app-finder.json
+++ b/cli-tool/components/mcps/web/lumi-app-finder.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "lumi-app-finder": {
+      "description": "Finds which Lumi Studio iPhone or iPad app fits a task in learning, productivity, photo, travel, or wellness, using a read-only first-party catalog of 28 verified live apps across all 50 Apple locales. Returns localized publisher-authored evidence, purchase model, and direct App Store links; it is not an independent ranking. Fetches public catalog data over HTTPS without sending the user's query and falls back to a bundled snapshot. No account, API key, or analytics; requires Node.js 20+.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "https://github.com/alice51849/lumi-mcp/releases/download/v1.1.2/lumi-app-finder-npx.tgz"
+      ]
+    }
+  }
+}

--- a/cli-tool/components/mcps/web/lumi-app-finder.json
+++ b/cli-tool/components/mcps/web/lumi-app-finder.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "https://github.com/alice51849/lumi-mcp/releases/download/v1.1.2/lumi-app-finder-npx.tgz"
+        "https://codeload.github.com/alice51849/lumi-mcp/tar.gz/2234f2263d914d80bacb7ca428f6b5afb6522396"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Add Lumi App Finder as a commit-pinned stdio MCP component in the `web` catalog.
- Match learning, productivity, photo, travel, and wellness needs to 29 verified live Lumi Studio iPhone and iPad apps across all 50 Apple locales.
- Return localized publisher-authored context, purchase models, and direct App Store links while clearly disclosing that results are first-party and not independent rankings.

## Security and privacy

- One read-only, idempotent tool; no mutation capability.
- No account, API key, environment variable, analytics, or tracking required.
- User query text stays in the local MCP process. The server refreshes only public catalog data over HTTPS and falls back to its bundled snapshot.
- Uses an immutable, full 40-character commit SHA for the `v1.1.3` codeload archive: `89d5cf5c13cb943163267b8ddcd62e6164971578`.
- Requires Node.js 20+.

## Validation

- Parsed and structurally checked the component JSON.
- Installed the commit-addressed archive through `npx` with a clean npm cache.
- Completed MCP `initialize`, `tools/list`, and real `find_ios_apps` calls; returned live-catalog matches with direct `apps.apple.com` URLs.
- Independently reviewed with the repository's `component-reviewer`; no blocking issues found.

The generated dashboard catalog is intentionally not committed: this repository's PR welcome flow states that catalog regeneration happens after merge, `.github/workflows/update-json-data.yml` runs the generator automatically, and merged MCP PR #693 follows the same single-source-file pattern.

Disclosure: I maintain Lumi App Finder and Lumi Studio publishes every app in its catalog.