### PR TITLE
feat(skills): add patentfig skill (creative-design)

### DIFF
--- a/cli-tool/components/skills/creative-design/patentfig/SKILL.md
+++ b/cli-tool/components/skills/creative-design/patentfig/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: patentfig
+description: Generate patent-office-compliant figures via the PatentFig AI API — patent line art from text (PNG or SVG), vectorize drawings to SVG/DXF/vector PDF, AI-upscale images, and convert to filing-ready TIFF/PDF/PNG. Use when the user asks for patent drawings, patent figures, invention diagrams, USPTO/EPO-compliant line art, vectorizing a drawing for CAD, or preparing figures for a patent filing. Requires a PATENTFIG_API_KEY environment variable.
+version: 1.0.0
+author: TopLocalAI
+license: MIT
+tags: [Patent, Patent Drawings, Line Art, SVG, Vectorize, DXF, USPTO, Image Generation, API]
+metadata:
+  homepage: https://patentfig.ai
+  docs: https://patentfig.ai/docs
+---
+
+# PatentFig AI API
+
+Generate and convert patent figures through the PatentFig AI REST API.
+
+- **Base URL**: `https://patentfig.ai/api/v1`
+- **Auth**: `Authorization: Bearer $PATENTFIG_API_KEY`
+- **All endpoints are synchronous** and return JSON: `{ "success": true, "data": {...} }` on success, `{ "success": false, "error": { "code", "message" } }` on failure.
+- Generated files are returned as URLs on `https://cdn.patentfig.ai` — pass them to the user or feed them into follow-up calls.
+
+## Setup
+
+The key comes from the `PATENTFIG_API_KEY` environment variable. Never hardcode it, print it, or write it into files or logs.
+
+If the variable is not set, tell the user to create a key at https://patentfig.ai/settings/api-keys (requires a PatentFig AI account; keys start with `pfig_`) and export it:
+
+```bash
+export PATENTFIG_API_KEY="pfig_..."
+```
+
+Verify connectivity and credit balance (free call):
+
+```bash
+curl -s https://patentfig.ai/api/v1/credits \
+  -H "Authorization: Bearer $PATENTFIG_API_KEY"
+# → { "success": true, "data": { "balance": 500 } }
+```
+
+## Generate a patent figure (10 credits)
+
+`POST /figures` — the core endpoint. One prompt → one figure. Views, diagram type, and composition are all controlled through the prompt; for a multi-view set (front/side/top), make one call per view.
+
+```bash
+curl -s -X POST https://patentfig.ai/api/v1/figures \
+  -H "Authorization: Bearer $PATENTFIG_API_KEY" \
+  -H "Content-Type: application/json" \
+  --max-time 300 \
+  -d '{
+    "prompt": "Exploded view of a wireless earbud charging case showing lid, hinge, charging coil, and battery",
+    "output": "svg",
+    "labeled": true
+  }'
+```
+
+- `output`: `"png"` (raster figure) or `"svg"` (stroke-based line art, CAD-friendly). Default `"png"`.
+- `labeled: true` adds patent-style numeric reference callouts (100, 102, …).
+- `referenceImageUrls`: up to 4 public image URLs (sketch/photo/prior figure) used as the structural baseline.
+- Response `data.url` is the figure; with `output: "svg"` the full SVG source is also in `data.svg`.
+
+Prompting tips: name the parts to draw (names tell the model WHAT to draw, not what to label); for flowcharts/block diagrams, name every node explicitly.
+
+## Convert an existing image
+
+All three endpoints accept either JSON with `imageUrl` (public URL) or `multipart/form-data` with a `file` field (PNG/JPEG/WebP/TIFF, ≤10 MB).
+
+**Vectorize (20 credits)** — raster → SVG / DXF / vector PDF:
+
+```bash
+curl -s -X POST https://patentfig.ai/api/v1/vectorize \
+  -H "Authorization: Bearer $PATENTFIG_API_KEY" \
+  -H "Content-Type: application/json" \
+  --max-time 300 \
+  -d '{ "imageUrl": "https://example.com/drawing.png", "format": "dxf", "engine": "lineart" }'
+```
+
+`engine: "lineart"` (default) redraws as clean single-stroke patent line art — use for CAD/DXF. `engine: "trace"` reproduces the input pixels faithfully, preserving fills — use when output must match the original.
+
+**Enhance (20 credits)** — AI super-resolution: `POST /enhance` with `scale` (2 or 4, controls pixels) and `dpi` (300 or 600, metadata stamp only).
+
+**Convert (20 credits)** — filing-ready raster: `POST /convert` with `format` (`png`/`tiff`/`pdf`) and `dpi` (300 or 600).
+
+Full parameter tables for every endpoint: see [references/endpoints.md](references/endpoints.md). Machine-readable spec: https://patentfig.ai/api/openapi.yaml
+
+## Operational rules
+
+- **Set a client timeout of at least 300 seconds** — generation and vectorization take from ~20s up to a few minutes.
+- Credits are charged **only on success**; retrying a failed call never double-bills.
+- Rate limit: 60 requests/minute per key. On `429` back off (start at 5s) and retry.
+- On `402 INSUFFICIENT_CREDITS`, stop and tell the user to top up at https://patentfig.ai/pricing.
+- On `500 GENERATION_FAILED`, one retry is reasonable; persistent failures usually mean the input doesn't suit the pipeline (e.g., a photo sent for line-art vectorization — suggest `POST /figures` with the photo as `referenceImageUrls` instead).
+- Before a batch of billable calls, check `GET /credits` and confirm the balance covers it.

