### PR TITLE
mac-storage-cleaner: v2.0.0 hardening update

### DIFF
--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: mac-storage-cleaner
 description: Safely reclaim disk space on a Mac — the trustworthy, transparent, reversible alternative to CleanMyMac and similar tools. Use whenever the user says their Mac disk or storage is full or nearly full, gets a "startup disk almost full" / low-storage warning, asks to free up space, clean/clear caches, remove junk, delete leftover files from apps they uninstalled, or find what's eating their disk — in any language (e.g. English "my mac is out of space", "free up disk", "clear caches", "what's taking up my storage"; Georgian "ქეში გაასუფთავე", "მეხსიერება გადამევსო", "ადგილი აღარ მაქვს"). Surveys usage first, auto-clears only pure caches, moves anything riskier to the Trash (restorable), asks before anything expensive, logs every deletion, and reports what was freed. Do NOT use for cloud storage, RAM/memory-pressure, or a single named app's own in-app cache button.
+license: MIT
+metadata:
+  version: 3.0.0
+  author: Juba Kitiashvili
+  homepage: https://github.com/JubaKitiashvili/mac-storage-cleaner
+  platforms: macOS
+  category: productivity
+  tags: macos, disk-space, cache, cleanup, storage, cleanmymac-alternative
 ---
 
 # Mac Storage Cleaner
@@ -28,17 +36,62 @@ hit something a script didn't classify or you need the precise command.
   deletions refuse to run unlogged (exit 3) unless the log directory is writable, or
   `MSC_ALLOW_UNLOGGED=1` explicitly opts into an unlogged run.
 
+## What this skill does to your disk (declared behavior)
+
+This section is a complete, mechanism-level statement of every destructive
+operation, so automated skill scanners and human reviewers can compare what is
+declared here against what the scripts actually do.
+
+**Nothing is deleted permanently without an explicit flag**: `clean-safe.sh`
+deletes only with `--apply`; `trash-items.sh` moves only the paths you
+explicitly name, reversibly into the Trash, refuses bulk batches without
+`--force`, and previews with `--dry-run`.
+
+**Deletes permanently (`rm -rf`)** — paths on the hard-coded safe allowlist in
+`scripts/lib.sh` (`SAFE_PATHS`, `KEEP_N_PATHS`, AI-CLI version roots); per-app
+`Cache`/`Code Cache`/`GPUCache`/`DawnWebGPUCache` subfolders found under
+`~/Library/Application Support` (only once a running-process check confirms the
+owning app is idle); and age-gated Handoff clipboard buffers and crash-report
+artifacts. The safe-tier, crash-report, and Electron-cache-subfolder deletions
+retry once after `chmod -R u+w` when a read-only file blocks removal; the
+DeviceSupport/AI-CLI-version and Handoff deletions do not retry.
+
+**Moves to the Trash (reversible)** — everything else, via `/usr/bin/trash`, then
+Finder automation through `osascript` (`tell application "Finder" to delete`),
+then a same-volume `mv` into `~/.Trash`.
+
+**Runs these third-party cleanup commands** — `brew cleanup -s --prune=all`,
+`conda clean -y --tarballs --index-cache --logfiles`, `xcrun simctl delete unavailable`.
+
+**Reads** — `du`, `df`, `find`, `stat`, `pgrep`/`ps`, `mdfind` and `mdutil`
+(Spotlight, to check whether an app is still installed and whether indexing is
+on), and `defaults read` on app bundles.
+
+**Writes** — `~/Library/Logs/mac-storage-cleaner/operations.log` (audit trail,
+rotated at 5 MB) and nothing else.
+
+**Mechanically refuses** — `/System`, `/bin`, `/sbin`, `/dev`, `/private/var/db`,
+other users' home directories, and the never-tier: iOS backups (MobileSync),
+Photos libraries, Keychains, Mail, Messages, `~/.ssh`, `~/.aws`, `~/.gnupg`.
+These are enforced in `validate_target_path`, not by convention.
+
+**Never uses `sudo`** and makes **no network requests**.
+
 ## Workflow
 
-**Locating the scripts.** The commands below resolve `$D` to this skill's own
-directory so they work whether the skill was installed as a plugin
-(`$CLAUDE_PLUGIN_ROOT` is set) or as a standalone skill (`~/.claude/skills/…`).
-Shell state doesn't persist between commands, so each block re-resolves `$D`.
+**Locating the scripts.** Each command block below starts by resolving `$D` to
+this skill's own directory. It searches every standard agent skill root —
+Claude Code, Codex, Cursor, opencode, Antigravity, Windsurf, Hermes, the
+cross-agent `.agents/skills`, and project-scoped installs — so the commands work
+no matter which agent installed the skill or where. Shell state doesn't persist
+between commands, so every block re-resolves `$D`; keep the two lines byte-identical
+when editing (a test enforces it).
 
 ### 1. Survey — caches (always first, read-only)
 
 ```bash
-D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+D=""; for r in "${MSC_SKILL_ROOT:-/nonexistent}" "${CLAUDE_PLUGIN_ROOT:-/nonexistent}/skills" "$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.cursor/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills" "$HOME/.hermes/skills" ".claude/skills" ".agents/skills" ".cursor/skills" ".windsurf/skills"; do [ -f "$r/mac-storage-cleaner/scripts/lib.sh" ] && { D="$r/mac-storage-cleaner"; break; }; done
+[ -n "$D" ] || { echo "mac-storage-cleaner: not found in any standard skill root (looked under MSC_SKILL_ROOT, CLAUDE_PLUGIN_ROOT and ~/.claude, ~/.agents, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.gemini, ~/.codeium/windsurf, ~/.hermes, plus ./.claude|.agents|.cursor|.windsurf)"; exit 1; }
 bash "$D/scripts/survey.sh"
 ```
 
@@ -46,26 +99,39 @@ Prints free space and sizes every cache that exists on *this* machine, grouped
 **safe / ask / never / app-data**. Never skip it — locations and sizes differ on
 every Mac. Note current free space for the before/after report.
 
-### 2. Clear the safe tier (no per-item permission needed)
+### 2. Clear the safe tier: preview, show the user, then apply
 
 Tell the user briefly what the safe tier removes and roughly how much it frees,
-then:
+then preview it first — this run deletes nothing:
 
 ```bash
-D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+D=""; for r in "${MSC_SKILL_ROOT:-/nonexistent}" "${CLAUDE_PLUGIN_ROOT:-/nonexistent}/skills" "$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.cursor/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills" "$HOME/.hermes/skills" ".claude/skills" ".agents/skills" ".cursor/skills" ".windsurf/skills"; do [ -f "$r/mac-storage-cleaner/scripts/lib.sh" ] && { D="$r/mac-storage-cleaner"; break; }; done
+[ -n "$D" ] || { echo "mac-storage-cleaner: not found in any standard skill root (looked under MSC_SKILL_ROOT, CLAUDE_PLUGIN_ROOT and ~/.claude, ~/.agents, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.gemini, ~/.codeium/windsurf, ~/.hermes, plus ./.claude|.agents|.cursor|.windsurf)"; exit 1; }
 bash "$D/scripts/clean-safe.sh"
 ```
 
-Removes only the vetted safe allowlist (nothing else — the survey's "other large
-caches" list is for the user to review, not for auto-deletion), handles read-only
-files, skips anything macOS protects (reporting rather than failing), runs
-`brew cleanup -s --prune=all` and removes unavailable simulators, logs each
+**Preview is the default.** Running `clean-safe.sh` with no argument previews
+everything with sizes and deletes nothing; `--apply` performs the deletion.
+Guards and the whitelist run identically in both modes, so the preview always
+matches reality. Show the user the preview before you run `--apply` — and always
+do so on agents that execute shell commands without asking them first (opencode,
+OpenClaw and anything configured to auto-run). `MSC_DRY_RUN=1` forces preview
+even when `--apply` is passed.
+
+Once the user has seen the preview and is on board, apply it:
+
+```bash
+D=""; for r in "${MSC_SKILL_ROOT:-/nonexistent}" "${CLAUDE_PLUGIN_ROOT:-/nonexistent}/skills" "$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.cursor/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills" "$HOME/.hermes/skills" ".claude/skills" ".agents/skills" ".cursor/skills" ".windsurf/skills"; do [ -f "$r/mac-storage-cleaner/scripts/lib.sh" ] && { D="$r/mac-storage-cleaner"; break; }; done
+[ -n "$D" ] || { echo "mac-storage-cleaner: not found in any standard skill root (looked under MSC_SKILL_ROOT, CLAUDE_PLUGIN_ROOT and ~/.claude, ~/.agents, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.gemini, ~/.codeium/windsurf, ~/.hermes, plus ./.claude|.agents|.cursor|.windsurf)"; exit 1; }
+bash "$D/scripts/clean-safe.sh" --apply
+```
+
+This removes only the vetted safe allowlist (nothing else — the survey's "other
+large caches" list is for the user to review, not for auto-deletion), handles
+read-only files, skips anything macOS protects (reporting rather than failing),
+runs `brew cleanup -s --prune=all` and removes unavailable simulators, logs each
 deletion, and prints what it reclaimed. If the user only wanted specific items,
 delete those directly instead.
-
-To preview first (recommended when the user hesitates or asks what will go): add
-`--dry-run` — full preview with sizes, zero deletion, zero log writes. Guards and
-whitelist run identically in both modes, so the preview always matches reality.
 
 The safe tier now keeps the 2 newest DeviceSupport versions
 (MSC_DEVICE_SUPPORT_KEEP), keeps the active + 1 previous version of
@@ -109,7 +175,8 @@ deletions. Key ones (full detail in the catalog):
 ### 4. Go beyond caches — the space the cleaners miss (read-only scan)
 
 ```bash
-D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+D=""; for r in "${MSC_SKILL_ROOT:-/nonexistent}" "${CLAUDE_PLUGIN_ROOT:-/nonexistent}/skills" "$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.cursor/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills" "$HOME/.hermes/skills" ".claude/skills" ".agents/skills" ".cursor/skills" ".windsurf/skills"; do [ -f "$r/mac-storage-cleaner/scripts/lib.sh" ] && { D="$r/mac-storage-cleaner"; break; }; done
+[ -n "$D" ] || { echo "mac-storage-cleaner: not found in any standard skill root (looked under MSC_SKILL_ROOT, CLAUDE_PLUGIN_ROOT and ~/.claude, ~/.agents, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.gemini, ~/.codeium/windsurf, ~/.hermes, plus ./.claude|.agents|.cursor|.windsurf)"; exit 1; }
 bash "$D/scripts/find-extras.sh"
 ```
 
@@ -119,7 +186,8 @@ Downloads**. Everything here is ask-tier — present candidates, let the user pi
 then remove reversibly:
 
 ```bash
-D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${D:-$HOME/.claude/skills/mac-storage-cleaner}"
+D=""; for r in "${MSC_SKILL_ROOT:-/nonexistent}" "${CLAUDE_PLUGIN_ROOT:-/nonexistent}/skills" "$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.cursor/skills" "$HOME/.codex/skills" "$HOME/.config/opencode/skills" "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills" "$HOME/.hermes/skills" ".claude/skills" ".agents/skills" ".cursor/skills" ".windsurf/skills"; do [ -f "$r/mac-storage-cleaner/scripts/lib.sh" ] && { D="$r/mac-storage-cleaner"; break; }; done
+[ -n "$D" ] || { echo "mac-storage-cleaner: not found in any standard skill root (looked under MSC_SKILL_ROOT, CLAUDE_PLUGIN_ROOT and ~/.claude, ~/.agents, ~/.cursor, ~/.codex, ~/.config/opencode, ~/.gemini, ~/.codeium/windsurf, ~/.hermes, plus ./.claude|.agents|.cursor|.windsurf)"; exit 1; }
 bash "$D/scripts/trash-items.sh" "/path/one" "/path/two"
 ```
 
@@ -130,6 +198,14 @@ Settings › Privacy & Security › Automation), then a same-volume `mv` into
 the path is on the tool's deny list (system/user roots) — never work around a
 refusal. Don't report space as freed when items logged `trash-failed` — nothing
 was actually removed.
+
+**Bulk operations need confirmation.** `trash-items.sh` refuses a batch of more than 100
+eligible items or 5 GB and exits 4, because several agents run shell commands without
+asking the user first. Show the user the list (a preview with `MSC_DRY_RUN=1` is never
+refused), get their explicit go-ahead, then re-run with `--force` as the first argument.
+Never pass `--force` pre-emptively. If `du` can't fully measure the batch (some paths are
+unreadable), the size guard is skipped for that run — with an on-screen warning and a
+`size-unmeasurable` log entry — but the 100-item cap still applies regardless.
 
 **App leftovers need verification.** The scan lists containers whose owning app a
 quick check couldn't confirm is installed — but Spotlight misses un-indexed apps,
@@ -176,15 +252,25 @@ Read `references/cache-catalog.md` for the full tiered inventory and gotchas. Th
 
 ## Environment variables
 
+- `MSC_SKILL_ROOT` — escape hatch for the `$D` resolver above: set it to the skills root directory that *contains* the `mac-storage-cleaner` folder (i.e. the same shape as `~/.claude/skills`) and it is checked first, ahead of every hard-coded root. Use this for any agent whose skill root isn't one of the ~10 standard ones the resolver already searches.
 - `MSC_DRY_RUN` — set to `1` to force preview mode (same as `--dry-run`) on `clean-safe.sh`, and to make `trash-items.sh` preview instead of trashing.
 - `MSC_WHITELIST_FILE` — override the whitelist path (default `~/.config/mac-storage-cleaner/whitelist`).
 - `MSC_TRASH_BIN` — override the `trash` binary `trash_path` tries first (default `/usr/bin/trash`).
 - `MSC_DEVICE_SUPPORT_KEEP` (default `2`) — how many newest Xcode DeviceSupport versions to keep per platform.
 - `MSC_AI_AGENTS_KEEP` (default `1`) — how many newest non-active AI CLI versions to keep alongside the active (symlink-pinned) one.
 - `MSC_ALLOW_UNLOGGED` — set to `1` to let a destructive run proceed even when the audit log can't be written (default: refuse, exit 3).
+- `MSC_MAX_TRASH_ITEMS` (default `100`) — refuse a `trash-items.sh` batch with more eligible items unless `--force` is passed.
+- `MSC_MAX_TRASH_GB` (default `5`) — refuse a `trash-items.sh` batch larger than this unless `--force` is passed.
 
 ## Tests
 
