### PR TITLE
Add terminal-tab-unread-marker hook (monitoring)

### DIFF
--- a/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.json
+++ b/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/terminal-tab-unread-marker.sh mark"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/terminal-tab-unread-marker.sh mark"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/terminal-tab-unread-marker.sh clear"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/terminal-tab-unread-marker.sh clear"
           }
         ]
       }

--- a/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.json
+++ b/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.json
@@ -1,0 +1,27 @@
+{
+  "description": "Marks the macOS Terminal.app tab of a Claude Code session that finished while you were looking somewhere else, and clears the mark when you next type in it. Solves the problem you get once several sessions run at once: a notification tells you something finished, but not which window. This puts the answer in the tab bar. Two non-obvious details are handled: Claude Code pipes stdin to hooks so `tty` reports 'not a tty' and the session tty has to be recovered by walking the process tree, and Claude Code re-asserts the terminal title about a second after Stop when the session goes idle, silently wiping a marker a Stop hook just wrote (set CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1 if you would rather own the title outright). A zero-width WORD JOINER marks the prefix so it can be stripped without storing a copy of your title, which means it cannot clobber a title you set with /rename. Change the glyph with TABTINT_MARK. macOS Terminal.app only, exits silently elsewhere; iTerm2, Ghostty and kitty already have native tab colours. Prerequisite: the script terminal-tab-unread-marker.sh in .claude/hooks/. Full version with per-project window colours and a palette: https://github.com/dotcomjack/claude-session-tint",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/terminal-tab-unread-marker.sh mark"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/terminal-tab-unread-marker.sh clear"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.sh
+++ b/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.sh
@@ -97,8 +97,22 @@ REST=${STATE#*|}
 FRONT=${REST%%|*}
 TITLE=${REST#*|}
 
-# Strip any marker we previously wrote, without keeping a copy of the title.
-BARE="${TITLE##*"$WJ" }"
+# Strip our own marker prefix, and only ours. The marker is always
+# "<glyph><WJ><space>" at position 0, so a WORD JOINER later in a title cannot
+# be ours. An unanchored longest-match would truncate a user title that happened
+# to contain a WJ-space sequence. Requiring it inside the first few bytes stays
+# glyph-agnostic, so TABTINT_MARK can be a multi-byte emoji.
+strip_mark() {
+  local s="$1" pre
+  pre=${s%%"$WJ" *}
+  if [ "$pre" != "$s" ] && [ ${#pre} -le 8 ]; then
+    printf '%s' "${s#*"$WJ" }"
+  else
+    printf '%s' "$s"
+  fi
+}
+
+BARE=$(strip_mark "$TITLE")
 
 case "${1:-mark}" in
   mark)
@@ -106,12 +120,27 @@ case "${1:-mark}" in
     [ "$SELECTED" = "true" ] && [ "$FRONT" = "true" ] && exit 0
     # Never replace a title we cannot read; a lone marker is unremovable.
     [ -n "$BARE" ] || exit 0
-    # Re-assert past Claude Code's own idle-transition title rewrite. This runs
-    # detached so Stop returns immediately instead of stalling the session for
-    # the length of the loop.
+    # Re-assert past Claude Code's own idle-transition title rewrite, detached so
+    # Stop returns immediately.
+    #
+    # Every iteration re-reads the tab rather than replaying the title captured
+    # at Stop. Two reasons, both real:
+    #   - If you focus the tab and submit a prompt inside this window, `clear`
+    #     strips the marker and the next tick would put it straight back, so the
+    #     tab you are actively using shows a stale unread mark. Re-reading lets
+    #     the loop see `selected` and stop.
+    #   - If you /rename inside this window, replaying the captured title would
+    #     silently overwrite the name you just set.
     (
       for _ in 1 2 3 4 5 6; do
-        set_title "/dev/$TTY" "$MARK$WJ $BARE"
+        st=$(tab_state "/dev/$TTY") || exit 0
+        [ -n "$st" ] || exit 0
+        sel=${st%%|*}; rest=${st#*|}; fr=${rest%%|*}; ttl=${rest#*|}
+        # You are looking at it now, so the signal has done its job.
+        [ "$sel" = "true" ] && [ "$fr" = "true" ] && exit 0
+        bare=$(strip_mark "$ttl")
+        [ -n "$bare" ] || exit 0
+        [ "$ttl" = "$MARK$WJ $bare" ] || set_title "/dev/$TTY" "$MARK$WJ $bare"
         sleep 0.7
       done
     ) >/dev/null 2>&1 &

--- a/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.sh
+++ b/cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Marks the Terminal.app tab of a Claude Code session that finished while you
+# were looking somewhere else, and clears the mark when you type in it again.
+#
+#   terminal-tab-unread-marker.sh mark     (wire to Stop)
+#   terminal-tab-unread-marker.sh clear    (wire to UserPromptSubmit)
+#
+# macOS Terminal.app only. Exits silently everywhere else.
+#
+# Two things here are less obvious than they look, both learned the hard way.
+#
+# 1. Claude Code pipes stdin to hooks, so `tty` reports "not a tty". The session
+#    tty has to be recovered by walking up the process tree instead.
+#
+# 2. Claude Code re-asserts the terminal title about a second after Stop, when
+#    the session transitions to idle, which silently wipes a marker written by a
+#    Stop hook. This script writes it repeatedly for a few seconds to outlast
+#    that. Setting CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1 is the other way, at the
+#    cost of losing the built-in title.
+#
+# A zero-width WORD JOINER marks our own prefix so it can be stripped without
+# storing a copy of your title, which means it cannot clobber a title you set
+# with /rename.
+#
+# Full version (per-project window colours, palette, plugin install):
+# https://github.com/dotcomjack/claude-session-tint
+
+set -uo pipefail
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+MARK="${TABTINT_MARK:-●}"
+WJ=$(printf '\xe2\x81\xa0')
+
+# A wedged Terminal must not wedge the hook, so cap every Apple Event.
+osa() { perl -e 'alarm 15; exec @ARGV' osascript "$@" 2>/dev/null; }
+
+# Walk up the process tree until a real ttys* turns up.
+session_tty() {
+  local pid=$PPID t i=0
+  while [ -n "$pid" ] && [ "$pid" != "1" ] && [ $i -lt 12 ]; do
+    t=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$t" in ttys*) printf '%s' "$t"; return 0 ;; esac
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Returns "<selected>|<frontmost>|<title>" for the tab on this tty.
+tab_state() {
+  osa - "$1" <<'APPLESCRIPT'
+on run argv
+	tell application "Terminal"
+		set fm to frontmost
+		set i to 0
+		repeat with w in windows
+			set i to i + 1
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set ttl to ""
+					try
+						set ttl to custom title of t
+					end try
+					return ((selected of t) as string) & "|" & ((fm and i is 1) as string) & "|" & ttl
+				end if
+			end repeat
+		end repeat
+	end tell
+	return ""
+end run
+APPLESCRIPT
+}
+
+set_title() {
+  osa - "$1" "$2" <<'APPLESCRIPT' >/dev/null
+on run argv
+	tell application "Terminal"
+		repeat with w in windows
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set custom title of t to (item 2 of argv)
+					return
+				end if
+			end repeat
+		end repeat
+	end tell
+end run
+APPLESCRIPT
+}
+
+TTY=$(session_tty) || exit 0
+STATE=$(tab_state "/dev/$TTY") || exit 0
+[ -n "$STATE" ] || exit 0
+
+SELECTED=${STATE%%|*}
+REST=${STATE#*|}
+FRONT=${REST%%|*}
+TITLE=${REST#*|}
+
+# Strip any marker we previously wrote, without keeping a copy of the title.
+BARE="${TITLE##*"$WJ" }"
+
+case "${1:-mark}" in
+  mark)
+    # You are already looking at it, so there is nothing to tell you.
+    [ "$SELECTED" = "true" ] && [ "$FRONT" = "true" ] && exit 0
+    # Never replace a title we cannot read; a lone marker is unremovable.
+    [ -n "$BARE" ] || exit 0
+    # Re-assert past Claude Code's own idle-transition title rewrite. This runs
+    # detached so Stop returns immediately instead of stalling the session for
+    # the length of the loop.
+    (
+      for _ in 1 2 3 4 5 6; do
+        set_title "/dev/$TTY" "$MARK$WJ $BARE"
+        sleep 0.7
+      done
+    ) >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+    ;;
+  clear)
+    [ "$TITLE" = "$BARE" ] && exit 0
+    set_title "/dev/$TTY" "$BARE"
+    ;;
+esac
+exit 0


### PR DESCRIPTION
Adds a `monitoring` hook that marks the macOS Terminal.app tab of a Claude Code session which finished while you were looking somewhere else, and clears the mark the next time you type in that session.

It complements the existing `desktop-notification-on-stop`: a notification tells you *something* finished, this tells you *which window*. Once you are running five or six sessions that is the question you actually have.

Two files, matching the `langsmith-tracing` pattern of a component JSON plus its script:

- `cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.json`
- `cli-tool/components/hooks/monitoring/terminal-tab-unread-marker.sh`

**Two non-obvious things it handles**, both of which cost me real time and are documented inline so the next person does not repeat them:

1. Claude Code pipes stdin to hooks, so `tty` reports "not a tty". The session tty has to be recovered by walking up the process tree.
2. Claude Code re-asserts the terminal title roughly a second after `Stop`, when the session transitions to idle. A marker written by a naive `Stop` hook is silently wiped, with no error, so it looks like the hook never ran. This re-asserts past that window, detached so `Stop` returns immediately. `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` is noted as the alternative.

**Safety and scope:** it never stores a copy of your title. A zero-width WORD JOINER marks its own prefix so it can be stripped, which means it cannot clobber a title set with `/rename`, and it declines to write when the title reads back empty (a lone marker would be unremovable). Every Apple Event is capped with a 15 second alarm so a wedged Terminal cannot wedge the hook. No network calls. Exits silently on non-macOS and when the tty is not a Terminal tab.

Component shape verified identical to `desktop-notification-on-stop.json` (`description` + `hooks`, no extra keys), JSON validates, script passes `bash -n` and shellcheck, and `tab_state` was tested against live Terminal tabs.

Not applicable to iTerm2, Ghostty or kitty, which already have native tab colours. MIT. Fuller version with per-project window tinting: https://github.com/dotcomjack/claude-session-tint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a monitoring hook that marks the macOS Terminal tab when a Claude Code session finishes unfocused, and clears it on your next input. Improves robustness for path quoting, safe marker stripping, and avoiding stale re-marks.

- Area: components (`cli-tool/components/`)
- Adds new hook component `hooks/monitoring/terminal-tab-unread-marker` (JSON + `.sh`) to mark on `Stop` and clear on `UserPromptSubmit`; quotes `$CLAUDE_PROJECT_DIR`; anchors marker stripping; re-reads tab state and stops once selected/frontmost to avoid re-marking
- macOS Terminal.app only; exits silently on other terminals
- No new required env vars; optional `TABTINT_MARK`; supports `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1`
- New component added; regenerate catalog `docs/components.json`

<sup>Written for commit a6774bdce643d7c6c80825d4c0aaffee621549d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

