### PR TITLE
Add craft to the plugins list

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -61,6 +61,7 @@ REPOS = [
     ("chu2bard/pinion-os", None),
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
+    ("drobins25/craft", None),
 ]
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")


### PR DESCRIPTION
Adds [craft](https://github.com/drobins25/craft) (`drobins25/craft`) to the REPOS list - a development harness plugin that keeps the codebase read-only until a planned story, an investigated fix, or a live tweak opens it, with per-chunk validation and a claims auditor that verifies "done" against the git diff.

The repo hosts its own marketplace (`.claude-plugin/marketplace.json`), so the existing pipeline should pick up components automatically. Validated with `claude plugin validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `drobins25/craft` to the plugin sources so the dashboard marketplace picks up its components automatically through the existing pipeline.

- **Notes**
  - Area: website (update `scripts/generate_plugins_json.py` → affects `dashboard/public/plugins.json`)
  - No new components added; catalog regeneration not required.
  - No new environment variables or secrets.

<sup>Written for commit d48117c040a6fae9e31bde3b8cfa3f4599925862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

