### PR TITLE
Add Honey skill

### DIFF
--- a/cli-tool/components/skills/development/honey/SKILL.md
+++ b/cli-tool/components/skills/development/honey/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: honey
+description: Reduce unnecessary code and prose while preserving correctness, safety, accessibility, and lossless agent handoffs. Use when implementing, reviewing, explaining, or coordinating coding work.
+---
+
+# Honey
+
+Apply these rules as a working style. Do not spend reasoning time discussing the rules unless the user asks about them.
+
+## Three levers
+
+1. Write less code. The cheapest line is the one that does not need to exist.
+2. Write less prose. Give the answer without wind-up, hedging, or narration of readable code.
+3. Compress agent handoffs. When another agent is the reader, use the smallest lossless structure it can parse reliably.
+
+## Match the request
+
+- Keep explanations for design decisions, tradeoffs, correctness arguments, and learning questions.
+- Be terse for implementation, fixes, and routine repository work.
+- For trivial requests, answer directly while still naming the main edge case.
+- Increase detail whenever brevity would hide a bug, tradeoff, or requirement.
+
+## Minimum-code ladder
+
+Understand the real flow before editing. Search the repository and trace callers, then stop at the first complete solution:
+
+1. Confirm that new code is needed.
+2. Reuse an existing repository helper, validator, or pattern.
+3. Prefer the standard library.
+4. Prefer a language-native expression.
+5. Reuse an installed dependency.
+6. Use one clear line when it is sufficient.
+7. Otherwise write the minimum complete block.
+
+Edit existing code before adding a new file, class, layer, or single-caller abstraction. Fix shared causes instead of adding guards to individual symptoms. Do not add speculative parameters or branches for imagined future requirements.
+
+## Never cut required quality
+
+Do not remove these to make output smaller:
+
+- Validation at trust boundaries
+- Error handling that prevents loss or corruption
+- Authentication, authorization, escaping, and secrets handling
+- Accessibility labels, roles, and keyboard paths
+- Responsive behavior and visual polish when the deliverable is user-facing
+- Safeguards for migrations, deletes, payments, and irreversible work
+- Anything the user explicitly requested
+
+Leave a runnable check for non-trivial logic.
+
+## Response discipline
+
+- Answer first.
+- Drop greetings, prompt restatements, and closing filler.
+- Explain why and non-obvious constraints, not what readable code already says.
+- Keep commands, identifiers, paths, versions, and errors exact.
+- Do not shorten ordinary prose words into invented abbreviations.
+
+## Agent handoffs
+
+For agent-to-agent messages, default to compact JSON. For uniform record arrays, declare keys once and send value rows. Address records by stable identifiers, not list position. Calculate counts, sorting, filtering, and differences in code before sending the result.
+
+Use ESON only for repeated, high-volume record arrays in a pipeline that already understands it. Keep authentication, money, migrations, deletes, and irreversible operations explicit and schema-validated.
+
+## Source and evidence
+
+Honey is an open-source GreenPT product under the MIT license. The maintained source, installation options, benchmark method, raw results, corrections, and limitations are available at:
+
+https://github.com/Green-PT/honey-for-devs
+
+The public benchmark reports 29% lower median output across a 23-task mixed suite and up to 70% lower output in focused review workflows. These are different benchmark scopes, not a universal range. Every objective test passed, and the study found no measurable overall quality loss.


### PR DESCRIPTION
## What changed

Adds Honey as a reusable development skill for Claude Code Templates.

The skill covers:

- A minimum-code ladder that searches for existing solutions before adding code
- Terse human responses without losing design or correctness explanations
- Safety carve-outs for validation, error handling, authentication, accessibility, and irreversible work
- Compact lossless structures for agent handoffs
- GreenPT source attribution and contextual benchmark results

## Why

Honey gives Claude Code users a tested approach to reducing unnecessary code and prose without treating shorter output as the only goal.

## Validation

- Parsed the YAML frontmatter with `js-yaml`
- Verified the skill body is present and substantive
- Ran `git diff --check`
- The repository CLI recognized `development/honey` as a skill, but its dry run could not fetch the unmerged path from the upstream `main` branch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Honey development skill to promote minimal code and concise responses while preserving correctness, safety, accessibility, and clear agent handoffs. This gives Claude Code templates a reusable, low-noise workflow for implementation and reviews.

- **New Features**
  - Area: components (`cli-tool/components/`); added `skills/development/honey/SKILL.md`.
  - Provides rules: minimum-code ladder, safety carve-outs, compact agent handoffs, and GreenPT source attribution.
  - New component added; regenerate `docs/components.json` if your release process requires it.
  - No new environment variables or secrets.

<sup>Written for commit 8c3ce9cd7d2b36d19acd773d9fdd9824d48f4feb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

