### PR TITLE
Add Live Tennis API MCP (integration)

### DIFF
--- a/cli-tool/components/mcps/integration/livetennisapi.json
+++ b/cli-tool/components/mcps/integration/livetennisapi.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "livetennisapi": {
+      "description": "Real-time and historical tennis data for LLM agents — live scores, match state (server, break point, retirement/walkover), players, rankings, fixtures, head-to-head and the 1968-2022 results archive across ATP, WTA, Challenger, ITF and juniors. Free tier, no card: https://livetennisapi.com/subscribe/free",
+      "command": "npx",
+      "args": ["-y", "livetennisapi-mcp"],
+      "env": {
+        "LIVETENNISAPI_KEY": "YOUR_LIVE_TENNIS_API_KEY"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `cli-tool/components/mcps/integration/livetennisapi.json` — the **Live Tennis API** MCP server, in the same `integration` category as `alpaca-trading` and `footballbin-predictions`.

**Disclosure:** we run the Live Tennis API — vendor-authored, judge on the merits.

`livetennisapi-mcp` (on npm and the official MCP Registry) gives Claude/Cursor/etc real-time and historical tennis data: live scores, match state (server, break-point, retirement/walkover), players, rankings, fixtures, head-to-head and the 1968-2022 archive (ATP, WTA, Challenger, ITF, juniors).

- npm: https://www.npmjs.com/package/livetennisapi-mcp
- Repo (MIT): https://github.com/livetennisapi/livetennisapi-mcp
- Free key, no card: https://livetennisapi.com/subscribe/free

Runs via `npx -y livetennisapi-mcp`; the free tier works with no key for status and returns data with a free key. Follows the MCP component JSON schema (mcpServers + description + command/args + env placeholder).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Live Tennis API MCP server as a new component so agents can access real-time and historical tennis data. Previously not available; now listed under integration with `npx` launch support and an optional API key.

- Area: components (`cli-tool/components/`). Adds `cli-tool/components/mcps/integration/livetennisapi.json`.
- New component added; no `docs/components.json` regeneration needed.
- Requires `LIVETENNISAPI_KEY` (free tier works for status; provide a key to return data).
- Runs via `npx -y livetennisapi-mcp`.

<sup>Written for commit 6be736a6affe8b5bf11cd824fc5067bed690cb80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

