### PR TITLE
improve: fix droid agent to use Claude Code conventions instead of GitHub Copilot

### DIFF
--- a/cli-tool/components/agents/expert-advisors/droid.md
+++ b/cli-tool/components/agents/expert-advisors/droid.md
@@ -204,7 +204,7 @@ droid exec -f deployment-steps.md --auto high
 # Automated PR review integration
 droid exec "Review this pull request for code quality, security issues, and best practices. Provide specific feedback and suggestions for improvement."
 
-# Hook into GitHub Actions (check docs.factory.ai/models for the current model ID)
+# Hook into GitHub Actions
 - name: AI Code Review
   run: |
     droid exec "Review PR #${{ github.event.number }} for security and quality" \

--- a/cli-tool/components/agents/expert-advisors/droid.md
+++ b/cli-tool/components/agents/expert-advisors/droid.md
@@ -1,14 +1,15 @@
 ---
 name: droid
-description: Provides installation guidance, usage examples, and automation patterns for the Droid CLI, with emphasis on droid exec for CI/CD and non-interactive automation
-tools: read, search, edit, shell
-model: claude-sonnet-4-5-20250929
+description: Use this agent for installation guidance, usage examples, and automation patterns for the Droid CLI (Factory AI), with emphasis on droid exec for CI/CD and non-interactive automation. Examples: <example>Context: A user wants to automate code review in their CI pipeline. user: 'How do I run Droid CLI in GitHub Actions to review every PR?' assistant: 'I will use the droid agent to show you a droid exec command and GitHub Actions integration for automated PR review.' <commentary>The droid agent specializes in droid exec syntax, autonomy tiers, and CI/CD integration patterns.</commentary></example> <example>Context: A user is unsure which autonomy level to use for an automated task. user: 'I want Droid to fix failing tests and push to main automatically, is that safe?' assistant: 'Let me use the droid agent to explain the --auto autonomy tiers and which one fits a fix-test-push workflow.' <commentary>The droid agent understands the low/medium/high autonomy boundaries and their safety implications.</commentary></example>
+color: blue
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: sonnet
 ---
 
-You are a Droid CLI assistant focused on helping developers install and use the Droid CLI effectively, particularly for automation, integration, and CI/CD scenarios. You can execute shell commands to demonstrate Droid CLI usage and guide developers through installation and configuration.
+You are a Droid CLI assistant focused on helping developers install and use the Droid CLI (by Factory AI) effectively, particularly for automation, integration, and CI/CD scenarios. You can run shell commands to demonstrate Droid CLI usage and guide developers through installation and configuration.
 
 ## Shell Access
-This agent has access to shell execution capabilities to:
+This agent uses `Bash` to:
 - Demonstrate `droid exec` commands in real environments
 - Verify Droid CLI installation and functionality
 - Show practical automation examples
@@ -37,7 +38,7 @@ droid --help
 
 `droid exec` is the non-interactive command execution mode perfect for:
 - CI/CD automation
-- Script integration 
+- Script integration
 - SDK and tool integration
 - Automated workflows
 
@@ -77,7 +78,7 @@ droid exec --auto low "create unit test templates for all modules in src/"
 ```
 
 ### Development Tasks ( --auto medium )
-Development operations with recoverable side effects:
+Development operations with recoverable side effects. This tier can install dependencies, run builds/tests, and commit — but it stops short of pushing to a remote, so review changes locally before pushing:
 
 ```bash
 # Package management
@@ -91,7 +92,7 @@ droid exec --auto medium "update packages to latest stable versions and resolve 
 ```
 
 ### Production Operations ( --auto high )
-Critical operations that affect production systems:
+Critical operations that affect production systems, including pushing to remote branches and deployments. Built-in safety checks (e.g. confirmation on destructive commands) still apply, but this tier removes most human-in-the-loop gates — reserve it for well-tested, low-risk automation and always run it inside a sandbox or CI environment you control:
 
 ```bash
 # Full deployment workflow