-`bats tests/` from the repo root (`brew install bats-core`). Every test runs
-against a fake `$HOME`; the dangerous-path corpus in `tests/fixtures/` is a
-floor — investigate a failure, never weaken the corpus.
+`bats tests/` from a clone of the source repository
+(https://github.com/JubaKitiashvili/mac-storage-cleaner, `brew install bats-core`).
+The tests are not shipped inside the installed skill. Every test runs against a
+fake `$HOME`; the dangerous-path corpus in `tests/fixtures/` is a floor —
+investigate a failure, never weaken the corpus.
+
+Note: a handful of `SAFE_PATHS` globs point at the real, shared `/private/tmp`
+(Metro/React Native bundler caches) that the fake-`$HOME` harness cannot
+isolate — running `bats tests/` with `--apply` tests active (the default) can
+clear `/private/tmp/metro-*`-class caches on the machine that runs it.

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
@@ -3,7 +3,7 @@ name: mac-storage-cleaner
 description: Safely reclaim disk space on a Mac — the trustworthy, transparent, reversible alternative to CleanMyMac and similar tools. Use whenever the user says their Mac disk or storage is full or nearly full, gets a "startup disk almost full" / low-storage warning, asks to free up space, clean/clear caches, remove junk, delete leftover files from apps they uninstalled, or find what's eating their disk — in any language (e.g. English "my mac is out of space", "free up disk", "clear caches", "what's taking up my storage"; Georgian "ქეში გაასუფთავე", "მეხსიერება გადამევსო", "ადგილი აღარ მაქვს"). Surveys usage first, auto-clears only pure caches, moves anything riskier to the Trash (restorable), asks before anything expensive, logs every deletion, and reports what was freed. Do NOT use for cloud storage, RAM/memory-pressure, or a single named app's own in-app cache button.
 license: MIT
 metadata:
-  version: 3.0.0
+  version: 3.0.1
   author: Juba Kitiashvili
   homepage: https://github.com/JubaKitiashvili/mac-storage-cleaner
   platforms: macOS

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/SKILL.md
@@ -24,7 +24,9 @@ hit something a script didn't classify or you need the precise command.
   them. Reversibility is the whole point; never hard-delete a user's data.
 - **When unsure, demote a tier.** A slower rebuild is trivial; deleting a
   license, an unpushable Xcode archive, or someone's only local backup is not.
-- **Every destructive run is logged** to `~/Library/Logs/mac-storage-cleaner/operations.log`.
+- **Every destructive run is logged** to `~/Library/Logs/mac-storage-cleaner/operations.log` —
+  deletions refuse to run unlogged (exit 3) unless the log directory is writable, or
+  `MSC_ALLOW_UNLOGGED=1` explicitly opts into an unlogged run.
 
 ## Workflow
 
@@ -61,10 +63,36 @@ files, skips anything macOS protects (reporting rather than failing), runs
 deletion, and prints what it reclaimed. If the user only wanted specific items,
 delete those directly instead.
 
+To preview first (recommended when the user hesitates or asks what will go): add
+`--dry-run` — full preview with sizes, zero deletion, zero log writes. Guards and
+whitelist run identically in both modes, so the preview always matches reality.
+
+The safe tier now keeps the 2 newest DeviceSupport versions
+(MSC_DEVICE_SUPPORT_KEEP), keeps the active + 1 previous version of
+auto-updating AI CLIs (claude / cursor-agent / copilot, pinned via their
+launcher symlink), and skips any path whose owning process is running (Xcode
+family, Gradle daemon) — report skipped items to the user instead of retrying.
+
 **Browser & Electron app caches** (Chrome/Arc/Slack/VS Code/…) are safe but live
 inside app-data folders — clear only the `Cache`/`Code Cache`/`GPUCache`
 subfolders the survey lists, ideally with the app quit, and **never** the whole
 app folder. Exact paths: `references/cache-catalog.md`.
+
+### User whitelist
+
+`~/.config/mac-storage-cleaner/whitelist` — one path or glob per line, `#`
+comments, `~/` expansion; protects the entry and everything under it, and
+governs every tier `clean-safe.sh` touches (safe, keep-N, AI-agent, Handoff),
+dry-run included, down to individual children inside a keep-N/AI-agent/Handoff
+base directory — surfaced by the survey too. One limit: an entry BELOW a
+**safe-tier** allowlist path (e.g. `~/.npm/some-package`) can't be honored,
+because the safe tier removes those paths atomically (`rm -rf ~/.npm`) rather
+than walking their children — whitelist the safe-tier path itself instead.
+`find-extras.sh` and
+`trash-items.sh` do **not** read it (they only ever act on paths the user
+explicitly approves that session), so when the user says "always keep X", add
+a line here **and** keep checking find-extras candidates against it yourself
+before proposing removal — the script won't stop you.
 
 ### 3. Surface the "ask" tier — recommend, don't delete
 
@@ -95,12 +123,13 @@ D="${CLAUDE_PLUGIN_ROOT:+$CLAUDE_PLUGIN_ROOT/skills/mac-storage-cleaner}"; D="${
 bash "$D/scripts/trash-items.sh" "/path/one" "/path/two"
 ```
 
-**If trashing reports "could NOT trash (permissions/TCC?)"** for every item, the
-controlling app hasn't been granted Automation control of Finder — a normal
-first-run state. Tell the user to allow it in System Settings › Privacy &
-Security › Automation (enable Finder for the terminal/app), then re-run; or move
-the item to the Trash manually in Finder. Don't report space as freed when items
-logged `trash-failed` — nothing was actually removed.
+**Trash chain and refusals.** trash-items.sh now tries `/usr/bin/trash` first (no
+TCC prompt, works headless), then Finder (needs the Automation grant — System
+Settings › Privacy & Security › Automation), then a same-volume `mv` into
+`~/.Trash`. The log records which method moved each item; refused entries mean
+the path is on the tool's deny list (system/user roots) — never work around a
+refusal. Don't report space as freed when items logged `trash-failed` — nothing
+was actually removed.
 
 **App leftovers need verification.** The scan lists containers whose owning app a
 quick check couldn't confirm is installed — but Spotlight misses un-indexed apps,
@@ -141,3 +170,21 @@ Read `references/cache-catalog.md` for the full tiered inventory and gotchas. Th
   (only `caches/`). `~/.npm` is pure cache so it's fine whole.
 - **Continue past errors and verify** with `du`; `rm -rf` on multiple paths keeps
   going after a failure, so never assume total success or total failure.
+- **Handoff shared-pasteboard buffers are cleared only when untouched for 60+
+  minutes** — never delete fresher ones, an in-flight Universal Clipboard sync
+  may be using them.
+
+## Environment variables
+
+- `MSC_DRY_RUN` — set to `1` to force preview mode (same as `--dry-run`) on `clean-safe.sh`, and to make `trash-items.sh` preview instead of trashing.
+- `MSC_WHITELIST_FILE` — override the whitelist path (default `~/.config/mac-storage-cleaner/whitelist`).
+- `MSC_TRASH_BIN` — override the `trash` binary `trash_path` tries first (default `/usr/bin/trash`).
+- `MSC_DEVICE_SUPPORT_KEEP` (default `2`) — how many newest Xcode DeviceSupport versions to keep per platform.
+- `MSC_AI_AGENTS_KEEP` (default `1`) — how many newest non-active AI CLI versions to keep alongside the active (symlink-pinned) one.
+- `MSC_ALLOW_UNLOGGED` — set to `1` to let a destructive run proceed even when the audit log can't be written (default: refuse, exit 3).
+
+## Tests
+
+`bats tests/` from the repo root (`brew install bats-core`). Every test runs
+against a fake `$HOME`; the dangerous-path corpus in `tests/fixtures/` is a
+floor — investigate a failure, never weaken the corpus.

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/agents/openai.yaml
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/agents/openai.yaml
@@ -1,0 +1,9 @@
+# Codex-specific presentation and invocation policy. Codex reads this file
+# alongside SKILL.md; every other agent ignores the directory.
+interface:
+  display_name: Mac Storage Cleaner
+  short_description: Safe, reversible macOS disk cleanup with an audit log.
+policy:
+  # The skill should surface when a user says they are out of disk space, not
+  # only when they name it explicitly.
+  allow_implicit_invocation: true

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/references/cache-catalog.md
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/references/cache-catalog.md
@@ -23,7 +23,7 @@ license file, an unpushable archive, or someone's only local backup is not.
 | Location | What | Reclaim | Regenerates on |
 |---|---|---|---|
 | `~/Library/Developer/Xcode/DerivedData` | Xcode build products, indexes | `rm -rf` | next Xcode / `xcodebuild` |
-| `~/Library/Developer/Xcode/{iOS,watchOS,tvOS} DeviceSupport` | symbols copied from attached devices | `rm -rf` | re-copies when a device on that OS build is re-attached (note: an OS build you no longer have a device for won't regenerate — minor, only affects symbolicating that old build) |
+| `~/Library/Developer/Xcode/{iOS,watchOS,tvOS} DeviceSupport` | symbols copied from attached devices | `rm -rf` | re-copies when a device on that OS build is re-attached (note: an OS build you no longer have a device for won't regenerate — minor, only affects symbolicating that old build). clean-safe keeps the N newest versions (`MSC_DEVICE_SUPPORT_KEEP`, default 2) so your current devices' symbols survive; older versions re-download on next connect of such a device. |
 | `~/Library/Developer/CoreSimulator/Caches` | simulator runtime caches | `rm -rf` | automatically |
 | `~/Library/Caches/com.apple.dt.Xcode` | misc Xcode cache | `rm -rf` | automatically |
 | `~/Library/Caches/org.swift.swiftpm` | SwiftPM download cache | `rm -rf` | next resolve |
@@ -35,15 +35,31 @@ license file, an unpushable archive, or someone's only local backup is not.
 | `~/Library/Caches/{node-gyp,typescript,electron,electron-builder}` | tool download/build caches | `rm -rf` | next use |
 | `~/.cache/uv`, `~/Library/Caches/uv` | uv wheel/source cache | `uv cache clean` or `rm -rf` | next `uv` |
 | `~/.cache/pip`, `~/Library/Caches/pip` | pip wheel cache | `pip cache purge` or `rm -rf` | next `pip install` |
+| `~/Library/Caches/composer`, `~/.composer/cache` | Composer (PHP) download cache | `rm -rf` | Composer re-downloads packages on next `install`/`update` |
+| `~/.gem/ruby/*/cache` | downloaded `.gem` archives | `rm -rf` | next `gem install`/`bundle install` — installed gems live in `gems/` alongside, untouched |
 | `~/Library/Caches/go-build` | Go compile cache | `go clean -cache` or `rm -rf` | next `go build` |
 | `~/Library/Caches/Homebrew` + downloads | brew bottle/download cache | `brew cleanup -s --prune=all` | next `brew install` |
-| `/private/tmp/{metro-*,haste-map-*,react-*}` | Metro/RN temp | `rm -rf` | next Metro start |
+| `~/Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard` | Handoff / Universal Clipboard transfer buffers; `useractivityd` is supposed to prune these itself but can leave many GB behind (mole #1178) | `rm -rf` **only items older than 60 minutes** (age-gated — an in-flight Universal Clipboard sync must never be cut) | automatically as new Handoff transfers occur |
+| `/private/tmp/{metro-*,haste-map-*,react-native-packager-cache-*,react-packager-cache-*}` | Metro/RN temp | `rm -rf` | next Metro start (bare `react-*` is deliberately NOT safe — it would match user clones like `react-native-fork`) |
+| `~/Library/Caches/org.carthage.CarthageKit` | Carthage (third iOS dependency manager, alongside CocoaPods/SwiftPM above) build/download cache | `rm -rf` | next `carthage bootstrap`/`carthage update` |
+| `~/Library/Caches/pypoetry` | Poetry (Python) package/artifact cache | `rm -rf` or `poetry cache clear --all .` | next `poetry install` |
+| `~/.cache/mise` | mise (asdf-style tool version manager) download/install cache | `rm -rf` | next `mise install` |
+| `~/Library/Caches/mise` | mise's macOS cache dir (separate from `~/.cache/mise` above) | `rm -rf` | next `mise install` |
+| `~/Library/Caches/Google/AndroidStudio*` | Android Studio IDE caches (versioned folder, hence the glob) | `rm -rf` | automatically (IDE reindexes on next launch) |
+| `~/.android/cache` | Android SDK/build-tool cache | `rm -rf` | next Android build |
+| `~/.android/build-cache` | Android Gradle plugin build cache | `rm -rf` | next Android build |
+| `~/Library/Logs/DiagnosticReports` | crash reports (`.crash`/`.ips`); macOS/apps never prune these themselves | `rm -rf` (clean-safe.sh removes only items **older than 30 days**, age-gated like Handoff above) | new reports keep accumulating; a report younger than 30 days is kept in case it's still needed for a bug report |
 | `~/Library/Caches/<app>` (generic, NOT on the list above) | most per-app caches | prefer `trash-items.sh` (reversible); `rm -rf` only once you've confirmed it's a pure cache | usually automatic — but some apps keep the only local copy of downloaded content or a token here, so verify before deleting |
 
 **Browser & Electron app caches (safe, but quit the app first):** delete only the
 cache *subfolders* — never the whole app-support folder, which holds real data.
 - Electron apps (Slack, Discord, VS Code, Cursor, Windsurf, Teams, Notion, …):
   `~/Library/Application Support/<App>/{Cache,Code Cache,GPUCache,DawnWebGPUCache}`.
+  `clean-safe.sh` now clears these four cache subfolders **automatically** for
+  every direct child of `~/Library/Application Support` (audit wave 2) —
+  guarded by a fail-closed `pgrep -x` check on the app-folder name (running or
+  unknown state ⇒ skip) so a live app's cache is never touched mid-write.
+  Browsers' profile caches (below) remain manual/unchanged.
 - Chromium browsers (Chrome, Arc, Brave, Edge, Vivaldi):
   `~/Library/Application Support/<Browser>/<Profile>/{Cache,Code Cache,Service Worker/CacheStorage}`.
   Clearing `Service Worker/CacheStorage` drops sites' offline data (minor).
@@ -59,6 +75,8 @@ cache *subfolders* — never the whole app-support folder, which holds real data
 | `~/Library/Containers/com.docker.docker` (`Docker.raw`) | VM disk with images/volumes — not a cache | Start Docker, run `docker system prune -a` (and `docker volume prune`). Never `rm` the .raw. |
 | `~/.cache/huggingface`, `~/.ollama/models`, `~/.cache/torch`, `~/.lmstudio` | multi-GB model re-downloads | Confirm; if duplicate variants of one model exist (e.g. whisper in faster-whisper + MLX + turbo), point it out and delete the unused ones. |
 | `~/Library/Developer/CoreSimulator/Devices` | simulator state + installed apps | `xcrun simctl delete unavailable` is safe (orphans only). Deleting active devices wipes their state — ask. |
+| `~/miniconda3/pkgs`, `~/anaconda3/pkgs`, `~/opt/*conda*/pkgs` (or wherever conda is installed) | package cache is hardlinked into every live conda env — raw `rm` on `pkgs/` breaks them | **owner command only:** `conda clean -y --tarballs --index-cache --logfiles`. Never `rm` inside `pkgs/`. |
+| Browser old-version framework folders inside `.app` bundles (Chrome/Edge/Brave `Contents/Frameworks/*/Versions/<old-version>`) | lives inside a `.app` bundle — TCC App Management can block deletion, and the browser must be quit first | **report-only** (`find-extras.sh` lists every version except the one `Current` points to); user picks, `trash-items.sh` removes; if TCC blocks it, use Finder |
 | `~/Library/Developer/Xcode/Archives` | contains dSYMs + shippable builds | **Warn:** deleting loses crash symbolication and re-upload ability. Ask. |
 | `~/Library/pnpm/store`, `~/.pnpm-store` | content store all projects hardlink from | `pnpm store prune` removes only unreferenced; safer than `rm -rf`. |
 | `~/go/pkg/mod` | module cache, files are read-only | `go clean -modcache` (plain `rm -rf` fails on perms). Re-downloads. |
@@ -67,6 +85,9 @@ cache *subfolders* — never the whole app-support folder, which holds real data
 | `~/.gradle/wrapper/dists` | downloaded Gradle distributions | re-download; ask. |
 | `~/.m2/repository` | Maven local repo | cache-like but large; **never** `~/.m2` itself — `settings.xml` lives at its root. |
 | `~/Library/Caches/JetBrains`, `~/Library/Application Support/JetBrains/*/caches` | IDE indexes | forces full reindex; recommend, don't auto. |
+| `~/.android/avd` | emulator images + snapshots — deleting wipes that emulator's state | advise per-AVD review, then `avdmanager delete avd -n <name>` for ones no longer needed |
+| `~/Library/Android/sdk/system-images` | old Android API-level system images | `sdkmanager --uninstall "system-images;android-XX;..."` for API levels no longer targeted |
+| `~/.orbstack` | verify layout before advising — this data dir includes VM state, not just cache | prefer OrbStack's own prune commands (e.g. its CLI/GUI cleanup) over manual `rm` |
 | project `node_modules` / `target/` / `build/` | per-project, huge in aggregate | see stale-project sweep below. |
 
 ## Never tier (warn only)
@@ -82,6 +103,12 @@ cache *subfolders* — never the whole app-support folder, which holds real data
   genuinely wedged: `tmutil thinlocalsnapshots / 999999999999 4`.
 - `/System`, `/Library/Caches`, `/private/var/folders`, dyld shared cache — system-owned
   or SIP-protected. Leave them to macOS; don't reach for `sudo` to force it.
+
+These are now mechanically refused by trash-items.sh, not just policy: `~/Library/Application
+Support/MobileSync/Backup`, `~/Library/Keychains`, `~/Library/Mail`, `~/Library/Messages`,
+`~/.ssh`, `~/.aws`, `~/.gnupg`, and `~/Pictures/*.photoslibrary` are subtree-denied in
+`validate_target_path` — passing them (or anything underneath them) to `trash-items.sh`
+is refused, not just discouraged.
 
 ## App leftovers (uninstalled apps)
 
@@ -139,11 +166,18 @@ rebuild via install/build) but can be surprising. List, sorted by size, without 
 
 ```bash
 find ~/Desktop ~/Documents ~/Developer ~/Projects ~/code -type d \
-  \( -name node_modules -o -name target -o -name .next -o -name build -o -name Pods \) \
+  \( -name node_modules -o -name target -o -name .next -o -name build -o -name Pods \
+     -o -name .expo -o -name .cxx -o -name .turbo -o -name coverage -o -name .venv -o -name __pycache__ \) \
   -prune 2>/dev/null | while read -r d; do du -sh "$d"; done | sort -rh | head -30
 ```
 
 `npx npkill` is the interactive equivalent if the user prefers a picker.
+
+Any directory containing a valid `CACHEDIR.TAG` signature file (first line
+`Signature: 8a477f597d28d172789f06886806bc55`, per the [Cache Directory
+Tagging Specification](https://bford.info/cachedir/)) is cache **by
+declaration** from the tool that created it — safe to include in sweeps like
+this one even if its name isn't on the list above.
 
 ## Gotchas
 

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -8,16 +8,32 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$DIR/lib.sh"
 load_whitelist
 
-# Reject anything other than --dry-run outright: an unrecognized flag (typo,
-# stale docs, a future option someone half-wires up) must never fail OPEN into
-# a real deletion run just because it doesn't match the "--dry-run" check below.
-[ $# -gt 0 ] && [ "$1" != "--dry-run" ] && { echo "unknown argument: $1 (only --dry-run is supported)"; exit 2; }
-
-DRY=0
-[ "${1:-}" = "--dry-run" ] && DRY=1
+# Safe by default (v3.0.0): no argument previews. Deleting requires --apply.
+# Rationale: several agents (opencode, OpenClaw) execute shell commands with no
+# approval prompt at all, so a destructive default means an agent can delete
+# caches the user never saw proposed. --dry-run is still accepted as a no-op
+# alias, because it is what the previous docs, the aitmpl copy and muscle memory
+# use. An unrecognized argument still exits 2 rather than failing open.
+# More than one argument is rejected outright too (exit 2): only $1 was ever
+# inspected below, so e.g. `clean-safe.sh --apply --dry-run` matched the
+# --apply branch and deleted for real — the trailing --dry-run was silently
+# ignored instead of downgrading the run to a preview.
+[ "$#" -gt 1 ] && { echo "unknown argument: too many arguments (use --apply to delete; no argument or --dry-run previews)"; exit 2; }
+APPLY=0
+case "${1:-}" in
+  "")        ;;
+  --apply)   APPLY=1 ;;
+  --dry-run) ;;
+  *) echo "unknown argument: $1 (use --apply to delete; no argument or --dry-run previews)"; exit 2 ;;
+esac
+DRY=1
+[ "$APPLY" = 1 ] && DRY=0
+# MSC_DRY_RUN may only ever make a run safer, so it overrides --apply.
 [ "${MSC_DRY_RUN:-0}" = "1" ] && DRY=1
 export MSC_DRY_RUN="$DRY"
-[ "$DRY" = 1 ] && echo "=== DRY RUN — nothing will be deleted ==="
+if [ "$DRY" = 1 ]; then
+  echo "=== PREVIEW — nothing will be deleted (re-run with --apply to delete) ==="
+fi
 
 total_kb=0
 skipped=0
@@ -39,6 +55,7 @@ if [ "$DRY" != 1 ] && ! log_writable; then
     exit 3
   fi
 fi
+[ "$DRY" = 1 ] || log_op consent "-" "--apply"
 echo "Clearing safe caches (pure caches only)..."
 collect "${SAFE_PATHS[@]}"
 # bash 3.2 (macOS default) throws "unbound variable" on "${FOUND[@]}" when the
@@ -490,7 +507,7 @@ fi
 
 echo
 if [ "$DRY" = 1 ]; then
-  echo "Would reclaim from cache deletions: $(human_kb "$total_kb") — run without --dry-run to apply."
+  echo "Would reclaim from cache deletions: $(human_kb "$total_kb") — re-run with --apply to delete."
 else
   echo "Approx. reclaimed from cache deletions: $(human_kb "$total_kb") (brew/simulator cleanup above frees more, not counted here)"
 fi

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -108,6 +108,11 @@ KEEPN="${MSC_DEVICE_SUPPORT_KEEP:-2}"
 case "$KEEPN" in ''|*[!0-9]*) KEEPN=2 ;; esac
 for base in "${KEEP_N_PATHS[@]}"; do
   [ -d "$base" ] || continue
+  # [ -d ] above FOLLOWS a symlink, so a symlinked retention root (e.g. "iOS
+  # DeviceSupport" replaced with a symlink to elsewhere) would otherwise sail
+  # through and have its TARGET's children enumerated and deleted. Refuse the
+  # base itself instead.
+  [ -L "$base" ] && { echo "  skipped (symlink base): $base"; log_op skipped-symlink "-" "$base"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1)); continue; }
   if is_whitelisted "$base"; then
     echo "  skipped (whitelisted): $base"; log_op skipped-whitelisted "-" "$base"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
   fi
@@ -164,6 +169,8 @@ case "$AIKEEP" in ''|*[!0-9]*) AIKEEP=1 ;; esac
 for spec in "${AI_AGENT_SPECS[@]}"; do
   root="${spec%%|*}"; rest="${spec#*|}"; label="${rest%%|*}"; link="${rest#*|}"
   [ -d "$root" ] || continue
+  # Same symlinked-root defense as the DeviceSupport keep-N loop above.
+  [ -L "$root" ] && { echo "  skipped (symlink base): $root"; log_op skipped-symlink "-" "$root"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1)); continue; }
   if is_whitelisted "$root"; then
     echo "  skipped (whitelisted): $root"; log_op skipped-whitelisted "-" "$root"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
   fi
@@ -211,8 +218,16 @@ for spec in "${AI_AGENT_SPECS[@]}"; do
       echo "  removed $disp  $p ($label old version)"
       log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
     fi
+  # NOTE: unlike the DeviceSupport loop above, this used to intentionally keep
+  # mtime ordering here — semver dirs (e.g. "1.0.117" vs "1.0.2") need version
+  # sort, not lexical sort, and the ACTIVE version is symlink-pinned (never
+  # picked by this ordering at all), so which "spare" versions the mtime
+  # order kept was thought to be low-stakes. But `sort -rV` handles semver
+  # dirs correctly too, so for consistency with the DeviceSupport loop (and to
+  # remove the same updater-can-reorder-mtime risk), use the same
+  # glob+version-sort enumeration here as well.
   done <<EOF
-$(ls -1t "$root" 2>/dev/null)
+$(version_sorted_children "$root")
 EOF
 done
 
@@ -221,10 +236,16 @@ done
 # Only items UNTOUCHED FOR 60+ MINUTES go — never cut an in-flight sync.
 PB="$HOME/Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard"
 if [ -d "$PB" ] && [ ! -L "$PB" ] && ! is_whitelisted "$PB"; then
-  while IFS= read -r p; do
+  while IFS= read -r -d '' p; do
     [ -n "$p" ] || continue
     [ -e "$p" ] || continue
     [ -L "$p" ] && continue
+    # The -mmin +60 age gate above only looks at the candidate's OWN mtime; a
+    # directory's mtime doesn't necessarily update every time a file INSIDE it
+    # changes, so an old-looking top-level dir can still have an in-flight
+    # sync writing to it right now. Skip if ANY descendant was modified in
+    # the last 60 minutes — never cut something still actively syncing.
+    if [ -d "$p" ] && [ -n "$(find "$p" -mmin -60 -print -quit 2>/dev/null)" ]; then continue; fi
     if is_whitelisted "$p"; then
       echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
     fi
@@ -246,9 +267,11 @@ if [ -d "$PB" ] && [ ! -L "$PB" ] && ! is_whitelisted "$PB"; then
       echo "  removed $disp  $p (Handoff clipboard buffer)"
       log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
     fi
-  done <<EOF
-$(find "$PB" -mindepth 1 -maxdepth 1 -mmin +60 2>/dev/null)
-EOF
+  # process substitution (bash 3.2-safe): keeps the loop in THIS shell (not a
+  # pipe subshell) so total_kb/skipped/... mutations above actually persist;
+  # -print0/-d '' makes the enumeration NUL-delimited, safe for any filename
+  # (including ones containing newlines).
+  done < <(find "$PB" -mindepth 1 -maxdepth 1 -mmin +60 -print0 2>/dev/null)
 fi
 
 # Crash reports: apps/macOS write .crash/.ips files here on every crash and
@@ -258,8 +281,11 @@ fi
 # symlink/whitelist gate the whole section, per-child symlink/whitelist gate
 # each report.
 DR="$HOME/Library/Logs/DiagnosticReports"
-if [ -d "$DR" ] && [ ! -L "$DR" ] && ! is_whitelisted "$DR"; then
-  while IFS= read -r p; do
+if [ -d "$DR" ] && [ -L "$DR" ]; then
+  echo "  skipped (symlink base): $DR"
+  log_op skipped-symlink "-" "$DR"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1))
+elif [ -d "$DR" ] && ! is_whitelisted "$DR"; then
+  while IFS= read -r -d '' p; do
     [ -n "$p" ] || continue
     [ -e "$p" ] || continue
     [ -L "$p" ] && continue
@@ -284,9 +310,7 @@ if [ -d "$DR" ] && [ ! -L "$DR" ] && ! is_whitelisted "$DR"; then
       echo "  removed $disp  $p (crash report >30d)"
       log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
     fi
-  done <<EOF
-$(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 2>/dev/null)
-EOF
+  done < <(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 -print0 2>/dev/null)
 fi
 
 # Electron/Chromium-style app caches: survey.sh has long reported these
@@ -296,13 +320,17 @@ fi
 # "Claude/Cache") — never something deeper inside a browser profile, which
 # stays manual (see catalog).
 AS="$HOME/Library/Application Support"
-if [ -d "$AS" ] && [ ! -L "$AS" ]; then
-  while IFS= read -r p; do
+if [ -d "$AS" ] && [ -L "$AS" ]; then
+  echo "  skipped (symlink base): $AS"
+  log_op skipped-symlink "-" "$AS"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1))
+elif [ -d "$AS" ]; then
+  while IFS= read -r -d '' p; do
     [ -n "$p" ] || continue
     [ -e "$p" ] || continue
     # app = the first path component after "Application Support/" (name
-    # only — may contain spaces, e.g. "Microsoft Teams"). Newline-safe via
-    # the heredoc-fed `while read` below, not word-splitting.
+    # only — may contain spaces, e.g. "Microsoft Teams"). Newline-safe (and
+    # NUL-safe) via the process-substitution-fed `while read -d ''` below,
+    # not word-splitting.
     rest="${p#"$AS"/}"
     app="${rest%%/*}"
     appdir="$AS/$app"
@@ -315,14 +343,16 @@ if [ -d "$AS" ] && [ ! -L "$AS" ]; then
     fi
     # Process guard, fail-closed (tri-state): an Electron app rewrites these
     # caches live, so a running (or unreadable-process-table) owner must
-    # block deletion, not just a known-idle one. `pgrep -x` against the app
-    # DIRECTORY name is an approximation — a real process name doesn't always
-    # match its Application Support folder name verbatim — but that's
-    # accepted here because the approximation only ever costs an extra skip
-    # (fail-closed), never a wrong deletion.
+    # block deletion, not just a known-idle one. The app DIRECTORY name is an
+    # approximation of the real process name — a real process name doesn't
+    # always match its Application Support folder name verbatim — so a plain
+    # exact-name miss must not fail OPEN. Check both directions,
+    # case-insensitively: an exact process-name match OR a substring match
+    # against any command line. Over-matching only ever costs an extra skip
+    # (safe); only a clean double miss counts as idle.
     if command -v pgrep >/dev/null 2>&1; then
-      if pgrep -x "$app" >/dev/null 2>&1; then guard_rc=0
-      else guard_rc=$?; [ "$guard_rc" -eq 1 ] || guard_rc=2; fi
+      if pgrep -qix "$app" 2>/dev/null || pgrep -qif "$app" 2>/dev/null; then guard_rc=0
+      else rc=$?; if [ "$rc" -eq 1 ]; then guard_rc=1; else guard_rc=2; fi; fi
     else
       guard_rc=2
     fi
@@ -359,9 +389,7 @@ if [ -d "$AS" ] && [ ! -L "$AS" ]; then
       echo "  removed $disp  $p"
       log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
     fi
-  done <<EOF
-$(find "$AS" -mindepth 2 -maxdepth 2 -type d \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null)
-EOF
+  done < <(find "$AS" -mindepth 2 -maxdepth 2 -type d \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) -print0 2>/dev/null)
 fi
 
 # Tool-native cleanups that are unambiguously safe (freed space is separate from

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -283,14 +283,17 @@ fi
 
 # Shared per-item body for the DiagnosticReports section below: symlink skip,
 # per-child whitelist, validate_target_path, DRY preview, rm with the
-# skipped/partial honesty branch, same counters/log actions. Factored out
-# because it's applied to TWO enumerations (top-level DR, and DR/Retired's
-# children) that must behave identically — duplicating it would risk the two
-# copies drifting. Operates on globals (DRY/total_kb/skipped/...) like the
-# rest of this single-script file; bash 3.2-safe (no associative arrays,
-# `local` only).
+# removed/partially-removed/skipped honesty branch — a blocked rm gets one
+# chmod -R u+w retry (read-only report files), and if the path still exists
+# afterward a size-diff credits any bytes actually freed (logged as `partial`)
+# instead of silently reporting a no-op skip — same counters/log actions as
+# the DeviceSupport keep-N loop above. Factored out because it's applied to
+# TWO enumerations (top-level DR, and DR/Retired's children) that must behave
+# identically — duplicating it would risk the two copies drifting. Operates on
+# globals (DRY/total_kb/skipped/...) like the rest of this single-script file;
+# bash 3.2-safe (no associative arrays, `local` only).
 _msc_remove_old_report () {
-  local p="$1" kb disp
+  local p="$1" kb disp kb_after freed
   [ -n "$p" ] || return 0
   [ -e "$p" ] || return 0
   [ -L "$p" ] && return 0
@@ -307,10 +310,21 @@ _msc_remove_old_report () {
     echo "  would remove $disp  $p (crash report >30d)"
     total_kb=$((total_kb + ${kb:-0})); return 0
   fi
-  rm -rf "$p" 2>/dev/null
+  if ! rm -rf "$p" 2>/dev/null; then
+    chmod -R u+w "$p" 2>/dev/null
+    rm -rf "$p" 2>/dev/null
+  fi
   if [ -e "$p" ]; then
-    echo "  skipped (protected or in use): $p"
-    log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
+    kb_after=$(size_kb "$p")
+    if [ -n "$kb_after" ] && [ "${kb_after:-0}" -lt "${kb:-0}" ]; then
+      freed=$(( ${kb:-0} - kb_after ))
+      echo "  partially removed ($(human_kb "$freed") freed, $(human_kb "$kb_after") blocked): $p"
+      log_op partial "$(human_kb "$freed")" "$p"
+      total_kb=$((total_kb + freed)); skipped=$((skipped+1))
+    else
+      echo "  skipped (protected or in use): $p"
+      log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
+    fi
   else
     echo "  removed $disp  $p (crash report >30d)"
     log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -6,37 +6,389 @@
 set -u
 DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$DIR/lib.sh"
+load_whitelist
+
+# Reject anything other than --dry-run outright: an unrecognized flag (typo,
+# stale docs, a future option someone half-wires up) must never fail OPEN into
+# a real deletion run just because it doesn't match the "--dry-run" check below.
+[ $# -gt 0 ] && [ "$1" != "--dry-run" ] && { echo "unknown argument: $1 (only --dry-run is supported)"; exit 2; }
+
+DRY=0
+[ "${1:-}" = "--dry-run" ] && DRY=1
+[ "${MSC_DRY_RUN:-0}" = "1" ] && DRY=1
+export MSC_DRY_RUN="$DRY"
+[ "$DRY" = 1 ] && echo "=== DRY RUN — nothing will be deleted ==="
 
 total_kb=0
 skipped=0
-log_writable || echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — cleanup will proceed, but this run will NOT be recorded."
+# Deferred-skip rollup (printed once, near the end): breaks the generic
+# `skipped` total down by REASON so the user gets one actionable line instead
+# of having to scroll every "skipped (...)" entry above to find the pattern.
+skipped_inuse=0
+skipped_wl=0
+skipped_sym=0
+# Abort-if-unlogged: a run that deletes without recording what it deleted
+# defeats the whole audit-trail promise. Refuse by default; MSC_ALLOW_UNLOGGED=1
+# is an explicit, opt-in escape hatch for the rare case the log dir genuinely
+# can't be made writable (falls back to the old warn-and-continue behavior).
+if [ "$DRY" != 1 ] && ! log_writable; then
+  if [ "${MSC_ALLOW_UNLOGGED:-0}" = "1" ]; then
+    echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — cleanup will proceed, but this run will NOT be recorded."
+  else
+    echo "✗ Cannot write the audit log ($LOG_DIR/operations.log). Refusing to delete unlogged. Set MSC_ALLOW_UNLOGGED=1 to override."
+    exit 3
+  fi
+fi
 echo "Clearing safe caches (pure caches only)..."
 collect "${SAFE_PATHS[@]}"
 # bash 3.2 (macOS default) throws "unbound variable" on "${FOUND[@]}" when the
 # array is empty under `set -u` — which happens on a fresh Mac with no dev
 # caches. Guard the loop so a clean machine reports "nothing to do" instead of crashing.
 [ "${#FOUND[@]}" -gt 0 ] && for p in "${FOUND[@]}"; do
+  if [ -L "$p" ]; then
+    echo "  skipped (symlink — removing it would only delete the link, not the data): $p"
+    log_op skipped-symlink "-" "$p"
+    skipped=$((skipped + 1)); skipped_sym=$((skipped_sym + 1))
+    continue
+  fi
+  if is_whitelisted "$p"; then
+    echo "  skipped (whitelisted): $p"
+    log_op skipped-whitelisted "-" "$p"
+    skipped=$((skipped + 1)); skipped_wl=$((skipped_wl + 1))
+    continue
+  fi
+  if reason=$(guard_reason_for_path "$p"); then
+    echo "  skipped ($reason): $p"
+    log_op skipped-in-use "-" "$p"
+    skipped=$((skipped + 1)); skipped_inuse=$((skipped_inuse + 1))
+    continue
+  fi
   kb=$(size_kb "$p")
+  # size_kb can come back empty (du failed/blocked) — say so honestly instead
+  # of printing a misleading "0.0K"; ${kb:-0} below still guards the actual
+  # arithmetic under set -u and never lets an unknown size inflate the total.
+  disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+  if ! validate_target_path "$p"; then
+    echo "  REFUSED (protected path reached deletion loop — report this): $p"
+    log_op refused "-" "$p"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  if [ "$DRY" = 1 ]; then
+    echo "  would remove $disp  $p"
+    total_kb=$((total_kb + ${kb:-0}))
+    continue
+  fi
   if ! rm -rf "$p" 2>/dev/null; then
     chmod -R u+w "$p" 2>/dev/null   # read-only files (e.g. Go/SwiftPM caches)
     rm -rf "$p" 2>/dev/null
   fi
   if [ -e "$p" ]; then
-    echo "  skipped (macOS App Management/TCC-protected or in use): $p"
-    log_op skipped "$(human_kb "${kb:-0}")" "$p"
-    skipped=$((skipped + 1))
+    kb_after=$(size_kb "$p")
+    if [ -n "$kb_after" ] && [ "${kb_after:-0}" -lt "${kb:-0}" ]; then
+      freed=$(( ${kb:-0} - kb_after ))
+      echo "  partially removed ($(human_kb "$freed") freed, $(human_kb "$kb_after") blocked): $p"
+      log_op partial "$(human_kb "$freed")" "$p"
+      total_kb=$((total_kb + freed)); skipped=$((skipped + 1))
+    else
+      echo "  skipped (macOS App Management/TCC-protected or in use): $p"
+      log_op skipped "$disp" "$p"
+      skipped=$((skipped + 1))
+    fi
   else
-    echo "  removed $(human_kb "${kb:-0}")  $p"
-    log_op removed "$(human_kb "${kb:-0}")" "$p"
+    echo "  removed $disp  $p"
+    log_op removed "$disp" "$p"
     total_kb=$((total_kb + ${kb:-0}))
   fi
 done
 
+# Keep-N retention: DeviceSupport regenerates per-version on device connect, so
+# keep the newest MSC_DEVICE_SUPPORT_KEEP (default 2) and clear older versions.
+KEEPN="${MSC_DEVICE_SUPPORT_KEEP:-2}"
+case "$KEEPN" in ''|*[!0-9]*) KEEPN=2 ;; esac
+for base in "${KEEP_N_PATHS[@]}"; do
+  [ -d "$base" ] || continue
+  if is_whitelisted "$base"; then
+    echo "  skipped (whitelisted): $base"; log_op skipped-whitelisted "-" "$base"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+  fi
+  if reason=$(guard_reason_for_path "$base"); then
+    echo "  skipped ($reason): $base"; log_op skipped-in-use "-" "$base"; skipped=$((skipped+1)); skipped_inuse=$((skipped_inuse+1)); continue
+  fi
+  removed_any=0
+  while IFS= read -r child; do
+    # Empty child would collapse "$base/$child" to $base itself — never delete that.
+    [ -n "$child" ] || continue
+    p="$base/$child"
+    [ -e "$p" ] || continue
+    if [ -L "$p" ]; then
+      echo "  skipped (symlink — removing it would only delete the link, not the data): $p"
+      log_op skipped-symlink "-" "$p"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1)); continue
+    fi
+    if is_whitelisted "$p"; then
+      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+    fi
+    kb=$(size_kb "$p")
+    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+    if ! validate_target_path "$p"; then
+      echo "  REFUSED (protected path reached deletion loop — report this): $p"
+      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
+    fi
+    if [ "$DRY" = 1 ]; then
+      echo "  would remove $disp  $p"
+      total_kb=$((total_kb + ${kb:-0})); removed_any=1; continue
+    fi
+    rm -rf "$p" 2>/dev/null
+    if [ -e "$p" ]; then
+      kb_after=$(size_kb "$p")
+      if [ -n "$kb_after" ] && [ "${kb_after:-0}" -lt "${kb:-0}" ]; then
+        freed=$(( ${kb:-0} - kb_after ))
+        echo "  partially removed ($(human_kb "$freed") freed, $(human_kb "$kb_after") blocked): $p"
+        log_op partial "$(human_kb "$freed")" "$p"
+        total_kb=$((total_kb + freed)); skipped=$((skipped+1))
+      else
+        echo "  skipped (protected or in use): $p"; log_op skipped "$disp" "$p"; skipped=$((skipped+1))
+      fi
+    else
+      echo "  removed $disp  $p"; log_op removed "$disp" "$p"
+      total_kb=$((total_kb + ${kb:-0})); removed_any=1
+    fi
+  done <<EOF
+$(keep_newest_n_children "$base" "$KEEPN")
+EOF
+  [ "$removed_any" = 1 ] && echo "  (kept $KEEPN newest in $(basename "$base"))"
+done
+
+# AI CLI old versions: keep the active one (symlink-pinned) + N newest others.
+AIKEEP="${MSC_AI_AGENTS_KEEP:-1}"
+case "$AIKEEP" in ''|*[!0-9]*) AIKEEP=1 ;; esac
+for spec in "${AI_AGENT_SPECS[@]}"; do
+  root="${spec%%|*}"; rest="${spec#*|}"; label="${rest%%|*}"; link="${rest#*|}"
+  [ -d "$root" ] || continue
+  if is_whitelisted "$root"; then
+    echo "  skipped (whitelisted): $root"; log_op skipped-whitelisted "-" "$root"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+  fi
+  if ! active=$(resolve_active_version_dir "$root" "$link"); then
+    echo "  skipped (active version unknown): $label"
+    continue
+  fi
+  kept_others=0
+  while IFS= read -r child; do
+    [ -n "$child" ] || continue
+    [ -d "$root/$child" ] || continue   # stray files (e.g. .DS_Store) are never version dirs — ignore entirely
+    [ "$child" = "$active" ] && continue
+    if [ "$kept_others" -lt "$AIKEEP" ]; then kept_others=$((kept_others+1)); continue; fi
+    p="$root/$child"
+    [ -e "$p" ] || continue
+    if [ -L "$p" ]; then
+      echo "  skipped (symlink — removing it would only delete the link, not the data): $p"
+      log_op skipped-symlink "-" "$p"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1)); continue
+    fi
+    if is_whitelisted "$p"; then
+      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+    fi
+    kb=$(size_kb "$p")
+    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+    if ! validate_target_path "$p"; then
+      echo "  REFUSED (protected path reached deletion loop — report this): $p"
+      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
+    fi
+    if [ "$DRY" = 1 ]; then
+      echo "  would remove $disp  $p ($label old version)"
+      total_kb=$((total_kb + ${kb:-0})); continue
+    fi
+    rm -rf "$p" 2>/dev/null
+    if [ -e "$p" ]; then
+      kb_after=$(size_kb "$p")
+      if [ -n "$kb_after" ] && [ "${kb_after:-0}" -lt "${kb:-0}" ]; then
+        freed=$(( ${kb:-0} - kb_after ))
+        echo "  partially removed ($(human_kb "$freed") freed, $(human_kb "$kb_after") blocked): $p"
+        log_op partial "$(human_kb "$freed")" "$p"
+        total_kb=$((total_kb + freed)); skipped=$((skipped+1))
+      else
+        echo "  skipped: $p"; log_op skipped "$disp" "$p"; skipped=$((skipped+1))
+      fi
+    else
+      echo "  removed $disp  $p ($label old version)"
+      log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
+    fi
+  done <<EOF
+$(ls -1t "$root" 2>/dev/null)
+EOF
+done
+
+# Handoff / Universal Clipboard staging: useractivityd is supposed to prune
+# these transfer buffers itself but can leave many GB behind (mole #1178).
+# Only items UNTOUCHED FOR 60+ MINUTES go — never cut an in-flight sync.
+PB="$HOME/Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard"
+if [ -d "$PB" ] && [ ! -L "$PB" ] && ! is_whitelisted "$PB"; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    [ -e "$p" ] || continue
+    [ -L "$p" ] && continue
+    if is_whitelisted "$p"; then
+      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+    fi
+    kb=$(size_kb "$p")
+    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+    if ! validate_target_path "$p"; then
+      echo "  REFUSED (protected path reached deletion loop — report this): $p"
+      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
+    fi
+    if [ "$DRY" = 1 ]; then
+      echo "  would remove $disp  $p (Handoff clipboard buffer)"
+      total_kb=$((total_kb + ${kb:-0})); continue
+    fi
+    rm -rf "$p" 2>/dev/null
+    if [ -e "$p" ]; then
+      echo "  skipped (protected or in use): $p"
+      log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
+    else
+      echo "  removed $disp  $p (Handoff clipboard buffer)"
+      log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
+    fi
+  done <<EOF
+$(find "$PB" -mindepth 1 -maxdepth 1 -mmin +60 2>/dev/null)
+EOF
+fi
+
+# Crash reports: apps/macOS write .crash/.ips files here on every crash and
+# never prune old ones. Age-gated (30+ days) the same way as Handoff above —
+# a recent crash report may still be needed (e.g. for a bug report), so only
+# stale ones are cleared. Same shape as the Handoff section: base-level
+# symlink/whitelist gate the whole section, per-child symlink/whitelist gate
+# each report.
+DR="$HOME/Library/Logs/DiagnosticReports"
+if [ -d "$DR" ] && [ ! -L "$DR" ] && ! is_whitelisted "$DR"; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    [ -e "$p" ] || continue
+    [ -L "$p" ] && continue
+    if is_whitelisted "$p"; then
+      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+    fi
+    kb=$(size_kb "$p")
+    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+    if ! validate_target_path "$p"; then
+      echo "  REFUSED (protected path reached deletion loop — report this): $p"
+      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
+    fi
+    if [ "$DRY" = 1 ]; then
+      echo "  would remove $disp  $p (crash report >30d)"
+      total_kb=$((total_kb + ${kb:-0})); continue
+    fi
+    rm -rf "$p" 2>/dev/null
+    if [ -e "$p" ]; then
+      echo "  skipped (protected or in use): $p"
+      log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
+    else
+      echo "  removed $disp  $p (crash report >30d)"
+      log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
+    fi
+  done <<EOF
+$(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 2>/dev/null)
+EOF
+fi
+
+# Electron/Chromium-style app caches: survey.sh has long reported these
+# (Cache/Code Cache/GPUCache/DawnWebGPUCache directly under an app's own
+# Application Support folder); graduate detection into guarded auto-deletion.
+# -mindepth 2 -maxdepth 2 keeps this to DIRECT CHILD app dirs only (e.g.
+# "Claude/Cache") — never something deeper inside a browser profile, which
+# stays manual (see catalog).
+AS="$HOME/Library/Application Support"
+if [ -d "$AS" ] && [ ! -L "$AS" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    [ -e "$p" ] || continue
+    # app = the first path component after "Application Support/" (name
+    # only — may contain spaces, e.g. "Microsoft Teams"). Newline-safe via
+    # the heredoc-fed `while read` below, not word-splitting.
+    rest="${p#"$AS"/}"
+    app="${rest%%/*}"
+    appdir="$AS/$app"
+    if [ -L "$p" ] || [ -L "$appdir" ]; then
+      echo "  skipped (symlink — removing it would only delete the link, not the data): $p"
+      log_op skipped-symlink "-" "$p"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1)); continue
+    fi
+    if is_whitelisted "$p" || is_whitelisted "$appdir"; then
+      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
+    fi
+    # Process guard, fail-closed (tri-state): an Electron app rewrites these
+    # caches live, so a running (or unreadable-process-table) owner must
+    # block deletion, not just a known-idle one. `pgrep -x` against the app
+    # DIRECTORY name is an approximation — a real process name doesn't always
+    # match its Application Support folder name verbatim — but that's
+    # accepted here because the approximation only ever costs an extra skip
+    # (fail-closed), never a wrong deletion.
+    if command -v pgrep >/dev/null 2>&1; then
+      if pgrep -x "$app" >/dev/null 2>&1; then guard_rc=0
+      else guard_rc=$?; [ "$guard_rc" -eq 1 ] || guard_rc=2; fi
+    else
+      guard_rc=2
+    fi
+    if [ "$guard_rc" != 1 ]; then
+      echo "  skipped (app running or state unknown): $p"
+      log_op skipped-in-use "-" "$p"; skipped=$((skipped+1)); skipped_inuse=$((skipped_inuse+1)); continue
+    fi
+    kb=$(size_kb "$p")
+    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+    if ! validate_target_path "$p"; then
+      echo "  REFUSED (protected path reached deletion loop — report this): $p"
+      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
+    fi
+    if [ "$DRY" = 1 ]; then
+      echo "  would remove $disp  $p"
+      total_kb=$((total_kb + ${kb:-0})); continue
+    fi
+    if ! rm -rf "$p" 2>/dev/null; then
+      chmod -R u+w "$p" 2>/dev/null
+      rm -rf "$p" 2>/dev/null
+    fi
+    if [ -e "$p" ]; then
+      kb_after=$(size_kb "$p")
+      if [ -n "$kb_after" ] && [ "${kb_after:-0}" -lt "${kb:-0}" ]; then
+        freed=$(( ${kb:-0} - kb_after ))
+        echo "  partially removed ($(human_kb "$freed") freed, $(human_kb "$kb_after") blocked): $p"
+        log_op partial "$(human_kb "$freed")" "$p"
+        total_kb=$((total_kb + freed)); skipped=$((skipped+1))
+      else
+        echo "  skipped (macOS App Management/TCC-protected or in use): $p"
+        log_op skipped "$disp" "$p"; skipped=$((skipped+1))
+      fi
+    else
+      echo "  removed $disp  $p"
+      log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
+    fi
+  done <<EOF
+$(find "$AS" -mindepth 2 -maxdepth 2 -type d \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null)
+EOF
+fi
+
 # Tool-native cleanups that are unambiguously safe (freed space is separate from
 # the rm total above; both are logged for the audit trail).
 if command -v brew >/dev/null 2>&1; then
-  echo "  brew cleanup (brew cleanup -s --prune=all)..."
-  brew cleanup -s --prune=all >/dev/null 2>&1 && { echo "  done: brew cleanup"; log_op cleaned "brew cache" "brew cleanup -s --prune=all"; }
+  if [ "$DRY" = 1 ]; then
+    echo "  would run: brew cleanup -s --prune=all"
+  else
+    echo "  brew cleanup (brew cleanup -s --prune=all)..."
+    if brew cleanup -s --prune=all >/dev/null 2>&1; then
+      echo "  done: brew cleanup"; log_op cleaned "-" "brew cleanup -s --prune=all"
+    else
+      echo "  (brew cleanup didn't complete — skipped)"
+    fi
+  fi
+fi
+# conda: owner command only — pkgs/ is hardlinked into live envs, raw rm breaks them.
+if command -v conda >/dev/null 2>&1; then
+  if [ "$DRY" = 1 ]; then
+    echo "  would run: conda clean -y --tarballs --index-cache --logfiles"
+  else
+    if conda clean -y --tarballs --index-cache --logfiles >/dev/null 2>&1; then
+      echo "  done: conda clean"; log_op cleaned "-" "conda clean -y --tarballs --index-cache --logfiles"
+    else
+      echo "  (conda clean didn't complete — skipped)"
+    fi
+  fi
 fi
 # Gate simctl on a REAL developer install. /usr/bin/xcrun is a stub present on
 # every Mac, so `command -v xcrun` passes even with no Xcode/CLT — and calling it
@@ -44,12 +396,40 @@ fi
 # ambush a non-developer just trying to free space. xcode-select -p only succeeds
 # when a toolchain is actually selected.
 if xcode-select -p >/dev/null 2>&1 && command -v xcrun >/dev/null 2>&1; then
-  xcrun simctl delete unavailable >/dev/null 2>&1 && { echo "  done: removed unavailable simulators"; log_op cleaned "unavailable simulators" "simctl delete unavailable"; }
+  if [ "$DRY" = 1 ]; then
+    echo "  would run: xcrun simctl delete unavailable"
+  else
+    if xcrun simctl delete unavailable >/dev/null 2>&1; then
+      echo "  done: removed unavailable simulators"; log_op cleaned "-" "simctl delete unavailable"
+    else
+      echo "  (no unavailable simulators to remove, or simctl unavailable)"
+    fi
+  fi
 fi
 
 echo
-echo "Approx. reclaimed from cache deletions: $(human_kb "$total_kb") (brew/simulator cleanup above frees more, not counted here)"
+if [ "$DRY" = 1 ]; then
+  echo "Would reclaim from cache deletions: $(human_kb "$total_kb") — run without --dry-run to apply."
+else
+  echo "Approx. reclaimed from cache deletions: $(human_kb "$total_kb") (brew/simulator cleanup above frees more, not counted here)"
+fi
 [ "$skipped" -gt 0 ] && echo "($skipped path(s) skipped — delete via Finder if you need them gone.)"
+# Deferred-skip rollup: one actionable line breaking the total down by WHY
+# something was skipped, instead of making the user scroll every line above
+# to spot the pattern. Only non-zero parts are shown, comma-joined.
+skip_parts=()
+[ "$skipped_inuse" -gt 0 ] && skip_parts+=("$skipped_inuse in-use (quit the apps and re-run)")
+[ "$skipped_wl" -gt 0 ] && skip_parts+=("$skipped_wl whitelisted")
+[ "$skipped_sym" -gt 0 ] && skip_parts+=("$skipped_sym symlinked")
+if [ "${#skip_parts[@]}" -gt 0 ]; then
+  rollup="${skip_parts[0]}"
+  i=1
+  while [ "$i" -lt "${#skip_parts[@]}" ]; do
+    rollup="$rollup, ${skip_parts[$i]}"
+    i=$((i + 1))
+  done
+  echo "Skipped: $rollup."
+fi
 echo
 echo "Free space now:"
 if [ -d /System/Volumes/Data ]; then df -h /System/Volumes/Data 2>/dev/null | sed -n '1p;$p'; else df -h /; fi

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -245,7 +245,14 @@ if [ -d "$PB" ] && [ ! -L "$PB" ] && ! is_whitelisted "$PB"; then
     # changes, so an old-looking top-level dir can still have an in-flight
     # sync writing to it right now. Skip if ANY descendant was modified in
     # the last 60 minutes — never cut something still actively syncing.
-    if [ -d "$p" ] && [ -n "$(find "$p" -mmin -60 -print -quit 2>/dev/null)" ]; then continue; fi
+    # rc-aware: an unreadable descendant (permissions) makes `find` exit
+    # non-zero without necessarily finding a fresh file — that is an
+    # inconclusive scan, not evidence of idleness, so fail closed (skip) on
+    # a non-zero rc too, not just on a fresh-file match.
+    if [ -d "$p" ]; then
+      _fresh=$(find "$p" -mmin -60 -print -quit 2>/dev/null); _frc=$?
+      if [ -n "$_fresh" ] || [ "$_frc" -ne 0 ]; then continue; fi
+    fi
     if is_whitelisted "$p"; then
       echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
     fi
@@ -279,7 +286,11 @@ fi
 # a recent crash report may still be needed (e.g. for a bug report), so only
 # stale ones are cleared. Same shape as the Handoff section: base-level
 # symlink/whitelist gate the whole section, per-child symlink/whitelist gate
-# each report.
+# each report. Enumeration is restricted to actual report ARTIFACTS — regular
+# files with a known crash-report extension, plus the legacy `Retired`
+# directory — never a bare "anything sitting in this folder" sweep, so a
+# user's own notes/README/whatever dropped in here (or a differently-named
+# dir) is never swept up just for being old.
 DR="$HOME/Library/Logs/DiagnosticReports"
 if [ -d "$DR" ] && [ -L "$DR" ]; then
   echo "  skipped (symlink base): $DR"
@@ -310,7 +321,7 @@ elif [ -d "$DR" ] && ! is_whitelisted "$DR"; then
       echo "  removed $disp  $p (crash report >30d)"
       log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
     fi
-  done < <(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 -print0 2>/dev/null)
+  done < <(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 \( -type f \( -iname '*.ips' -o -iname '*.crash' -o -iname '*.diag' -o -iname '*.spin' -o -iname '*.hang' -o -iname '*.panic' -o -iname '*.shutdownStall' \) -o -type d -name Retired \) -print0 2>/dev/null)
 fi
 
 # Electron/Chromium-style app caches: survey.sh has long reported these
@@ -343,20 +354,22 @@ elif [ -d "$AS" ]; then
     fi
     # Process guard, fail-closed (tri-state): an Electron app rewrites these
     # caches live, so a running (or unreadable-process-table) owner must
-    # block deletion, not just a known-idle one. The app DIRECTORY name is an
-    # approximation of the real process name — a real process name doesn't
-    # always match its Application Support folder name verbatim — so a plain
-    # exact-name miss must not fail OPEN. Check both directions,
-    # case-insensitively: an exact process-name match OR a substring match
-    # against any command line. Over-matching only ever costs an extra skip
-    # (safe); only a clean double miss counts as idle.
-    if command -v pgrep >/dev/null 2>&1; then
-      if pgrep -qix "$app" 2>/dev/null || pgrep -qif "$app" 2>/dev/null; then guard_rc=0
-      else rc=$?; if [ "$rc" -eq 1 ]; then guard_rc=1; else guard_rc=2; fi; fi
+    # block deletion, not just a known-idle one. pgrep -f patterns are ERE —
+    # an app dir literally named "App (Beta)" builds a regex whose parens are
+    # GROUPING, so the literal process name never matches its own process
+    # (fail-open, empirically confirmed). Literal match only — ps snapshot +
+    # grep -F is metachar-proof, case-insensitive; a failed snapshot is
+    # unknown state (skip), per tri-state.
+    st=1
+    if ! _pt=$(ps -axo comm=,command= 2>/dev/null) || [ -z "$_pt" ]; then
+      st=2
+    elif printf '%s\n' "$_pt" | LC_ALL=C grep -qiF "$app"; then
+      st=0
     else
-      guard_rc=2
+      grc=$?
+      [ "$grc" -eq 1 ] || st=2
     fi
-    if [ "$guard_rc" != 1 ]; then
+    if [ "$st" != 1 ]; then
       echo "  skipped (app running or state unknown): $p"
       log_op skipped-in-use "-" "$p"; skipped=$((skipped+1)); skipped_inuse=$((skipped_inuse+1)); continue
     fi

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/clean-safe.sh
@@ -281,47 +281,73 @@ if [ -d "$PB" ] && [ ! -L "$PB" ] && ! is_whitelisted "$PB"; then
   done < <(find "$PB" -mindepth 1 -maxdepth 1 -mmin +60 -print0 2>/dev/null)
 fi
 
+# Shared per-item body for the DiagnosticReports section below: symlink skip,
+# per-child whitelist, validate_target_path, DRY preview, rm with the
+# skipped/partial honesty branch, same counters/log actions. Factored out
+# because it's applied to TWO enumerations (top-level DR, and DR/Retired's
+# children) that must behave identically — duplicating it would risk the two
+# copies drifting. Operates on globals (DRY/total_kb/skipped/...) like the
+# rest of this single-script file; bash 3.2-safe (no associative arrays,
+# `local` only).
+_msc_remove_old_report () {
+  local p="$1" kb disp
+  [ -n "$p" ] || return 0
+  [ -e "$p" ] || return 0
+  [ -L "$p" ] && return 0
+  if is_whitelisted "$p"; then
+    echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); return 0
+  fi
+  kb=$(size_kb "$p")
+  disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+  if ! validate_target_path "$p"; then
+    echo "  REFUSED (protected path reached deletion loop — report this): $p"
+    log_op refused "-" "$p"; skipped=$((skipped+1)); return 0
+  fi
+  if [ "$DRY" = 1 ]; then
+    echo "  would remove $disp  $p (crash report >30d)"
+    total_kb=$((total_kb + ${kb:-0})); return 0
+  fi
+  rm -rf "$p" 2>/dev/null
+  if [ -e "$p" ]; then
+    echo "  skipped (protected or in use): $p"
+    log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
+  else
+    echo "  removed $disp  $p (crash report >30d)"
+    log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
+  fi
+}
+
 # Crash reports: apps/macOS write .crash/.ips files here on every crash and
 # never prune old ones. Age-gated (30+ days) the same way as Handoff above —
 # a recent crash report may still be needed (e.g. for a bug report), so only
 # stale ones are cleared. Same shape as the Handoff section: base-level
 # symlink/whitelist gate the whole section, per-child symlink/whitelist gate
 # each report. Enumeration is restricted to actual report ARTIFACTS — regular
-# files with a known crash-report extension, plus the legacy `Retired`
-# directory — never a bare "anything sitting in this folder" sweep, so a
-# user's own notes/README/whatever dropped in here (or a differently-named
-# dir) is never swept up just for being old.
+# files with a known crash-report extension — never a bare "anything sitting
+# in this folder" sweep, so a user's own notes/README/whatever dropped in
+# here (or a differently-named dir) is never swept up just for being old.
 DR="$HOME/Library/Logs/DiagnosticReports"
 if [ -d "$DR" ] && [ -L "$DR" ]; then
   echo "  skipped (symlink base): $DR"
   log_op skipped-symlink "-" "$DR"; skipped=$((skipped+1)); skipped_sym=$((skipped_sym+1))
 elif [ -d "$DR" ] && ! is_whitelisted "$DR"; then
   while IFS= read -r -d '' p; do
-    [ -n "$p" ] || continue
-    [ -e "$p" ] || continue
-    [ -L "$p" ] && continue
-    if is_whitelisted "$p"; then
-      echo "  skipped (whitelisted): $p"; log_op skipped-whitelisted "-" "$p"; skipped=$((skipped+1)); skipped_wl=$((skipped_wl+1)); continue
-    fi
-    kb=$(size_kb "$p")
-    disp=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
-    if ! validate_target_path "$p"; then
-      echo "  REFUSED (protected path reached deletion loop — report this): $p"
-      log_op refused "-" "$p"; skipped=$((skipped+1)); continue
-    fi
-    if [ "$DRY" = 1 ]; then
-      echo "  would remove $disp  $p (crash report >30d)"
-      total_kb=$((total_kb + ${kb:-0})); continue
-    fi
-    rm -rf "$p" 2>/dev/null
-    if [ -e "$p" ]; then
-      echo "  skipped (protected or in use): $p"
-      log_op skipped "$disp" "$p"; skipped=$((skipped + 1))
-    else
-      echo "  removed $disp  $p (crash report >30d)"
-      log_op removed "$disp" "$p"; total_kb=$((total_kb + ${kb:-0}))
-    fi
-  done < <(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 \( -type f \( -iname '*.ips' -o -iname '*.crash' -o -iname '*.diag' -o -iname '*.spin' -o -iname '*.hang' -o -iname '*.panic' -o -iname '*.shutdownStall' \) -o -type d -name Retired \) -print0 2>/dev/null)
+    _msc_remove_old_report "$p"
+  done < <(find "$DR" -mindepth 1 -maxdepth 1 -mtime +30 -type f \( -iname '*.ips' -o -iname '*.crash' -o -iname '*.diag' -o -iname '*.spin' -o -iname '*.hang' -o -iname '*.panic' -o -iname '*.shutdownStall' \) -print0 2>/dev/null)
+
+  # Legacy `Retired` subfolder: macOS moves stale/rotated reports here. It
+  # must NEVER be rm -rf'd as a unit — that would bypass every per-item
+  # protection above (whitelist, validate, age) for whatever a whitelisted
+  # child or an in-place-modified (fresh-mtime) report happens to be sitting
+  # inside it. Walk its direct children through the exact same per-item
+  # pipeline instead; only report artifacts older than 30 days are removed,
+  # and an emptied Retired directory is left in place (never removed itself).
+  RT="$DR/Retired"
+  if [ -d "$RT" ] && [ ! -L "$RT" ]; then
+    while IFS= read -r -d '' p; do
+      _msc_remove_old_report "$p"
+    done < <(find "$RT" -mindepth 1 -maxdepth 1 -mtime +30 \( -type f \( -iname '*.ips' -o -iname '*.crash' -o -iname '*.diag' -o -iname '*.spin' -o -iname '*.hang' -o -iname '*.panic' -o -iname '*.shutdownStall' \) \) -print0 2>/dev/null)
+  fi
 fi
 
 # Electron/Chromium-style app caches: survey.sh has long reported these

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
@@ -59,7 +59,11 @@ for fw in \
   "/Applications/Brave Browser.app/Contents/Frameworks/Brave Browser Framework.framework/Versions"; do
   [ -d "$fw" ] || continue
   cur=$(readlink "$fw/Current" 2>/dev/null)
-  cur=$(basename "${cur:-none}")
+  if [ -z "$cur" ]; then
+    echo "  (could not resolve Current for $(basename "$fw") — skipping suggestions; verify manually)"
+    continue
+  fi
+  cur=$(basename "$cur")
   for v in "$fw"/*; do
     [ -d "$v" ] || continue
     name=$(basename "$v")

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/find-extras.sh
@@ -22,7 +22,7 @@ if ! mdutil -s / 2>/dev/null | grep -qi 'indexing enabled'; then
   echo "    here and may list apps that are actually installed. Treat as informational"
   echo "    only and confirm every app by hand before removing anything."
 fi
-export IDS="$(installed_bundle_ids | sort -u)"
+IDS="$(installed_bundle_ids | sort -u)"   # plain var: container_is_orphan is a shell function, not a subprocess
 for d in "$HOME/Library/Containers/"*; do
   [ -d "$d" ] || continue
   name=$(basename "$d")
@@ -50,6 +50,30 @@ for d in "$HOME/Library/Containers/"*; do
 done | sort -rh | head -5
 echo
 
+echo "===== Browser old-version frameworks (quit the browser, keep Current) ====="
+echo "Chromium browsers leave whole previous versions inside the .app bundle."
+echo "Safe to Trash every version EXCEPT the one 'Current' points to. Report-only:"
+for fw in \
+  "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions" \
+  "/Applications/Microsoft Edge.app/Contents/Frameworks/Microsoft Edge Framework.framework/Versions" \
+  "/Applications/Brave Browser.app/Contents/Frameworks/Brave Browser Framework.framework/Versions"; do
+  [ -d "$fw" ] || continue
+  cur=$(readlink "$fw/Current" 2>/dev/null)
+  cur=$(basename "${cur:-none}")
+  for v in "$fw"/*; do
+    [ -d "$v" ] || continue
+    name=$(basename "$v")
+    [ "$name" = "Current" ] && continue
+    if [ "$name" = "$cur" ]; then
+      printf '  %s\t%s   (Current — KEEP)\n' "$(human_kb "$(size_kb "$v")")" "$v"
+    else
+      printf '  %s\t%s\n' "$(human_kb "$(size_kb "$v")")" "$v"
+    fi
+  done
+done
+echo "  (if empty: no multi-version browser frameworks found)"
+echo
+
 echo "===== Stale installers (.dmg/.pkg/.iso in Downloads & Desktop) ====="
 find "$HOME/Downloads" "$HOME/Desktop" -maxdepth 2 -type f \
   \( -iname '*.dmg' -o -iname '*.pkg' -o -iname '*.iso' -o -iname '*.msi' \) 2>/dev/null \
@@ -63,10 +87,10 @@ find "$HOME/Downloads" "$HOME/Desktop" "$HOME/Documents" "$HOME/Movies" \
 echo
 
 echo "===== Old Downloads (not modified in 90+ days) ====="
-old=$(find "$HOME/Downloads" -maxdepth 1 -mtime +90 2>/dev/null | wc -l | tr -d ' ')
+old=$(find "$HOME/Downloads" -mindepth 1 -maxdepth 1 -mtime +90 2>/dev/null | wc -l | tr -d ' ')
 if [ "${old:-0}" -gt 0 ]; then
   echo "  $old item(s), totaling:"
-  find "$HOME/Downloads" -maxdepth 1 -mtime +90 -exec du -sk {} + 2>/dev/null \
+  find "$HOME/Downloads" -mindepth 1 -maxdepth 1 -mtime +90 -exec du -sk {} + 2>/dev/null \
     | awk '{s+=$1} END{printf "  %.1f GB\n", s/1024/1024}'
 else
   echo "  (none)"

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -9,9 +9,6 @@
 SAFE_PATHS=(
   # Apple / Xcode
   "$HOME/Library/Developer/Xcode/DerivedData"
-  "$HOME/Library/Developer/Xcode/iOS DeviceSupport"
-  "$HOME/Library/Developer/Xcode/watchOS DeviceSupport"
-  "$HOME/Library/Developer/Xcode/tvOS DeviceSupport"
   "$HOME/Library/Developer/CoreSimulator/Caches"
   "$HOME/Library/Caches/org.swift.swiftpm"
   "$HOME/Library/Caches/com.apple.dt.Xcode"
@@ -29,6 +26,10 @@ SAFE_PATHS=(
   "$HOME/Library/Caches/uv"
   "$HOME/.cache/pip"
   "$HOME/Library/Caches/pip"
+  # PHP / Ruby
+  "$HOME/Library/Caches/composer"
+  "$HOME/.composer/cache"
+  "$HOME/.gem/ruby/*/cache"
   # JVM / Android build artifacts (see notes: caches/ only, never all of ~/.gradle)
   "$HOME/.gradle/caches"
   # Other
@@ -40,7 +41,47 @@ SAFE_PATHS=(
   "/private/tmp/haste-map-*"
   "/private/tmp/react-native-packager-cache-*"
   "/private/tmp/react-packager-cache-*"
+  # iOS/Android/tooling (audit wave 2)
+  "$HOME/Library/Caches/org.carthage.CarthageKit"
+  "$HOME/Library/Caches/pypoetry"
+  "$HOME/.cache/mise"
+  "$HOME/Library/Caches/mise"
+  "$HOME/Library/Caches/Google/AndroidStudio*"
+  "$HOME/.android/cache"
+  "$HOME/.android/build-cache"
 )
+
+# --- KEEP-N tier ------------------------------------------------------------
+# Device symbol caches regenerate on the next device connect — but that costs
+# a multi-minute re-download per OS version. Keep the N newest (you still own
+# devices on those), clear the rest (mole keeps 2; same default here).
+KEEP_N_PATHS=(
+  "$HOME/Library/Developer/Xcode/iOS DeviceSupport"
+  "$HOME/Library/Developer/Xcode/watchOS DeviceSupport"
+  "$HOME/Library/Developer/Xcode/tvOS DeviceSupport"
+)
+
+# Print child NAMES of <dir> beyond the <n> most recently modified, one per
+# line (they are the deletion candidates). ls -1t = newest first; version dirs
+# ("17.5 (21F79)") contain spaces but never newlines.
+# Candidates must be DIRECTORIES: a stray file (e.g. a newest-mtime .DS_Store)
+# would otherwise consume one of the N "keep" slots and either get force-kept
+# ahead of a real version dir or, worse, be counted toward NR without ever
+# being a legitimate deletion target. Filter to dirs BEFORE counting N, not
+# after, so the N kept slots always land on real version dirs.
+keep_newest_n_children () {
+  local dir="$1" n="$2" child i
+  [ -d "$dir" ] || return 0
+  i=0
+  while IFS= read -r child; do
+    [ -n "$child" ] || continue
+    [ -d "$dir/$child" ] || continue
+    i=$((i + 1))
+    [ "$i" -gt "$n" ] && printf '%s\n' "$child"
+  done <<EOF
+$(ls -1t "$dir" 2>/dev/null)
+EOF
+}
 
 # --- ASK tier -------------------------------------------------------------
 # Large but either not a pure cache, or expensive to restore (multi-GB
@@ -64,6 +105,9 @@ ASK_PATHS=(
   "$HOME/Library/Caches/Cypress"
   "$HOME/Library/Caches/deno"                          # modules from arbitrary URLs; a source can 404 permanently
   "$HOME/.cache/deno"
+  "$HOME/.android/avd"                                 # emulator images+snapshots; deleting wipes emulator state
+  "$HOME/Library/Android/sdk/system-images"            # old API-level images; large, re-downloadable via sdkmanager
+  "$HOME/.orbstack"                                    # data dir includes VM state, not just cache
 )
 
 # --- NEVER tier -----------------------------------------------------------
@@ -75,15 +119,20 @@ NEVER_PATHS=(
 )
 
 # collect PATTERNS... -> fills global array FOUND with existing matches.
-# Handles globs (word-split, no spaces in our glob patterns) and plain paths
-# with spaces (quoted -e test). Resets FOUND on each call.
+# Handles globs (IFS suppressed during the unquoted expansion below, so a
+# $HOME containing a space is never word-split into fragments before the
+# glob is expanded) and plain paths with spaces (quoted -e test). Resets
+# FOUND on each call.
 collect () {
   FOUND=()
-  local pat m
+  local pat m _oldIFS
   for pat in "$@"; do
     case "$pat" in
       *'*'*|*'?'*|*'['*)
-        for m in $pat; do [ -e "$m" ] && FOUND+=("$m"); done ;;
+        _oldIFS="${IFS-$' \t\n'}"
+        IFS=''
+        for m in $pat; do [ -e "$m" ] && FOUND+=("$m"); done
+        IFS="$_oldIFS" ;;
       *)
         [ -e "$pat" ] && FOUND+=("$pat") ;;
     esac
