### PR TITLE
feat(speech): add optional Atlas Cloud TTS backend

### DIFF
--- a/cli-tool/components/skills/media/speech/SKILL.md
+++ b/cli-tool/components/skills/media/speech/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: "speech"
-description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation via the OpenAI Audio API; run the bundled CLI (`scripts/text_to_speech.py`) with built-in voices and require `OPENAI_API_KEY` for live calls. Custom voice creation is out of scope."
+description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation. OpenAI remains the default; Atlas Cloud is an explicit optional backend for asynchronous multilingual speech. Custom voice creation is out of scope."
 author: openai
 ---
 
 
 # Speech Generation Skill
 
-Generate spoken audio for the current project (narration, product demo voiceover, IVR prompts, accessibility reads). Defaults to `gpt-4o-mini-tts-2025-12-15` and built-in voices, and prefers the bundled CLI for deterministic, reproducible runs.
+Generate spoken audio for the current project (narration, product demo voiceover, IVR prompts, accessibility reads). OpenAI remains the default with `gpt-4o-mini-tts-2025-12-15`; Atlas Cloud is available only when the user explicitly selects it. Prefer the bundled CLIs for deterministic, reproducible runs.
 
 ## When to use
 - Generate a single spoken clip from text
@@ -22,7 +22,7 @@ Generate spoken audio for the current project (narration, product demo voiceover
 2. Collect inputs up front: exact text (verbatim), desired voice, delivery style, format, and any constraints.
 3. If batch: write a temporary JSONL under tmp/ (one job per line), run once, then delete the JSONL.
 4. Augment instructions into a short labeled spec without rewriting the input text.
-5. Run the bundled CLI (`scripts/text_to_speech.py`) with sensible defaults (see references/cli.md).
+5. Run `scripts/text_to_speech.py` for the default OpenAI path, or `scripts/atlas_text_to_speech.py` only when Atlas Cloud was selected (see `references/cli.md`).
 6. For important clips, validate: intelligibility, pacing, pronunciation, and adherence to constraints.
 7. Iterate with a single targeted change (voice, speed, or instructions), then re-check.
 8. Save/return final outputs and note the final text + instructions + flags used.
@@ -35,7 +35,7 @@ Generate spoken audio for the current project (narration, product demo voiceover
 ## Dependencies (install if missing)
 Prefer `uv` for dependency management.
 
-Python packages:
+OpenAI backend package:
 ```
 uv pip install openai
 ```
@@ -44,18 +44,22 @@ If `uv` is unavailable:
 python3 -m pip install openai
 ```
 
-## Environment
-- `OPENAI_API_KEY` must be set for live API calls.
+The Atlas Cloud backend uses only the Python standard library.
 
-If the key is missing, give the user these steps:
-1. Create an API key in the OpenAI platform UI: https://platform.openai.com/api-keys
-2. Set `OPENAI_API_KEY` as an environment variable in their system.
+## Environment
+- Default OpenAI calls require `OPENAI_API_KEY`.
+- Optional Atlas Cloud calls require `ATLASCLOUD_API_KEY`.
+
+If the selected provider key is missing, give the user these steps:
+1. Create an API key in that provider's console.
+2. Set `OPENAI_API_KEY` or `ATLASCLOUD_API_KEY` as an environment variable in their system.
 3. Offer to guide them through setting the environment variable for their OS/shell if needed.
-- Never ask the user to paste the full key in chat. Ask them to set it locally and confirm when ready.
+- Keep provider credentials out of chat. Direct the user to set the selected key locally and confirm when ready.
 
 If installation isn't possible in this environment, tell the user which dependency is missing and how to install it locally.
 
 ## Defaults & rules
+- Keep OpenAI as the default provider. Do not switch to Atlas Cloud unless the user requests it.
 - Use `gpt-4o-mini-tts-2025-12-15` unless the user requests another model.
 - Default voice: `cedar`. If the user wants a brighter tone, prefer `marin`.
 - Built-in voices only. Custom voices are out of scope for this skill.
@@ -63,10 +67,12 @@ If installation isn't possible in this environment, tell the user which dependen
 - Input length must be <= 4096 characters per request. Split longer text into chunks.
 - Enforce 50 requests/minute. The CLI caps `--rpm` at 50.
 - Require `OPENAI_API_KEY` before any live API call.
+- For Atlas Cloud, default to `xai/tts-v1`, voice `eve`, language `auto`, and require `ATLASCLOUD_API_KEY`.
+- Atlas generation submits exactly one POST. Only prediction GET requests may retry, and polling must stay finite.
+- Download Atlas outputs without an Authorization header and reject non-HTTPS or private-network targets.
 - Provide a clear disclosure to end users that the voice is AI-generated.
-- Use the OpenAI Python SDK (`openai` package) for all API calls; do not use raw HTTP.
-- Prefer the bundled CLI (`scripts/text_to_speech.py`) over writing new one-off scripts.
-- Never modify `scripts/text_to_speech.py`. If something is missing, ask the user before doing anything else.
+- Use the OpenAI Python SDK (`openai` package) for default OpenAI calls; the dedicated Atlas CLI uses its asynchronous HTTP contract.
+- Prefer the matching bundled CLI over writing new one-off scripts.
 
 ## Instruction augmentation
 Reformat user direction into a short, labeled spec. Only make implicit details explicit; do not invent new requirements.
@@ -129,12 +135,14 @@ Use these modules when the request is for a specific delivery style. They provid
 ## CLI + environment notes
 - CLI commands + examples: `references/cli.md`
 - API parameter quick reference: `references/audio-api.md`
+- Atlas Cloud asynchronous workflow and safeguards: `references/atlas-cloud.md`
 - Instruction patterns + examples: `references/voice-directions.md`
 - If network approvals / sandbox settings are getting in the way: `references/codex-network.md`
 
 ## Reference map
 - **`references/cli.md`**: how to run speech generation/batches via `scripts/text_to_speech.py` (commands, flags, recipes).
 - **`references/audio-api.md`**: API parameters, limits, voice list.
+- **`references/atlas-cloud.md`**: optional Atlas Cloud model, CLI, polling, and download contract.
 - **`references/voice-directions.md`**: instruction patterns and examples.
 - **`references/prompting.md`**: instruction best practices (structure, constraints, iteration patterns).
 - **`references/sample-prompts.md`**: copy/paste instruction recipes (examples only; no extra theory).

--- a/cli-tool/components/skills/media/speech/references/atlas-cloud.md
+++ b/cli-tool/components/skills/media/speech/references/atlas-cloud.md
@@ -1,0 +1,73 @@
+# Atlas Cloud speech backend
+
+Use this backend only when the user explicitly selects Atlas Cloud. The default
+OpenAI speech workflow and `scripts/text_to_speech.py` remain unchanged.
+
+## Configuration
+
+Set the API key locally and never place it in prompts, committed files, command
+output, or generated metadata:
+
+```
+export ATLASCLOUD_API_KEY="your-key"
+```
+
+The Atlas CLI is stdlib-only:
+
+```
+export ATLAS_TTS_GEN="$CODEX_HOME/skills/speech/scripts/atlas_text_to_speech.py"
+python "$ATLAS_TTS_GEN" speak --input "Hello from Atlas Cloud" --dry-run
+```
+
+## Live generation
+
+The default model is `xai/tts-v1`. Its default multilingual voice is `eve`,
+language is `auto`, codec is `mp3`, and speed is `1.0`:
+
+```
+python "$ATLAS_TTS_GEN" speak \
+  --input "Welcome to the product tour." \
+  --voice eve \
+  --language en \
+  --codec mp3 \
+  --out output/speech/tour.mp3
+```
+
+The five multilingual voices are `ara`, `eve`, `leo`, `rex`, and `sal`. Run
+`python "$ATLAS_TTS_GEN" list-voices` to print them. The supported speed range
+is 0.7 through 1.5.
+
+## Batch generation
+
+Each JSONL line is one job. Per-job `model`, `language`, `voice`, `codec`,
+`speed`, and `out` values override command defaults:
+
+```
+python "$ATLAS_TTS_GEN" speak-batch \
+  --input tmp/speech/jobs.jsonl \
+  --out-dir output/speech
+```
+
+## Request contract
+
+1. The CLI sends one `POST /api/v1/model/generateAudio` request. It never
+   automatically retries a generation submission.
+2. It prints the prediction ID to stderr before polling, so an interrupted task
+   remains recoverable.
+3. It polls `GET /api/v1/model/prediction/{id}` with bounded retries and stops
+   after `--poll-attempts` (120 by default).
+4. It downloads the first completed output over HTTPS without an Authorization
+   header, validates redirects, rejects private-network targets, limits the file
+   to 100 MiB, and refuses to overwrite unless `--force` is set.
+
+If submission fails, report the error and do not resubmit automatically. If
+polling is interrupted after an ID was printed, inspect that existing prediction
+rather than starting a second paid generation.
+
+## Model-specific notes
+
+- `xai/tts-v1` accepts up to 15,000 text characters.
+- Use `language=auto` unless the user requests an explicit language.
+- Inline speech tags such as `[pause]` are part of the text. The separate OpenAI
+  `instructions` parameter is not sent to Atlas Cloud.
+- Valid codecs are `mp3`, `wav`, `pcm`, `mulaw`, and `alaw`.

--- a/cli-tool/components/skills/media/speech/references/audio-api.md
+++ b/cli-tool/components/skills/media/speech/references/audio-api.md
@@ -1,5 +1,8 @@
 # Audio Speech API quick reference
 
+This page documents the default OpenAI backend. For the optional asynchronous
+Atlas Cloud backend, use `references/atlas-cloud.md` and its dedicated CLI.
+
 ## Endpoint
 - Create speech: `POST /v1/audio/speech`
 

--- a/cli-tool/components/skills/media/speech/references/cli.md
+++ b/cli-tool/components/skills/media/speech/references/cli.md
@@ -9,18 +9,33 @@ This file contains the "command catalog" for the bundled speech generation CLI. 
 
 Real API calls require network access + `OPENAI_API_KEY`. `--dry-run` does not.
 
+OpenAI remains the default workflow. When the user explicitly selects Atlas Cloud,
+use `scripts/atlas_text_to_speech.py`; it has the same three subcommands, requires
+`ATLASCLOUD_API_KEY` for live calls, and needs no third-party Python package.
+
 ## Quick start (works from any repo)
 Set a stable path to the skill CLI (default `CODEX_HOME` is `~/.codex`):
 
 ```
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 export TTS_GEN="$CODEX_HOME/skills/speech/scripts/text_to_speech.py"
+export ATLAS_TTS_GEN="$CODEX_HOME/skills/speech/scripts/atlas_text_to_speech.py"
 ```
 
 Dry-run (no API call; no network required; does not require the `openai` package):
 
 ```
 python "$TTS_GEN" speak --input "Test" --dry-run
+```
+
+Atlas Cloud dry-run:
+
+```
+python "$ATLAS_TTS_GEN" speak \
+  --input "Test" \
+  --voice eve \
+  --language auto \
+  --dry-run
 ```
 
 Generate (requires `OPENAI_API_KEY` + network):
@@ -41,9 +56,11 @@ python "$TTS_GEN" speak --input "Hello" --voice cedar --out speech.mp3
 ```
 
 ## Guardrails (important)
-- Use `python "$TTS_GEN" ...` (or equivalent full path) for all TTS work.
+- Use `python "$TTS_GEN" ...` (or equivalent full path) for the default OpenAI workflow.
+- Use `python "$ATLAS_TTS_GEN" ...` only after the user selects Atlas Cloud.
+- Atlas generation POSTs are never retried. Its prediction GET polling is finite.
+- Atlas output downloads never receive the API key and reject private-network URLs.
 - Do **not** create one-off runners (e.g., `gen_audio.py`) unless the user explicitly asks.
-- **Never modify** `scripts/text_to_speech.py`. If something is missing, ask the user before doing anything else.
 
 ## Defaults (unless overridden by flags)
 - Model: `gpt-4o-mini-tts-2025-12-15`
@@ -51,6 +68,9 @@ python "$TTS_GEN" speak --input "Hello" --voice cedar --out speech.mp3
 - Response format: `mp3`
 - Speed: `1.0`
 - Batch rpm cap: `50`
+
+Atlas Cloud defaults are model `xai/tts-v1`, multilingual voice `eve`, language
+`auto`, codec `mp3`, 2-second polling, and at most 120 polls.
 
 ## Input limits
 - Input text must be <= 4096 characters per request.
@@ -96,4 +116,5 @@ Notes:
 
 ## See also
 - API parameter quick reference: `references/audio-api.md`
+- Atlas Cloud workflow: `references/atlas-cloud.md`
 - Instruction patterns and examples: `references/voice-directions.md`

--- a/cli-tool/components/skills/media/speech/scripts/atlas_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/scripts/atlas_text_to_speech.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Generate speech with Atlas Cloud's asynchronous audio API.
+
+The generation POST is sent exactly once. Only prediction GET requests are
+retried, and every polling loop is finite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import socket
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+API_BASE = "https://api.atlascloud.ai/api/v1"
+DEFAULT_MODEL = "xai/tts-v1"
+DEFAULT_VOICE = "eve"
+DEFAULT_LANGUAGE = "auto"
+DEFAULT_CODEC = "mp3"
+DEFAULT_POLL_INTERVAL = 2.0
+DEFAULT_POLL_ATTEMPTS = 120
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+MAX_INPUT_CHARS = 15_000
+USER_AGENT = "claude-code-templates-speech/atlas-tts"
+
+VOICES = {"ara", "eve", "leo", "rex", "sal"}
+LANGUAGES = {
+    "auto",
+    "en",
+    "zh",
+    "ar-EG",
+    "ar-SA",
+    "ar-AE",
+    "bn",
+    "fr",
+    "de",
+    "hi",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "pt-BR",
+    "pt-PT",
+    "ru",
+    "es-MX",
+    "es-ES",
+    "tr",
+    "vi",
+}
+CODECS = {"mp3", "wav", "pcm", "mulaw", "alaw"}
+TERMINAL_FAILURES = {"failed", "timeout", "canceled", "cancelled"}
+BENCHMARK_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+
+
+def _die(message: str, code: int = 1) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _read_text(text: Optional[str], text_file: Optional[str]) -> str:
+    if text and text_file:
+        _die("Use --input or --input-file, not both.")
+    if text_file:
+        path = Path(text_file)
+        if not path.is_file():
+            _die(f"Input file not found: {path}")
+        value = path.read_text(encoding="utf-8").strip()
+    elif text:
+        value = text.strip()
+    else:
+        _die("Missing input. Use --input or --input-file.")
+        return ""  # unreachable
+    if not value:
+        _die("Input text is empty.")
+    if len(value) > MAX_INPUT_CHARS:
+        _die(f"Input text exceeds {MAX_INPUT_CHARS} characters.")
+    return value
+
+
+def _choice(value: str, allowed: Iterable[str], label: str) -> str:
+    if value not in allowed:
+        _die(f"{label} must be one of: {', '.join(sorted(allowed))}")
+    return value
+
+
+def _speed(value: float) -> float:
+    if value < 0.7 or value > 1.5:
+        _die("speed must be between 0.7 and 1.5")
+    return value
+
+
+def _output_path(value: Optional[str], codec: str) -> Path:
+    path = Path(value) if value else Path(f"speech.{codec}")
+    if path.exists() and path.is_dir():
+        return path / f"speech.{codec}"
+    if not path.suffix:
+        return path.with_suffix(f".{codec}")
+    return path
+
+
+def _api_key(dry_run: bool) -> str:
+    key = os.getenv("ATLASCLOUD_API_KEY", "").strip()
+    if key:
+        return key
+    if dry_run:
+        return ""
+    _die("ATLASCLOUD_API_KEY is not set. Export it before running.")
+    return ""  # unreachable
+
+
+def _request_json(
+    url: str,
+    *,
+    api_key: str,
+    method: str,
+    payload: Optional[Dict[str, Any]] = None,
+    attempts: int = 1,
+) -> Dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                result = json.loads(response.read().decode("utf-8"))
+            if not isinstance(result, dict):
+                raise ValueError("API response was not a JSON object")
+            return result
+        except urllib.error.HTTPError as exc:
+            if (
+                method == "GET"
+                and exc.code in {408, 429, 500, 502, 503, 504}
+                and attempt < attempts
+            ):
+                time.sleep(min(4.0, 2.0 ** (attempt - 1)))
+                continue
+            # Do not print response bodies: upstream errors may include request data.
+            raise RuntimeError(
+                f"Atlas API returned HTTP {exc.code}: {exc.reason}"
+            ) from exc
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as exc:
+            last_error = exc
+            if attempt >= attempts:
+                raise
+            time.sleep(min(4.0, 2.0 ** (attempt - 1)))
+    if last_error:
+        raise last_error
+    raise RuntimeError("request failed without an error")
+
+
+def _response_data(response: Dict[str, Any], operation: str) -> Dict[str, Any]:
+    code = response.get("code")
+    data = response.get("data")
+    if code not in {0, 200} or not isinstance(data, dict):
+        message = response.get("message") or response.get("msg") or "unknown error"
+        _die(f"Atlas {operation} failed: {message}")
+    return data
+
+
+def _submit(payload: Dict[str, Any], api_key: str) -> str:
+    response = _request_json(
+        f"{API_BASE}/model/generateAudio",
+        api_key=api_key,
+        method="POST",
+        payload=payload,
+        attempts=1,
+    )
+    data = _response_data(response, "submission")
+    prediction_id = str(data.get("id") or "").strip()
+    if not prediction_id:
+        _die("Atlas submission response did not include a prediction ID.")
+    print(f"Atlas prediction ID: {prediction_id}", file=sys.stderr)
+    return prediction_id
+
+
+def _poll(
+    prediction_id: str,
+    api_key: str,
+    *,
+    attempts: int,
+    interval: float,
+) -> str:
+    if attempts < 1:
+        _die("poll-attempts must be at least 1")
+    if interval < 0:
+        _die("poll-interval must not be negative")
+    quoted_id = urllib.parse.quote(prediction_id, safe="")
+    url = f"{API_BASE}/model/prediction/{quoted_id}"
+
+    for poll_number in range(1, attempts + 1):
+        response = _request_json(
+            url,
+            api_key=api_key,
+            method="GET",
+            attempts=3,
+        )
+        data = _response_data(response, "prediction lookup")
+        status = str(data.get("status") or "").lower()
+        if status in {"completed", "succeeded"}:
+            outputs = data.get("outputs")
+            if (
+                not isinstance(outputs, list)
+                or not outputs
+                or not isinstance(outputs[0], str)
+            ):
+                _die("Atlas prediction completed without an output URL.")
+            return outputs[0]
+        if status in TERMINAL_FAILURES:
+            detail = data.get("error") or status
+            _die(f"Atlas prediction {status}: {detail}")
+        if poll_number < attempts:
+            time.sleep(interval)
+    _die(f"Atlas prediction did not finish after {attempts} polls.")
+    return ""  # unreachable
+
+
+def _is_safe_ip(address: str, *, named_host: bool) -> bool:
+    ip = ipaddress.ip_address(address)
+    if named_host and ip in BENCHMARK_NETWORK:
+        # macOS proxy/TUN clients commonly synthesize public DNS into this block.
+        return True
+    return ip.is_global
+
+
+def _validate_download_url(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        _die("Atlas output URL must use HTTPS.")
+    if parsed.username or parsed.password:
+        _die("Atlas output URL must not include user information.")
+    host = parsed.hostname
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if not _is_safe_ip(str(literal), named_host=False):
+            _die("Atlas output URL resolves to a non-public address.")
+        return
+    if host.lower() == "localhost" or host.lower().endswith(".localhost"):
+        _die("Atlas output URL must not target localhost.")
+    try:
+        addresses = {
+            item[4][0]
+            for item in socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
+        }
+    except socket.gaierror as exc:
+        _die(f"Could not resolve Atlas output host: {exc}")
+        return
+    if not addresses or any(
+        not _is_safe_ip(address, named_host=True) for address in addresses
+    ):
+        _die("Atlas output URL resolves to a non-public address.")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        _validate_download_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _download(url: str, out_path: Path, *, force: bool) -> None:
+    _validate_download_url(url)
+    if out_path.exists() and not force:
+        _die(f"Output already exists: {out_path} (use --force to overwrite)")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "audio/*", "User-Agent": USER_AGENT},
+        method="GET",
+    )
+    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    written = 0
+    with opener.open(request, timeout=60) as response, out_path.open("wb") as target:
+        while True:
+            chunk = response.read(64 * 1024)
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > MAX_DOWNLOAD_BYTES:
+                target.close()
+                out_path.unlink(missing_ok=True)
+                _die("Atlas output exceeds the 100 MiB download limit.")
+            target.write(chunk)
+    if written == 0:
+        out_path.unlink(missing_ok=True)
+        _die("Atlas output download was empty.")
+    print(f"Wrote {out_path}")
+
+
+def _payload(args: argparse.Namespace, text: str) -> Dict[str, Any]:
+    return {
+        "model": args.model,
+        "text": text,
+        "language": _choice(args.language, LANGUAGES, "language"),
+        "voice_id": _choice(args.voice, VOICES, "voice"),
+        "codec": _choice(args.codec, CODECS, "codec"),
+        "speed": _speed(args.speed),
+    }
+
+
+def _generate(
+    payload: Dict[str, Any], out_path: Path, args: argparse.Namespace
+) -> None:
+    if out_path.exists() and not args.force and not args.dry_run:
+        _die(f"Output already exists: {out_path} (use --force to overwrite)")
+    key = _api_key(args.dry_run)
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        print(f"Would write {out_path}")
+        return
+    prediction_id = _submit(payload, key)
+    output_url = _poll(
+        prediction_id,
+        key,
+        attempts=args.poll_attempts,
+        interval=args.poll_interval,
+    )
+    _download(output_url, out_path, force=args.force)
+
+
+def _read_jobs(path: str) -> List[Dict[str, Any]]:
+    jobs: List[Dict[str, Any]] = []
+    for line_number, raw in enumerate(
+        Path(path).read_text(encoding="utf-8").splitlines(), 1
+    ):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            job = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _die(f"Invalid JSON on line {line_number}: {exc}")
+        if not isinstance(job, dict):
+            _die(f"Invalid job on line {line_number}: expected an object")
+        jobs.append(job)
+    if not jobs:
+        _die("No jobs found in input file.")
+    return jobs
+
+
+def _run_speak(args: argparse.Namespace) -> int:
+    text = _read_text(args.input, args.input_file)
+    codec = _choice(args.codec, CODECS, "codec")
+    _generate(_payload(args, text), _output_path(args.out, codec), args)
+    return 0
+
+
+def _run_batch(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    for index, job in enumerate(_read_jobs(args.input), 1):
+        child = argparse.Namespace(**vars(args))
+        child.model = str(job.get("model", args.model))
+        child.language = str(job.get("language", args.language))
+        child.voice = str(job.get("voice", job.get("voice_id", args.voice)))
+        child.codec = str(job.get("codec", args.codec))
+        child.speed = float(job.get("speed", args.speed))
+        text = _read_text(str(job.get("input") or job.get("text") or ""), None)
+        filename = str(job.get("out") or f"{index:03d}-speech.{child.codec}")
+        out_path = out_dir / Path(filename).name
+        _generate(_payload(child, text), out_path, child)
+    return 0
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--voice", default=DEFAULT_VOICE)
+    parser.add_argument("--language", default=DEFAULT_LANGUAGE)
+    parser.add_argument("--codec", default=DEFAULT_CODEC)
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--poll-interval", type=float, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument("--poll-attempts", type=int, default=DEFAULT_POLL_ATTEMPTS)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate speech using Atlas Cloud.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    voices = subparsers.add_parser("list-voices", help="List multilingual voices")
+    voices.set_defaults(func=lambda _args: print("\n".join(sorted(VOICES))) or 0)
+
+    speak = subparsers.add_parser("speak", help="Generate one audio file")
+    speak.add_argument("--input")
+    speak.add_argument("--input-file")
+    speak.add_argument("--out")
+    _add_common_args(speak)
+    speak.set_defaults(func=_run_speak)
+
+    batch = subparsers.add_parser("speak-batch", help="Generate from JSONL jobs")
+    batch.add_argument("--input", required=True)
+    batch.add_argument("--out-dir", default="out")
+    _add_common_args(batch)
+    batch.set_defaults(func=_run_batch)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli-tool/components/skills/media/speech/tests/test_atlas_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/tests/test_atlas_text_to_speech.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "atlas_text_to_speech.py"
+SPEC = importlib.util.spec_from_file_location("atlas_tts", SCRIPT)
+assert SPEC and SPEC.loader
+atlas_tts = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(atlas_tts)
+
+
+class _Response:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _size=-1):
+        return self._body
+
+
+class AtlasTextToSpeechTests(unittest.TestCase):
+    def test_dry_run_does_not_require_key(self):
+        stdout = io.StringIO()
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            mock.patch("sys.stdout", stdout),
+        ):
+            result = atlas_tts.main(["speak", "--input", "Hello", "--dry-run"])
+        self.assertEqual(result, 0)
+        self.assertIn('"model": "xai/tts-v1"', stdout.getvalue())
+        self.assertNotIn("Bearer", stdout.getvalue())
+
+    def test_submission_post_is_not_retried(self):
+        calls = 0
+
+        def fail(_request, timeout):
+            nonlocal calls
+            calls += 1
+            raise urllib.error.URLError("offline")
+
+        with mock.patch.object(atlas_tts.urllib.request, "urlopen", side_effect=fail):
+            with self.assertRaises(urllib.error.URLError):
+                atlas_tts._submit({"model": "xai/tts-v1"}, "key")
+        self.assertEqual(calls, 1)
+
+    def test_requests_use_explicit_user_agent(self):
+        seen = []
+
+        def respond(request, timeout):
+            seen.append(request)
+            return _Response(b'{"code":200,"data":{"id":"pred-1"}}')
+
+        with mock.patch.object(
+            atlas_tts.urllib.request, "urlopen", side_effect=respond
+        ):
+            self.assertEqual(
+                atlas_tts._submit({"model": "xai/tts-v1"}, "key"), "pred-1"
+            )
+        self.assertEqual(seen[0].get_header("User-agent"), atlas_tts.USER_AGENT)
+
+    def test_http_error_is_sanitized_and_not_retried(self):
+        calls = 0
+
+        def fail(request, timeout):
+            nonlocal calls
+            calls += 1
+            raise urllib.error.HTTPError(request.full_url, 403, "Forbidden", {}, None)
+
+        with mock.patch.object(atlas_tts.urllib.request, "urlopen", side_effect=fail):
+            with self.assertRaisesRegex(
+                RuntimeError, "Atlas API returned HTTP 403: Forbidden"
+            ):
+                atlas_tts._submit({"model": "xai/tts-v1"}, "secret-key")
+        self.assertEqual(calls, 1)
+
+    def test_poll_retries_get_and_returns_output(self):
+        responses = [
+            urllib.error.URLError("temporary"),
+            _Response(b'{"code":200,"data":{"status":"processing"}}'),
+            _Response(
+                b'{"code":200,"data":{"status":"completed","outputs":["https://cdn.example/audio.mp3"]}}'
+            ),
+        ]
+        with (
+            mock.patch.object(
+                atlas_tts.urllib.request, "urlopen", side_effect=responses
+            ),
+            mock.patch.object(atlas_tts.time, "sleep"),
+        ):
+            output = atlas_tts._poll("pred-1", "key", attempts=2, interval=0)
+        self.assertEqual(output, "https://cdn.example/audio.mp3")
+
+    def test_poll_retries_transient_http_error(self):
+        error = urllib.error.HTTPError(
+            f"{atlas_tts.API_BASE}/model/prediction/pred-1",
+            503,
+            "Unavailable",
+            {},
+            None,
+        )
+        responses = [
+            error,
+            _Response(
+                b'{"code":200,"data":{"status":"completed","outputs":["https://cdn.example/audio.mp3"]}}'
+            ),
+        ]
+        with (
+            mock.patch.object(
+                atlas_tts.urllib.request, "urlopen", side_effect=responses
+            ),
+            mock.patch.object(atlas_tts.time, "sleep"),
+        ):
+            output = atlas_tts._poll("pred-1", "key", attempts=1, interval=0)
+        self.assertEqual(output, "https://cdn.example/audio.mp3")
+
+    def test_private_literal_download_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            atlas_tts._validate_download_url("https://127.0.0.1/audio.mp3")
+
+    def test_named_private_host_is_rejected(self):
+        with mock.patch.object(
+            atlas_tts.socket,
+            "getaddrinfo",
+            return_value=[(None, None, None, None, ("10.0.0.8", 443))],
+        ):
+            with self.assertRaises(SystemExit):
+                atlas_tts._validate_download_url("https://cdn.example/audio.mp3")
+
+    def test_tun_fake_ip_is_allowed_for_named_host_only(self):
+        with mock.patch.object(
+            atlas_tts.socket,
+            "getaddrinfo",
+            return_value=[(None, None, None, None, ("198.18.0.10", 443))],
+        ):
+            atlas_tts._validate_download_url("https://cdn.example/audio.mp3")
+        with self.assertRaises(SystemExit):
+            atlas_tts._validate_download_url("https://198.18.0.10/audio.mp3")
+
+    def test_existing_output_stops_before_submission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "speech.mp3"
+            output.write_bytes(b"existing")
+            args = mock.Mock(force=False, dry_run=False)
+            with (
+                mock.patch.object(atlas_tts, "_api_key") as api_key,
+                self.assertRaises(SystemExit),
+            ):
+                atlas_tts._generate({"model": "xai/tts-v1"}, output, args)
+        api_key.assert_not_called()
+
+    def test_batch_dry_run_uses_job_overrides(self):
+        with tempfile.TemporaryDirectory() as directory:
+            jobs = Path(directory) / "jobs.jsonl"
+            jobs.write_text(
+                '{"input":"Ni hao","language":"zh","voice":"leo","codec":"wav"}\n',
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with (
+                mock.patch.dict("os.environ", {}, clear=True),
+                mock.patch("sys.stdout", stdout),
+            ):
+                result = atlas_tts.main(
+                    [
+                        "speak-batch",
+                        "--input",
+                        str(jobs),
+                        "--out-dir",
+                        directory,
+                        "--dry-run",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn('"language": "zh"', output)
+        self.assertIn('"voice_id": "leo"', output)
+        self.assertIn("001-speech.wav", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a dedicated, standard-library Atlas Cloud TTS CLI while keeping OpenAI as the default backend
- support single and JSONL batch generation with `xai/tts-v1`, multilingual voices, language, codec, and speed controls
- submit generation exactly once, bound prediction polling, and download outputs without credentials after HTTPS/private-network validation
- document the explicit provider selection, environment setup, request lifecycle, and recovery behavior

## Validation

- `python3 -m unittest discover -s cli-tool/components/skills/media/speech/tests` (11 passed)
- `python3 -m py_compile cli-tool/components/skills/media/speech/scripts/*.py cli-tool/components/skills/media/speech/tests/*.py`
- `ruff check --select E4,E7,E9,F,I` and `ruff format --check` on the new Python files
- PR-equivalent SkillSpector changed-skill gate: 1 scanned, 0 flagged, 0 errors, risk score 49 (threshold 50)
- root `npm run build` and `npm test`
- live `xai/tts-v1` smoke generated and downloaded a valid 51,840-byte MP3

The existing `cli-tool` Jest suite has unrelated failures in analytics, WebSocket mocks, service tests, and `ReferenceValidator`; the same representative failures reproduce from unmodified `origin/main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional Atlas Cloud TTS backend behind a dedicated CLI while keeping OpenAI as the default. Previously only OpenAI via `scripts/text_to_speech.py`; now users can explicitly run `scripts/atlas_text_to_speech.py` for asynchronous multilingual TTS without changing default behavior; live Atlas calls require `ATLASCLOUD_API_KEY`.

**Review notes**
- Area: components (`cli-tool/components/`). Adds `scripts/atlas_text_to_speech.py`, `references/atlas-cloud.md`, and tests; no new packages (stdlib-only).
- Implementation: single POST submission, bounded GET polling, HTTPS-only output download with private-network rejection and 100 MiB cap; supports single and JSONL batch; defaults `xai/tts-v1`, voices `ara|eve|leo|rex|sal`, language `auto`, codec `mp3`, speed 0.7–1.5.

**Rollout**
- Default OpenAI flow unchanged (`scripts/text_to_speech.py`); Atlas runs only when explicitly invoked. No new components; no `docs/components.json` regeneration needed.
- New env var: `ATLASCLOUD_API_KEY` (OpenAI continues to use `OPENAI_API_KEY`). Commands documented in `references/cli.md` and `references/atlas-cloud.md`.

<sup>Written for commit 4a4a957101cd8a5f001a40a5e88e89bbe22ce42f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