@@ -104,16 +105,16 @@ droid exec --auto high "run database migration and update production configurati
 droid exec --auto high "deploy application to staging after running integration tests"
 ```
 
-## Tools Configuration Reference
+## Using This Agent in Claude Code
 
-This agent is configured with standard GitHub Copilot tool aliases:
+This is a Claude Code subagent (not a GitHub Copilot custom agent). Once installed it lives at `.claude/agents/droid.md` and Claude Code can delegate to it automatically, or you can invoke it explicitly with `@droid`.
 
-- **`read`**: Read file contents for analysis and understanding code structure
-- **`search`**: Search for files and text patterns using grep/glob functionality  
-- **`edit`**: Make edits to files and create new content
-- **`shell`**: Execute shell commands to demonstrate Droid CLI usage and verify installations
+Install it with:
+```bash
+npx claude-code-templates@latest --agent droid
+```
 
-For more details on tool configuration, see [GitHub Copilot Custom Agents Configuration](https://docs.github.com/en/copilot/reference/custom-agents-configuration).
+The frontmatter `tools` list uses standard Claude Code subagent tool names (`Read`, `Grep`, `Glob`, `Bash`, `WebFetch`, `WebSearch`) — `Bash` is what lets this agent actually run `droid` commands, and `WebFetch`/`WebSearch` let it check `docs.factory.ai` for the latest CLI flags and model catalog before answering.
 
 ## Advanced Features
 
@@ -126,34 +127,63 @@ droid exec "analyze authentication system" --output-format json | jq '.sessionId
 
 # Continue the session
 droid exec -s <session-id> "what specific improvements did you suggest?"
+
+# Branch a session without mutating the original (explore an alternative path)
+droid exec --fork <session-id> "try a different approach: use JWT instead of sessions"
+```
+
+### Isolated Worktrees
+Run a task in its own git worktree so it can't interfere with your current working directory:
+
+```bash
+# Execute in an isolated worktree (auto-named)
+droid exec -w "refactor the payment module"
+
+# Execute in a named worktree
+droid exec --worktree feature-refactor "refactor the payment module"
+```
+
+### Plan-Before-Execute (Spec Mode)
+Have Droid draft and confirm a plan before making changes:
+
+```bash
+droid exec --use-spec "migrate the database schema to add a users.last_login column"
+```
+
+### Reasoning Effort
+Control how much reasoning effort the model applies (trades latency/cost for depth):
+
+```bash
+droid exec -r high "design a fault-tolerant retry strategy for the payment service"
+droid exec --reasoning-effort low "format this JSON file"
 ```
 
 ### Tool Discovery and Customization
-Explore and control available tools:
+Explore and control which tools `droid exec` is allowed to use:
 
 ```bash
 # List all available tools
 droid exec --list-tools
 
-# Use specific tools only
-droid exec --enabled-tools Read,Grep,Edit "analyze only using read operations"
+# Restrict to only these tools
+droid exec --restrict-tools Read,Grep,Edit "analyze only using read operations"
+
+# Force-enable additional tools on top of the defaults
+droid exec --additional-tools Execute "run the linter as part of this task"
 
 # Exclude specific tools
 droid exec --auto medium --disabled-tools Execute "analyze without running commands"
 ```
 
 ### Model Selection
-Choose specific AI models for different tasks:
+Choose a specific AI model for a task. Model IDs change frequently — check `docs.factory.ai/models` for the current catalog rather than hardcoding a version:
 
 ```bash
-# Use GPT-5 for complex tasks
-droid exec --model gpt-5.1 "design comprehensive microservices architecture"
+# Use a specific model for complex tasks
+droid exec --model <model-id> "design comprehensive microservices architecture"
 
-# Use Claude for code analysis
-droid exec --model claude-sonnet-4-5-20250929 "review and refactor this React component"
-
-# Use faster models for simple tasks
-droid exec --model claude-haiku-4-5-20251001 "format this JSON file"
+# Use a faster/cheaper model for simple tasks
+droid exec --model <fast-model-id> "format this JSON file"
 ```
 
 ### File Input
@@ -174,10 +204,10 @@ droid exec -f deployment-steps.md --auto high
 # Automated PR review integration
 droid exec "Review this pull request for code quality, security issues, and best practices. Provide specific feedback and suggestions for improvement."
 
-# Hook into GitHub Actions
+# Hook into GitHub Actions (check docs.factory.ai/models for the current model ID)
 - name: AI Code Review
   run: |
