### PR TITLE
Add rote skill (workflow-automation)

### DIFF
--- a/cli-tool/components/skills/workflow-automation/rote/SKILL.md
+++ b/cli-tool/components/skills/workflow-automation/rote/SKILL.md
@@ -61,11 +61,11 @@ uv --version                              # install uv first if missing
 uvx --from 'rote-cli>=0.12.1' rote --version        # confirm the CLI resolves
 ```
 
-If uv is missing, one command installs it:
-
-```sh
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+If uv is missing, do not pipe a remote script into a shell. Ask the user to
+install it through their package manager (`brew install uv`, `pipx install uv`,
+or `pip install uv`) or to follow the official guide at
+https://docs.astral.sh/uv/getting-started/installation/ and choose the method
+they trust.
 
 `pip install rote-cli` works too if the user prefers a virtualenv.
 

--- a/cli-tool/components/skills/workflow-automation/rote/SKILL.md
+++ b/cli-tool/components/skills/workflow-automation/rote/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: rote
+description: "Compile a proven agent skill (a SKILL.md plus references) into a deterministic pipeline that runs without an LLM in the loop, then serve it back to Claude as an MCP tool. Use when: rote, compile this skill, turn this skill into a workflow, make this skill deterministic, make this skill cheaper or faster, harden this skill for production, run this skill as a background job."
+license: Apache-2.0
+metadata:
+  author: trevhud
+  version: "0.12.0"
+  homepage: https://github.com/trevhud/rote
+---
+
+# rote: compile a skill into a deterministic pipeline
+
+You orchestrate the `rote` CLI. It runs an LLM compiler agent over a source
+skill once, and emits a pipeline that runs forever after without an agent
+loop. Your job is to resolve the inputs, run the CLI, and interpret the
+output. You never classify nodes or write `pipeline.yaml` yourself; the
+CLI's compiler agent does that.
+
+## When this applies
+
+Use it on a skill the user has already run many times and wants to run many
+more, unattended. Exploratory or one-off work should stay an agent loop:
+flexibility is the point there, and there is nothing proven to compile yet.
+Say so and stop if that is what you are looking at.
+
+## 1. Identify the source skill
+
+The source is a directory containing a `SKILL.md`, optionally with a
+`references/` folder. The user names it, or you infer it from context: a
+skill just discussed, a path in the conversation, `.claude/skills/*` or
+`skills/*` in the project.
+
+Confirm the resolved absolute path with the user before running.
+Compilation costs real time and tokens, so never guess and go. If the
+directory has no `SKILL.md`, stop and ask.
+
+## 2. Pick a runtime target
+
+| Runtime | `--runtime` | Language | Choose when |
+| --- | --- | --- | --- |
+| DBOS (default) | `dbos` | Python | No orchestrator to deploy. SQLite for dev, Postgres for prod |
+| Temporal | `temporal` | Python | You already operate a Temporal cluster |
+| Plain Python | `python` | Python | Max legibility, stdlib only. Refuses pipelines with HITL gates |
+| Cloudflare Workflows | `cloudflare` | TypeScript | Serverless, managed, `wrangler deploy`-ready |
+| DBOS (TypeScript) | `dbos-ts` | TypeScript | Zero orchestrator on the TS side. Postgres only |
+| Inngest | `inngest` | TypeScript | Mounting into an existing Node or Next.js app |
+
+If the user has no opinion and no existing infrastructure, use `dbos`. It is
+the default and the only Python target with zero standing infrastructure, so
+you can omit `--runtime` entirely.
+
+## 3. Resolve the CLI
+
+The CLI ships on PyPI as `rote-cli` and its executable is named `rote`. With
+`uvx` that means every invocation is `uvx --from rote-cli rote <args>`. Do
+not run `uvx rote-cli ...`; uvx looks for an executable named after the
+package, and the published wheel does not ship one.
+
+```sh
+uv --version                              # install uv first if missing
+uvx --from rote-cli rote --version        # confirm the CLI resolves
+```
+
+If uv is missing, one command installs it:
+
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+`pip install rote-cli` works too if the user prefers a virtualenv.
+
+`rote compile` runs an LLM agent, so it needs a driver: Claude Code
+(`claude`) or Codex (`codex`) installed and authed, or `ANTHROPIC_API_KEY`
+for the in-process `api` driver. The default `claude` driver deliberately
+scrubs `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` from the child
+environment so the run bills against the user's Claude subscription rather
+than per-token API charges. Do not "fix" auth by exporting an API key. If
+the user explicitly wants API billing, pass `--agent api`.
+
+## 4. Run the compilation
+
+```sh
+uvx --from rote-cli rote compile <skill-dir> --runtime <runtime> --out <out-dir>
+```
+
+Pick an out-dir the user will find, such as `./compiled/<skill-name>` next
+to the source skill, and make sure it does not clobber existing work.
+
+Set expectations before launching. This is not a quick command: a realistic
+skill takes roughly 13 minutes of wall clock and 30 to 40 agent turns on
+Sonnet. Run it in the background, tell the user you did, and poll rather
+than blocking the session.
+
+If the run exits nonzero, check whether `<out-dir>/compiled/pipeline.yaml`
+exists anyway. The CLI recovers completed work from transient subprocess
+failures and says so in its output. Surface stderr to the user either way.
+
+## 5. Report the result
+
+Read `<out-dir>/compiled/pipeline.yaml` and
+`<out-dir>/compiled/compile-report.md`, then summarize:
+
+1. **Node-kind table.** Count nodes per kind and say what each means here:
+
+   | Kind | Meaning |
+   | --- | --- |
+   | `pure_function` | Deterministic code. The LLM is gone |
+   | `external_call` | Direct API call with retry and timeout |
+   | `llm_judge` | Typed LLM signature, kept but bounded |
+   | `agent_loop` | Still agentic, because the input is genuinely unbounded |
+   | `hitl_gate` | Durable human approval point |
+
+2. **Codified fraction.** How many nodes no longer need an LLM, which nodes
+   are mandatory, and what each HITL gate blocks on.
+3. **Where things landed.** `<out-dir>/compiled/` holds the IR, `extracted/`,
+   `signatures/`, and the report. `<out-dir>/runtime/<runtime>/` holds the
+   deployable code.
+4. **Next steps.** The `extracted/*` modules are scaffolds that raise
+   `NotImplementedError`. The user fills in real client code, then deploys
+   the runtime output.
+
+Be honest in this summary. A pipeline that came out mostly `agent_loop` means
+the skill was not as deterministic as it looked, and the user should know
+that rather than hear a success story.
+
+## 6. Serve compiled pipelines back to Claude
+
+`rote serve` is one MCP server exposing every registered pipeline as a
+callable tool. It triggers deployed workflows; it does not host them. The
+full flow:
+
+```
+rote compile -> deploy the runtime -> rote register -> rote serve -> call from Claude
+```
+
+Register the pipeline once the runtime side is actually running (a DBOS app
+in worker mode, a Temporal worker, or a deployed Cloudflare Worker):
+
+```sh
+uvx --from rote-cli rote register <out-dir>
+uvx --from rote-cli rote register <out-dir> --runtime temporal
+uvx --from rote-cli rote register <out-dir> --runtime cloudflare --url https://<worker>.workers.dev
+```
+
+This upserts `~/.rote/registry.json`. Re-registering updates in place. After
+recompiling a changed skill, register again: DBOS and Temporal workflow
+names derive from the pipeline content hash and must stay in sync with the
+emitted code.
+
+Then add the server:
+
+```sh
+claude mcp add --scope user rote -- uvx --from 'rote-cli[serve,dbos]' rote serve
+```
+
+Each registry entry becomes two tools, or three on DBOS: `<name>` starts a
+run and returns `{workflow_id, status: "started"}` immediately, since
+compiled pipelines run for minutes to days; `<name>_status` polls a run by
+`workflow_id`; and on DBOS `<name>_signal` resumes a run parked at a HITL
+gate, so Claude can deliver approvals itself.
+
+Two caveats worth stating proactively. A DBOS run stuck in `enqueued` means
+the emitted app process is not running against the registered system
+database. And while Claude Code picks up newly registered pipelines
+immediately via the server's `list_changed` notification, Claude Desktop and
+claude.ai snapshot tools at connect time, so a pipeline registered mid-session
+appears there only after a reconnect.
+
+## Reference
+
+- Repository and docs: https://github.com/trevhud/rote (Apache-2.0)
+- Package: https://pypi.org/project/rote-cli/

