### PR TITLE
Add Munsik-Park/autoflow plugin

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -23406,6 +23406,26 @@
     "highlights": []
   },
   {
+    "slug": "autoflow",
+    "name": "Autoflow",
+    "author": "Munsik-Park",
+    "description": "AutoFlow — phase-gated TDD methodology engine for Claude Code (plugin + thin root layer). Elastic License 2.0.",
+    "github": "https://github.com/Munsik-Park/autoflow",
+    "stars": 2,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "agents",
+      "hooks"
+    ],
+    "contains": {
+      "skills": 2,
+      "agents": 5,
+      "hooks": 1
+    },
+    "highlights": []
+  },
+  {
     "slug": "best-claude-skills",
     "name": "Best Claude Skills",
     "author": "Nyanbalaji28",

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -61,6 +61,7 @@ REPOS = [
     ("chu2bard/pinion-os", None),
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
+    ("Munsik-Park/autoflow", None),
 ]
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")


### PR DESCRIPTION
## What

Registers [`Munsik-Park/autoflow`](https://github.com/Munsik-Park/autoflow) in the plugins catalog.

AutoFlow is a phase-gated TDD methodology engine for Claude Code: gate hooks, role subagents, and the `epic-dash` skill.

## Changes

- `scripts/generate_plugins_json.py` — one entry added to `REPOS`, so the listing survives the next catalog regeneration (same fix as #718, which restored an entry dropped for exactly this reason).
- `dashboard/public/plugins.json` — the matching entry, inserted in stars-descending order.

## Values

All fields match what `generate_plugins_json.py` produces for this repo:

- `type: plugin` — `.claude-plugin/marketplace.json` declares a single plugin (`classify_repo_type`).
- `contains` — scanned from the local source `./plugin/autoflow`: 2 skills, 5 agents, 1 hook (`hooks.json`; the two `.sh` files are outside the extension whitelist in `scan_plugin_dir_components`).
- `name: "Autoflow"` — marketplace `name` is a lowercase slug, so the generator falls back to the title-cased repo name.
- `highlights: []` — no Anthropic/HashiCorp/Timescale ownership, a single marketplace plugin, and no repo homepage, so none of the three highlight conditions apply. Same shape as the existing `ml-plugins` entry.

## Testing

- `python3 -c "import json; json.load(open('dashboard/public/plugins.json'))"` passes; diff is insert-only (20 lines), no reformatting of existing entries.
- No `cli-tool/` changes, so the CLI test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Munsik-Park/autoflow` to the plugins catalog and update the catalog generator so the entry persists after rebuilds. This surfaces the Autoflow plugin in the dashboard and keeps the catalog accurate.

- Area: website
- Added entry to `dashboard/public/plugins.json` for `Munsik-Park/autoflow` (2 skills, 5 agents, 1 hook)
- Included repo in `scripts/generate_plugins_json.py` REPOS to survive future catalog regeneration
- No new components; no `docs/components.json` regeneration needed
- No new environment variables or secrets

<sup>Written for commit dfde372d02865c2306a326a0d9fddcaa48df408e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

