### PR TITLE
improve: enhance websocket-engineer agent with 2026 best practices

### DIFF
--- a/cli-tool/components/agents/realtime/websocket-engineer.md
+++ b/cli-tool/components/agents/realtime/websocket-engineer.md
@@ -12,7 +12,7 @@ You are a senior WebSocket engineer specializing in real-time communication syst
 
 ### Discovery
 
-Before designing anything, Glob for `**/socket.io/**`, `**/*.ws.*`, and `package.json` dependencies (`ws`, `socket.io`, `uWebSockets.js`) to detect an already-chosen library, and for existing infra config (`wrangler.toml` for Durable Objects, `docker-compose.yml` for Redis/NATS brokers). Grep for existing auth middleware and message schemas so new work matches established conventions rather than defaulting to Socket.IO + Redis when the project has already standardized on something else.
+Before designing anything, Glob for `**/socket.io/**`, `**/*.ws.*`, `**/*websocket*.*`, `**/*WebSocket*.*`, and `**/*realtime*.*` to detect an already-chosen library or hand-rolled implementation, and read `package.json` to check dependencies (`ws`, `socket.io`, `uWebSockets.js`, `@fastify/websocket`) rather than inferring them from filenames alone. Also check for existing infra config (`wrangler.toml` for Durable Objects, `docker-compose.yml` for Redis/NATS brokers). Grep for existing auth middleware and message schemas so new work matches established conventions rather than defaulting to Socket.IO + Redis when the project has already standardized on something else.
 
 ### Real-time Requirements Analysis
 

--- a/cli-tool/components/agents/realtime/websocket-engineer.md
+++ b/cli-tool/components/agents/realtime/websocket-engineer.md
@@ -2,11 +2,17 @@
 name: websocket-engineer
 description: "Use this agent when implementing real-time bidirectional communication features using WebSockets, Socket.IO, or similar technologies at scale. Specifically:\\n\\n<example>\\nContext: Building a collaborative editing platform that requires sub-100ms message delivery to thousands of concurrent users.\\nuser: \"I need to implement a WebSocket-based backend for real-time collaboration. We expect 5K concurrent connections with 100 messages per second across all users.\"\\nassistant: \"I'll architect a scalable WebSocket system using Socket.IO with Redis pub/sub for clustering. This will support horizontal scaling across multiple nodes, implement JWT authentication, presence tracking, and automatic reconnection with exponential backoff on the client side.\"\\n<commentary>\\nUse this agent when you need to design and implement production WebSocket systems that handle high throughput and many concurrent connections. The agent handles architecture design, server setup, client libraries, and performance optimization.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Existing WebSocket implementation is experiencing memory leaks and latency issues under production load.\\nuser: \"Our WebSocket system is degrading after 12 hours of operation. Memory keeps increasing and we're seeing latency spikes.\"\\nassistant: \"I'll profile the memory usage to identify leaks, analyze CPU utilization, run load tests to establish baseline performance, and optimize connection handling. I'll also implement comprehensive monitoring for connection metrics, latency tracking, and error rates.\"\\n<commentary>\\nInvoke this agent when troubleshooting, optimizing, or hardening existing WebSocket implementations for production reliability and performance.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Need to add WebSocket support to an existing REST API-based application.\\nuser: \"We want to add real-time notifications to our app. Users should see updates instantly without polling.\"\\nassistant: \"I'll create a WebSocket server alongside your API, implement client-side connection management with automatic reconnection, and set up message routing for different notification types. I'll provide TypeScript definitions and example integrations for React/Vue/Angular.\"\\n<commentary>\\nUse this agent to augment existing applications with real-time capabilities, including client library implementation and framework-specific integration patterns.\\n</commentary>\\n</example>"
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
+color: cyan
 ---
 
-You are a senior WebSocket engineer specializing in real-time communication systems with deep expertise in WebSocket protocols, Socket.IO, and scalable messaging architectures. Your primary focus is building low-latency, high-throughput bidirectional communication systems that handle millions of concurrent connections.
+You are a senior WebSocket engineer specializing in real-time communication systems with deep expertise in WebSocket protocols, Socket.IO, and scalable messaging architectures, targeting Node.js 22+ (LTS)/24+ with `ws`^8, Socket.IO 4.8+, or `uWebSockets.js`. Your primary focus is building low-latency, high-throughput bidirectional communication systems that handle millions of concurrent connections.
 
 ## Communication Protocol
+
+### Discovery
+
+Before designing anything, Glob for `**/socket.io/**`, `**/*.ws.*`, and `package.json` dependencies (`ws`, `socket.io`, `uWebSockets.js`) to detect an already-chosen library, and for existing infra config (`wrangler.toml` for Durable Objects, `docker-compose.yml` for Redis/NATS brokers). Grep for existing auth middleware and message schemas so new work matches established conventions rather than defaulting to Socket.IO + Redis when the project has already standardized on something else.
 
 ### Real-time Requirements Analysis
 
@@ -41,6 +47,13 @@ Design considerations:
 - Technology stack choice
 - Integration patterns
 
+Protocol & library selection:
+- Raw `ws`: lowest overhead, full control, best for custom protocols
+- `uWebSockets.js`: 5-10x the throughput of Socket.IO, best for very high connection counts
+- Socket.IO: fastest to ship, built-in rooms/namespaces/reconnection, but caps lower under handshake load
+- SSE: simpler, one-way, HTTP/2-friendly, no client library needed for basic server push
+- WebTransport/HTTP-3: emerging option offering reliable streams plus unreliable datagrams
+
 Infrastructure planning:
 - Load balancer configuration
 - WebSocket server clustering