--- a/cli-tool/components/skills/creative-design/patentfig/references/endpoints.md
+++ b/cli-tool/components/skills/creative-design/patentfig/references/endpoints.md
@@ -1,0 +1,76 @@
+# PatentFig AI API — Endpoint Reference
+
+Base URL: `https://patentfig.ai/api/v1` · Auth: `Authorization: Bearer $PATENTFIG_API_KEY` (or `x-api-key` header) · OpenAPI: https://patentfig.ai/api/openapi.yaml
+
+Error envelope (all endpoints):
+
+| HTTP | Code | Meaning | Retry? |
+| --- | --- | --- | --- |
+| 400 | `INVALID_INPUT` | Bad/missing parameter (message names the field) | No — fix request |
+| 401 | `UNAUTHORIZED` | Missing/invalid/revoked key | No — check key |
+| 402 | `INSUFFICIENT_CREDITS` | Balance too low | After top-up |
+| 422 | `FETCH_FAILED` | `imageUrl` unreachable | Check URL is public |
+| 429 | `RATE_LIMITED` | >60 req/min on this key | Yes — back off |
+| 500 | `GENERATION_FAILED` | Model/processing failure | One retry |
+
+## POST /figures — 10 credits
+
+Generate a patent figure from a prompt. JSON body only.
+
+| Field | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `prompt` | string ≤10000 | yes | — | What to draw; view/diagram type controlled via prompt |
+| `output` | `"png"` \| `"svg"` | no | `"png"` | `svg` = stroke-based line art, `fill="none"` |
+| `labeled` | boolean | no | `false` | Numeric reference callouts (100, 102, …) |
+| `referenceImageUrls` | string[] ≤4 | no | `[]` | Public URLs; SVG references are rasterized automatically |
+
+Response `data`: `url` (file URL), `format`, `svg` (source, only when `output: "svg"`), `creditsConsumed`.
+
+## POST /vectorize — 20 credits
+
+Raster image → vector file. JSON `imageUrl` or multipart `file`.
+
+| Field | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `imageUrl` / `file` | string / file | yes | — | PNG/JPEG/WebP/TIFF, ≤10 MB |
+| `format` | `"svg"` \| `"dxf"` \| `"pdf"` | no | `"svg"` | PDF embeds the SVG for extraction |
+| `engine` | `"lineart"` \| `"trace"` | no | `"lineart"` | lineart = single-stroke redraw (CAD-safe); trace = faithful, filled outlines (double lines in DXF) |
+
+Response `data`: `url`, `format`, `engine`, `creditsConsumed`.
+
+## POST /enhance — 20 credits
+
+AI super-resolution upscaling. Output is always PNG.
+
+| Field | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `imageUrl` / `file` | string / file | yes | — | |
+| `scale` | `2` \| `4` | no | `2` | Output pixels = input × scale |
+| `dpi` | `300` \| `600` | no | `300` | Density metadata stamp only — does not change pixels |
+
+Response `data`: `url`, `scale`, `dpi`, `width`, `height`, `creditsConsumed`.
+
+## POST /convert — 20 credits
+
+Filing-ready raster export.
+
+| Field | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `imageUrl` / `file` | string / file | yes | — | |
+| `format` | `"png"` \| `"tiff"` \| `"pdf"` | no | `"png"` | TIFF is flattened, LZW-compressed |
+| `dpi` | `300` \| `600` | no | `300` | 300 targets ~2K resolution, 600 targets ~4K; small inputs are AI-upscaled |
+
+Response `data`: `url`, `previewUrl` (PNG preview, for TIFF/PDF), `format`, `dpi`, `creditsConsumed`.
+
+## GET /credits — free
+
+Returns `data.balance` (integer). Use as connectivity check and before batches.
+
+## Multipart example
+
+```bash
+curl -s -X POST https://patentfig.ai/api/v1/enhance \
+  -H "Authorization: Bearer $PATENTFIG_API_KEY" \
+  --max-time 300 \
+  -F "file=@drawing.png" -F "scale=4" -F "dpi=600"
+```