--- a/cli-tool/components/skills/workflow-automation/rote/SKILL.md
+++ b/cli-tool/components/skills/workflow-automation/rote/SKILL.md
@@ -4,7 +4,7 @@ description: "Compile a proven agent skill (a SKILL.md plus references) into a d
 license: Apache-2.0
 metadata:
   author: trevhud
-  version: "0.12.0"
+  version: "0.12.1"
   homepage: https://github.com/trevhud/rote
 ---
 
@@ -52,13 +52,13 @@ you can omit `--runtime` entirely.
 ## 3. Resolve the CLI
 
 The CLI ships on PyPI as `rote-cli` and its executable is named `rote`. With
-`uvx` that means every invocation is `uvx --from rote-cli rote <args>`. Do
+`uvx` that means every invocation is `uvx --from 'rote-cli>=0.12.1' rote <args>`. Do
 not run `uvx rote-cli ...`; uvx looks for an executable named after the
 package, and the published wheel does not ship one.
 
 ```sh
 uv --version                              # install uv first if missing
-uvx --from rote-cli rote --version        # confirm the CLI resolves
+uvx --from 'rote-cli>=0.12.1' rote --version        # confirm the CLI resolves
 ```
 
 If uv is missing, one command installs it:
@@ -80,7 +80,7 @@ the user explicitly wants API billing, pass `--agent api`.
 ## 4. Run the compilation
 
 ```sh
-uvx --from rote-cli rote compile <skill-dir> --runtime <runtime> --out <out-dir>
+uvx --from 'rote-cli>=0.12.1' rote compile <skill-dir> --runtime <runtime> --out <out-dir>
 ```
 
 Pick an out-dir the user will find, such as `./compiled/<skill-name>` next
