### PR TITLE
fix: replace defunct Clearbit logo API in jobs dashboard

### DIFF
--- a/dashboard/src/components/JobsPreview.tsx
+++ b/dashboard/src/components/JobsPreview.tsx
@@ -59,11 +59,15 @@ function getCompanyLogoUrl(companyName: string, existingIcon?: string): string {
   // If icon exists in data, use it
   if (existingIcon) return existingIcon;
   
-  // Otherwise, try to fetch from Clearbit Logo API
+  // Otherwise, resolve it from the company's domain.
+  // Clearbit's logo API shut down on 1 December 2025 and now resolves to
+  // nothing. This is the same hotlinkable-image contract: a domain with no
+  // known logo answers 404, so the onError handlers below still fall back to
+  // the company's initial exactly as they did before.
   const domain = companyName.toLowerCase()
     .replace(/\s+/g, '')
     .replace(/[^a-z0-9]/g, '');
-  return `https://logo.clearbit.com/${domain}.com`;
+  return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R`;
 }
 
 interface Props {

--- a/dashboard/src/components/JobsPreview.tsx
+++ b/dashboard/src/components/JobsPreview.tsx
@@ -55,6 +55,15 @@ function safeUrl(url: string): string {
   return /^https?:\/\//i.test(url) ? url : '#';
 }
 
+// The dashboard themes itself by putting `light` or `dark` on <html>
+// (DashboardLayout.astro). Logos are read at call time so the right one is
+// requested for the theme in force: a mark that is invisible on the current
+// background is declined and the initial-letter fallback below takes over.
+function logoTheme(): 'light' | 'dark' {
+  if (typeof document === 'undefined') return 'dark';
+  return document.documentElement.classList.contains('light') ? 'light' : 'dark';
+}
+
 function getCompanyLogoUrl(companyName: string, existingIcon?: string): string {
   // If icon exists in data, use it
   if (existingIcon) return existingIcon;
@@ -67,7 +76,7 @@ function getCompanyLogoUrl(companyName: string, existingIcon?: string): string {
   const domain = companyName.toLowerCase()
     .replace(/\s+/g, '')
     .replace(/[^a-z0-9]/g, '');
-  return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R`;
+  return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=${logoTheme()}`;
 }
 
 interface Props {

--- a/dashboard/src/components/JobsView.tsx
+++ b/dashboard/src/components/JobsView.tsx
@@ -81,6 +81,15 @@ function safeUrl(url: string): string {
   return /^https?:\/\//i.test(url) ? url : '#';
 }
 
+// The dashboard themes itself by putting `light` or `dark` on <html>
+// (DashboardLayout.astro). Logos are read at call time so the right one is
+// requested for the theme in force: a mark that is invisible on the current
+// background is declined and the initial-letter fallback below takes over.
+function logoTheme(): 'light' | 'dark' {
+  if (typeof document === 'undefined') return 'dark';
+  return document.documentElement.classList.contains('light') ? 'light' : 'dark';
+}
+
 export default function JobsView() {
   const [data, setData] = useState<JobsData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -167,7 +176,7 @@ export default function JobsView() {
     const domain = companyName.toLowerCase()
       .replace(/\s+/g, '')
       .replace(/[^a-z0-9]/g, '');
-    return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R`;
+    return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=${logoTheme()}`;
   };
 
   const allTags = useMemo(() => {

--- a/dashboard/src/components/JobsView.tsx
+++ b/dashboard/src/components/JobsView.tsx
@@ -159,12 +159,15 @@ export default function JobsView() {
     // If companyIcon exists in data, use it
     if (job?.companyIcon) return job.companyIcon;
     
-    // Otherwise, try to fetch from Clearbit Logo API
-    // Format: https://logo.clearbit.com/{domain}
+    // Otherwise, resolve it from the company's domain.
+    // Clearbit's logo API shut down on 1 December 2025 and now resolves to
+    // nothing. This is the same hotlinkable-image contract: a domain with no
+    // known logo answers 404, so the onError handlers below still fall back to
+    // the company's initial exactly as they did before.
     const domain = companyName.toLowerCase()
       .replace(/\s+/g, '')
       .replace(/[^a-z0-9]/g, '');
-    return `https://logo.clearbit.com/${domain}.com`;
+    return `https://extractbrand.dev/img/${domain}.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R`;
   };
 
   const allTags = useMemo(() => {


### PR DESCRIPTION
Hi Daniel — following up on our email thread. Disclosure up front: **we build ExtractBrand**, the service this PR points at.

## The problem

Clearbit's Logo API shut down on **1 December 2025**. Both logo helpers in the jobs dashboard still point at it, so every company logo currently fails to load and falls through to the initial-letter fallback:

- `dashboard/src/components/JobsView.tsx` — `getCompanyLogo`
- `dashboard/src/components/JobsPreview.tsx` — `getCompanyLogoUrl`

## The change

Same contract as Clearbit: a plain hotlinkable image, **404 on a domain with no known logo**.

That is why the diff is small — every `<img>` using these helpers already has an `onError` handler that hides the image and renders the company's initial. Because the miss behaviour matches Clearbit's, **all five of those handlers keep working exactly as written**. Both existing short-circuits (`job?.companyIcon`, `existingIcon`) are untouched.

The one addition is `logoTheme()`. The dashboard is dark by default and offers a light theme, and a logo that suits one is frequently wrong on the other — a black mark vanishes on the dark card, and a mark with a white background baked in renders as a white rectangle on it. It reads the class `DashboardLayout.astro` puts on `<html>`, at call time, so each request asks for a mark that suits the background it is actually going onto.

## Live proof

Rendered from the endpoint right now, on your own dark card colour (`#161b22`):

| | | | |
|:-:|:-:|:-:|:-:|
| <img src="https://extractbrand.dev/img/google.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=dark" height="26"> | <img src="https://extractbrand.dev/img/netflix.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=dark" height="26"> | <img src="https://extractbrand.dev/img/stripe.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=dark" height="26"> | <img src="https://extractbrand.dev/img/anthropic.com?token=pub_C6rkKpFrdD8rUIRX77ClfY4R&theme=dark" height="26"> |
| Google | Netflix | Stripe | Anthropic |

Stripe and Anthropic publish their marks with the colour delegated to a stylesheet, so on `theme=dark` they come back drawn in a light ink instead of the black they would otherwise be. On `theme=light` the same two come back dark. Apple is the opposite case — its published mark has a white plate baked in, so on `theme=dark` the endpoint **declines** rather than hand you a white rectangle, and your initial-letter fallback takes over.

Rendering both components side by side over 16 representative company names, on your dark card colour: **0/16 logos loaded before, 12/16 after**, and every one of the 12 is legible. The other four (Apple, Datadog, Meta, Spotify) fall back to the initial exactly as they do today.

## About the token

`pub_C6rk…` is a **publishable** token, not a secret — it is meant to be readable by anyone who can read the page. It authorises one thing: a cached logo lookup. It cannot reach any other API, cannot trigger extraction, and cannot be billed against. It is ours, we meter it, and there is nothing for you to configure, rotate, or add to your deploy.

## Notes

- No new dependency, no config, no env var.
- Responses are edge-cached (`s-maxage=86400`), so this is not a per-render round trip to us.
- `&fallback=monogram` will return a generated letter tile instead of a 404 if you would ever prefer that. I left it off deliberately — your own fallback is already styled to the dashboard.

Happy to adjust anything here.
