### PR TITLE
fix(ci): skip PR report comments on fork PRs so the 403 doesn't fail the security jobs

### DIFF
--- a/.github/workflows/component-security-validation.yml
+++ b/.github/workflows/component-security-validation.yml
@@ -60,8 +60,11 @@ jobs:
           path: cli-tool/security-report.json
           retention-days: 30
 
+      # Fork PRs run with a read-only GITHUB_TOKEN, so createComment 403s and
+      # fails the job. Skip commenting for forks; the report is still available
+      # in the security-audit-report artifact.
       - name: Comment PR with Results
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/skill-security-scan.yml
+++ b/.github/workflows/skill-security-scan.yml
@@ -65,8 +65,11 @@ jobs:
           sarif_file: skillspector.sarif
           category: skillspector
 
+      # Fork PRs run with a read-only GITHUB_TOKEN, so createComment 403s and
+      # fails the job before Enforce gate can run. Skip commenting for forks;
+      # the report is still available in the skillspector-report artifact.
       - name: Comment PR with results
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
Fixes #776.

On fork PRs the `GITHUB_TOKEN` is read-only, so the report-comment step in both security workflows fails with `403 Resource not accessible by integration`. That failure alone turns the jobs red: SkillSpector's scan passed on the linked runs, and the Security Audit step's exit code is already masked by `continue-on-error`. Because SkillSpector's `Enforce gate` is ordered after the comment step, the 403 also fails that job before the gate can run, so the HIGH/CRITICAL block never enforces on fork PRs. Run links and details in #776.

This appends one conjunct to each comment step's existing `if:`:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

Behavior change:

- **Same-repo PRs:** none; the guard is true and the steps run exactly as today.
- **Fork PRs:** the comment step is skipped instead of failing. The jobs go green when the scans pass, and `Enforce gate` now runs: a fork skill scoring HIGH/CRITICAL fails the job with its `::error` message instead of the ambiguous 403 red. Reports remain available as the `skillspector-report` / `security-audit-report` artifacts.

Both workflows trigger on changes to their own file, and `pull_request` runs use the PR's version of the workflow, so this PR tests its own fix: it comes from a fork, which is exactly the path the guard changes. Both jobs are green on this PR, and the step logs confirm it is the guard at work: the comment step reports `skipped` in [Security Audit run 30862312597](https://github.com/davila7/claude-code-templates/actions/runs/30862312597) and [SkillSpector run 30862312602](https://github.com/davila7/claude-code-templates/actions/runs/30862312602). On current main, the same two jobs fail at the comment step on every fork PR (runs linked in #776, e.g. 30843950116: every scan step succeeded, the comment step 403'd, `Enforce gate` skipped).

If you would rather restore comments on fork PRs than skip them, the `workflow_run` pattern is the fix for that; happy to take a pass at it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip PR comment steps on fork PRs to prevent 403 failures in security workflows. This keeps scans green and lets gates run; same‑repo PRs are unchanged.

- **Bug Fixes**
  - Area: CI (GitHub Actions).
  - Added an `if:` guard to comment steps in `.github/workflows/skill-security-scan.yml` and `.github/workflows/component-security-validation.yml` requiring `github.event.pull_request.head.repo.full_name == github.repository`.
  - Fork PRs now skip PR comments to avoid 403; reports remain as artifacts and gates still run/enforce.
  - No new components; no catalog regen; no new env vars or secrets.

<sup>Written for commit 2cb9cb560ccac84d8f07a8af7614e0823abc023d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
