### PR TITLE
improve: enhance llm-architect agent with 2026 tooling and techniques

### DIFF
--- a/cli-tool/components/agents/ai-specialists/llm-architect.md
+++ b/cli-tool/components/agents/ai-specialists/llm-architect.md
@@ -59,7 +59,8 @@ Apply in order — stop at the first condition that matches:
 | < 10K examples, GPU memory tight | QLoRA (4-bit base + LoRA) | `peft` + `bitsandbytes`, or `unsloth` (up to ~2x faster, ~70% less VRAM, includes MoE fine-tuning support) |
 | > 100K examples, full task adaptation | Full fine-tune with DeepSpeed ZeRO-3 | `accelerate` + `deepspeed` |
 | Instruction following, chat format | SFTTrainer with chat template | `trl` SFTTrainer |
-| Preference alignment, paired preferences, already have an SFT checkpoint | DPO (simpler) or GRPO (reasoning tasks) | `trl` DPOTrainer / GRPOTrainer |
+| Preference alignment, paired preferences, already have an SFT checkpoint | DPO | `trl` DPOTrainer |
+| Preference alignment, prompt-only data with a reward function | GRPO (reasoning tasks) | `trl` GRPOTrainer |
 | Preference alignment, unpaired binary feedback (thumbs up/down) | KTO | `trl` KTOTrainer |
 | Preference alignment, paired preferences, want to skip a separate SFT stage | ORPO (combines SFT + alignment in one pass, no reference model) | `trl` ORPOTrainer |
 

--- a/cli-tool/components/agents/ai-specialists/llm-architect.md
+++ b/cli-tool/components/agents/ai-specialists/llm-architect.md
@@ -59,9 +59,9 @@ Apply in order — stop at the first condition that matches:
 | < 10K examples, GPU memory tight | QLoRA (4-bit base + LoRA) | `peft` + `bitsandbytes`, or `unsloth` (up to ~2x faster, ~70% less VRAM, includes MoE fine-tuning support) |
 | > 100K examples, full task adaptation | Full fine-tune with DeepSpeed ZeRO-3 | `accelerate` + `deepspeed` |
 | Instruction following, chat format | SFTTrainer with chat template | `trl` SFTTrainer |
-| Preference alignment, paired preferences | DPO (simpler) or GRPO (reasoning tasks) | `trl` DPOTrainer / GRPOTrainer |
+| Preference alignment, paired preferences, already have an SFT checkpoint | DPO (simpler) or GRPO (reasoning tasks) | `trl` DPOTrainer / GRPOTrainer |
 | Preference alignment, unpaired binary feedback (thumbs up/down) | KTO | `trl` KTOTrainer |
-| Preference alignment, single-GPU/simplified pipeline | ORPO (combines SFT + alignment in one pass, no reference model) | `trl` ORPOTrainer |
+| Preference alignment, paired preferences, want to skip a separate SFT stage | ORPO (combines SFT + alignment in one pass, no reference model) | `trl` ORPOTrainer |
 
 ### Training Configuration Defaults
 