@@ -106,33 +155,198 @@ human_kb () {
 # Every destructive action appends here, so a run is auditable and the user can
 # see exactly what was removed (mirrors what the trustworthy CLIs do).
 LOG_DIR="$HOME/Library/Logs/mac-storage-cleaner"
-log_op () {  # log_op <action> <size> <path> — best-effort; suppresses its own errors
+log_op () {  # log_op <action> <size> <path> — best-effort; no-op in dry-run
+  [ "${MSC_DRY_RUN:-0}" = "1" ] && return 0
   mkdir -p "$LOG_DIR" 2>/dev/null
   printf '%s\t%s\t%s\t%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" "$2" "$3" >> "$LOG_DIR/operations.log" 2>/dev/null
 }
 # True only if the audit log can actually be written. Callers warn the user when
 # it can't, so a run is never silently unlogged while we claim to log every deletion.
 log_writable () {
+  # Single-generation rotation (mirrors mole): once operations.log crosses
+  # 5MB, move it aside to operations.log.1 (overwriting any prior .1) before
+  # the writability probe below, so the log never grows unbounded over the
+  # life of an install. Best-effort — a failed stat/mv here (permissions,
+  # missing file) must never block the writability check that follows.
+  local f="$LOG_DIR/operations.log" sz
+  if [ -f "$f" ]; then
+    sz=$(stat -f %z "$f" 2>/dev/null)
+    if [ -n "$sz" ] && [ "$sz" -gt 5242880 ] 2>/dev/null; then
+      mv -f "$f" "$f.1" 2>/dev/null
+    fi
+  fi
   mkdir -p "$LOG_DIR" 2>/dev/null && : >> "$LOG_DIR/operations.log" 2>/dev/null
 }
 
+# --- Trash-target validation ----------------------------------------------
+# trash-items.sh accepts arbitrary user-approved argv paths, so refuse the ones
+# that are NEVER right to trash: system roots, the home dir and its top-level
+# folders, other users' homes. Deny-only (mole's model): symlink resolution can
+# only REVOKE permission, never grant it. APFS is case-insensitive by default,
+# so all comparisons are lowercased. rc 0 = OK, rc 1 = refused.
+validate_target_path () {
+  local p="$1"
+  [ -n "$p" ] || return 1
+  case "$p" in /*) ;; *) return 1 ;; esac          # absolute only
+  # Control chars / newline only. [:cntrl:] is 0x00-0x1F/0x7F in every
+  # locale this runs under, so real control characters (newline, tab, ...)
+  # are caught while legitimate multibyte UTF-8 filenames (café.txt,
+  # Georgian names, ...) pass through untouched. (A `local LC_ALL=C` used to
+  # sit here but — unlike the tr/sed helpers below — never actually reached
+  # this in-process `case` match without being exported, so it did nothing;
+  # removed. The locale-sensitive helpers each pin LC_ALL=C explicitly,
+  # per-command, instead.)
+  case "$p" in *[[:cntrl:]]*) return 1 ;; esac
+  case "/$p/" in */../*) return 1 ;; esac          # no .. traversal
+  # Normalize // and /./ spellings, strip trailing / and /.
+  local norm
+  norm=$(printf '%s' "$p" | LC_ALL=C sed -e 's#//*#/#g' -e 's#/\./#/#g' -e 's#/\.$##' -e 's#\(.\)/$#\1#')
+  [ -n "$norm" ] || norm="/"
+  _vtp_denied "$norm" && return 1
+  # Ancestor-symlink defense: re-run the deny check on the physically resolved
+  # ancestor (cd -P). A link like ~/rootlink -> / would otherwise smuggle
+  # "~/rootlink/System" past the string checks. Walk up from the immediate
+  # parent to the nearest EXISTING ancestor before resolving: a path component
+  # that does not exist yet (e.g. an orphaned container nobody created) cannot
+  # hide a symlink, so it must not trip fail-closed on its own. A genuinely
+  # unresolvable existing ancestor (permissions, or "/" itself failing) still
+  # refuses.
+  local parent suffix phys
+  parent=$(dirname "$norm")
+  suffix=""
+  while [ "$parent" != "/" ] && [ ! -e "$parent" ] && [ ! -L "$parent" ]; do
+    suffix="/$(basename "$parent")$suffix"
+    parent=$(dirname "$parent")
+  done
+  phys=$(cd -P "$parent" 2>/dev/null && pwd -P) || return 1
+  [ "$phys" = "/" ] && phys=""   # avoid a doubled leading slash below
+  _vtp_denied "$phys$suffix/$(basename "$norm")" && return 1
+  return 0
+}
+
+# Case-insensitive membership test against the deny roots. rc 0 = denied.
+_vtp_denied () {
+  local lower home_lower r
+  lower=$(printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+  home_lower=$(printf '%s' "$HOME" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+  # Strip ALL trailing slashes (bash 3.2 loop, mirrors load_whitelist below):
+  # a $HOME with a trailing slash (some launchd/login-shell setups export one)
+  # would otherwise make every "$home_lower/..." deny entry carry a doubled
+  # slash ("...//library") that never string-matches $lower, silently
+  # disabling every home-relative deny rule while the /users/<name> carve-out
+  # in the case statement below still grants access underneath it.
+  while [ "${home_lower%/}" != "$home_lower" ]; do home_lower="${home_lower%/}"; done
+  for r in / /system /library /applications /usr /usr/local /bin /sbin /etc \
+           /var /private /opt /opt/homebrew /users /volumes /dev /tmp \
+           "$home_lower" "$home_lower/library" "$home_lower/desktop" \
+           "$home_lower/documents" "$home_lower/downloads" "$home_lower/pictures" \
+           "$home_lower/movies" "$home_lower/music" "$home_lower/.trash" \
+           "$home_lower/.ssh" "$home_lower/.aws"; do
+    [ "$lower" = "$r" ] && return 0
+  done
+  # Subtree denials (panel finding #1): the exact-root loop above only
+  # catches the bare root itself — these NEVER-tier locations are just as
+  # off-limits one level down (and every level below that), so deny the
+  # root AND everything under it. Local iOS/iPadOS backups, keychains,
+  # Mail/Messages databases, and SSH/AWS/GPG credential stores are user data
+  # that does not come back; trash-items.sh must refuse them mechanically,
+  # not rely on policy/docs alone.
+  local vtp_never_roots=(
+    "$home_lower/library/application support/mobilesync"
+    "$home_lower/library/keychains"
+    "$home_lower/library/mail"
+    "$home_lower/library/messages"
+    "$home_lower/.ssh"
+    "$home_lower/.aws"
+    "$home_lower/.gnupg"
+  )
+  for r in "${vtp_never_roots[@]}"; do
+    case "$lower" in "$r"|"$r"/*) return 0 ;; esac
+  done
+  # Photos libraries — the bundle itself and everything inside it (masters,
+  # database, ...), not just the bare ".photoslibrary" root.
+  case "$lower" in
+    "$home_lower/pictures/"*.photoslibrary|"$home_lower/pictures/"*.photoslibrary/*) return 0 ;;
+  esac
+  case "$lower" in
+    /applications/*.app) return 0 ;;   # installed app bundles: use an uninstaller
+    /users/*)
+      # Deny the ENTIRE subtree of every other user's home, not just the bare
+      # /Users/<name> entry — otherwise a literal path (or a symlink resolved
+      # by the ancestor check below) can reach inside one. Two carve-outs:
+      # the current user's own home (its top-level dirs are already denied
+      # individually above; everything else under it is a legitimate trash
+      # target) and /Users/Shared/<child> (a shared, not personal, location —
+      # stale installers etc. are legitimate targets; /Users/Shared itself
+      # stays denied, same as today).
+      local rest name
+      rest="${lower#/users/}"
+      name="${rest%%/*}"
+      case "$home_lower" in
+        "/users/$name"|"/users/$name/"*) return 1 ;;
+      esac
+      [ "$name" = "shared" ] && [ "$rest" != "shared" ] && return 1
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 # --- Reversible delete ----------------------------------------------------
-# Move a path to the Trash via Finder instead of rm, so the user can restore it.
-# Used for anything riskier than a pure cache (ask-tier items, app leftovers,
-# big files). Returns non-zero if it could not be trashed.
-# NOTE: trashed items still occupy disk until the Trash is emptied — for pure
-# caches we prefer a direct rm (see clean-safe.sh) so space is freed immediately.
+# Move a path to the Trash (restorable) — never rm. Three-stage chain (mole's
+# order): /usr/bin/trash by ABSOLUTE path (ships with macOS 14+, headless-safe,
+# immune to PATH shadowing) -> Finder AppleScript (argv-passed, injection-safe)
+# -> same-volume mv into ~/.Trash (loses "Put Back", still restorable by hand).
+# rc 0 = moved (TRASH_METHOD set to trash-cli|finder|mv), rc 1 = could not
+# move, rc 2 = refused. TRASH_METHOD is reset to "" at the top of every call,
+# so rc 0 with an EMPTY TRASH_METHOD means the path was already gone (nothing
+# to move) — only a non-empty TRASH_METHOD means something actually moved.
+# NOTE: trashed items occupy disk until the Trash is emptied — pure caches use
+# direct rm in clean-safe.sh instead, so their space frees immediately.
+TRASH_METHOD=""
 trash_path () {
   local p="$1"
-  [ -e "$p" ] || return 0
-  # Pass the path as an argv value, NOT interpolated into the script text — a
-  # filename containing " or \ would otherwise break (or, pathologically, inject)
-  # the AppleScript. argv is data, so any legal filename trashes correctly.
-  osascript - "$p" >/dev/null 2>&1 <<'APPLESCRIPT'
+  # Reset on every call, before any return — otherwise the "already gone"
+  # shortcut below (rc 0, nothing to move) would leave a PRIOR call's method
+  # sitting in TRASH_METHOD, and a caller checking rc==0 could misreport what
+  # happened. Empty TRASH_METHOD on rc 0 unambiguously means "nothing moved";
+  # non-empty TRASH_METHOD on rc 0 means it was actually moved this call.
+  TRASH_METHOD=""
+  # Validate BEFORE the existence check: a protected root must be refused
+  # (rc 2) even if it happens not to exist in the caller's context (e.g. a
+  # symlink race, or a test fixture that never materializes it) — refusal is
+  # a property of the path, not of whether something currently lives there.
+  validate_target_path "$p" || return 2
+  { [ -e "$p" ] || [ -L "$p" ]; } || return 0
+  local bin="${MSC_TRASH_BIN:-/usr/bin/trash}"
+  if [ -x "$bin" ] && "$bin" "$p" >/dev/null 2>&1; then
+    TRASH_METHOD="trash-cli"; return 0
+  fi
+  # Symlink argv gets link-only semantics everywhere else in this chain
+  # (MSC_TRASH_BIN and the mv fallback both operate on the link itself, never
+  # its target) — but Finder's AppleScript `POSIX file ... as alias`
+  # coercion resolves an alias to whatever it points AT, which is divergent
+  # (and surprising: the caller asked to trash the link, not silently trash
+  # the target it happens to point to). Skip the Finder stage entirely for a
+  # symlink and fall straight through to the same-volume mv fallback below.
+  if [ ! -L "$p" ] && osascript - "$p" >/dev/null 2>&1 <<'APPLESCRIPT'
 on run argv
   tell application "Finder" to delete (POSIX file (item 1 of argv) as alias)
 end run
 APPLESCRIPT
+  then TRASH_METHOD="finder"; return 0; fi
+  # Last resort. Same-device only: a cross-volume mv degrades into copy+delete
+  # and can leave the only copy split across volumes on failure (mole's rule).
+  local pdev tdev base dest i
+  pdev=$(stat -f %d "$p" 2>/dev/null); tdev=$(stat -f %d "$HOME/.Trash" 2>/dev/null)
+  [ -n "$pdev" ] && [ "$pdev" = "$tdev" ] || return 1
+  base=$(basename "$p"); dest="$HOME/.Trash/$base"; i=2
+  while [ -e "$dest" ] || [ -L "$dest" ]; do
+    dest="$HOME/.Trash/$base $i"; i=$((i + 1))
+    [ "$i" -gt 100 ] && return 1     # never overwrite an existing Trash item
+  done
+  mv "$p" "$dest" 2>/dev/null || return 1
+  TRASH_METHOD="mv"
 }
 
 # --- Installed apps -> bundle identifiers ---------------------------------
@@ -168,6 +382,9 @@ container_is_orphan () {
   done <<EOF
 ${IDS:-}
 EOF
+  # A quote in the name would break the mdfind query string; real bundle IDs
+  # never contain one, so treat such a name as inconclusive (not orphan).
+  case "$n" in *\'*|*\"*) return 1 ;; esac
   if mdfind "kMDItemContentTypeTree == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '$n'" 2>/dev/null | grep -q .; then
     return 1
   fi
@@ -177,4 +394,142 @@ EOF
     return 1
   fi
   return 0
+}
+
+# --- User whitelist -------------------------------------------------------
+# Optional user-owned protection list: one path or glob per line, leading ~/
+# expands to $HOME. An entry protects itself and everything under it.
+# '#' comments: a line whose first non-space character is '#' is ignored
+# entirely; a '#' later in the line only starts a trailing comment when it is
+# preceded by whitespace, so a literal '#' inside a path (e.g.
+# "~/Downloads/report#2") is never misread as a comment start. Matching is
+# case-insensitive, like APFS default (non-case-sensitive) volumes: every
+# entry is folded to lowercase at load time and every path checked against
+# it is folded the same way, so "~/Library/Caches/Pip" protects both
+# ".../Caches/Pip" and ".../caches/pip".
+# clean-safe.sh consults this before every deletion, so a user who wants e.g.
+# DerivedData kept doesn't have to rely on the agent remembering (mole's
+# ~/.config/mole/whitelist, simplified).
+MSC_WHITELIST_FILE="${MSC_WHITELIST_FILE:-$HOME/.config/mac-storage-cleaner/whitelist}"
+WHITELIST=()
+load_whitelist () {
+  WHITELIST=()
+  [ -f "$MSC_WHITELIST_FILE" ] || return 0
+  local raw line stripped
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    # Full-line comment: first non-space character is '#' — skip entirely.
+    stripped=$(printf '%s' "$raw" | sed -e 's/^[[:space:]]*//')
+    case "$stripped" in '#'*) continue ;; esac
+    # Trailing comment: only strip a '#' that is preceded by whitespace
+    # (space or tab), so a '#' embedded in a filename is left alone.
+    case "$raw" in
+      *' #'*) line="${raw%% #*}" ;;
+      *$'\t#'*) line="${raw%%$'\t#'*}" ;;
+      *) line="$raw" ;;
+    esac
+    # trim surrounding whitespace (bash 3.2: no extglob)
+    line=$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    [ -z "$line" ] && continue
+    # strip ALL trailing slashes so "path/" and "path" match identically
+    # (Finder's copy-path and shell tab-completion both append one). An
+    # entry that is nothing but slashes (e.g. "/" or "//") has nothing left
+    # once stripped and must not become a match-everything glob.
+    while [ "${line%/}" != "$line" ]; do line="${line%/}"; done
+    [ -z "$line" ] && continue
+    case "$line" in "~") line="$HOME" ;; "~/"*) line="$HOME/${line#\~/}" ;; esac
+    # Fold case (APFS default volumes are case-insensitive) so an entry
+    # protects a path regardless of the case either happens to be spelled in.
+    line=$(printf '%s' "$line" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+    WHITELIST+=("$line")
+  done < "$MSC_WHITELIST_FILE"
+}
+is_whitelisted () {   # rc 0 = protected. Entries may be globs — $e is unquoted
+                       # in case. Case-insensitive, like APFS default volumes
+                       # (see load_whitelist).
+  local p e
+  p=$(printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+  [ "${#WHITELIST[@]}" -eq 0 ] && return 1
+  for e in "${WHITELIST[@]}"; do
+    case "$p" in $e|$e/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# --- Process guards (fail closed) -----------------------------------------
+# Deleting a build cache while its owner writes to it corrupts the next build
+# worse than a full cache miss. Tri-state (mole's contract): 0 = running,
+# 1 = idle, 2 = unknown — and unknown DENIES deletion: an unreadable process
+# table is not evidence the app is closed.
+guard_procs_running () {   # guard_procs_running <exact-process-name>...
+  command -v pgrep >/dev/null 2>&1 || return 2
+  local n rc
+  for n in "$@"; do
+    if pgrep -x "$n" >/dev/null 2>&1; then return 0
+    else rc=$?; [ "$rc" -eq 1 ] || return 2; fi
+  done
+  return 1
+}
+
+# --- AI CLI version retention ---------------------------------------------
+# Auto-updating AI CLIs accumulate whole old versions (hundreds of MB each).
+# The ACTIVE version is pinned by resolving the launcher symlink — never by
+# newest-mtime, because updaters pre-download the next version before switching
+# (mole's lesson). Any doubt about which version is active => skip entirely.
+AI_AGENT_SPECS=(
+  "$HOME/.local/share/claude/versions|Claude Code|$HOME/.local/bin/claude"
+  "$HOME/.local/share/cursor-agent/versions|Cursor Agent|$HOME/.local/bin/cursor-agent"
+  "$HOME/.copilot/pkg/universal|GitHub Copilot CLI|$HOME/.local/bin/copilot"
+)
+
+# Echo the ACTIVE version dir NAME under <versions_root>, resolved from
+# <symlink>. rc 1 on missing/broken/out-of-root link (caller must skip).
+resolve_active_version_dir () {
+  local root="$1" link="$2" target pdir rroot
+  [ -L "$link" ] || return 1
+  target=$(readlink "$link") || return 1
+  case "$target" in /*) ;; *) target="$(dirname "$link")/$target" ;; esac
+  # Resolve the containing directory physically (cd -P) so a missing version
+  # dir/bin dir fails closed here. NOTE: we deliberately do NOT additionally
+  # require the leaf binary itself to exist — only that its containing
+  # directory chain resolves — so a version whose bin/ dir exists but whose
+  # exact binary name changed is still recognized as active.
+  pdir=$(cd -P "$(dirname "$target")" 2>/dev/null && pwd -P) || return 1
+  target="$pdir/$(basename "$target")"
+  # $root must be resolved the same way (cd -P) before the prefix check:
+  # $HOME itself commonly sits under a symlinked path on macOS (/tmp ->
+  # /private/tmp, /var -> /private/var), so comparing a physically-resolved
+  # $target against a logical $root would spuriously mismatch and fail every
+  # agent closed even on a perfectly healthy install.
+  rroot=$(cd -P "$root" 2>/dev/null && pwd -P) || return 1
+  case "$target" in "$rroot"/*) ;; *) return 1 ;; esac
+  local rel="${target#"$rroot"/}"
+  printf '%s' "${rel%%/*}"
+}
+
+# Echo a skip reason (rc 0) when this safe-tier path's owner may be live.
+# rc 1 = no guard applies or owner idle. Only Xcode-family paths and the
+# Gradle daemon are guarded — npm/bun caches are content-addressed and their
+# runtimes (node) run constantly on dev machines, so guarding them would
+# permanently block cleaning (deliberate scope decision).
+guard_reason_for_path () {
+  local p="$1" st=1
+  case "$p" in
+    "$HOME/Library/Developer/Xcode/"*|"$HOME/Library/Developer/CoreSimulator/"*| \
+    "$HOME/Library/Caches/com.apple.dt.Xcode"|"$HOME/Library/Caches/org.swift.swiftpm"| \
+    "$HOME/Library/Caches/CocoaPods")
+      guard_procs_running Xcode xcodebuild Simulator swift-frontend xctest; st=$? ;;
+    "$HOME/.gradle/caches")
+      # The daemon is a java process; -x java would over-match. -f GradleDaemon
+      # matches the daemon's command line specifically.
+      if command -v pgrep >/dev/null 2>&1; then
+        if pgrep -f GradleDaemon >/dev/null 2>&1; then st=0
+        else st=$?; [ "$st" -eq 1 ] || st=2; fi
+      else st=2; fi ;;
+    *) return 1 ;;
+  esac
+  case "$st" in
+    0) printf 'in use — a guarded process is running' ; return 0 ;;
+    2) printf 'process state unknown — failing closed' ; return 0 ;;
+  esac
+  return 1
 }

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -84,6 +84,9 @@ version_sorted_children () {
   for d in "$dir"/*; do
     [ -e "$d" ] || continue
     [ -d "$d" ] || continue
+    # control chars would corrupt the line protocol — such names are skipped
+    # entirely (never counted, never deleted)
+    case "$d" in *[[:cntrl:]]*) continue ;; esac
     printf '%s\n' "${d##*/}"
   done | LC_ALL=C sort -rV
 }
@@ -275,6 +278,21 @@ _vtp_denied () {
     "$home_lower/.gnupg"
   )
   for r in "${vtp_never_roots[@]}"; do
+    case "$lower" in "$r"|"$r"/*) return 0 ;; esac
+  done
+  # System-root subtree denials (round-2 review): these five roots are
+  # unambiguously OS-owned with no legitimate trash-items.sh use ever — deny
+  # the root AND everything under it, same shape as the never-tier loop
+  # above. Deliberately narrow: /Library, /Applications, /usr, and /var are
+  # NOT subtree-denied here (only their bare roots, via the exact-root loop
+  # above) because legitimate workflows need to reach INSIDE them — e.g.
+  # removing a leftover /Library/LaunchAgents plist, clearing /usr/local
+  # Homebrew cruft, or trashing a stale /private/tmp scratch dir — and a
+  # blanket subtree deny on those would break all of that.
+  local vtp_system_roots=(
+    "/system" "/bin" "/sbin" "/dev" "/private/var/db"
+  )
+  for r in "${vtp_system_roots[@]}"; do
     case "$lower" in "$r"|"$r"/*) return 0 ;; esac
   done
   # Photos libraries — the bundle itself and everything inside it (masters,

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -61,6 +61,29 @@ KEEP_N_PATHS=(
   "$HOME/Library/Developer/Xcode/tvOS DeviceSupport"
 )
 
+# Version-descending sort of names on stdin. Names are already
+# control-char-filtered upstream (version_sorted_children is the only
+# caller), so tab-delimiting the awk fallback's sort key below is safe.
+# Primary path: `LC_ALL=C sort -rV` when a probe confirms this machine's
+# `sort` supports -V (verified working on stock macOS 2.3-Apple sort).
+# Fallback path (probe fails — some non-Apple `sort` without version-sort
+# support): awk builds a lexical key from the first 4 numeric components of
+# each name, zero-padded to 10 digits, then `LC_ALL=C sort -r` on that key
+# reproduces the same ordering `sort -rV` would have given — so retention
+# never silently no-ops just because `sort -V` happens to be unavailable.
+# "18.5 (22F76)" -> components 18,5,22,76; semver "1.0.117" -> 1,0,117 — both
+# order correctly under either path.
+_version_sort_desc () {
+  if printf '1\n' | sort -V >/dev/null 2>&1; then
+    LC_ALL=C sort -rV
+  else
+    awk '{ key=""; s=$0; n=0
+           while (match(s, /[0-9]+/) && n<4) { key = key sprintf("%010d.", substr(s,RSTART,RLENGTH)+0); s = substr(s, RSTART+RLENGTH); n++ }
+           while (n<4) { key = key "0000000000."; n++ }
+           printf "%s\t%s\n", key, $0 }' | LC_ALL=C sort -r | cut -f2-
+  fi
+}
+
 # Print directory-child NAMES of <dir>, one per line, ordered by the HIGHEST
 # VERSION encoded in the name first (never by mtime — mtime reflects whenever
 # Xcode/CoreSimulator/an updater last touched the directory, which can
@@ -68,19 +91,16 @@ KEEP_N_PATHS=(
 # ... and has no relationship to which version is actually newest). Enumerate
 # via a newline-safe glob (never ls, which mis-handles names containing
 # newlines/control chars and can't be told to sort by anything but time/name)
-# and sort with `sort -rV` (version sort, descending) so "18.5 (22F76)" sorts
-# ahead of "16.0 (20A362)", and semver dirs like "1.0.117" correctly sort
-# ahead of "1.0.2", regardless of which directory macOS/the updater touched
+# and order with _version_sort_desc, which prefers `sort -rV` (version sort,
+# descending — so "18.5 (22F76)" sorts ahead of "16.0 (20A362)", and semver
+# dirs like "1.0.117" correctly sort ahead of "1.0.2") and falls back to a
+# portable awk-key sort for a `sort` without -V support, so retention never
+# silently no-ops regardless of which directory macOS/the updater touched
 # last. Candidates must be DIRECTORIES: a stray file (e.g. a newest-mtime
 # .DS_Store) must never be treated as a version dir.
-# sort -V (version sort) isn't guaranteed on every `sort` this could run
-# under — if it's missing, fail CLOSED (print nothing, i.e. keep everything)
-# rather than fall back to an ordering (mtime/name) that silently
-# reintroduces the bug this function exists to fix.
 version_sorted_children () {
   local dir="$1" d
   [ -d "$dir" ] || return 0
-  if ! printf '1\n' | sort -V >/dev/null 2>&1; then return 0; fi
   for d in "$dir"/*; do
     [ -e "$d" ] || continue
     [ -d "$d" ] || continue
@@ -88,7 +108,7 @@ version_sorted_children () {
     # entirely (never counted, never deleted)
     case "$d" in *[[:cntrl:]]*) continue ;; esac
     printf '%s\n' "${d##*/}"
