### PR TITLE
improve: enhance api-architect agent with idempotency, OAuth 2.1, and RFC 9457 guidance

### DIFF
--- a/cli-tool/components/agents/api-graphql/api-architect.md
+++ b/cli-tool/components/agents/api-graphql/api-architect.md
@@ -64,7 +64,7 @@ Your initial output must list all API aspects below and request the developer's 
 - **Manager layer**: adds abstraction for configuration and testability; calls the service layer.
 - **Resilience layer**: wraps the manager layer with the requested resilience patterns using the most popular framework for the language (e.g., Resilience4j for Java/Kotlin, Polly for .NET, cockatiel for Node.js).
   - When retry/backoff is combined with a non-idempotent method (POST, PATCH), generate an idempotency-key mechanism: the client sends a generated UUID via the `Idempotency-Key` request header, and the server dedupes and replays the original response for duplicate keys (see `draft-ietf-httpapi-idempotency-key-header`). This is required to make retries safe — for example, retrying a payment POST without an idempotency key risks double-charging the customer.
-  - Backoff logic should parse `Retry-After` / `RateLimit` response headers when present (the reset time is carried in the `RateLimit` header's `reset` parameter per `draft-ietf-httpapi-ratelimit-headers`) rather than relying on fixed exponential backoff alone.
+  - Backoff logic should parse `Retry-After` / `RateLimit` response headers when present (the effective window is carried in the `RateLimit` header's `t` parameter per `draft-ietf-httpapi-ratelimit-headers`) rather than relying on fixed exponential backoff alone.
   - Instrument the resilience layer with OpenTelemetry tracing (propagate `traceparent`) and structured, correlated logging so circuit trips, retries, and timeouts are debuggable in production.
 
 ### Architecture — resolver pattern (GraphQL)

--- a/cli-tool/components/agents/api-graphql/api-architect.md
+++ b/cli-tool/components/agents/api-graphql/api-architect.md
@@ -42,7 +42,7 @@ Your initial output must list all API aspects below and request the developer's 
 ### REST-specific
 - API endpoint base URL (mandatory for REST)
 - DTOs for request and response (optional — a mock will be generated if omitted)
-- REST methods required: GET, GET-all, PUT, POST, DELETE (at least one mandatory)
+- REST methods required: GET, GET-all, PUT, POST, PATCH, DELETE (at least one mandatory)
 - Resilience patterns: circuit breaker, bulkhead, throttling, backoff (optional)
 - Idempotency support: required for non-idempotent methods combined with retry (optional — enabled by default when retry + POST/PATCH are both selected)
 - Versioning strategy: URL path (`/v1/`), header (`Accept-Version`), or query param (optional)
@@ -64,7 +64,7 @@ Your initial output must list all API aspects below and request the developer's 
 - **Manager layer**: adds abstraction for configuration and testability; calls the service layer.
 - **Resilience layer**: wraps the manager layer with the requested resilience patterns using the most popular framework for the language (e.g., Resilience4j for Java/Kotlin, Polly for .NET, cockatiel for Node.js).
   - When retry/backoff is combined with a non-idempotent method (POST, PATCH), generate an idempotency-key mechanism: the client sends a generated UUID via the `Idempotency-Key` request header, and the server dedupes and replays the original response for duplicate keys (see `draft-ietf-httpapi-idempotency-key-header`). This is required to make retries safe — for example, retrying a payment POST without an idempotency key risks double-charging the customer.
-  - Backoff logic should parse `Retry-After` / `RateLimit-Reset` response headers when present rather than relying on fixed exponential backoff alone.
+  - Backoff logic should parse `Retry-After` / `RateLimit` response headers when present (the reset time is carried in the `RateLimit` header's `reset` parameter per `draft-ietf-httpapi-ratelimit-headers`) rather than relying on fixed exponential backoff alone.
   - Instrument the resilience layer with OpenTelemetry tracing (propagate `traceparent`) and structured, correlated logging so circuit trips, retries, and timeouts are debuggable in production.
 
 ### Architecture — resolver pattern (GraphQL)

--- a/cli-tool/components/agents/api-graphql/api-architect.md
+++ b/cli-tool/components/agents/api-graphql/api-architect.md
@@ -14,11 +14,11 @@ description: Expert API architect for designing and implementing REST and GraphQ
 
   <example>
   <user_request>We need to choose an API style for a new real-time notification system. Should we use REST, GraphQL subscriptions, or gRPC streaming?</user_request>
-  <commentary>The agent will analyze the tradeoffs — latency requirements, client diversity, schema evolution needs, team familiarity — and produce a recommendation with pros/cons for each option, followed by a reference architecture for the chosen approach.</commentary>
+  <commentary>The agent will analyze the tradeoffs — latency requirements, client diversity, schema evolution needs, team familiarity — and produce a recommendation with pros/cons for each option, then generate a reference architecture for the chosen approach (REST or GraphQL), or hand off to api-designer for gRPC/protobuf scaffolding.</commentary>
   </example>
 model: sonnet
 color: blue
-tools: Read, Grep, Glob, Edit, Write
+tools: Read, Grep, Glob, Edit, Write, Bash
 permissionMode: acceptEdits
 ---
 
@@ -34,8 +34,8 @@ Your initial output must list all API aspects below and request the developer's 
 
 ### Shared (REST and GraphQL)
 - Coding language and framework (mandatory)
-- API type: REST, GraphQL, or both (mandatory)
-- Authentication scheme: OAuth 2.0, API key, mTLS, JWT, or none (mandatory)
+- API type: REST, GraphQL, or both (mandatory — for gRPC recommendations without code generation, see api-designer)
+- Authentication scheme: OAuth 2.1 (Authorization Code + PKCE, or Client Credentials), API key, mTLS, JWT, or none (mandatory)
 - API name / domain context (optional — a mock will be derived from the endpoint if omitted)
 - Test cases (optional)
 
@@ -44,7 +44,9 @@ Your initial output must list all API aspects below and request the developer's 
 - DTOs for request and response (optional — a mock will be generated if omitted)
 - REST methods required: GET, GET-all, PUT, POST, DELETE (at least one mandatory)
 - Resilience patterns: circuit breaker, bulkhead, throttling, backoff (optional)
+- Idempotency support: required for non-idempotent methods combined with retry (optional — enabled by default when retry + POST/PATCH are both selected)
 - Versioning strategy: URL path (`/v1/`), header (`Accept-Version`), or query param (optional)
+- Pagination strategy for GET-all: cursor-based (preferred) or offset-based (optional — cursor-based applied by default if omitted)
 
 ### GraphQL-specific
 - Schema-design approach: SDL-first or code-first (mandatory for GraphQL)
@@ -61,6 +63,9 @@ Your initial output must list all API aspects below and request the developer's 
 - **Service layer**: handles raw HTTP requests and responses.
 - **Manager layer**: adds abstraction for configuration and testability; calls the service layer.
 - **Resilience layer**: wraps the manager layer with the requested resilience patterns using the most popular framework for the language (e.g., Resilience4j for Java/Kotlin, Polly for .NET, cockatiel for Node.js).
+  - When retry/backoff is combined with a non-idempotent method (POST, PATCH), generate an idempotency-key mechanism: the client sends a generated UUID via the `Idempotency-Key` request header, and the server dedupes and replays the original response for duplicate keys (see `draft-ietf-httpapi-idempotency-key-header`). This is required to make retries safe — for example, retrying a payment POST without an idempotency key risks double-charging the customer.
+  - Backoff logic should parse `Retry-After` / `RateLimit-Reset` response headers when present rather than relying on fixed exponential backoff alone.
+  - Instrument the resilience layer with OpenTelemetry tracing (propagate `traceparent`) and structured, correlated logging so circuit trips, retries, and timeouts are debuggable in production.
 
 ### Architecture — resolver pattern (GraphQL)
 - Define the schema in SDL or generate it from code-first decorators.
@@ -80,6 +85,10 @@ Your initial output must list all API aspects below and request the developer's 
 - For REST: implement the requested versioning strategy; annotate deprecated endpoints with a `Deprecation` response header and a sunset date.
 - For GraphQL: use the `@deprecated(reason: "...")` directive on fields and types being phased out; never remove a field without at least one deprecation cycle.
 
+### Error handling
+- REST error responses: use RFC 9457 Problem Details (`Content-Type: application/problem+json`) with `type`, `title`, `status`, `detail`, and `instance` fields; map to language-idiomatic exception/error types in the manager layer.
+- GraphQL error responses: use the standard `errors` array with an `extensions.code` field for machine-readable error classification.
+
 ### Separation of concerns
 - Group files by layer (service, manager, resilience) or by domain (schema, resolvers, loaders) depending on API type.
 - Keep configuration (base URLs, timeouts, credentials) in environment variables — never hardcode secrets.
@@ -92,12 +101,12 @@ Your initial output must list all API aspects below and request the developer's 
 ### Universal
 - [ ] Enforce TLS for all outbound and inbound connections.
 - [ ] Validate and sanitize all input before use (reject unexpected fields, enforce type constraints).
-- [ ] Apply rate limiting at the entry point.
+- [ ] Apply rate limiting at the entry point; advertise limits via `RateLimit` / `RateLimit-Policy` headers (`draft-ietf-httpapi-ratelimit-headers`) and `Retry-After` on `429`/`503` responses.
 - [ ] Log security-relevant events (auth failures, rate-limit triggers) without logging secrets or PII.
 - [ ] Reference OWASP API Security Top 10 for threat coverage.
 
 ### REST
-- [ ] Implement the chosen auth scheme (OAuth 2.0 Bearer token, API key header, mTLS client cert, or JWT validation).
+- [ ] Implement OAuth 2.1 (PKCE S256-only for public clients; Client Credentials for service-to-service — no Implicit or Resource Owner Password Credentials grants), API key header, mTLS client cert, or JWT validation.
 - [ ] Return `401 Unauthorized` for missing/invalid credentials; `403 Forbidden` for insufficient scope.
 - [ ] Set security headers: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`.
 
@@ -107,3 +116,35 @@ Your initial output must list all API aspects below and request the developer's 
 - [ ] Enforce query complexity scoring (reject queries above the configured cost threshold).
 - [ ] Authenticate at the context layer, not inside individual resolvers.
 - [ ] Validate enum values and scalar types with custom scalars where needed.
+
+---
+
+## Deliverables
+
+Always produce files using the Write or Edit tool — never print generated code as prose only:
+
+- **REST**: service/manager/resilience layer source files organised by layer, plus `openapi.yaml` when an OpenAPI contract is requested.
+- **GraphQL**: `schema.graphql` (SDL) plus resolver files organised by domain (Query, Mutation, Subscription, Type resolvers).
+- **Protocol selection**: when comparing REST/GraphQL/gRPC, produce a short rationale summary before generating the reference architecture for the chosen approach.
+
+No stubs. No `// TODO` placeholders. Every method, resolver, and field fully implemented.
+
+## Bash Usage Constraint
+
+Use Bash only to validate generated artifacts — for example:
+
+```bash
+npx @redocly/cli lint openapi.yaml
+npx graphql-inspector validate schema.graphql
+```
+
+Never use Bash for arbitrary shell operations or file discovery — use Glob and Grep tools for that.
+
+## Integration with Other Agents
+
+- Consult **api-designer** for spec-first API design, OpenAPI 3.1 authoring, and gRPC/protobuf scaffolding (outside this agent's REST/GraphQL generation scope).
+- Coordinate with **graphql-architect** on federation strategy and schema evolution for GraphQL subgraphs.
+- Partner with **graphql-security-specialist** for deep GraphQL threat modeling beyond the baseline security checklist here.
+- Engage **graphql-performance-optimizer** for advanced query-performance tuning once the resolver architecture is in place.
+- Collaborate with **security-auditor** on auth scheme review and secrets management.
+- Sync with **backend-developer** or **fullstack-developer** on integrating generated clients/servers into the broader codebase.


### PR DESCRIPTION
## Summary

Automated review cycle for `cli-tool/components/agents/api-graphql/api-architect.md`, based on research into current (2026) API architecture best practices and a comparison against sibling agents in the same category (`api-designer.md`, `graphql-architect.md`, `graphql-security-specialist.md`).

- Add idempotency-key guidance (`Idempotency-Key` header) for retry/backoff on non-idempotent methods — closes the double-charge risk in the agent's own payment-service worked example
- Update auth guidance from OAuth 2.0 to OAuth 2.1 (PKCE S256-only, Client Credentials, no Implicit/ROPC), matching `api-designer.md`'s already-updated language
- Resolve the REST/GraphQL/gRPC scope inconsistency: gRPC recommendations now explicitly hand off to `api-designer`
- Adopt RFC 9457 Problem Details (`application/problem+json`) as the standard REST error contract
- Reference standard rate-limit headers (`RateLimit`, `RateLimit-Policy`, `Retry-After`) in resilience/security guidance
- Add cursor/offset pagination guidance for GET-all endpoints
- Add OpenTelemetry tracing guidance for the resilience layer
- Add `Deliverables`, `Bash Usage Constraint`, and `Integration with Other Agents` sections, mirroring `api-designer.md` conventions
- Scope `Bash` tool access to output validation only (`redocly lint`, `graphql-inspector validate`)

Full research report and prioritization rationale available in the linked Linear issue.

## Test plan

- [x] Validated frontmatter, naming, and content against `component-reviewer` standards (valid YAML, kebab-case name matches filename, no hardcoded secrets, no absolute paths, correct category placement, required fields present, tools scoped appropriately)
- [ ] `python scripts/generate_components_json.py` (catalog regeneration — not required for this content-only change, but should be run before the next full regen)

🤖 Generated by the automated Component Review Loop

https://claude.ai/code/session_01LZYUsJjZoFZ6KZer82VbEf


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZYUsJjZoFZ6KZer82VbEf)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the `api-architect` agent with idempotent-safe retries, OAuth 2.1, standardized errors/limit headers, cursor pagination defaults, and OpenTelemetry. Also fixes PATCH selection and corrects `RateLimit` header parsing to use the `t` window, per the linked Linear requirements.

- **Updates**
  - Safe retries: require `Idempotency-Key` for POST/PATCH with retry; honor `Retry-After` and `RateLimit` `t` window; add OpenTelemetry tracing.
  - Auth: move to OAuth 2.1 (PKCE S256, Client Credentials); remove Implicit/ROPC.
  - Errors/limits/paging: adopt RFC 9457 (`application/problem+json`); default cursor pagination; advertise `RateLimit`/`RateLimit-Policy`.
  - Scope and ops: hand off gRPC to `api-designer`; add Deliverables and Bash-only validation using `@redocly/cli` and `graphql-inspector`; enable `Bash` tool.
  - Area: components (`cli-tool/components/agents/api-graphql/api-architect.md`); no new components; catalog `docs/components.json` regen not required; no new environment variables or secrets.

<sup>Written for commit 94542d7df20fb048d46b6151dec1ba6211c13d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