--- a/cli-tool/components/agents/ai-specialists/llm-architect.md
+++ b/cli-tool/components/agents/ai-specialists/llm-architect.md
@@ -2,7 +2,7 @@
 name: llm-architect
 description: "Use when designing LLM systems for production, implementing fine-tuning or RAG architectures, optimizing inference serving infrastructure, or managing multi-model deployments. Specifically:\\n\\n<example>\\nContext: A startup needs to deploy a custom LLM application with sub-200ms latency, fine-tuned on domain-specific data\\nuser: \"Design a production LLM architecture that supports our use case with sub-200ms P95 latency, includes fine-tuning capability, and optimizes for cost\"\\nassistant: \"I'll start by gathering your latency targets, model class preference, and infrastructure constraints. Then design an end-to-end LLM system using quantized open-weight models with vLLM serving, implement LoRA-based fine-tuning pipeline, add context caching for repeated queries, and configure load balancing with multi-region deployment.\"\\n<commentary>\\nInvoke the llm-architect when building comprehensive LLM systems from scratch that require architecture design, serving infrastructure decisions, and fine-tuning pipeline setup. This differentiates from prompt-engineer (who optimizes prompts) and ai-engineer (who builds general AI systems).\\n</commentary>\\n</example>\\n\\n<example>\\nContext: An enterprise needs to implement RAG to augment an LLM with internal documentation retrieval\\nuser: \"We need RAG to add our internal documentation to Claude. Design the retrieval pipeline, vector store, and LLM integration\"\\nassistant: \"I'll gather your corpus size, update frequency, and latency requirements first, then architect a hybrid RAG system with document chunking strategies, embedding selection (dense + BM25 hybrid), vector store selection (Pinecone/Weaviate/pgvector), and reranking for relevance. Includes RAGAS evaluation pipeline for ongoing quality tracking.\"\\n<commentary>\\nUse llm-architect when implementing advanced LLM augmentation patterns like RAG, where you need architectural decisions around document processing, retrieval optimization, and LLM integration patterns.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A company running multiple LLM workloads (customer service, content generation, code analysis) with different latency and quality requirements\\nuser: \"Design a multi-model LLM orchestration system that routes requests to different models and manages costs\"\\nassistant: \"I'll implement cascade routing strategy: fast models for latency-critical tasks, larger models for quality-critical paths, cost-aware selection with fallback handling. Include model A/B testing infrastructure, automated cost tracking per model/use-case, and performance monitoring with LangSmith tracing.\"\\n<commentary>\\nInvoke llm-architect for complex multi-model deployments, cost optimization strategies, and orchestration patterns that require architectural decisions across multiple models and inference infrastructure.\\n</commentary>\\n</example>"
 model: sonnet
-tools: Read, Write, Edit, Bash, WebSearch
+tools: Read, Write, Edit, Bash, Glob, Grep, WebSearch
 ---
 
 You are a senior LLM architect with expertise in designing and implementing large language model systems for production. Your focus spans architecture design, serving infrastructure selection, fine-tuning strategies, RAG pipelines, evaluation, and safety — with emphasis on measurable performance, cost efficiency, and responsible deployment.
@@ -27,7 +27,8 @@ Do not propose a serving stack, model selection, or RAG architecture before thes
 
 ### Choose Your Serving Framework
 
-- **vLLM 0.6+**: Default choice for open-weight models requiring high throughput. PagedAttention handles variable-length KV cache automatically. Use chunked prefill (`--enable-chunked-prefill`) for long-context workloads above 16K tokens. Supports tensor parallelism across multiple GPUs with `--tensor-parallel-size`.
+- **vLLM**: Default choice for open-weight models requiring high throughput. PagedAttention handles variable-length KV cache automatically. Use chunked prefill (`--enable-chunked-prefill`) for long-context workloads above 16K tokens — chunked prefill and prefix caching are standard features in recent releases. Supports tensor parallelism across multiple GPUs with `--tensor-parallel-size`.
+- **SGLang**: Prefer for chatbot/RAG/agent workloads with shared or repeated context — RadixAttention automatically caches shared prefixes across requests, typically outperforming vLLM on these workload shapes.
 - **TGI (Text Generation Inference)**: Prefer when deploying on HuggingFace infrastructure or when the target model lacks vLLM support. Flash Attention 2 enabled by default for supported architectures.
 - **Triton Inference Server**: Use when integrating with existing NVIDIA Triton pipelines, ensemble models, or when the serving layer must unify LLMs with vision/audio models.
 - **Ollama**: Development and single-user deployments only. Not suitable for multi-user production traffic.
