### PR TITLE
feat(mcp): add Agent Guild and validate remote transports

### DIFF
--- a/cli-tool/components/mcps/integration/agent-guild.json
+++ b/cli-tool/components/mcps/integration/agent-guild.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "agent-guild": {
+      "description": "Vet AI agents and endpoints before delegating work or money with live preflight checks, evidence-backed reputation, and signed payment-safety decisions. Hosted remote server; no API key required.",
+      "type": "http",
+      "url": "https://agent-guild-5d5r.onrender.com/mcp"
+    }
+  }
+}

--- a/cli-tool/components/mcps/integration/agent-guild.json
+++ b/cli-tool/components/mcps/integration/agent-guild.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "agent-guild": {
-      "description": "Vet AI agents and endpoints before delegating work or money with live preflight checks, evidence-backed reputation, and signed payment-safety decisions. Hosted remote server; no API key required.",
+      "description": "Vet AI agents and endpoints before delegating work or money with live preflight checks, evidence-backed reputation, and signed payment-safety decisions. Hosted remote server; no API key required; optional paid operations use x402.",
       "type": "http",
       "url": "https://agent-guild-5d5r.onrender.com/mcp"
     }

--- a/cli-tool/src/health-check.js
+++ b/cli-tool/src/health-check.js
@@ -644,6 +644,51 @@ class HealthChecker {
     }
   }
 