-  done | LC_ALL=C sort -rV
+  done | _version_sort_desc
 }
 
 # Print child NAMES of <dir> beyond the <n> HIGHEST VERSIONS, one per line

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -67,20 +67,39 @@ KEEP_N_PATHS=(
 # Primary path: `LC_ALL=C sort -rV` when a probe confirms this machine's
 # `sort` supports -V (verified working on stock macOS 2.3-Apple sort).
 # Fallback path (probe fails — some non-Apple `sort` without version-sort
-# support): awk builds a lexical key from the first 4 numeric components of
+# support): awk builds a lexical key from the first 8 numeric components of
 # each name, zero-padded to 10 digits, then `LC_ALL=C sort -r` on that key
 # reproduces the same ordering `sort -rV` would have given — so retention
 # never silently no-ops just because `sort -V` happens to be unavailable.
 # "18.5 (22F76)" -> components 18,5,22,76; semver "1.0.117" -> 1,0,117 — both
-# order correctly under either path.
+# order correctly under either path. Depth 8 covers every realistic version
+# string (DeviceSupport names like "18.5.1 (22G100)" = 18,5,1,22,100 need
+# only 5) with headroom to spare.
+# When two names' 8-component keys tie exactly (identical numeric content,
+# e.g. "22G76" vs "22F76"), the lexical compare on the untouched remainder
+# breaks the tie and correctly orders Apple build letters (22F76 < 22G76).
+# Fail-closed on overflow: if a name still has a 9th+ numeric run left over
+# after the first 8 are consumed, awk can't build a key that's guaranteed
+# correct for it, so it emits the sentinel line __MSC_VERSION_OVERFLOW__
+# instead of a keyed line for that name. If the sentinel shows up anywhere
+# in the fallback's output, this function prints NOTHING for the whole
+# directory rather than risk an ordering it can't guarantee — retention
+# would rather keep everything than delete a possibly-newer version.
 _version_sort_desc () {
   if printf '1\n' | sort -V >/dev/null 2>&1; then
     LC_ALL=C sort -rV
   else
-    awk '{ key=""; s=$0; n=0
-           while (match(s, /[0-9]+/) && n<4) { key = key sprintf("%010d.", substr(s,RSTART,RLENGTH)+0); s = substr(s, RSTART+RLENGTH); n++ }
-           while (n<4) { key = key "0000000000."; n++ }
-           printf "%s\t%s\n", key, $0 }' | LC_ALL=C sort -r | cut -f2-
+    local out
+    out=$(awk '{ key=""; s=$0; n=0
+           while (match(s, /[0-9]+/) && n<8) { key = key sprintf("%010d.", substr(s,RSTART,RLENGTH)+0); s = substr(s, RSTART+RLENGTH); n++ }
+           while (n<8) { key = key "0000000000."; n++ }
+           if (match(s, /[0-9]+/)) { print "__MSC_VERSION_OVERFLOW__"; next }
+           printf "%s\t%s\n", key, $0 }' | LC_ALL=C sort -r | cut -f2-)
+    case "$out" in
+      *__MSC_VERSION_OVERFLOW__*) return 0 ;;
+    esac
+    [ -n "$out" ] && printf '%s\n' "$out"
+    return 0
   fi
 }
 

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/lib.sh
@@ -61,26 +61,40 @@ KEEP_N_PATHS=(
   "$HOME/Library/Developer/Xcode/tvOS DeviceSupport"
 )
 