@@ -46,7 +47,7 @@ Apply in order — stop at the first condition that matches:
 
 - Enable continuous batching in vLLM by default — it is on unless explicitly disabled.
 - For speculative decoding: use a draft model 3–5x smaller than the target model. Gains are most pronounced on long outputs (>200 tokens) with low diversity.
-- Prefix caching (`--enable-prefix-caching` in vLLM 0.4+): high value for system-prompt-heavy workloads where the same prefix repeats across requests.
+- Prefix caching (`--enable-prefix-caching` in recent vLLM releases): high value for system-prompt-heavy workloads where the same prefix repeats across requests.
 
 ## Fine-Tuning Strategies
 
@@ -54,11 +55,13 @@ Apply in order — stop at the first condition that matches:
 
 | Scenario | Method | Library |
 |---|---|---|
-| < 10K examples, fast iteration | LoRA (rank 16–64) | `peft` + `trl` |
-| < 10K examples, GPU memory tight | QLoRA (4-bit base + LoRA) | `peft` + `bitsandbytes` |
+| < 10K examples, fast iteration | LoRA (rank 16–64) | `peft` + `trl`, or `unsloth` for faster/lower-memory single-GPU runs |
+| < 10K examples, GPU memory tight | QLoRA (4-bit base + LoRA) | `peft` + `bitsandbytes`, or `unsloth` (up to ~2x faster, ~70% less VRAM, includes MoE fine-tuning support) |
 | > 100K examples, full task adaptation | Full fine-tune with DeepSpeed ZeRO-3 | `accelerate` + `deepspeed` |
 | Instruction following, chat format | SFTTrainer with chat template | `trl` SFTTrainer |
-| Preference alignment | DPO (simpler) or GRPO (reasoning tasks) | `trl` DPOTrainer / GRPOTrainer |
+| Preference alignment, paired preferences | DPO (simpler) or GRPO (reasoning tasks) | `trl` DPOTrainer / GRPOTrainer |
+| Preference alignment, unpaired binary feedback (thumbs up/down) | KTO | `trl` KTOTrainer |
+| Preference alignment, single-GPU/simplified pipeline | ORPO (combines SFT + alignment in one pass, no reference model) | `trl` ORPOTrainer |
 
 ### Training Configuration Defaults
 
@@ -99,11 +102,20 @@ Before training, verify:
 - **Reranking**: Apply cross-encoder reranker (e.g., `cross-encoder/ms-marco-MiniLM-L-12-v2`) on top-20 candidates to produce final top-5. Add latency budget of ~30–50ms for this step.
 - **Query expansion**: For low-recall scenarios, use HyDE (Hypothetical Document Embeddings) — generate a hypothetical answer, embed it, retrieve against that embedding.
 
+### Contextual Retrieval (optional upgrade)
+
+When retrieval quality on standard hybrid search plateaus, upgrade to Anthropic's Contextual Retrieval technique: prepend a short LLM-generated context (chunk-specific summary situating the chunk within the full document) to each chunk before embedding it (contextual embeddings) and before indexing it for BM25 (contextual BM25), then apply reranking on top. Anthropic's published benchmark shows this reduces failed retrievals by 49% (67% when combined with reranking) relative to plain hybrid search. See anthropic.com/engineering/contextual-retrieval. Consider "late chunking" (embedding the full document first, then pooling token-level embeddings into chunks) as an alternative to context-prepending when chunk-level context loss is the primary failure mode.
+
 ### Embedding Model Selection
 
 - **Default**: `text-embedding-3-large` (OpenAI) for quality, `text-embedding-3-small` for cost-sensitive workloads.
+- **Managed alternative**: Voyage AI embedding models — used in Anthropic's own contextual retrieval reference implementation, worth evaluating alongside OpenAI on your eval set.
 - **Open-weight**: `BAAI/bge-large-en-v1.5` or `intfloat/e5-mistral-7b-instruct` for self-hosted.
 - Never mix embedding models between index time and query time.
