### PR TITLE
improve: enhance llms-maintainer agent (framework-aware discovery, more frameworks, safety)

### DIFF
--- a/cli-tool/components/agents/ai-specialists/llms-maintainer.md
+++ b/cli-tool/components/agents/ai-specialists/llms-maintainer.md
@@ -14,8 +14,7 @@ Your core responsibility is to create or update the llms.txt file following this
 Determine where to write llms.txt, and which directories to scan for candidate pages in Step 3, based on the project framework:
 - If `astro.config.*` exists → output `public/llms.txt`; scan `src/pages/`, `src/content/`
 - If `nuxt.config.*` exists → output `public/llms.txt`; scan `pages/`, `content/`
-- If `next.config.*` exists and `app/` exists (App Router) → output `public/llms.txt`; scan `app/`
-- If `next.config.*` exists and `pages/` exists (Pages Router) → output `public/llms.txt`; scan `pages/`
+- If `next.config.*` exists → output `public/llms.txt`; if `app/` exists (App Router), scan `app/` — and also scan `pages/` if it exists too, since hybrid/half-migrated Next projects keep legacy routes there; otherwise (no `app/`) scan `pages/` (Pages Router)
 - If `svelte.config.*` exists → output `static/llms.txt`; scan `src/routes/`
 - If `hugo.toml` or `hugo.yaml` exists → output `static/llms.txt`; scan `content/`
 - If `docusaurus.config.*` exists → output `static/llms.txt`; scan `docs/`, `blog/`
@@ -31,7 +30,7 @@ Determine where to write llms.txt, and which directories to scan for candidate p
 **3. DISCOVER CANDIDATE PAGES**
 - Recursively scan the directories identified for the detected framework in Step 1. If no framework was detected, fall back to scanning: /app, /pages, /content, /docs, /blog
 - IGNORE files matching these patterns:
-  - Paths with /_* (private/internal)
+  - Paths with /_* (private/internal) — EXCEPT Jekyll's `_posts/` (blog content), which must be scanned despite the underscore prefix; still ignore other Jekyll internals like `_layouts/`, `_includes/`, `_data/`, `_sass/`
   - /api/ routes
   - /admin/ or /beta/ paths
   - Files ending in .test, .spec, .stories

--- a/cli-tool/components/agents/ai-specialists/llms-maintainer.md
+++ b/cli-tool/components/agents/ai-specialists/llms-maintainer.md
@@ -30,7 +30,7 @@ Determine where to write llms.txt, and which directories to scan for candidate p
 **3. DISCOVER CANDIDATE PAGES**
 - Recursively scan the directories identified for the detected framework in Step 1. If no framework was detected, fall back to scanning: /app, /pages, /content, /docs, /blog
 - IGNORE files matching these patterns:
-  - Paths with /_* (private/internal) — EXCEPT Jekyll's `_posts/` (blog content), which must be scanned despite the underscore prefix; still ignore other Jekyll internals like `_layouts/`, `_includes/`, `_data/`, `_sass/`
+  - Paths with /_* (private/internal) — EXCEPT Jekyll's `_posts/` and any configured collection dirs from `_config.yml` (e.g. `_projects/`, `_team/`), which must be scanned despite the underscore prefix; still ignore other Jekyll internals like `_layouts/`, `_includes/`, `_data/`, `_sass/`
   - /api/ routes
   - /admin/ or /beta/ paths
   - Files ending in .test, .spec, .stories

--- a/cli-tool/components/agents/ai-specialists/llms-maintainer.md
+++ b/cli-tool/components/agents/ai-specialists/llms-maintainer.md
@@ -90,8 +90,10 @@ Organize by top-level section using H2 headings (Docs, Blog, Marketing, etc.) an
 **8. OPTIONAL GIT OPERATIONS**
 If Git is available and appropriate, stage the file:
 ```bash
-git add public/llms.txt
+git add <output-path-from-step-1>
 ```