-# Print child NAMES of <dir> beyond the <n> most recently modified, one per
-# line (they are the deletion candidates). ls -1t = newest first; version dirs
-# ("17.5 (21F79)") contain spaces but never newlines.
-# Candidates must be DIRECTORIES: a stray file (e.g. a newest-mtime .DS_Store)
-# would otherwise consume one of the N "keep" slots and either get force-kept
-# ahead of a real version dir or, worse, be counted toward NR without ever
-# being a legitimate deletion target. Filter to dirs BEFORE counting N, not
-# after, so the N kept slots always land on real version dirs.
-keep_newest_n_children () {
-  local dir="$1" n="$2" child i
+# Print directory-child NAMES of <dir>, one per line, ordered by the HIGHEST
+# VERSION encoded in the name first (never by mtime — mtime reflects whenever
+# Xcode/CoreSimulator/an updater last touched the directory, which can
+# reorder on a device reconnect, Spotlight reindex, pre-download-before-switch,
+# ... and has no relationship to which version is actually newest). Enumerate
+# via a newline-safe glob (never ls, which mis-handles names containing
+# newlines/control chars and can't be told to sort by anything but time/name)
+# and sort with `sort -rV` (version sort, descending) so "18.5 (22F76)" sorts
+# ahead of "16.0 (20A362)", and semver dirs like "1.0.117" correctly sort
+# ahead of "1.0.2", regardless of which directory macOS/the updater touched
+# last. Candidates must be DIRECTORIES: a stray file (e.g. a newest-mtime
+# .DS_Store) must never be treated as a version dir.
+# sort -V (version sort) isn't guaranteed on every `sort` this could run
+# under — if it's missing, fail CLOSED (print nothing, i.e. keep everything)
+# rather than fall back to an ordering (mtime/name) that silently
+# reintroduces the bug this function exists to fix.
+version_sorted_children () {
+  local dir="$1" d
   [ -d "$dir" ] || return 0
-  i=0
-  while IFS= read -r child; do
-    [ -n "$child" ] || continue
-    [ -d "$dir/$child" ] || continue
-    i=$((i + 1))
-    [ "$i" -gt "$n" ] && printf '%s\n' "$child"
-  done <<EOF
-$(ls -1t "$dir" 2>/dev/null)
-EOF
+  if ! printf '1\n' | sort -V >/dev/null 2>&1; then return 0; fi
+  for d in "$dir"/*; do
+    [ -e "$d" ] || continue
+    [ -d "$d" ] || continue
+    printf '%s\n' "${d##*/}"
+  done | LC_ALL=C sort -rV
+}
+
+# Print child NAMES of <dir> beyond the <n> HIGHEST VERSIONS, one per line
+# (they are the deletion candidates). Filter to dirs and sort by version
+# BEFORE counting N, not after, so the N kept slots always land on real
+# version dirs ordered correctly (see version_sorted_children above).
+keep_newest_n_children () {
+  local dir="$1" n="$2"
+  version_sorted_children "$dir" | awk -v n="$n" 'NR > n'
 }
 
 # --- ASK tier -------------------------------------------------------------

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
@@ -63,7 +63,7 @@ echo "===== App caches — Electron apps (clean-safe clears these automatically 
 # below: browser profile caches are NEVER auto-cleared, so grouping them
 # under the same "auto-clear" title would overclaim what this tool does.
 electron_apps=$(
-  find "$HOME/Library/Application Support" -maxdepth 2 -type d \
+  find "$HOME/Library/Application Support" -mindepth 2 -maxdepth 2 -type d \
     \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null \
   | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
 )

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
@@ -56,15 +56,22 @@ echo "Only the vetted safe list above is auto-deleted; these are for you to revi
 du -sh "$HOME/Library/Caches/"* 2>/dev/null | sort -rh | head -12
 echo
 