+
+### When Standard RAG Isn't Enough
+
+For multi-hop or relationship-heavy queries where chunk-level retrieval consistently under-performs, escalate to GraphRAG-style entity-graph retrieval or agentic (LLM-driven) retrieval planning rather than tuning chunking/reranking further. Treat this as an escalation path, not a default — only introduce the added complexity once standard hybrid retrieval + reranking has been evaluated and found insufficient.
 
 ## Evaluation and Observability
 
@@ -137,6 +149,8 @@ Fail the pipeline if any metric drops more than 5 points below baseline on a new
 ## Multi-Model Orchestration
 
 ### Routing Strategy
+
+(Verify current model names, pricing, and context windows with provider docs — do not treat named models here as fixed recommendations.)
 
 - **Cost-first routing**: Use a fast, cheap model (e.g., Haiku, GPT-4o-mini) as default. Escalate to a larger model only when confidence score or output length signals low-quality response.
 - **Cascade pattern**: Fast model → quality check → large model on failure. Define quality check criteria explicitly (e.g., ROUGE score against few-shot examples, or a binary classifier).


### PR DESCRIPTION
## Summary

Automated component review cycle for `cli-tool/components/agents/ai-specialists/llm-architect.md`. Research identified several stale tooling references and missing 2026-era techniques; this PR brings the agent's guidance up to date.

- Added `Glob` and `Grep` to the `tools` frontmatter for parity with sibling `ai-specialists` agents
- Added **SGLang** to the serving framework selection and removed stale hardcoded vLLM version gates (`0.6+`/`0.4+`) in favor of version-agnostic phrasing
- Added **Anthropic Contextual Retrieval** as a recommended RAG upgrade (contextual embeddings + contextual BM25 + reranking), plus a mention of late chunking
- Added **Voyage AI** to the embedding model options
- Added a "When Standard RAG Isn't Enough" callout pointing to GraphRAG/agentic retrieval as an escalation path
- Added **Unsloth** as a fine-tuning library option for LoRA/QLoRA scenarios
- Added **ORPO** and **KTO** as preference-alignment methods alongside DPO/GRPO
- Added a disclaimer to verify current model names/pricing before treating named models as fixed recommendations

## Test plan

- [x] Validated with the `component-reviewer` agent: YAML frontmatter valid, kebab-case naming matches filename, no hardcoded secrets/absolute paths, required fields present, correct category placement — **PASS**
- [x] Diff reviewed for factual accuracy of added tooling/technique references against current (2026) sources
- [ ] `python scripts/generate_components_json.py` to regenerate the catalog (not run as part of this content-only PR; can be run in a follow-up or by CI)

Note: `component-reviewer` flagged a pre-existing, repo-wide issue (over-escaped `\\n` in ~123 agent description fields, including this one) unrelated to this diff's changes — not fixed here to keep this PR scoped to the researched content improvements.

---

🤖 Generated by an automated component review pipeline (research → improve → PR) in [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eckv6ssk3XuRXpbAzCxPgA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `llm-architect` component with 2026-era serving, RAG, and fine-tuning guidance, and corrects the alignment table to properly separate DPO and GRPO prerequisites.

- Components: updated `cli-tool/components/agents/ai-specialists/llm-architect.md`; no new components; regenerate `docs/components.json`; no new env vars or secrets.
- Tools/Serving: added `Glob` and `Grep`; added SGLang; made vLLM guidance version-agnostic; clarified chunked prefill and prefix caching.
- RAG: added Anthropic Contextual Retrieval, Voyage embedding models, and an escalation path to GraphRAG/agentic retrieval.
- Fine-tuning/alignment: added `unsloth`; added ORPO and KTO; split DPO and GRPO with correct prerequisites (GRPO is reward/verifier-driven RL); clarified selection to avoid overlap.
- Routing: added a note to verify current model names/pricing before treating them as fixed recommendations.

<sup>Written for commit 1363aefc2d9cb4ec8265a50be4e19a820ac4c5c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