@@ -137,9 +137,9 @@ Register the pipeline once the runtime side is actually running (a DBOS app
 in worker mode, a Temporal worker, or a deployed Cloudflare Worker):
 
 ```sh
-uvx --from rote-cli rote register <out-dir>
-uvx --from rote-cli rote register <out-dir> --runtime temporal
-uvx --from rote-cli rote register <out-dir> --runtime cloudflare --url https://<worker>.workers.dev
+uvx --from 'rote-cli>=0.12.1' rote register <out-dir>
+uvx --from 'rote-cli>=0.12.1' rote register <out-dir> --runtime temporal
+uvx --from 'rote-cli>=0.12.1' rote register <out-dir> --runtime cloudflare --url https://<worker>.workers.dev
 ```
 
 This upserts `~/.rote/registry.json`. Re-registering updates in place. After
@@ -150,7 +150,7 @@ emitted code.
 Then add the server:
 
 ```sh
-claude mcp add --scope user rote -- uvx --from 'rote-cli[serve,dbos]' rote serve
+claude mcp add --scope user rote -- uvx --from 'rote-cli[serve,dbos]>=0.12.1' rote serve
 ```
 
 Each registry entry becomes two tools, or three on DBOS: `<name>` starts a


### PR DESCRIPTION
Adds one component: `cli-tool/components/skills/workflow-automation/rote/SKILL.md`.

### What it does

The skill drives [rote](https://github.com/trevhud/rote), an open source CLI (Apache-2.0, `pip install rote-cli` or `uvx --from rote-cli rote ...`) that compiles a proven agent skill, meaning a SKILL.md plus its references, into a deterministic pipeline that runs without an LLM in the loop.

The fixed logic comes out as reviewable Python or TypeScript with per-step tests. The steps that genuinely need judgment stay as typed LLM-judge signatures instead of being pretended away, and human approval points become durable HITL gates. Targets are DBOS, Temporal, plain Python, Cloudflare Workflows, DBOS TypeScript, and Inngest.

The skill also covers `rote register` and `rote serve`, which expose compiled pipelines back to Claude as MCP tools so Claude can trigger a deployed workflow rather than re-running the skill.

### Why workflow-automation

It sits next to the existing `inngest`, `trigger-dev`, and `n8n` skills in that category, and its compile targets are those same durable execution engines.

### Notes

- Category placement only, no new category created.
- Prose-only Markdown. No scripts, no executable code, no new env vars or secrets.
- Frontmatter follows the third-party shape already used in this repo (`name`, `description`, `license`, `metadata.author`, `metadata.version`).
- The skill tells Claude to run compilation in the background and sets honest expectations: a realistic skill takes roughly 13 minutes and 30 to 40 agent turns. It also tells Claude to say so when a skill turns out not to be very compilable.
- I did not regenerate `docs/components.json`; happy to if you would rather that land in the PR.

Disclosure: I am the author of rote. The project is new and I am not claiming traction it does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow-automation skill for `rote` that compiles a proven `SKILL.md` into a deterministic pipeline and exposes deployed workflows back to Claude as MCP tools.

- Area: components — added `cli-tool/components/skills/workflow-automation/rote/SKILL.md`; regenerate `docs/components.json`.
- Covers `rote compile`, `register`, and `serve`; targets DBOS (Py/TS), Temporal, plain Python, Cloudflare Workflows, and Inngest.
- All `uvx --from` commands pin to `rote-cli>=0.12.1`, and uv installs are guided to package managers or the official docs instead of a piped remote script.
- No new env vars or secrets; `ANTHROPIC_API_KEY` is only needed with `--agent api`.

<sup>Written for commit 98849d0cb0b593c14e60074eab6383cb2ae54a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