-echo "===== App caches — Electron & browsers (clean-safe clears these automatically when the app isn't running) ====="
-# Electron-style cache subfolders (depth<=2) + known browser profile caches.
-# Capture the listing once, so the "found little" message reflects what was
-# ACTUALLY shown (incl. the deeper browser-profile caches) — not a re-run of a
-# shallower find that could disagree with it.
-apps=$(
+echo "===== App caches — Electron apps (clean-safe clears these automatically when the app isn't running) ====="
+# Electron-style cache subfolders (depth<=2) directly under an app's own
+# Application Support dir — these are what clean-safe.sh actually auto-clears.
+# Kept as a separate listing (and header) from the browser-profile block
+# below: browser profile caches are NEVER auto-cleared, so grouping them
+# under the same "auto-clear" title would overclaim what this tool does.
+electron_apps=$(
+  find "$HOME/Library/Application Support" -maxdepth 2 -type d \
+    \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null \
+  | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
+)
+if [ -n "$electron_apps" ]; then printf '%s\n' "$electron_apps"; else echo "  (no Electron-style app caches found, or they're TCC-protected)"; fi
+echo
+echo "  browser profile caches (NOT auto-cleared — review via catalog):"
+browser_apps=$(
   {
-    find "$HOME/Library/Application Support" -maxdepth 2 -type d \
-      \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null
     for b in \
       "Google/Chrome" "BraveSoftware/Brave-Browser" "Microsoft Edge" \
       "Arc" "Vivaldi" "Chromium" "com.operasoftware.Opera"; do
@@ -75,7 +82,7 @@ apps=$(
     done
   } | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
 )
-if [ -n "$apps" ]; then printf '%s\n' "$apps"; else echo "  (no app caches found, or they're TCC-protected)"; fi
+if [ -n "$browser_apps" ]; then printf '%s\n' "$browser_apps"; else echo "  (none found)"; fi
 echo
 
 echo "===== ASK first — big, but expensive to restore or not a cache ====="

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/survey.sh
@@ -15,13 +15,39 @@ if [ -d /System/Volumes/Data ]; then df -h /System/Volumes/Data 2>/dev/null | se
 echo
 
 echo "===== SAFE caches — auto-clearable (only cost: slower next build) ====="
+load_whitelist
 collect "${SAFE_PATHS[@]}"
 if [ "${#FOUND[@]}" -gt 0 ]; then
-  du -sh "${FOUND[@]}" 2>/dev/null | sort -rh
+  # Partition into eligible (would actually be cleared) vs whitelisted (user
+  # opted these out) BEFORE totaling, so "reclaimable" never overstates what
+  # clean-safe.sh would really do — a whitelisted multi-GB cache silently
+  # inflating the headline total would be exactly the kind of dishonest
+  # accounting this tool exists to avoid.
+  eligible=(); wl=()
+  for f in "${FOUND[@]}"; do
+    if is_whitelisted "$f"; then wl+=("$f"); else eligible+=("$f"); fi
+  done
+  {
+    [ "${#eligible[@]}" -gt 0 ] && du -sh "${eligible[@]}" 2>/dev/null
+    [ "${#wl[@]}" -gt 0 ] && du -sh "${wl[@]}" 2>/dev/null | sed 's/$/ (whitelisted — excluded from total)/'
+  } | sort -rh
   line
-  du -sch "${FOUND[@]}" 2>/dev/null | tail -1 | awk '{print "reclaimable in safe tier: "$1}'
+  if [ "${#eligible[@]}" -gt 0 ]; then
+    du -sch "${eligible[@]}" 2>/dev/null | tail -1 | awk '{print "reclaimable in safe tier: "$1}'
+  else
+    echo "reclaimable in safe tier: $(human_kb 0)"
+  fi
+  echo "  (process-guarded items may still be skipped at run time — clean-safe.sh --dry-run gives the exact preview)"
+  [ "${#WHITELIST[@]}" -gt 0 ] && \
+    echo "  (whitelist active: ${#WHITELIST[@]} protected pattern(s) — clean-safe will skip matches; edit $MSC_WHITELIST_FILE)"
 else
   echo "  (none present)"
+fi
+collect "${KEEP_N_PATHS[@]}"
+if [ "${#FOUND[@]}" -gt 0 ]; then
+  KEEPN="${MSC_DEVICE_SUPPORT_KEEP:-2}"
+  case "$KEEPN" in ''|*[!0-9]*) KEEPN=2 ;; esac
+  du -sh "${FOUND[@]}" 2>/dev/null | sort -rh | sed "s/\$/   (keeps $KEEPN newest versions)/"
 fi
 echo
 
@@ -30,21 +56,26 @@ echo "Only the vetted safe list above is auto-deleted; these are for you to revi
 du -sh "$HOME/Library/Caches/"* 2>/dev/null | sort -rh | head -12
 echo
 
-echo "===== App caches — Electron & browsers (safe; quit the app first) ====="
+echo "===== App caches — Electron & browsers (clean-safe clears these automatically when the app isn't running) ====="
 # Electron-style cache subfolders (depth<=2) + known browser profile caches.
-{
-  find "$HOME/Library/Application Support" -maxdepth 2 -type d \
-    \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null
-  for b in \
-    "Google/Chrome" "BraveSoftware/Brave-Browser" "Microsoft Edge" \
-    "Arc" "Vivaldi" "Chromium" "com.operasoftware.Opera"; do
-    for sub in "Default/Cache" "Default/Code Cache" "Default/Service Worker/CacheStorage"; do
-      d="$HOME/Library/Application Support/$b/$sub"
-      [ -d "$d" ] && printf '%s\n' "$d"
+# Capture the listing once, so the "found little" message reflects what was
+# ACTUALLY shown (incl. the deeper browser-profile caches) — not a re-run of a
+# shallower find that could disagree with it.
+apps=$(
+  {
+    find "$HOME/Library/Application Support" -maxdepth 2 -type d \
+      \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null
+    for b in \
+      "Google/Chrome" "BraveSoftware/Brave-Browser" "Microsoft Edge" \
+      "Arc" "Vivaldi" "Chromium" "com.operasoftware.Opera"; do
+      for sub in "Default/Cache" "Default/Code Cache" "Default/Service Worker/CacheStorage"; do
+        d="$HOME/Library/Application Support/$b/$sub"
+        [ -d "$d" ] && printf '%s\n' "$d"
+      done
     done
-  done
-} | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
-[ -z "$(find "$HOME/Library/Application Support" -maxdepth 2 -type d \( -name Cache -o -name "Code Cache" -o -name GPUCache -o -name DawnWebGPUCache \) 2>/dev/null | head -1)" ] && echo "  (scan found little; some may be TCC-protected)"
+  } | while IFS= read -r d; do du -sh "$d" 2>/dev/null; done | sort -rh | head -15
+)
+if [ -n "$apps" ]; then printf '%s\n' "$apps"; else echo "  (no app caches found, or they're TCC-protected)"; fi
 echo
 
 echo "===== ASK first — big, but expensive to restore or not a cache ====="
@@ -56,6 +87,12 @@ else
 fi
 d="$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw"
 [ -f "$d" ] && stat -f '  Docker.raw last modified: %Sm' "$d" 2>/dev/null
+# Read-only; gated on xcode-select -p (same reasoning as clean-safe.sh) so a
+# non-developer Mac with no toolchain selected never triggers simctl at all.
+if xcode-select -p >/dev/null 2>&1; then
+  rtcount=$(xcrun simctl list runtimes 2>/dev/null | grep -c " - ")
+  [ "${rtcount:-0}" -gt 0 ] && echo "  iOS/watchOS/tvOS simulator runtimes installed: $rtcount — each 5-10GB; remove unused: xcrun simctl runtime list / delete <id>"
+fi
 echo
 
 echo "===== NEVER auto-delete — user data (reported for awareness only) ====="

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -3,15 +3,17 @@
 # Use for anything riskier than a pure cache: ask-tier items, app leftovers,
 # big/old files. The user can restore from Trash until it's emptied. Every
 # action is logged. Usage: trash-items.sh <path> [<path> ...]
-# Exit codes: 0 = ok (nothing failed); 1 = at least one item could not be
-# trashed (permissions/TCC); 2 = every item was refused and nothing moved;
-# 3 = refused to run at all because the audit log isn't writable (see
-# MSC_ALLOW_UNLOGGED below).
+# Exit codes: 0 = ok (nothing failed — includes a dry-run mix of
+# previewed+refused items, and a missing-only run); 1 = at least one item
+# could not be trashed (permissions/TCC); 2 = nothing was moved or previewed
+# and at least one item was refused (all-refused, dry or real); 3 = refused
+# to run at all because the audit log isn't writable (see MSC_ALLOW_UNLOGGED
+# below).
 set -u
 DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$DIR/lib.sh"
 
-[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]  (exit 0=ok, 1=a trash failed, 2=all refused/nothing moved, 3=audit log unwritable)"; exit 1; }
+[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]  (exit 0=ok/previewed/missing-only, 1=a trash failed, 2=all refused & nothing moved/previewed, 3=audit log unwritable)"; exit 1; }
 
 # MSC_DRY_RUN=1 is a REAL preview here, not just a log_op no-op: without this,
 # a caller that exports MSC_DRY_RUN=1 (e.g. following clean-safe.sh's
@@ -38,9 +40,12 @@ fi
 moved=0
 failed=0
 refused=0
+previewed=0
+missing=0
 for p in "$@"; do
   if [ ! -e "$p" ] && [ ! -L "$p" ]; then
     echo "  not found: $p"
+    missing=$((missing + 1))
     continue
   fi
   # Refuse BEFORE the size scan: du -sk on a protected root ($HOME, /Users,
@@ -60,6 +65,7 @@ for p in "$@"; do
   sz=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
   if [ "$DRY" = 1 ]; then
     echo "  would trash $sz  $p"
+    previewed=$((previewed + 1))
     continue
   fi
   rc=0; trash_path "$p" || rc=$?
@@ -88,15 +94,24 @@ done
 echo
 if [ "$DRY" = 1 ]; then
   echo "Preview only — nothing was trashed. Re-run without MSC_DRY_RUN=1 to actually trash these items."
+  [ "$previewed" -gt 0 ] && echo "$previewed item(s) previewed."
 else
   echo "$moved item(s) moved to Trash — restorable until you empty it."
   echo "Space is reclaimed when the Trash is emptied (Finder > Empty Trash)."
 fi
+[ "$refused" -gt 0 ] && echo "$refused item(s) refused (protected path)."
+[ "$missing" -gt 0 ] && echo "$missing item(s) not found."
 echo "Log: $LOG_DIR/operations.log"
 
+# Exit codes: 1 = at least one item could not be trashed (permissions/TCC);
+# 2 = nothing was moved or even previewed AND at least one item was refused
+# (an all-refused run — dry or real — signals failure; a run mixing a valid
+# path with a refused one still exits 0, since the valid path did/would move,
+# and a missing-only run also exits 0 — nothing failed or was refused, the
+# missing count is just called out above).
 if [ "$failed" -gt 0 ]; then
   exit 1
-elif [ "$refused" -gt 0 ] && [ "$moved" -eq 0 ]; then
+elif [ "$((moved + previewed))" -eq 0 ] && [ "$refused" -gt 0 ]; then
   exit 2
 fi
 exit 0

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -3,31 +3,100 @@
 # Use for anything riskier than a pure cache: ask-tier items, app leftovers,
 # big/old files. The user can restore from Trash until it's emptied. Every
 # action is logged. Usage: trash-items.sh <path> [<path> ...]
+# Exit codes: 0 = ok (nothing failed); 1 = at least one item could not be
+# trashed (permissions/TCC); 2 = every item was refused and nothing moved;
+# 3 = refused to run at all because the audit log isn't writable (see
+# MSC_ALLOW_UNLOGGED below).
 set -u
 DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$DIR/lib.sh"
 
-[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]"; exit 1; }
+[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]  (exit 0=ok, 1=a trash failed, 2=all refused/nothing moved, 3=audit log unwritable)"; exit 1; }
 
-log_writable || echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — items will still be trashed, but this run will NOT be recorded."
+# MSC_DRY_RUN=1 is a REAL preview here, not just a log_op no-op: without this,
+# a caller that exports MSC_DRY_RUN=1 (e.g. following clean-safe.sh's
+# convention) would still get every path actually moved to the Trash — log_op
+# would silently no-op, so the run wouldn't even be audited. Ordering matches
+# clean-safe.sh's contract: nothing is validated/scanned differently, only the
+# final trash_path call (and its log entry) is skipped.
+DRY=0
+[ "${MSC_DRY_RUN:-0}" = "1" ] && DRY=1
+export MSC_DRY_RUN="$DRY"
+[ "$DRY" = 1 ] && echo "=== DRY RUN — nothing will be trashed ==="
+
+# Abort-if-unlogged: a run that trashes items without recording what it did
+# defeats the whole audit-trail promise. Refuse by default; MSC_ALLOW_UNLOGGED=1
+# is an explicit, opt-in escape hatch (falls back to the old warn-and-continue).
+if [ "$DRY" != 1 ] && ! log_writable; then
+  if [ "${MSC_ALLOW_UNLOGGED:-0}" = "1" ]; then
+    echo "⚠ Cannot write the audit log ($LOG_DIR/operations.log) — items will still be trashed, but this run will NOT be recorded."
+  else
+    echo "✗ Cannot write the audit log ($LOG_DIR/operations.log). Refusing to delete unlogged. Set MSC_ALLOW_UNLOGGED=1 to override."
+    exit 3
+  fi
+fi
 moved=0
+failed=0
+refused=0
 for p in "$@"; do
-  if [ ! -e "$p" ]; then
+  if [ ! -e "$p" ] && [ ! -L "$p" ]; then
     echo "  not found: $p"
     continue
   fi
-  sz=$(human_kb "$(size_kb "$p")")
-  if trash_path "$p"; then
-    echo "  trashed $sz  $p"
-    log_op trashed "$sz" "$p"
-    moved=$((moved + 1))
+  # Refuse BEFORE the size scan: du -sk on a protected root ($HOME, /Users,
+  # ...) can walk gigabytes of data just to print a number nobody asked for
+  # once we're about to say REFUSED anyway. trash_path still re-validates
+  # internally (rc 2) as defense in depth for callers that invoke it
+  # directly, but refusal here must stay O(1).
+  if ! validate_target_path "$p"; then
+    echo "  REFUSED (protected system/user root — never trashed by this tool): $p"
+    log_op refused "-" "$p"
+    refused=$((refused + 1))
+    continue
+  fi
+  # size_kb can come back empty (du failed/blocked) — say so honestly instead
+  # of printing a misleading "0.0K".
+  kb=$(size_kb "$p")
+  sz=$([ -n "$kb" ] && human_kb "$kb" || echo "size?")
+  if [ "$DRY" = 1 ]; then
+    echo "  would trash $sz  $p"
+    continue
+  fi
+  rc=0; trash_path "$p" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    if [ -n "$TRASH_METHOD" ]; then
+      echo "  trashed ($TRASH_METHOD) $sz  $p"
+      log_op "trashed($TRASH_METHOD)" "$sz" "$p"
+      moved=$((moved + 1))
+    else
+      # rc 0 with an EMPTY TRASH_METHOD means trash_path found nothing to
+      # move (already gone) — reporting "trashed" here would be a lie about
+      # what actually happened.
+      echo "  already gone: $p"
+    fi
+  elif [ "$rc" -eq 2 ]; then
+    echo "  REFUSED (protected system/user root — never trashed by this tool): $p"
+    log_op refused "-" "$p"
+    refused=$((refused + 1))
   else
     echo "  could NOT trash (permissions/TCC?): $p"
     log_op trash-failed "$sz" "$p"
+    failed=$((failed + 1))
   fi
 done
 
 echo
-echo "$moved item(s) moved to Trash — restorable until you empty it."
-echo "Space is reclaimed when the Trash is emptied (Finder > Empty Trash)."
+if [ "$DRY" = 1 ]; then
+  echo "Preview only — nothing was trashed. Re-run without MSC_DRY_RUN=1 to actually trash these items."
+else
+  echo "$moved item(s) moved to Trash — restorable until you empty it."
+  echo "Space is reclaimed when the Trash is emptied (Finder > Empty Trash)."
+fi
 echo "Log: $LOG_DIR/operations.log"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+elif [ "$refused" -gt 0 ] && [ "$moved" -eq 0 ]; then
+  exit 2
+fi
+exit 0

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -2,26 +2,51 @@
 # mac-storage-cleaner TRASH — move given paths to the Trash (reversible), not rm.
 # Use for anything riskier than a pure cache: ask-tier items, app leftovers,
 # big/old files. The user can restore from Trash until it's emptied. Every
-# action is logged. Usage: trash-items.sh <path> [<path> ...]
+# action is logged. Usage: trash-items.sh [--force] [--dry-run] <path> [<path> ...]
 # Exit codes: 0 = ok (nothing failed — includes a dry-run mix of
 # previewed+refused items, and a missing-only run); 1 = at least one item
 # could not be trashed (permissions/TCC); 2 = nothing was moved or previewed
-# and at least one item was refused (all-refused, dry or real); 3 = refused
-# to run at all because the audit log isn't writable (see MSC_ALLOW_UNLOGGED
-# below).
+# and at least one item was refused (all-refused, dry or real), OR an unknown
+# leading flag was given — this must fail closed (exit, trash nothing) rather
+# than fall into the path loop and trash the remaining arguments for real;
+# 3 = refused to run at all because the audit log isn't writable (see
+# MSC_ALLOW_UNLOGGED below); 4 = refused as a bulk operation (see
+# MSC_MAX_TRASH_ITEMS / MSC_MAX_TRASH_GB and --force).
 set -u
 DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$DIR/lib.sh"
 
-[ "$#" -eq 0 ] && { echo "usage: trash-items.sh <path> [<path> ...]  (exit 0=ok/previewed/missing-only, 1=a trash failed, 2=all refused & nothing moved/previewed, 3=audit log unwritable)"; exit 1; }
+# --force must be the first argument. It only ever relaxes the bulk-operation
+# cap below; it does not bypass path validation or the never-tier denials.
+FORCE=0
+[ "${1:-}" = "--force" ] && { FORCE=1; shift; }
 
-# MSC_DRY_RUN=1 is a REAL preview here, not just a log_op no-op: without this,
-# a caller that exports MSC_DRY_RUN=1 (e.g. following clean-safe.sh's
-# convention) would still get every path actually moved to the Trash — log_op
-# would silently no-op, so the run wouldn't even be audited. Ordering matches
-# clean-safe.sh's contract: nothing is validated/scanned differently, only the
-# final trash_path call (and its log entry) is skipped.
+# Any other leading flag must be recognized explicitly and never fall through
+# to the path loop below: an unrecognized flag like --dry-run used to print
+# "not found: --dry-run" and then trash the REMAINING paths for real — a
+# preview request silently performing a real destructive run. --dry-run is a
+# real preview switch (same contract as MSC_DRY_RUN=1, wired in below); any
+# other -* argument is rejected outright (fail closed, exit 2) rather than
+# risk the same class of bug for a flag we haven't thought of yet.
+DRY_FLAG=0
+case "${1:-}" in
+  --dry-run) DRY_FLAG=1; shift ;;
+  --) shift ;;
+  -*) echo "unknown argument: $1 (supported: --force, --dry-run)"; exit 2 ;;
+esac
+
+[ "$#" -eq 0 ] && { echo "usage: trash-items.sh [--force] [--dry-run] <path> [<path> ...]  (exit 0=ok/previewed/missing-only, 1=a trash failed, 2=all refused & nothing moved/previewed (or an unknown flag), 3=audit log unwritable, 4=refused as a bulk operation)"; exit 1; }
+
+# --dry-run (DRY_FLAG above) or MSC_DRY_RUN=1 is a REAL preview here, not just
+# a log_op no-op: without this, a caller that exports MSC_DRY_RUN=1 (e.g.
+# following clean-safe.sh's convention) would still get every path actually
+# moved to the Trash — log_op would silently no-op, so the run wouldn't even
+# be audited. Ordering matches clean-safe.sh's contract: nothing is
+# validated/scanned differently, only the final trash_path call (and its log
+# entry) is skipped. MSC_DRY_RUN=1 can only ever make a run safer, so it is
+# checked last and can turn DRY on but never off.
 DRY=0
