### PR TITLE
fix(analytics): count each assistant message once, not once per conte…

### DIFF
--- a/cli-tool/src/analytics.js
+++ b/cli-tool/src/analytics.js
@@ -193,7 +193,14 @@ class ClaudeAnalytics {
     const usageByMessage = new Map();
     parsedMessages.forEach((message, index) => {
       if (!message.usage) return;
-      const key = message.id || message.uuid || `__no_id_${index}`;
+      // Namespace each identifier source so a value that happens to appear as
+      // both an `id` and a `uuid` — or an id that looks like a generated key —
+      // cannot collapse two distinct records into one.
+      const key = message.id
+        ? `id:${message.id}`
+        : message.uuid
+          ? `uuid:${message.uuid}`
+          : `idx:${index}`;
       usageByMessage.set(key, message.usage);
     });
 

--- a/cli-tool/src/analytics.js
+++ b/cli-tool/src/analytics.js
@@ -185,21 +185,31 @@ class ClaudeAnalytics {
   }
 
   calculateRealTokenUsage(parsedMessages) {
+    // Claude Code writes a single assistant message as several JSONL records —
+    // one per content block (thinking / text / tool_use) — and every one of
+    // those records repeats the same `message.id` and an identical `usage`
+    // object. Collapse by message id before summing, otherwise each message's
+    // tokens are counted once per content block.
+    const usageByMessage = new Map();
+    parsedMessages.forEach((message, index) => {
+      if (!message.usage) return;
+      const key = message.id || message.uuid || `__no_id_${index}`;
+      usageByMessage.set(key, message.usage);
+    });
+
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let totalCacheCreationTokens = 0;
     let totalCacheReadTokens = 0;
-    let messagesWithUsage = 0;
 
-    parsedMessages.forEach(message => {
-      if (message.usage) {
-        totalInputTokens += message.usage.input_tokens || 0;
-        totalOutputTokens += message.usage.output_tokens || 0;
-        totalCacheCreationTokens += message.usage.cache_creation_input_tokens || 0;
-        totalCacheReadTokens += message.usage.cache_read_input_tokens || 0;
-        messagesWithUsage++;
-      }
+    usageByMessage.forEach(usage => {
+      totalInputTokens += usage.input_tokens || 0;
+      totalOutputTokens += usage.output_tokens || 0;
+      totalCacheCreationTokens += usage.cache_creation_input_tokens || 0;
+      totalCacheReadTokens += usage.cache_read_input_tokens || 0;
     });
+
+    const messagesWithUsage = usageByMessage.size;
 
     return {
       total: totalInputTokens + totalOutputTokens + totalCacheCreationTokens + totalCacheReadTokens,

--- a/cli-tool/src/analytics/core/ConversationAnalyzer.js
+++ b/cli-tool/src/analytics/core/ConversationAnalyzer.js
@@ -378,21 +378,31 @@ class ConversationAnalyzer {
    * @returns {Object} Token usage statistics
    */
   calculateRealTokenUsage(parsedMessages) {
+    // Claude Code writes a single assistant message as several JSONL records —
+    // one per content block (thinking / text / tool_use) — and every one of
+    // those records repeats the same `message.id` and an identical `usage`
+    // object. Collapse by message id before summing, otherwise each message's
+    // tokens are counted once per content block.
+    const usageByMessage = new Map();
+    parsedMessages.forEach((message, index) => {
+      if (!message.usage) return;
+      const key = message.id || message.uuid || `__no_id_${index}`;
+      usageByMessage.set(key, message.usage);
+    });
+
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let totalCacheCreationTokens = 0;
     let totalCacheReadTokens = 0;
-    let messagesWithUsage = 0;
 
-    parsedMessages.forEach(message => {
-      if (message.usage) {
-        totalInputTokens += message.usage.input_tokens || 0;
-        totalOutputTokens += message.usage.output_tokens || 0;
-        totalCacheCreationTokens += message.usage.cache_creation_input_tokens || 0;
-        totalCacheReadTokens += message.usage.cache_read_input_tokens || 0;
-        messagesWithUsage++;
-      }
+    usageByMessage.forEach(usage => {
+      totalInputTokens += usage.input_tokens || 0;
+      totalOutputTokens += usage.output_tokens || 0;
+      totalCacheCreationTokens += usage.cache_creation_input_tokens || 0;
+      totalCacheReadTokens += usage.cache_read_input_tokens || 0;
     });
+
+    const messagesWithUsage = usageByMessage.size;
 
     return {
       total: totalInputTokens + totalOutputTokens,

--- a/cli-tool/src/analytics/core/ConversationAnalyzer.js
+++ b/cli-tool/src/analytics/core/ConversationAnalyzer.js
@@ -386,7 +386,14 @@ class ConversationAnalyzer {
     const usageByMessage = new Map();
     parsedMessages.forEach((message, index) => {
       if (!message.usage) return;
-      const key = message.id || message.uuid || `__no_id_${index}`;
+      // Namespace each identifier source so a value that happens to appear as
+      // both an `id` and a `uuid` — or an id that looks like a generated key —
+      // cannot collapse two distinct records into one.
+      const key = message.id
+        ? `id:${message.id}`
+        : message.uuid
+          ? `uuid:${message.uuid}`
+          : `idx:${index}`;
       usageByMessage.set(key, message.usage);
     });
 

--- a/cli-tool/tests/unit/ConversationAnalyzer.test.js
+++ b/cli-tool/tests/unit/ConversationAnalyzer.test.js
@@ -1,0 +1,108 @@
+/**
+ * Unit Tests for ConversationAnalyzer token accounting
+ *
+ * Claude Code writes a single assistant message as several JSONL records — one
+ * per content block (thinking / text / tool_use) — and every record repeats the
+ * same `message.id` and an identical `usage` object. Token totals must count
+ * each message once, not once per record.
+ */
+
+const ConversationAnalyzer = require('../../src/analytics/core/ConversationAnalyzer');
+
+/** One parsed message as produced by parseAndCorrelateToolMessages(). */
+const record = (id, usage, extra = {}) => ({
+  id,
+  role: 'assistant',
+  usage,
+  ...extra,
+});
+
+const usage = (input, output, cacheCreation = 0, cacheRead = 0) => ({
+  input_tokens: input,
+  output_tokens: output,
+  cache_creation_input_tokens: cacheCreation,
+  cache_read_input_tokens: cacheRead,
+});
+
+describe('ConversationAnalyzer.calculateRealTokenUsage', () => {
+  let analyzer;
+
+  beforeEach(() => {
+    analyzer = new ConversationAnalyzer('/tmp/does-not-need-to-exist');
+  });
+
+  it('counts a message split across content blocks only once', () => {
+    // One assistant message emitted as three records, as Claude Code does for
+    // thinking + text + tool_use. Every record repeats the same usage object.
+    const u = usage(10, 100, 1000, 5000);
+    const result = analyzer.calculateRealTokenUsage([
+      record('msg_01AAA', u),
+      record('msg_01AAA', u),
+      record('msg_01AAA', u),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(1);
+    expect(result.inputTokens).toBe(10);
+    expect(result.outputTokens).toBe(100);
+    expect(result.cacheCreationTokens).toBe(1000);
+    expect(result.cacheReadTokens).toBe(5000);
+    expect(result.total).toBe(110);
+  });
+
+  it('sums distinct messages', () => {
+    const result = analyzer.calculateRealTokenUsage([
+      record('msg_01AAA', usage(10, 100)),
+      record('msg_01AAA', usage(10, 100)),
+      record('msg_01BBB', usage(5, 50)),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(2);
+    expect(result.inputTokens).toBe(15);
+    expect(result.outputTokens).toBe(150);
+  });
+
+  it('ignores records without usage but still reports totalMessages', () => {
+    const result = analyzer.calculateRealTokenUsage([
+      record('msg_01AAA', usage(10, 100)),
+      { id: 'msg_01BBB', role: 'user', usage: null },
+      { id: null, role: 'user', usage: undefined },
+    ]);
+
+    expect(result.messagesWithUsage).toBe(1);
+    expect(result.totalMessages).toBe(3);
+    expect(result.outputTokens).toBe(100);
+  });
+
+  it('does not merge distinct records that carry no message id', () => {
+    // Falls back to uuid, then to positional identity — never collapses
+    // unrelated records into one another.
+    const result = analyzer.calculateRealTokenUsage([
+      record(null, usage(1, 10), { uuid: 'uuid-1' }),
+      record(null, usage(2, 20), { uuid: 'uuid-2' }),
+      record(null, usage(3, 30)),
+      record(null, usage(4, 40)),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(4);
+    expect(result.inputTokens).toBe(10);
+    expect(result.outputTokens).toBe(100);
+  });
+
+  it('keeps the last usage seen for a repeated message id', () => {
+    const result = analyzer.calculateRealTokenUsage([
+      record('msg_01AAA', usage(10, 100)),
+      record('msg_01AAA', usage(10, 250)),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(1);
+    expect(result.outputTokens).toBe(250);
+  });
+
+  it('returns zeroes for an empty conversation', () => {
+    const result = analyzer.calculateRealTokenUsage([]);
+
+    expect(result.messagesWithUsage).toBe(0);
+    expect(result.totalMessages).toBe(0);
+    expect(result.total).toBe(0);
+  });
+});

--- a/cli-tool/tests/unit/ConversationAnalyzer.test.js
+++ b/cli-tool/tests/unit/ConversationAnalyzer.test.js
@@ -88,6 +88,31 @@ describe('ConversationAnalyzer.calculateRealTokenUsage', () => {
     expect(result.outputTokens).toBe(100);
   });
 
+  it('does not merge an id with an unrelated record that reuses it as a uuid', () => {
+    // `id` and `uuid` are separate namespaces: ConversationAnalyzer.js sets
+    // `id: item.message.id || item.uuid`, so the same string can legitimately
+    // reach this function through either field on two different records. They
+    // must stay distinct, otherwise the conversation is undercounted.
+    const result = analyzer.calculateRealTokenUsage([
+      record('shared-identifier', usage(1, 10)),
+      record(null, usage(2, 20), { uuid: 'shared-identifier' }),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(2);
+    expect(result.inputTokens).toBe(3);
+    expect(result.outputTokens).toBe(30);
+  });
+
+  it('does not merge an id that looks like a generated positional key', () => {
+    const result = analyzer.calculateRealTokenUsage([
+      record('idx:1', usage(1, 10)),
+      record(null, usage(2, 20)),
+    ]);
+
+    expect(result.messagesWithUsage).toBe(2);
+    expect(result.outputTokens).toBe(30);
+  });
+
   it('keeps the last usage seen for a repeated message id', () => {
     const result = analyzer.calculateRealTokenUsage([
       record('msg_01AAA', usage(10, 100)),


### PR DESCRIPTION
## What

`calculateRealTokenUsage()` sums `message.usage` over every parsed record.
Claude Code writes a single assistant *message* as several JSONL *records* — one
per content block (thinking / text / tool_use) — and every one of those records
repeats the same `message.id` and a **byte-identical** `usage` object. So each
message's tokens are counted once per block, and everything downstream
(`conversation.tokens`, `summary.totalTokens`, per-project rollups, the
dashboard's Total Tokens) is inflated by the average block count.

This collapses by `message.id` before summing. `message.id` already survives
parsing — `ConversationAnalyzer.js:297` sets `id: item.message.id || item.uuid
|| null` — so the change is local to the one function.

## How big

Measured on a real ~50-day Claude Code corpus (78 main transcripts, 8,123
distinct assistant `message.id`s):

| property | value |
|---|---|
| ids appearing on exactly one record | 2,533 |
| ids appearing on more than one record | 5,590 (**68.8%**) |
| of those, ids where **every** record's `usage` is identical | 5,590 (**100.0%**) |
| records-per-id histogram | `{1: 2533, 2: 1351, 3: 3553, 4: 415, 5: 58, 6: 138, 7: 24, 8: 33}` |
| assistant records with usage ÷ distinct ids | **≈2.36×** |

Three records per message is the mode: thinking + text + tool_use.

Driving the analyzer over a synthetic corpus with known-exact totals, before and
after:

| field | before | after | ground truth |
|---|---|---|---|
| input_tokens | 27,678 | 11,447 | 11,447 |
| output_tokens | 2,632,674 | 1,115,321 | 1,115,321 |
| cache_creation | 19,609,374 | 8,130,148 | 8,130,148 |
| cache_read | 59,626,489 | 24,447,923 | 24,447,923 |
| total (in+out) | 2,660,352 | 1,126,768 | 1,126,768 |
| messagesWithUsage | 1,308 | 540 | 540 (distinct ids) |

Before, every field equalled the per-record sum *exactly*, which is what pins
the cause to record-level summation rather than anything in parsing.

A check needing no external corpus: `messagesWithUsage` should equal the number
of distinct `message.id`s, and previously equalled the number of records.

## Reproducing independently

The end-to-end harness is self-contained (~1 min, no real `~/.claude` data
touched — it generates a synthetic `$HOME`, and the only thing it supplies to
your code is the directory plus a two-method `stateCalculator` stub):

```bash
git clone https://github.com/lizhuojunx86/traceguard
cd traceguard/usage-tracker-audit/cct-dedup-check
./run_check.sh                       # red on current main
./run_check.sh --commit <this-pr-sha>  # green with this change
```

## Tests

`cli-tool/tests/unit/ConversationAnalyzer.test.js` — 6 cases, red before this
change (3 failures) and green after. Covers the split-message case, distinct
messages, records without usage, records without an id (must **not** merge), and
last-write-wins on a repeated id.

## Notes for review

- **User-visible numbers will drop by roughly 2–2.5×** after this ships. That is
  the correction, but it will look like a regression to anyone watching the
  dashboard — probably worth a release-note line.
- The fallback chain is `message.id → message.uuid → positional key`. The
  positional key matters: a plain `null` key would merge every id-less record
  into one.
- Applied to both copies of the function. `cli-tool/src/analytics.js:187` appears
  to have no call sites since the extraction into `ConversationAnalyzer`, but I
  kept it in sync rather than leaving the two to diverge — happy to delete it
  instead if you prefer.
- Unrelated, spotted while reading: the two copies disagree on what `total`
  means — `ConversationAnalyzer.js` returns `input + output`, `analytics.js`
  returns `input + output + cacheCreation + cacheRead`. Left both as they were.
- Other trackers in this space key on `messageId:requestId` (ccusage, opcode,
  ccseva). On the corpus above the two are equivalent — distinct
  `(message.id, requestId)` pairs came out equal to distinct `message.id`s — so
  `message.id` alone is sufficient here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts each assistant message’s token usage once (not per content block) and namespaces dedup keys to prevent `id`/`uuid` collisions. Fixes inflated analytics; dashboards and rollups will show lower, correct totals (~2–2.5x decrease).

- **Bug Fixes**
  - Area: CLI (`cli-tool/src/`); no new components; no docs catalog changes; no new env vars/secrets.
  - Collapse usage by a namespaced key: `id:<message.id>` → `uuid:<message.uuid>` → `idx:<position>` to avoid merging unrelated records.
  - Updated `calculateRealTokenUsage` in `cli-tool/src/analytics.js` and `cli-tool/src/analytics/core/ConversationAnalyzer.js` to aggregate by unique message; `messagesWithUsage` now reflects that count.
  - Added tests in `cli-tool/tests/unit/ConversationAnalyzer.test.js`, covering split messages, id/uuid collisions, and positional-key lookalikes.

<sup>Written for commit 7793bba88f3d36d674c00601ec10055de9bc4d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