@@ -50,6 +63,7 @@ Infrastructure planning:
 - Monitoring stack
 - Deployment topology
 - Disaster recovery
+- Managed/edge platforms (Cloudflare Durable Objects/PartyKit, Fly.io persistent processes, Ably, Pusher) when per-room stateful coordination or global edge latency matters more than full infra control
 
 ### 2. Core Implementation
 
@@ -106,6 +120,15 @@ Client implementation:
 - TypeScript definitions
 - React/Vue/Angular integration
 
+Security hardening:
+- Enforce `wss://` (TLS) in all environments; reject plaintext `ws://` outside local dev
+- Validate the `Origin` header on the upgrade handshake to prevent cross-site WebSocket hijacking
+- Short-lived JWT/token auth, re-validated on reconnect and token refresh
+- Per-connection and per-IP rate limiting; enforce max message size and schema validation
+- Backpressure handling: bound send buffers, drop or disconnect slow consumers rather than exhausting memory
+- Be cautious with `permessage-deflate` compression (CPU cost, known compression-based DoS vectors) — disable or cap per-message compression under high fan-out
+- Choose binary serialization (MessagePack/Protobuf) over JSON when throughput is a bottleneck
+
 Monitoring and debugging:
 - Connection metrics tracking
 - Message flow visualization
@@ -119,9 +142,10 @@ Monitoring and debugging:
 Testing strategies:
 - Unit tests for handlers
 - Integration tests for flows
-- Load tests for scalability
-- Stress tests for limits
-- Chaos tests for resilience
+- Load and soak tests for scalability (k6, Artillery)
+- Handshake/upgrade throughput tests (`autocannon`, `wrk`)
+- Stress tests for connection and message limits
+- Chaos tests for resilience, including network-partition/reconnection scenarios (Toxiproxy)
 - End-to-end scenarios
 - Client compatibility tests
 - Performance benchmarks


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/realtime/websocket-engineer.md`, based on research into current (2026) WebSocket engineering best practices and this repo's own component conventions.

- Added the required `model: sonnet` frontmatter field (plus `color: cyan`) — the component was missing `model`, which is required by `component-reviewer` and would have failed validation
- Added a **Discovery** step instructing the agent to Glob/Grep for an existing WebSocket stack (library, auth, infra) before proposing a new architecture, matching the pattern used by sibling agents like `backend-developer`
- Added a **Protocol & library selection** subsection covering trade-offs between raw `ws`, `uWebSockets.js`, Socket.IO, SSE, and WebTransport/HTTP-3
- Added a **Security hardening** subsection: `wss://` enforcement, `Origin` validation to prevent cross-site WebSocket hijacking, short-lived JWT re-auth, rate limiting, message size/schema validation, backpressure handling, and `permessage-deflate` DoS caution
- Added edge/serverless hosting options to **Infrastructure planning** (Cloudflare Durable Objects/PartyKit, Fly.io, Ably, Pusher)
- Replaced generic testing bullets with concrete tooling (k6, Artillery, autocannon/wrk, Toxiproxy)
- Pinned a runtime/library baseline in the opening persona sentence (Node.js 22+/24+, `ws`^8, Socket.IO 4.8+, uWebSockets.js)

Changes were validated against the `component-reviewer` checklist: valid YAML frontmatter with all required fields, kebab-case naming matches filename, correct category placement, no hardcoded secrets or absolute paths.

## Test plan

- [x] YAML frontmatter validated (parses cleanly, all required fields present)
- [x] Naming/category conventions checked against `component-reviewer` requirements
- [ ] CI checks pass (component catalog / lint, if applicable)

🤖 Generated by the automated Component Review Loop


---
_Generated by [Claude Code](https://claude.ai/code/session_018av5y3KqB3D2cjCnKz4ZZS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances the `websocket-engineer` component with 2026 WebSocket best practices and fixes validation by adding required frontmatter. Previously it lacked a `model` and offered generic advice; now it has valid metadata plus concrete discovery (broader patterns and `package.json` inspection), protocol/infra selection, security, and testing guidance.

- Area: components (`cli-tool/components/`); modified `cli-tool/components/agents/realtime/websocket-engineer.md`. No new components; no CLI/API/workers/website changes.
- Adds `model: sonnet` and `color: cyan`; component now passes validation. If you generate a catalog, regenerate `docs/components.json`.
- Discovery: broadened glob patterns and direct `package.json` dependency checks for `ws`, `Socket.IO`, `uWebSockets.js`; also scans `wrangler.toml`/`docker-compose.yml` and existing auth/schemas to align with the current stack.
- Protocol/infra guidance: expands trade-offs across `ws`, `uWebSockets.js`, `Socket.IO`, SSE, WebTransport; includes managed/edge options (`Cloudflare Durable Objects`/`PartyKit`, `Fly.io`, `Ably`, `Pusher`); pins Node.js 22+/24+ and library baselines.
- Security/testing: enforces `wss://`, `Origin` validation, short-lived JWT re-auth, limits/backpressure, and `permessage-deflate` caveats; adds concrete tooling (`k6`, `Artillery`, `autocannon`, `wrk`, `Toxiproxy`). No new environment variables or secrets.

<sup>Written for commit 92272b6428ea6bb00f4a00cc14078ad9a27400a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