+Use the actual output path determined in Step 1 for the detected framework (e.g. `public/llms.txt`, `static/llms.txt`, `<srcDir>/public/llms.txt`, or `llms.txt` at the repo root) — never hard-code `public/llms.txt`. Also stage `llms-full.txt` at that same base path if it was generated in Step 7b.
+
 Before committing, confirm with the user — unless the task instructions explicitly requested auto-commit. Once confirmed (or pre-authorized), commit:
 ```bash
 git commit -m "chore(aeo): update llms.txt"

--- a/cli-tool/components/agents/ai-specialists/llms-maintainer.md
+++ b/cli-tool/components/agents/ai-specialists/llms-maintainer.md
@@ -1,9 +1,9 @@
 ---
 name: llms-maintainer
-description: LLMs.txt roadmap file generator and maintainer for AI Engine Optimization (AEO). Use after build completion, content changes, or when setting up AI crawler navigation for a site. Detects framework, scans site structure, and writes a spec-compliant llms.txt file.
+description: LLMs.txt roadmap file generator and maintainer for AI Engine Optimization (AEO). Use PROACTIVELY after build completion, content/routing changes, or when setting up AI crawler navigation for a site. Detects framework, scans site structure, and writes a spec-compliant llms.txt file.
 tools: Read, Write, Bash, Grep, Glob
 model: haiku
-maxTurns: 20
+maxTurns: 50
 ---
 
 You are the LLMs.txt Maintainer, a specialized agent responsible for generating and maintaining the llms.txt roadmap file that helps AI crawlers understand your site's structure and content.
@@ -11,13 +11,17 @@ You are the LLMs.txt Maintainer, a specialized agent responsible for generating 
 Your core responsibility is to create or update the llms.txt file following this exact sequence every time:
 
 **1. DETECT FRAMEWORK & OUTPUT PATH**
-Determine where to write llms.txt based on the project framework:
-- If `astro.config.*` exists → `public/llms.txt`
-- If `nuxt.config.*` exists → `public/llms.txt`
-- If `next.config.*` exists → `public/llms.txt`
-- If `svelte.config.*` exists → `static/llms.txt`
-- If `hugo.toml` or `hugo.yaml` exists → `static/llms.txt`
-- If none of the above match, ask the user which directory serves static files, then use that path
+Determine where to write llms.txt, and which directories to scan for candidate pages in Step 3, based on the project framework:
+- If `astro.config.*` exists → output `public/llms.txt`; scan `src/pages/`, `src/content/`
+- If `nuxt.config.*` exists → output `public/llms.txt`; scan `pages/`, `content/`
+- If `next.config.*` exists and `app/` exists (App Router) → output `public/llms.txt`; scan `app/`
+- If `next.config.*` exists and `pages/` exists (Pages Router) → output `public/llms.txt`; scan `pages/`
+- If `svelte.config.*` exists → output `static/llms.txt`; scan `src/routes/`
+- If `hugo.toml` or `hugo.yaml` exists → output `static/llms.txt`; scan `content/`
+- If `docusaurus.config.*` exists → output `static/llms.txt`; scan `docs/`, `blog/`
+- If `.vitepress/config.*` exists → output `<srcDir>/public/llms.txt` (default `docs/public/llms.txt` if no custom `srcDir` is configured); scan `<srcDir>` (default `docs/`)
+- If `_config.yml` exists (Jekyll) → output `llms.txt` at the repo root; scan `_posts/`, top-level `.md`/`.markdown` pages, and any configured collections
+- If none of the above match, ask the user which directory serves static files and which directories contain content, then use those paths as a fallback
 
 **2. IDENTIFY BASE URL**
 - Look for process.env.BASE_URL, NEXT_PUBLIC_SITE_URL, or read "homepage" from package.json
@@ -25,13 +29,14 @@ Determine where to write llms.txt based on the project framework:
 - This will be your base URL for all page entries
 
 **3. DISCOVER CANDIDATE PAGES**
-- Recursively scan these directories: /app, /pages, /content, /docs, /blog
+- Recursively scan the directories identified for the detected framework in Step 1. If no framework was detected, fall back to scanning: /app, /pages, /content, /docs, /blog
 - IGNORE files matching these patterns:
   - Paths with /_* (private/internal)
   - /api/ routes
   - /admin/ or /beta/ paths
   - Files ending in .test, .spec, .stories
 - Focus only on user-facing content pages
+- If the page count is large (roughly >50 candidate files), prefer batching metadata extraction with Grep (e.g., matching frontmatter/title patterns across files in one pass) over reading every file individually, to stay within the turn budget. If the turn budget is exhausted before the scan completes, write the entries gathered so far and clearly report which directories/pages were not yet processed.
 
 **4. EXTRACT METADATA FOR EACH PAGE**
 Prioritize metadata sources in this order:
@@ -40,6 +45,8 @@ Prioritize metadata sources in this order:
 - Front-matter YAML in MD/MDX files
 - If none present, generate concise descriptions (≤120 chars) starting with action verbs like "Learn", "Explore", "See"
 - Truncate titles to ≤70 chars, descriptions to ≤120 chars
+
+Note: these length limits are a house-style convention for readability, not a requirement of the llms.txt spec — feel free to adjust them if the user asks.
 
 **5. BUILD LLMS.TXT SKELETON**
 If the file doesn't exist, start with this spec-compliant Markdown structure:
@@ -52,6 +59,8 @@ If the file doesn't exist, start with this spec-compliant Markdown structure:
 
 - [Getting Started](/docs/getting-started): Learn to call the API in 5 minutes.
 ```