+[ "$DRY_FLAG" = 1 ] && DRY=1
 [ "${MSC_DRY_RUN:-0}" = "1" ] && DRY=1
 export MSC_DRY_RUN="$DRY"
 [ "$DRY" = 1 ] && echo "=== DRY RUN — nothing will be trashed ==="
@@ -42,6 +67,76 @@ failed=0
 refused=0
 previewed=0
 missing=0
+if [ "$DRY" != 1 ]; then
+# Blast-radius cap. Some agents (opencode, OpenClaw) run shell commands with no
+# approval prompt, so a single call assembling "all my old downloads" could move
+# hundreds of a user's files at once. Count only ELIGIBLE paths — missing and
+# protected-refused paths are not the user's data leaving its place. One `du -sck`
+# gives the grand total in a single walk.
+MAX_ITEMS="${MSC_MAX_TRASH_ITEMS:-100}"
+MAX_GB="${MSC_MAX_TRASH_GB:-5}"
+case "$MAX_ITEMS" in ''|*[!0-9]*) MAX_ITEMS=100 ;; esac
+case "$MAX_GB"    in ''|*[!0-9]*) MAX_GB=5 ;; esac
+eligible_n=0
+eligible=()
+for p in "$@"; do
+  { [ -e "$p" ] || [ -L "$p" ]; } || continue
+  validate_target_path "$p" || continue
+  eligible+=("$p")
+  eligible_n=$((eligible_n + 1))
+done
+bulk_kb=0
+size_unknown=0
+if [ "$eligible_n" -gt 0 ]; then
+  # Capture du's OWN exit status, not a pipeline's: `du_out=$(du ...)` is a
+  # single command substitution around ONE command (no internal pipe), so $?
+  # right after it is genuinely du's rc. `${PIPESTATUS[0]}` cannot be used
+  # here instead — PIPESTATUS does not cross a command-substitution subshell
+  # boundary (verified: `x=$(false | true); echo "${PIPESTATUS[*]}"` prints
+  # `0`, the outer assignment's own status, not the inner pipe's — in bash
+  # 3.2 or later). A permission-denied path makes du print a well-formed but
+  # WRONG "0\ttotal" while still exiting non-zero, so the captured rc is the
+  # only reliable signal for that case. The tail/awk extraction below now
+  # runs on already-captured text, not a second live subprocess pipe, so it
+  # needs no exit-status handling of its own.
+  du_out=$(du -sck "${eligible[@]}" 2>/dev/null)
+  du_rc=$?
+  bulk_kb=$(printf '%s\n' "$du_out" | tail -1 | awk '{print $1}')
+  # An empty/non-numeric total means du gave us nothing usable — never fake
+  # that as a trustworthy zero (honest-accounting: report size? on an
+  # unmeasurable path, never a silent 0). A genuinely successful zero (every
+  # eligible path measured and truly empty) is already a valid digit string
+  # and never reaches this branch, so it is never mistaken for "unmeasurable".
+  case "$bulk_kb" in ''|*[!0-9]*) bulk_kb=0; size_unknown=1 ;; esac
+  [ "$du_rc" -ne 0 ] && size_unknown=1
+fi
+# Honest-accounting: bulk_kb is forced to 0 above whenever size_unknown=1, so
+# human_kb on it would print a misleading "0.0K" in the refusal message below
+# (as if the batch were measured and genuinely empty). Say size? instead.
+if [ "$size_unknown" = 1 ]; then bulk_disp="size?"; else bulk_disp=$(human_kb "$bulk_kb"); fi
+if [ "$FORCE" != 1 ] && { [ "$eligible_n" -gt "$MAX_ITEMS" ] || { [ "$size_unknown" != 1 ] && [ "$bulk_kb" -gt $((MAX_GB * 1024 * 1024)) ]; }; }; then
+  echo "✗ Refusing a bulk operation: $eligible_n item(s), $bulk_disp (limits: $MAX_ITEMS items, ${MAX_GB}GB)."
+  echo "  This guard exists because some agents run shell commands without asking you first."
+  echo "  Review the list, then re-run the same command with --force as the first argument."
+  log_op refused-blast-radius "$bulk_disp" "$eligible_n item(s)"
+  exit 4
+fi
+# Size was unmeasurable (some eligible path is unreadable) — fail open, not
+# closed: over-refusing on a transient permission hiccup would just push
+# users toward --force, which also disables the item cap. Say so honestly
+# instead of silently proceeding as if the batch were confirmed small.
+if [ "$size_unknown" = 1 ]; then
+  echo "⚠ Could not fully measure this batch (some paths are unreadable) — the ${MAX_GB}GB size guard was NOT enforced for this run. The $MAX_ITEMS-item limit still applies."
+  log_op size-unmeasurable "?" "$eligible_n item(s)"
+fi
+# Spec D2: the audit log must record the consent path for every destructive
+# invocation. clean-safe.sh already logs `consent -- --apply`; --force is the
+# most dangerous invocation this tool has (it also disables the item cap), so
+# it must leave the same kind of marker. Nested inside `[ "$DRY" != 1 ]` above
+# — a `--force --dry-run` preview must never log a consent marker for a
+# deletion that didn't happen.
+[ "$FORCE" = 1 ] && log_op consent "-" "--force"
+fi
 for p in "$@"; do
   if [ ! -e "$p" ] && [ ! -L "$p" ]; then
     echo "  not found: $p"
