### PR TITLE
Add HumanPen MCP under productivity

### DIFF
--- a/cli-tool/components/mcps/productivity/humanpen.json
+++ b/cli-tool/components/mcps/productivity/humanpen.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "humanpen": {
+      "description": "Lower a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact.",
+      "command": "npx",
+      "args": ["-y", "humanpen-mcp"],
+      "env": {
+        "HUMANPEN_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}

--- a/cli-tool/components/mcps/productivity/humanpen.json
+++ b/cli-tool/components/mcps/productivity/humanpen.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "humanpen": {
-      "description": "Lower a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact.",
+      "description": "Document-level AI humanizer — rewrite a whole .docx/.pptx, selected passages, or Turnitin/iThenticate-flagged text in place, keeping formatting, tables, citations and formulas intact.",
       "command": "npx",
       "args": ["-y", "humanpen-mcp"],
       "env": {


### PR DESCRIPTION
Adds an `ai-services`-style MCP component under `cli-tool/components/mcps/productivity/humanpen.json`.

[HumanPen](https://github.com/humanpen/humanpen-mcp) lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact. Standard stdio server (`npx -y humanpen-mcp`, `HUMANPEN_API_KEY`), in the official MCP Registry as `io.github.humanpen/humanpen-mcp`. Apache-2.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the HumanPen MCP under productivity to run `humanpen-mcp` for humanizing .docx/.pptx documents while preserving content and formatting. Uses a stdio server via `npx` and requires an API key; clarified that PDF is not supported.

- Area: components (`cli-tool/components/`); added `cli-tool/components/mcps/productivity/humanpen.json`.
- New MCP: `humanpen` (MCP Registry: `io.github.humanpen/humanpen-mcp`) executed with `npx -y humanpen-mcp`.
- Env: requires `HUMANPEN_API_KEY`.
- Catalog: new component added; regenerate `docs/components.json`.

<sup>Written for commit d136edc408b82decab22c87466753bd48def3d75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

