### PR TITLE
feat: add 5dive MCP server (devtools)

### DIFF
--- a/cli-tool/components/mcps/devtools/5dive-mcp.json
+++ b/cli-tool/components/mcps/devtools/5dive-mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "5dive": {
+      "description": "Model Context Protocol (stdio) server for 5dive. Exposes the 5dive agent-fleet CLI (tasks, agents, digest) as MCP tools.",
+      "command": "npx",
+      "args": ["-y", "@5dive/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Adds an MCP component for [@5dive/mcp](https://www.npmjs.com/package/@5dive/mcp) under `mcps/devtools/`.

It's a stdio MCP server exposing the 5dive agent-fleet CLI (tasks, agents, digest) as MCP tools. Source: [5dive-ai/5dive-mcp](https://github.com/5dive-ai/5dive-mcp). Runs via `npx -y @5dive/mcp`, no env vars required.

Happy to move it to a different category if devtools isn't the right fit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new devtools MCP server for 5dive that exposes the agent-fleet CLI (tasks, agents, digest) as MCP tools. Previously absent; now configured to run via `npx -y @5dive/mcp`.

- Area: components (`cli-tool/components/`); adds mcps/devtools/5dive-mcp.json; no changes to CLI, API, website, or workers.
- Invokes `@5dive/mcp` via `npx -y`; first run downloads the package.
- No new environment variables or secrets.
- Regenerate the component catalog `docs/components.json`.

<sup>Written for commit 7afa9798606342b2eb1d072c8663a4568f1b32b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

