### PR TITLE
Remove flatten-mcp MCP (project retired)

### DIFF
--- a/cli-tool/components/mcps/devtools/flatten-mcp.json
+++ b/cli-tool/components/mcps/devtools/flatten-mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "flatten": {
-      "description": "Flatten Claude Code sessions: moves bulky tool output into a sidecar file and keeps every prompt and event verbatim, so the same conversation resumes at a lower token count instead of being compacted into a lossy summary. Reversible and crash-safe. Optional ANTHROPIC_API_KEY enables exact token counting.",
-      "command": "npx",
-      "args": ["-y", "flatten-mcp@latest"]
-    }
-  }
-}


### PR DESCRIPTION
flatten-mcp has been retired by its author and its repository is no longer public, so the component's links no longer resolve.

This removes `cli-tool/components/mcps/devtools/flatten-mcp.json` — the single file added by #632. The dashboard copies and the generated indexes (`components.json`, `search-index.json`, `mcps.json`) are produced by your build, so I left them untouched rather than hand-editing generated output; let me know if you'd prefer them regenerated in this PR.

Thanks for the project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the retired `flatten-mcp` MCP component. Its repo is no longer public and links no longer resolve.

- Area: components (`cli-tool/components/`)
- Deleted: `cli-tool/components/mcps/devtools/flatten-mcp.json`
- No new components; catalog regen required: `docs/components.json`, `components.json`, `search-index.json`, `mcps.json`
- No new environment variables or secrets

<sup>Written for commit ecc6d93c90ef5982881d1b5d2f05ce9216a37345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