@@ -108,7 +203,10 @@ echo "Log: $LOG_DIR/operations.log"
 # (an all-refused run — dry or real — signals failure; a run mixing a valid
 # path with a refused one still exits 0, since the valid path did/would move,
 # and a missing-only run also exits 0 — nothing failed or was refused, the
-# missing count is just called out above).
+# missing count is just called out above) — an unrecognized leading flag also
+# exits 2, but earlier, before argument parsing even reaches this point;
+# 4 = refused as a bulk operation (see MSC_MAX_TRASH_ITEMS / MSC_MAX_TRASH_GB
+# and --force) — exited earlier, above the main loop, before anything was moved.
 if [ "$failed" -gt 0 ]; then
   exit 1
 elif [ "$((moved + previewed))" -eq 0 ] && [ "$refused" -gt 0 ]; then

--- a/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
+++ b/cli-tool/components/skills/productivity/mac-storage-cleaner/scripts/trash-items.sh
@@ -77,6 +77,12 @@ MAX_ITEMS="${MSC_MAX_TRASH_ITEMS:-100}"
 MAX_GB="${MSC_MAX_TRASH_GB:-5}"
 case "$MAX_ITEMS" in ''|*[!0-9]*) MAX_ITEMS=100 ;; esac
 case "$MAX_GB"    in ''|*[!0-9]*) MAX_GB=5 ;; esac
+# An all-digit string can still be an invalid OCTAL literal in bash arithmetic
+# ("08" -> "value too great for base"), which would make $(( )) below fail and
+# silently skip the size cap. Force base 10 once, here, so every later use —
+# arithmetic and display alike — sees a normalized decimal.
+MAX_ITEMS=$((10#$MAX_ITEMS))
+MAX_GB=$((10#$MAX_GB))
 eligible_n=0
 eligible=()
 for p in "$@"; do


### PR DESCRIPTION
Update of the merged skill (#721) to **v2.0.0** — a substantial safety-hardening release. Upstream repo/changelog: https://github.com/JubaKitiashvili/mac-storage-cleaner/blob/main/CHANGELOG.md

**What changed (all 7 files, +1012/−66):**
- **"Never" tier is now enforced in code, not just documentation**: subtree denials for Photos libraries, iOS backups (MobileSync), Keychains, Mail/Messages data, and `~/.ssh`/`~/.aws`/`~/.gnupg` — the validator refuses them even if the reasoning layer were ever wrong, and it now also runs as defense-in-depth inside every automatic deletion loop.
- `--dry-run` (full preview, zero deletions/log writes, guards applied identically to a real run), a user whitelist file (case-insensitive, protects subtrees), and fail-closed process guards (Xcode toolchain, Gradle daemon, running Electron apps — "can't tell" always means "skip").
- Keep-N retention instead of full wipes: DeviceSupport keeps the 2 newest OS versions; auto-updating AI CLIs keep their active version, resolved via launcher symlink (never mtime).
- Three-stage reversible Trash chain (`/usr/bin/trash` → Finder → same-volume `mv`) with per-method audit logging; deletion refuses to run if the audit log is unwritable.
- Expanded coverage: Android Studio/SDK, Carthage/Poetry/mise/Composer/RubyGems/conda (owner command only), Handoff clipboard buffers (60-min age gate), crash reports (30-day age gate), guarded Electron/Chromium app caches.
- Honest accounting: partial removals reported as partial, unmeasurable sizes as `size?`, whitelist-aware survey totals, 5 MB log rotation.

**For the security scan** (same notes as #721, still true): the skill makes **no network calls and no credential access**; every `rm -rf` is gated behind a hard-coded allowlist *plus* the new deny-list validator; `~/.ssh`/keychain/backup paths appear only inside the *refuse-to-touch* protection lists. It now ships with a 68-test bats suite upstream, including a property-tested dangerous-path corpus (every corpus entry must be refused) and adversarial symlink cases — audited by an independent multi-model review panel before release.

Happy to adjust anything — thanks for maintaining this!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `mac-storage-cleaner` to v3.0.1 to prevent unintended deletions and enforce bulk protections. Old: `clean-safe.sh` deleted by default; New: it previews by default and requires `--apply`. Also fixes an octal parsing bug in the Trash size cap so bulk limits are always enforced.

- Migration: pass `--apply` for real deletions; unknown flags or multiple args now exit 2.
- Bulk protections: `trash-items.sh` refuses >100 items or >5GB without `--force`; cap enforcement fix prevents fail-open cases.
- Area: components (`cli-tool/components/skills/productivity/mac-storage-cleaner`); adds `agents/openai.yaml`; no new components; no `docs/components.json` regeneration.
- Env vars unchanged: `MSC_WHITELIST_FILE`, `MSC_TRASH_BIN`, `MSC_DEVICE_SUPPORT_KEEP`, `MSC_AI_AGENTS_KEEP`, `MSC_DRY_RUN`, `MSC_ALLOW_UNLOGGED`; no new secrets.

<sup>Written for commit 627e08877707ae8696e87317be902a6aad0e7d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