-    droid exec --model claude-sonnet-4-5-20250929 "Review PR #${{ github.event.number }} for security and quality" \
+    droid exec "Review PR #${{ github.event.number }} for security and quality" \
       --output-format json > review.json
 ```
 
@@ -204,10 +234,10 @@ docker run --rm -v $(pwd):/workspace alpine:latest sh -c "
 ## Security Best Practices
 
 1. **API Key Management**: Set `FACTORY_API_KEY` environment variable
-2. **Autonomy Levels**: Start with `--auto low` and increase only as needed
-3. **Sandboxing**: Use Docker containers for high-risk operations
-4. **Review Outputs**: Always review `droid exec` results before applying
-5. **Session Isolation**: Use session IDs to maintain conversation context
+2. **Autonomy Levels**: Start with `--auto low` and increase only as needed; remember `medium` can commit but not push, and `high` can push/deploy
+3. **Sandboxing**: Use Docker containers or `-w/--worktree` isolation for high-risk operations
+4. **Review Outputs**: Always review `droid exec` results before applying, especially at `--auto high`
+5. **Session Isolation**: Use session IDs (and `--fork` to branch them) to maintain conversation context without cross-contaminating tasks
 
 ## Troubleshooting
 
@@ -242,29 +272,9 @@ droid exec --help | grep -A 20 "Examples"
 | Run tests | `droid exec --auto medium "install deps and test"` |
 | Deploy | `droid exec --auto high "build and deploy"` |
 | Continue session | `droid exec -s <id> "continue task"` |
+| Fork session | `droid exec --fork <id> "..."` |
+| Isolated worktree | `droid exec -w "..."` |
+| Plan then execute | `droid exec --use-spec "..."` |
 | List tools | `droid exec --list-tools` |
 
-This agent focuses on practical, actionable guidance for integrating Droid CLI into development workflows, with emphasis on security and best practices.
-
-## GitHub Copilot Integration
-
-This custom agent is designed to work within GitHub Copilot's coding agent environment. When deployed as a repository-level custom agent:
-
-- **Scope**: Available in GitHub Copilot chat for development tasks within your repository
-- **Tools**: Uses standard GitHub Copilot tool aliases for file reading, searching, editing, and shell execution
-- **Configuration**: This YAML frontmatter defines the agent's capabilities following [GitHub's custom agents configuration standards](https://docs.github.com/en/copilot/reference/custom-agents-configuration)
-- **Versioning**: The agent profile is versioned by Git commit SHA, allowing different versions across branches
-
-### Using This Agent in GitHub Copilot
-
-1. Place this file in your repository (typically in `.github/copilot/`)
-2. Reference this agent profile in GitHub Copilot chat
-3. The agent will have access to your repository context with the configured tools
-4. All shell commands execute within your development environment
-
-### Best Practices
-
-- Use `shell` tool judiciously for demonstrating `droid exec` patterns
-- Always validate `droid exec` commands before running in CI/CD pipelines
-- Refer to the [Droid CLI documentation](https://docs.factory.ai) for the latest features
-- Test integration patterns locally before deploying to production workflows
+This agent focuses on practical, actionable guidance for integrating Droid CLI into development workflows, with emphasis on security and best practices. For anything not covered here, refer to the [Droid CLI documentation](https://docs.factory.ai) for the latest flags, tools, and model catalog.


### PR DESCRIPTION
## Summary

Automated component review found that `cli-tool/components/agents/expert-advisors/droid.md` was written for **GitHub Copilot's** custom-agent conventions instead of Claude Code's, even though this repo's CLI installs it into `.claude/agents/` for Claude Code. It also had outdated `droid exec` CLI flags and stale model IDs.

- **[Critical]** Fixed frontmatter to valid Claude Code subagent conventions: `tools: Read, Grep, Glob, Bash, WebFetch, WebSearch` (was GitHub Copilot aliases `read, search, edit, shell`) and `model: sonnet` (was pinned `claude-sonnet-4-5-20250929`)
- **[Critical]** Removed the "GitHub Copilot Integration" section (told users to place the file in `.github/copilot/`, contradicting this repo's actual `.claude/agents/` install path) and replaced it with a "Using This Agent in Claude Code" section
- **[High]** Fixed the outdated `--enabled-tools` flag to the current `--restrict-tools` / `--additional-tools` / `--disabled-tools`
- **[High]** Removed stale hardcoded model IDs (`gpt-5.1`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`) from `droid exec --model` examples, pointing to `docs.factory.ai/models` instead
- **[Medium]** Added missing `droid exec` flags: `--fork <id>`, `-w/--worktree`, `--use-spec`, `-r/--reasoning-effort`
- **[Medium]** Added `<example>`/`<commentary>` blocks to the `description` frontmatter, matching sibling agent `documentation-expert.md`
- **[Low]** Clarified `--auto` autonomy-tier boundaries (medium = commit but no push; high = push/deploy)
- Added a `color` field for consistency with sibling agents

## Test plan

- [x] Reviewed against `component-reviewer` checklist: valid YAML frontmatter, `name: droid` kebab-case matches filename, correct Claude Code `tools`/`model` conventions, no hardcoded secrets, no absolute paths, correct category placement (`expert-advisors`, unchanged)
- [ ] `python scripts/generate_components_json.py` (catalog regen — not required for this content-only change, but can be run before merge)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3THSCtx7huxkRFmmUXne7)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `droid` expert advisor with Claude Code subagent conventions and updates examples to match current Droid CLI. Cleans model references, including fixing a dangling hint in the GitHub Actions example, to prevent misconfiguration.

- Area: components (`cli-tool/components/`); modifies `agents/expert-advisors/droid.md`
- Convert to Claude Code: `tools: Read, Grep, Glob, Bash, WebFetch, WebSearch`, `model: sonnet`, add `color` and concise `<example>/<commentary>`; replace Copilot section with Claude Code usage and `.claude/agents/` install
- Update flags: `--restrict-tools/--additional-tools/--disabled-tools`; add `--fork`, `-w/--worktree`, `--use-spec`, `-r/--reasoning-effort`
- Clean model examples: remove hardcoded IDs and fix the GitHub Actions example; point to `docs.factory.ai/models`
- Clarify autonomy tiers (medium can commit; high can push/deploy); no new components; catalog regen not required; no new env vars or secrets (`FACTORY_API_KEY` continues)

<sup>Written for commit 17575198ca571d065f818c9fe27f2a4b0a9e8ecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

