### PR TITLE
Add current MiniMax provider setting

### DIFF
--- a/cli-tool/components/settings/partnerships/minimax-provider.json
+++ b/cli-tool/components/settings/partnerships/minimax-provider.json
@@ -1,0 +1,10 @@
+{
+  "description": "MiniMax AI Provider - Configure Claude Code to use MiniMax's Anthropic-compatible API. MiniMax-M3 supports a 1,000,000-token context window and text, image, and video input. MiniMax-M2.7 remains available as an alternative. Requires a MiniMax API key from https://platform.minimax.io",
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "YOUR-MINIMAX-API-KEY",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M3",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M3"
+  }
+}

--- a/cli-tool/tests/unit/minimax-provider.test.js
+++ b/cli-tool/tests/unit/minimax-provider.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('MiniMax provider setting', () => {
+  const settingPath = path.join(
+    __dirname,
+    '../../components/settings/partnerships/minimax-provider.json'
+  );
+  let setting;
+
+  beforeAll(() => {
+    setting = JSON.parse(fs.readFileSync(settingPath, 'utf8'));
+  });
+
+  test('uses the international Anthropic-compatible endpoint', () => {
+    expect(setting.env.ANTHROPIC_BASE_URL).toBe(
+      'https://api.minimax.io/anthropic'
+    );
+  });
+
+  test('uses a safe API key placeholder', () => {
+    expect(setting.env.ANTHROPIC_AUTH_TOKEN).toBe('YOUR-MINIMAX-API-KEY');
+  });
+
+  test('maps current MiniMax models to Claude model classes', () => {
+    expect(setting.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('MiniMax-M2.7');
+    expect(setting.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('MiniMax-M3');
+    expect(setting.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('MiniMax-M3');
+  });
+
+  test('documents the MiniMax-M3 context window', () => {
+    expect(setting.description).toContain('1,000,000-token context window');
+    expect(setting.description).not.toMatch(/512K/i);
+  });
+
+  test.each(['text', 'image', 'video'])(
+    'documents %s input support',
+    (modality) => {
+      expect(setting.description).toMatch(
+        new RegExp(`\\b${modality}\\b`, 'i')
+      );
+    }
+  );
+
+  test('documents where to obtain an API key', () => {
+    expect(setting.description).toContain('https://platform.minimax.io');
+  });
+});


### PR DESCRIPTION
Reason: Open PR #547 adds MiniMax-M3 but still documents a 512K context window and omits the current text/image/video input capability.

## Summary

- Add an installable MiniMax provider setting for the international Anthropic-compatible endpoint.
- Map the current MiniMax-M3 and MiniMax-M2.7 model names.
- Document MiniMax-M3's 1,000,000-token context window and text, image, and video input support.

## Checks

- `npx --yes jest@30.0.4 --config <inline-config> --runInBand tests/unit/minimax-provider.test.js`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MiniMax provider setting for the Anthropic-compatible endpoint with current model mapping. Corrects docs to show MiniMax-M3’s 1,000,000-token context and text/image/video input.

- Area: components (`cli-tool/components/`); new provider config at `components/settings/partnerships/minimax-provider.json`. Regenerate `docs/components.json`.
- Uses `https://api.minimax.io/anthropic`; maps `MiniMax-M3` to Sonnet/Opus and `MiniMax-M2.7` to Haiku.
- Updates description with current context window and multimodal input support.
- New env vars/secrets: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` (MiniMax API key). Defaults set: `ANTHROPIC_DEFAULT_HAIKU_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`.
- Tests added: `cli-tool/tests/unit/minimax-provider.test.js`.

<sup>Written for commit 0057e602ad416ef185c71657fe838dc2f558e8a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