+  /**
+   * Validate the transport shape of one MCP server entry.
+   * Returns null when the entry is a valid local (stdio) or remote (http/sse)
+   * server definition, otherwise a short issue description.
+   */
+  validateMCPServerTransport(serverConfig) {
+    const hasCommand = typeof serverConfig.command === 'string' && serverConfig.command.trim() !== '';
+    const hasUrl = typeof serverConfig.url === 'string' && serverConfig.url.trim() !== '';
+    const type = serverConfig.type;
+
+    if (type !== undefined && !['stdio', 'http', 'sse'].includes(type)) {
+      return `Unsupported transport type "${type}"`;
+    }
+
+    if (type === 'http' || type === 'sse') {
+      if (!hasUrl) {
+        return `Missing url for ${type} transport`;
+      }
+    } else if (type === 'stdio') {
+      if (!hasCommand) {
+        return 'Missing command for stdio transport';
+      }
+    } else if (!hasCommand && !hasUrl) {
+      return 'Missing command';
+    }
+
+    if (hasUrl) {
+      let parsed;
+      try {
+        parsed = new URL(serverConfig.url);
+      } catch (error) {
+        return 'Invalid url';
+      }
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return 'Invalid url (must be http or https)';
+      }
+      if (serverConfig.headers !== undefined &&
+          (serverConfig.headers === null || typeof serverConfig.headers !== 'object' || Array.isArray(serverConfig.headers))) {
+        return 'Invalid headers format';
+      }
+    }
+
+    return null;
+  }
+
   checkMCPConfigurationSyntax() {
     const configPaths = [
       path.join(process.cwd(), '.mcp.json')
@@ -672,10 +717,13 @@ class HealthChecker {
                 continue;
               }
               
-              // Check required fields
-              if (!serverConfig.command) {
+              // Check required fields. Claude Code supports local stdio servers
+              // (`command` + optional `args`/`env`) and remote servers
+              // (`url` with `type` "http" or "sse", optional `headers`).
+              const transportIssue = this.validateMCPServerTransport(serverConfig);
+              if (transportIssue) {
                 invalidServers++;
-                issues.push(`Missing command for ${serverName} in ${path.basename(configPath)}`);
+                issues.push(`${transportIssue} for ${serverName} in ${path.basename(configPath)}`);
                 continue;
               }
               
@@ -1361,7 +1409,7 @@ class HealthChecker {
         } else if (result.check === 'MCP Config Syntax' && result.message.includes('Invalid JSON')) {
           recommendations.push('Fix JSON syntax errors in MCP configuration files');
         } else if (result.check === 'MCP Config Syntax' && result.message.includes('Missing command')) {
-          recommendations.push('Add missing command fields to MCP server configurations');
+          recommendations.push('Add a command (stdio) or url with type http/sse to each MCP server configuration');
         } else if (result.check === 'Local Hooks' && result.message.includes('Invalid JSON')) {
           recommendations.push('Fix JSON syntax error in .claude/settings.local.json');
         }

--- a/cli-tool/src/health-check.js
+++ b/cli-tool/src/health-check.js
@@ -645,48 +645,152 @@ class HealthChecker {
   }
 
   /**
-   * Validate the transport shape of one MCP server entry.
-   * Returns null when the entry is a valid local (stdio) or remote (http/sse)
-   * server definition, otherwise a short issue description.
+   * Scan a string for Claude Code environment-variable templates
+   * (`${VAR}` and `${VAR:-default}`, see "Environment variable expansion in
+   * .mcp.json"). This is a syntax check only: process.env is never read, so
+   * no secret or machine-specific value is resolved or exposed.
+   *
+   * Returns { malformed, unresolved, expanded } where `expanded` is the
+   * string with every `${VAR:-default}` replaced by its default and every
+   * bare `${VAR}` replaced by an empty string, and `unresolved` lists the
+   * variables that have no default (their real value is unknown here).
+   */
+  inspectEnvTemplates(value) {
+    const unresolved = [];
+    let expanded = '';
+    let rest = value;
+
+    for (;;) {
+      const open = rest.indexOf('${');
+      if (open === -1) {
+        expanded += rest;
+        break;
+      }
+      const close = rest.indexOf('}', open);
+      if (close === -1) {
+        return { malformed: true, unresolved, expanded: value };
+      }
+      const match = /^([A-Za-z_][A-Za-z0-9_]*)(?::-(.*))?$/s.exec(rest.slice(open + 2, close));
+      if (!match) {
+        return { malformed: true, unresolved, expanded: value };
+      }
+      expanded += rest.slice(0, open);
+      if (match[2] !== undefined) {
+        expanded += match[2];
+      } else {
+        unresolved.push(match[1]);
+      }
+      rest = rest.slice(close + 1);
+    }
+
+    return { malformed: false, unresolved, expanded };
+  }
+
+  /**
+   * Validate the transport shape of one MCP server entry against the shapes
+   * Claude Code documents for `.mcp.json`:
+   *   - local stdio servers: `command` (+ optional `args`/`env`);
+   *   - remote servers: `url` with `type` "http" (alias "streamable-http"),
+   *     "sse" or "ws", optional `headers`.
+   * A `url` entry without `type` is a documented configuration error (Claude
+   * Code reads it as stdio and skips it), so it is reported as an issue.
+   *
+   * Returns null when the entry is valid, `{ issue }` when it is invalid, or
+   * `{ warning }` when it is syntactically valid but its url depends on an
+   * environment variable without a default and therefore cannot be verified
+   * here.
    */
   validateMCPServerTransport(serverConfig) {
     const hasCommand = typeof serverConfig.command === 'string' && serverConfig.command.trim() !== '';
     const hasUrl = typeof serverConfig.url === 'string' && serverConfig.url.trim() !== '';
-    const type = serverConfig.type;
+    const remoteSchemes = {
+      http: ['http:', 'https:'],
+      sse: ['http:', 'https:'],
+      ws: ['ws:', 'wss:']
+    };
+    const typeAliases = { 'streamable-http': 'http' };
 
-    if (type !== undefined && !['stdio', 'http', 'sse'].includes(type)) {
-      return `Unsupported transport type "${type}"`;
+    let type = serverConfig.type;
+    if (type !== undefined) {
+      if (typeof type !== 'string') {
+        // Never interpolate a non-string value: an object such as
+        // {toString: null} would throw inside the template string.
+        return { issue: 'Unsupported transport type (must be a string)' };
+      }
+      type = typeAliases[type] || type;
+      if (type !== 'stdio' && !remoteSchemes[type]) {
+        return { issue: `Unsupported transport type "${serverConfig.type}"` };
+      }
     }
 
-    if (type === 'http' || type === 'sse') {
-      if (!hasUrl) {
-        return `Missing url for ${type} transport`;
+    if (type === undefined) {
+      if (hasUrl) {
+        return { issue: 'Missing type for url server (add "type": "http", "sse" or "ws")' };
       }
-    } else if (type === 'stdio') {
       if (!hasCommand) {
-        return 'Missing command for stdio transport';
+        return { issue: 'Missing command' };
       }
-    } else if (!hasCommand && !hasUrl) {
-      return 'Missing command';
+      return null;
     }
 
-    if (hasUrl) {
+    if (type === 'stdio') {
+      if (!hasCommand) {
+        return { issue: 'Missing command for stdio transport' };
+      }
+      return null;
+    }
+
+    // Remote transport (http / sse / ws)
+    if (!hasUrl) {
+      return { issue: `Missing url for ${serverConfig.type} transport` };
+    }
+    if (serverConfig.headers !== undefined) {
+      const headers = serverConfig.headers;
+      if (headers === null || typeof headers !== 'object' || Array.isArray(headers)) {
+        return { issue: 'Invalid headers format' };
+      }
+      // Header values are literal strings or `${VAR}` templates; anything
+      // else (object, array, number, null) is not a header value.
+      for (const [headerName, headerValue] of Object.entries(headers)) {
+        if (typeof headerValue !== 'string') {
+          return { issue: `Invalid headers format (value of "${headerName}" must be a string)` };
+        }
+      }
+    }
+
+    const templates = this.inspectEnvTemplates(serverConfig.url);
+    if (templates.malformed) {
+      return { issue: 'Invalid url (malformed ${VAR} template)' };
+    }
+
+    const allowedSchemes = remoteSchemes[type];
+    const schemeList = allowedSchemes.map(scheme => scheme.slice(0, -1)).join(' or ');
+
+    if (templates.unresolved.length === 0) {
+      // Literal url, or every template has a default: validate the resolved form.
       let parsed;
       try {
-        parsed = new URL(serverConfig.url);
+        parsed = new URL(templates.expanded);
       } catch (error) {
-        return 'Invalid url';
+        return { issue: 'Invalid url' };
       }
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        return 'Invalid url (must be http or https)';
+      if (!allowedSchemes.includes(parsed.protocol)) {
+        return { issue: `Invalid url (must be ${schemeList})` };
       }
-      if (serverConfig.headers !== undefined &&
-          (serverConfig.headers === null || typeof serverConfig.headers !== 'object' || Array.isArray(serverConfig.headers))) {
-        return 'Invalid headers format';
-      }
+      return null;
     }
 
-    return null;
+    // The url depends on an environment variable with no default. Only the
+    // part that is literal can be checked: when a scheme appears before the
+    // first template (or in a leading default), it must match the transport.
+    const literalScheme = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(templates.expanded);
+    if (literalScheme && !allowedSchemes.includes(`${literalScheme[1].toLowerCase()}:`)) {
+      return { issue: `Invalid url (must be ${schemeList})` };
+    }
+    return {
+      warning: `url depends on environment variable${templates.unresolved.length > 1 ? 's' : ''} ` +
+        `${templates.unresolved.map(name => '${' + name + '}').join(', ')} (not verified)`
+    };
   }
 
   checkMCPConfigurationSyntax() {
@@ -697,7 +801,9 @@ class HealthChecker {
     let totalServers = 0;
     let validServers = 0;
     let invalidServers = 0;
+    let unverifiedServers = 0;
     const issues = [];
+    const warnings = [];
     
     for (const configPath of configPaths) {
       if (fs.existsSync(configPath)) {
@@ -719,12 +825,17 @@ class HealthChecker {
               
               // Check required fields. Claude Code supports local stdio servers
               // (`command` + optional `args`/`env`) and remote servers
-              // (`url` with `type` "http" or "sse", optional `headers`).
-              const transportIssue = this.validateMCPServerTransport(serverConfig);
-              if (transportIssue) {
+              // (`url` with `type` "http"/"streamable-http", "sse" or "ws",
+              // optional `headers`).
+              const transport = this.validateMCPServerTransport(serverConfig);
+              if (transport && transport.issue) {
                 invalidServers++;
-                issues.push(`${transportIssue} for ${serverName} in ${path.basename(configPath)}`);
+                issues.push(`${transport.issue} for ${serverName} in ${path.basename(configPath)}`);
                 continue;
+              }
+              if (transport && transport.warning) {
+                unverifiedServers++;
+                warnings.push(`${transport.warning} for ${serverName} in ${path.basename(configPath)}`);
               }
               
               // Optional: Check if args is array when present
@@ -757,7 +868,12 @@ class HealthChecker {
       };
     }
     
-    if (invalidServers === 0) {
+    if (invalidServers === 0 && unverifiedServers > 0) {
+      return {
+        status: 'warn',
+        message: `All ${totalServers} MCP server configurations are valid; ${unverifiedServers} use unresolved environment variables in url (not verified)`
+      };
+    } else if (invalidServers === 0) {
       return {
         status: 'pass',
         message: `All ${totalServers} MCP server configurations are valid`
@@ -1409,7 +1525,7 @@ class HealthChecker {
         } else if (result.check === 'MCP Config Syntax' && result.message.includes('Invalid JSON')) {
           recommendations.push('Fix JSON syntax errors in MCP configuration files');
         } else if (result.check === 'MCP Config Syntax' && result.message.includes('Missing command')) {
-          recommendations.push('Add a command (stdio) or url with type http/sse to each MCP server configuration');
+          recommendations.push('Add a command (stdio) or url with type http, sse or ws to each MCP server configuration');
         } else if (result.check === 'Local Hooks' && result.message.includes('Invalid JSON')) {
           recommendations.push('Fix JSON syntax error in .claude/settings.local.json');
         }

--- a/cli-tool/src/health-check.js
+++ b/cli-tool/src/health-check.js
@@ -868,10 +868,11 @@ class HealthChecker {
       };
     }
     
+    const warningDetails = warnings.length > 0 ? `; ${warnings.join('; ')}` : '';
     if (invalidServers === 0 && unverifiedServers > 0) {
       return {
         status: 'warn',
-        message: `All ${totalServers} MCP server configurations are valid; ${unverifiedServers} use unresolved environment variables in url (not verified)`
+        message: `All ${totalServers} MCP server configurations are valid; ${unverifiedServers} use unresolved environment variables in url (not verified)${warningDetails}`
       };
     } else if (invalidServers === 0) {
       return {
@@ -881,12 +882,12 @@ class HealthChecker {
     } else if (validServers > 0) {
       return {
         status: 'warn',
-        message: `${validServers}/${totalServers} MCP servers valid, ${invalidServers} issues found`
+        message: `${validServers}/${totalServers} MCP servers valid, ${invalidServers} issues found${warningDetails}`
       };
     } else {
       return {
         status: 'fail',
-        message: `All ${totalServers} MCP server configurations have issues`
+        message: `All ${totalServers} MCP server configurations have issues${warningDetails}`
       };
     }
   }

--- a/cli-tool/tests/unit/health-check-mcp-syntax.test.js
+++ b/cli-tool/tests/unit/health-check-mcp-syntax.test.js
@@ -74,10 +74,12 @@ describe('HealthChecker.checkMCPConfigurationSyntax', () => {
         fullUrl: { type: 'http', url: '${MCP_URL}' },
         hostPort: { type: 'http', url: 'https://${MCP_HOST}:${MCP_PORT}/mcp' }
       });
-      expect(run()).toEqual({
-        status: 'warn',
-        message: 'All 2 MCP server configurations are valid; 2 use unresolved environment variables in url (not verified)'
-      });
+      const result = run();
+      expect(result.status).toBe('warn');
+      expect(result.message).toContain('2 use unresolved environment variables in url (not verified)');
+      expect(result.message).toContain('${MCP_URL} (not verified) for fullUrl in .mcp.json');
+      expect(result.message).toContain('${MCP_HOST}, ${MCP_PORT} (not verified) for hostPort in .mcp.json');
+      expect(result.message).not.toContain(process.env.MCP_URL);
     } finally {
       if (previous === undefined) {
         delete process.env.MCP_URL;
@@ -95,7 +97,10 @@ describe('HealthChecker.checkMCPConfigurationSyntax', () => {
       badName: { type: 'http', url: 'https://${1HOST}/mcp' },
       ok: { type: 'sse', url: 'https://${MCP_HOST}/sse' }
     });
-    expect(run()).toEqual({ status: 'warn', message: '1/5 MCP servers valid, 4 issues found' });
+    const result = run();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('1/5 MCP servers valid, 4 issues found');
+    expect(result.message).toContain('${MCP_HOST} (not verified) for ok in .mcp.json');
   });
 
   test('reports a url without type as a configuration error (Claude Code skips it)', () => {

--- a/cli-tool/tests/unit/health-check-mcp-syntax.test.js
+++ b/cli-tool/tests/unit/health-check-mcp-syntax.test.js
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for HealthChecker.checkMCPConfigurationSyntax().
+ *
+ * Claude Code MCP servers are either local stdio servers (`command`) or remote
+ * servers (`url` with `type` "http" or "sse"). The check used to require
+ * `command` for every server, so every remote catalog entry (e.g. sentry,
+ * huggingface, agent-guild) was reported as "Missing command".
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { HealthChecker } = require('../../src/health-check');
+
+describe('HealthChecker.checkMCPConfigurationSyntax', () => {
+  let tmpDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cct-health-mcp-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeConfig(mcpServers) {
+    fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify({ mcpServers }, null, 2));
+  }
+
+  function run() {
+    return new HealthChecker().checkMCPConfigurationSyntax();
+  }
+
+  test('accepts a local stdio server with command/args/env', () => {
+    writeConfig({ local: { command: 'npx', args: ['-y', 'some-server'], env: { KEY: 'value' } } });
+    expect(run()).toEqual({ status: 'pass', message: 'All 1 MCP server configurations are valid' });
+  });
+
+  test('accepts remote servers: explicit http, explicit sse, and url without type', () => {
+    writeConfig({
+      'agent-guild': { type: 'http', url: 'https://agent-guild-5d5r.onrender.com/mcp' },
+      devplan: { type: 'sse', url: 'https://mcp.devplanmcp.store/sse' },
+      sentry: { url: 'https://mcp.sentry.dev/mcp' },
+      authenticated: { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: 'Bearer ${TOKEN}' } }
+    });
+    expect(run()).toEqual({ status: 'pass', message: 'All 4 MCP server configurations are valid' });
+  });
+
+  test('still rejects a server with neither command nor url', () => {
+    writeConfig({ empty: {} });
+    expect(run()).toEqual({ status: 'fail', message: 'All 1 MCP server configurations have issues' });
+  });
+
+  test('rejects malformed remote definitions', () => {
+    writeConfig({
+      noUrl: { type: 'http' },
+      wrongTransport: { type: 'stdio', url: 'https://example.com/mcp' },
+      unsupportedType: { type: 'ws', url: 'wss://example.com' },
+      badScheme: { url: 'ftp://example.com/mcp' },
+      notAUrl: { type: 'sse', url: 'not a url' },
+      badHeaders: { type: 'http', url: 'https://example.com/mcp', headers: ['x'] }
+    });
+    expect(run()).toEqual({ status: 'fail', message: 'All 6 MCP server configurations have issues' });
+  });
+
+  test('keeps the existing args/env format checks for stdio servers', () => {
+    writeConfig({
+      badArgs: { command: 'npx', args: 'not-an-array' },
+      badEnv: { command: 'npx', env: 'not-an-object' },
+      fine: { command: 'npx' }
+    });
+    expect(run()).toEqual({ status: 'warn', message: '1/3 MCP servers valid, 2 issues found' });
+  });
+
+  test('warns when no servers are configured', () => {
+    writeConfig({});
+    expect(run()).toEqual({ status: 'warn', message: 'No MCP servers configured' });
+  });
+});

--- a/cli-tool/tests/unit/health-check-mcp-syntax.test.js
+++ b/cli-tool/tests/unit/health-check-mcp-syntax.test.js
@@ -1,10 +1,17 @@
 /**
  * Regression tests for HealthChecker.checkMCPConfigurationSyntax().
  *
- * Claude Code MCP servers are either local stdio servers (`command`) or remote
- * servers (`url` with `type` "http" or "sse"). The check used to require
- * `command` for every server, so every remote catalog entry (e.g. sentry,
- * huggingface, agent-guild) was reported as "Missing command".
+ * Claude Code MCP servers in .mcp.json are either local stdio servers
+ * (`command`) or remote servers (`url` with `type` "http" — alias
+ * "streamable-http" — "sse" or "ws"). The check used to require `command`
+ * for every server, so every remote catalog entry (e.g. agent-guild, devplan)
+ * was reported as "Missing command".
+ *
+ * Claude Code also expands `${VAR}` / `${VAR:-default}` templates inside
+ * `url`. The check must accept that syntax without reading the environment,
+ * and must not report a url it cannot resolve as verified.
+ *
+ * All fixtures are temp-dir files; no network, no environment lookups.
  */
 const fs = require('fs');
 const os = require('os');
@@ -40,14 +47,80 @@ describe('HealthChecker.checkMCPConfigurationSyntax', () => {
     expect(run()).toEqual({ status: 'pass', message: 'All 1 MCP server configurations are valid' });
   });
 
-  test('accepts remote servers: explicit http, explicit sse, and url without type', () => {
+  test('accepts remote servers: http, streamable-http alias, sse, ws, and headers', () => {
     writeConfig({
       'agent-guild': { type: 'http', url: 'https://agent-guild-5d5r.onrender.com/mcp' },
+      streamable: { type: 'streamable-http', url: 'https://example.com/mcp' },
       devplan: { type: 'sse', url: 'https://mcp.devplanmcp.store/sse' },
-      sentry: { url: 'https://mcp.sentry.dev/mcp' },
+      events: { type: 'ws', url: 'wss://mcp.example.com/socket', headers: { Authorization: 'Bearer token' } },
       authenticated: { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: 'Bearer ${TOKEN}' } }
     });
-    expect(run()).toEqual({ status: 'pass', message: 'All 4 MCP server configurations are valid' });
+    expect(run()).toEqual({ status: 'pass', message: 'All 5 MCP server configurations are valid' });
+  });
+
+  test('accepts a url whose environment template has a default (validated on the default)', () => {
+    writeConfig({
+      defaulted: { type: 'http', url: '${API_BASE_URL:-https://api.example.com}/mcp' },
+      defaultedPort: { type: 'ws', url: 'wss://${MCP_HOST:-localhost}:${MCP_PORT:-8080}/socket' }
+    });
+    expect(run()).toEqual({ status: 'pass', message: 'All 2 MCP server configurations are valid' });
+  });
+
+  test('warns, without reading the environment, when a url depends on an unresolved variable', () => {
+    const previous = process.env.MCP_URL;
+    process.env.MCP_URL = 'ftp://would-be-rejected-if-read';
+    try {
+      writeConfig({
+        fullUrl: { type: 'http', url: '${MCP_URL}' },
+        hostPort: { type: 'http', url: 'https://${MCP_HOST}:${MCP_PORT}/mcp' }
+      });
+      expect(run()).toEqual({
+        status: 'warn',
+        message: 'All 2 MCP server configurations are valid; 2 use unresolved environment variables in url (not verified)'
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MCP_URL;
+      } else {
+        process.env.MCP_URL = previous;
+      }
+    }
+  });
+
+  test('checks the literal scheme of a templated url against the transport', () => {
+    writeConfig({
+      ftpHost: { type: 'http', url: 'ftp://${MCP_HOST}/mcp' },
+      wsForHttp: { type: 'http', url: '${MCP_URL:-wss://example.com}/mcp' },
+      unbalanced: { type: 'http', url: 'https://${MCP_HOST/mcp' },
+      badName: { type: 'http', url: 'https://${1HOST}/mcp' },
+      ok: { type: 'sse', url: 'https://${MCP_HOST}/sse' }
+    });
+    expect(run()).toEqual({ status: 'warn', message: '1/5 MCP servers valid, 4 issues found' });
+  });
+
+  test('reports a url without type as a configuration error (Claude Code skips it)', () => {
+    writeConfig({ sentry: { url: 'https://mcp.sentry.dev/mcp' } });
+    expect(run()).toEqual({ status: 'fail', message: 'All 1 MCP server configurations have issues' });
+  });
+
+  test('rejects a non-string type without throwing (was reported valid)', () => {
+    writeConfig({
+      objectType: { type: { toString: null }, url: 'https://example.com/mcp' },
+      numberType: { type: 5, url: 'https://example.com/mcp' },
+      nullType: { type: null, url: 'https://example.com/mcp' }
+    });
+    expect(run()).toEqual({ status: 'fail', message: 'All 3 MCP server configurations have issues' });
+  });
+
+  test('requires remote header values to be strings (literal or ${VAR} template)', () => {
+    writeConfig({
+      objectValue: { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: { bad: true } } },
+      numberValue: { type: 'http', url: 'https://example.com/mcp', headers: { 'X-Retries': 3 } },
+      nullValue: { type: 'ws', url: 'wss://example.com/socket', headers: { Authorization: null } },
+      literal: { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: 'Bearer token' } },
+      template: { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: 'Bearer ${API_KEY}' } }
+    });
+    expect(run()).toEqual({ status: 'warn', message: '2/5 MCP servers valid, 3 issues found' });
   });
 
   test('still rejects a server with neither command nor url', () => {
@@ -59,12 +132,13 @@ describe('HealthChecker.checkMCPConfigurationSyntax', () => {
     writeConfig({
       noUrl: { type: 'http' },
       wrongTransport: { type: 'stdio', url: 'https://example.com/mcp' },
-      unsupportedType: { type: 'ws', url: 'wss://example.com' },
-      badScheme: { url: 'ftp://example.com/mcp' },
+      unsupportedType: { type: 'grpc', url: 'https://example.com' },
+      badScheme: { type: 'http', url: 'ftp://example.com/mcp' },
+      httpForWs: { type: 'ws', url: 'https://example.com/socket' },
       notAUrl: { type: 'sse', url: 'not a url' },
       badHeaders: { type: 'http', url: 'https://example.com/mcp', headers: ['x'] }
     });
-    expect(run()).toEqual({ status: 'fail', message: 'All 6 MCP server configurations have issues' });
+    expect(run()).toEqual({ status: 'fail', message: 'All 7 MCP server configurations have issues' });
   });
 
   test('keeps the existing args/env format checks for stdio servers', () => {


### PR DESCRIPTION
## Summary

Adds Agent Guild as a hosted HTTP MCP server and fixes the CLI health check that currently reports valid remote servers as missing a local command. Installing the Agent Guild component alongside a local stdio server now preserves both configurations and passes transport syntax validation.

The Agent Guild descriptor uses `type: "http"` with `https://agent-guild-5d5r.onrender.com/mcp`. Connecting requires no API key or local package; optional paid operations remain explicit caller decisions.

## Remote configuration validation

The generic check supports stdio, HTTP, the `streamable-http` alias, SSE and WebSocket entries. It requires an explicit type for remote URLs, checks literal URL schemes and header value types, and rejects malformed transport values without throwing. These shapes follow the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp) and [SDK transport notes](https://code.claude.com/docs/en/agent-sdk/mcp).

URL environment templates are inspected without reading environment values. Defaults are checked syntactically; unresolved variables produce a warning naming the affected server, variable names and configuration file, including when other servers have errors. Environment values are never read or included, and the eventual endpoint is not claimed verified. The existing args/env shape checks remain in place. This is configuration validation, not a connection or credential test.

## Validation

- **12 focused regression tests pass** at `ae427739e1b9be6206f92250f91e038a05c2795a`, including local/remote configurations, aliases, URL templates, malformed types and header values. Tests use temporary files and no network.
- Replaying the installer's description removal and merge with an existing stdio entry preserves both servers and passes the corrected check.
- The first repair's repository-wide run had 144 passed, 68 failed and 1 skipped; pristine upstream had 136 passed, 70 failed and 1 skipped across the same nine failing suites. Those unrelated analytics/validator failures remain; the full suite is not claimed green. Subsequent focused corrections were verified with the 12-test suite.
- `git diff --check` passes. The source descriptor is unchanged from the original PR. The affected health-check file is unchanged between the PR base and current upstream, so no merge or history rewrite was needed.

## Catalogue publication

Only the source component is included. The repository's contribution welcome describes catalogue regeneration after merge, and `update-json-data.yml` rebuilds generated catalogues on its daily schedule. Generated website/dashboard files remain in that established publication workflow.

Prepared and independently reviewed with AI assistance as AgentTanuki. Maintainer component review and acceptance remain pending.
