### PR TITLE
Add open-banking-io skill (EU/UK PSD2 bank data via API key, cert-free)

### DIFF
--- a/cli-tool/components/skills/open-banking-io/open-banking-io/SKILL.md
+++ b/cli-tool/components/skills/open-banking-io/open-banking-io/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: open-banking-io
+description: Read bank account balances and transactions from EU/UK banks via the open-banking.io PSD2 API. Use when the user wants to check balances, list recent transactions, categorise spending, or reconcile payments across European bank accounts — without eIDAS certificates or an AISP licence.
+---
+
+# open-banking.io
+
+Self-serve PSD2 bank-data API for EU/UK accounts: accounts, balances and
+transactions behind a single API key — no eIDAS QWAC/QSealC certificates
+required. Part of the [open-banking.io](https://open-banking.io) service
+([skills repository](https://github.com/open-banking-io/skills), MIT).
+
+## When to use
+
+- "What's my balance on <bank>?"
+- "Summarise last month's transactions" / "How much did I spend on groceries?"
+- "Which of my bank connections need re-consent?"
+- Reconciling invoices/payments against bank statement lines
+
+## Tool surface
+
+Prefer the official MCP server (read-only tools: `list_accounts`,
+`get_balances`, `get_transactions`, `list_connections`):
+[open-banking-io/mcp-server](https://github.com/open-banking-io/mcp-server)
+
+Direct REST works too: `GET /accounts`, `GET /accounts/{id}/balances`,
+`GET /accounts/{id}/transactions`.
+
+## Quick start
+
+```bash
+# 1. Sign up at https://open-banking.io (free tier) and get an API key
+# 2. Connect a bank (consent flow) — EU/UK, ~600+ institutions
+# 3. Read data
+curl -H "Authorization: Bearer $OPEN_BANKING_IO_KEY" \
+  "https://api.open-banking.io/accounts"
+```
+
+## PSD2 quirks worth knowing
+
+- Consents expire (~90 days by default; some banks cap at 90 days, some 120+)
+  — plan re-consent reminders.
+- Transactions come back as `interimBooked` (pending) and `booked` — pending
+  rows flip to booked with the SAME transaction id; treat it as an update, not
+  a new row.
+- Unattended fetch rates are capped per bank (~4 pulls/day typical) — budget
+  polling accordingly.


### PR DESCRIPTION
## What does this PR do?

Adds a community skill: **open-banking-io** — read bank account balances and
transactions from EU/UK banks via the [open-banking.io](https://open-banking.io)
PSD2 API (self-serve API key, no eIDAS QWAC/QSealC certificates or AISP licence
needed on the consumer side).

- One new file: `cli-tool/components/skills/open-banking-io/open-banking-io/SKILL.md`
- Frontmatter follows the existing convention (name + description), body documents
  when-to-use triggers, the MCP/REST tool surface, a quick start, and PSD2 quirks
  (consent expiry, interimBooked→booked updates, per-bank pull caps) that agents
  need to use bank data correctly.
- Related open-source assets: [skills repo](https://github.com/open-banking-io/skills),
  [MCP server](https://github.com/open-banking-io/mcp-server) (both MIT).

## Checklist

- [x] Added under `cli-tool/components/skills/<namespace>/<skill>/SKILL.md`
- [x] No changes to any other files
- [x] SKILL.md frontmatter: name + description in the established format
- [x] Content is original (adapted from our own skills repo, MIT)

Happy to adjust the namespace/category placement if maintainers prefer a
different spot in the tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `open-banking-io` skill documentation to components so agents can read EU/UK bank balances and transactions via the PSD2 API without certificates or an AISP licence. Expands the community skill catalog and documents MCP/REST tools and consent constraints.

- Area: components (`cli-tool/components/`); new component file added at `cli-tool/components/skills/open-banking-io/open-banking-io/SKILL.md`.
- Regenerate `docs/components.json` to include the new skill in the catalog.
- Requires `OPEN_BANKING_IO_KEY` for API access when using the documented tools.
- Review: confirm frontmatter format and placement match conventions; check tool surface and PSD2 quirks are accurate.

<sup>Written for commit 65ffaa7fdc9c73505e82cdf8894180fe6e071d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