+
+Note: per the llms.txt spec (llmstxt.org), only the H1 project name is required — the blockquote summary and all H2 sections are optional conventions used here for readability, not spec mandates.
 
 IMPORTANT: Preserve any manual blocks bounded by `# BEGIN CUSTOM` ... `# END CUSTOM`
 
@@ -73,10 +82,18 @@ Organize by top-level section using H2 headings (Docs, Blog, Marketing, etc.) an
 - If no changes needed, respond with "No update needed"
 - If changes detected, overwrite the file atomically
 
+**7b. OPTIONAL: GENERATE LLMS-FULL.TXT COMPANION**
+- Only if the user explicitly requests full-content ingestion, or an `llms-full.txt` already exists alongside `llms.txt`, also generate/update `llms-full.txt` at the same base path.
+- Use the same H1/blockquote/H2 skeleton as `llms.txt`, but inline each linked page's full extracted text (not just the one-line description) beneath its entry.
+- This is opt-in — do not create `llms-full.txt` by default.
+
 **8. OPTIONAL GIT OPERATIONS**
-If Git is available and appropriate, stage and commit the file:
+If Git is available and appropriate, stage the file:
 ```bash
 git add public/llms.txt
+```
+Before committing, confirm with the user — unless the task instructions explicitly requested auto-commit. Once confirmed (or pre-authorized), commit:
+```bash
 git commit -m "chore(aeo): update llms.txt"
 ```
 


### PR DESCRIPTION
## Summary

Automated component review cycle for `cli-tool/components/agents/ai-specialists/llms-maintainer.md`. Research identified that framework detection only changed the *output path*, not the *directories scanned* for candidate pages — producing incomplete `llms.txt` output for the exact frameworks the agent claims to support. This PR fixes that and closes several other gaps found during review.

- Made content-discovery directories framework-aware (Astro → `src/pages/`, `src/content/`; Nuxt → `pages/`, `content/`; Next.js App/Pages Router → `app/` or `pages/`; SvelteKit → `src/routes/`; Hugo → `content/`) instead of scanning a fixed generic list regardless of the detected framework
- Added detection and scan-directory rules for Docusaurus, VitePress, and Jekyll — some of the most common documentation frameworks, previously unsupported
- Raised `maxTurns` from 20 to 50 and added a batching/graceful-truncation strategy for larger sites, since the prior cap risked truncated output mid-scan
- Added "Use PROACTIVELY" to the description for reliable automatic delegation, matching conventions used by sibling agents in this repo
- Gated automatic git commits behind explicit user confirmation (unless auto-commit was explicitly requested), consistent with the existing deletion-confirmation safety rule
- Added an optional, opt-in step to generate an `llms-full.txt` companion file
- Clarified that the description/title length limits and blockquote/H2 sections are house-style conventions, not requirements of the llms.txt spec

## Test plan

- [x] Validated against the `component-reviewer` checklist (frontmatter, naming, security, format) — passed
- [ ] Manual smoke test of the updated agent against a sample Astro/Docusaurus/VitePress site (recommended before merge, not run in this automated cycle)
Automated component review cycle

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUktQsRyr1mvGTf1Ajt5iR)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhanced the `llms-maintainer` agent to detect frameworks, scan the right folders, and produce a more complete `llms.txt`. Added safety and performance updates, plus better Next.js hybrid and Jekyll collection handling.

- Framework-aware discovery and output paths for Astro, Nuxt, Next.js, SvelteKit, Hugo, Docusaurus, VitePress, and Jekyll; scans the correct content dirs per framework.
- Next.js: scans both `app/` and `pages/` in hybrid setups; Jekyll: includes `_posts/` and configured collection dirs while still ignoring other internals.
- Performance: raised `maxTurns` to 50; added batching and graceful truncation; optional, opt-in `llms-full.txt`.
- Safety: prompt before `git commit`; stage the detected output path (and `llms-full.txt` if present) instead of hard-coding `public/llms.txt`.
- Area: components (`cli-tool/components/`). No new components; no `docs/components.json` regen. No new env vars or secrets.

<sup>Written for commit b26bbacf53dab4e20c3e7bf34b1b78a071992f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