### PR DESCRIPTION
## What

Adds **patentfig** under `cli-tool/components/skills/creative-design/` — a skill that teaches the agent to call the [PatentFig AI](https://patentfig.ai) REST API:

- `POST /v1/figures` — generate patent-office-style figures from a text prompt (PNG or SVG line art, optional reference images)
- `POST /v1/vectorize` — raster drawing → editable SVG / DXF / vector PDF (line-art redraw or faithful trace)
- `POST /v1/enhance` — AI super-resolution upscaling (2× / 4×)
- `POST /v1/convert` — filing-ready PNG / TIFF / PDF export at 300 / 600 DPI
- `GET /v1/credits` — balance check

## Structure

- `SKILL.md` — usage triggers, auth via `PATENTFIG_API_KEY` env var (never hardcoded or printed), credit costs, timeout/backoff and error-handling rules
- `references/endpoints.md` — full request/response reference with curl examples

Canonical source repo: https://github.com/TopLocalAI/patentfig-skill (MIT). API docs: https://patentfig.ai/docs · OpenAPI: https://patentfig.ai/api/openapi.yaml

Follows the same pattern as other vendor/API skills in the collection (e.g. `imagegen`, `luma-imagegen`, `railway/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eh5mM5VPK3Rqf19GnLxSBJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `patentfig` skill to generate patent-style figures from prompts and convert/vectorize images via the PatentFig REST API. Supports figure generation (PNG/SVG), vectorization to SVG/DXF/PDF, upscaling, and filing-ready exports.

- Area: components (`cli-tool/components/`); new skill at `cli-tool/components/skills/creative-design/patentfig/`.
- New component added — regenerate the catalog (`docs/components.json`).
- New env var: `PATENTFIG_API_KEY` (required).
- Docs added: `SKILL.md` and `references/endpoints.md`. No changes to CLI (`src/, bin/`), website (`docs/` site content), API (`api/`), or workers (`cloudflare-workers/`).

<sup>Written for commit 64deeafde1e0e7ae28ff31235f8809d0e598e2a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

