### PR TITLE
improve: enhance accessibility-tester agent based on automated review

### DIFF
--- a/cli-tool/components/agents/accessibility/accessibility-tester.md
+++ b/cli-tool/components/agents/accessibility/accessibility-tester.md
@@ -47,7 +47,7 @@ Run after automated scan to surface human-judgement violations:
 - Forms: all inputs have associated labels; error messages are specific and programmatically linked
 - Live regions: dynamic content updates announced via `aria-live` with appropriate politeness
 - Documents: linked PDFs/Office files are tagged, have a logical reading order, and include alt text for embedded images (Section 508 and EAA scope commonly extends to downloadable documents, not just rendered web pages)
-- Forced colors: UI remains usable and all information is conveyed when Windows High Contrast / `forced-colors: active` is enabled; no information conveyed by background-image or box-shadow alone
+- Contrast preferences: UI remains usable and all information is conveyed when Windows High Contrast / `forced-colors: active` or `prefers-contrast: more` is enabled; no information conveyed by background-image or box-shadow alone
 
 ## WCAG 2.2 Reference Standard
 

--- a/cli-tool/components/agents/accessibility/accessibility-tester.md
+++ b/cli-tool/components/agents/accessibility/accessibility-tester.md
@@ -47,7 +47,7 @@ Run after automated scan to surface human-judgement violations:
 - Forms: all inputs have associated labels; error messages are specific and programmatically linked
 - Live regions: dynamic content updates announced via `aria-live` with appropriate politeness
 - Documents: linked PDFs/Office files are tagged, have a logical reading order, and include alt text for embedded images (Section 508 and EAA scope commonly extends to downloadable documents, not just rendered web pages)
-- Contrast preferences: UI remains usable and all information is conveyed when Windows High Contrast / `forced-colors: active` or `prefers-contrast: more` is enabled; no information conveyed by background-image or box-shadow alone
+- Contrast preferences: UI remains usable and all information is conveyed when Windows High Contrast / `forced-colors: active` and `prefers-contrast: more` are each enabled; no information conveyed by background-image or box-shadow alone
 
 ## WCAG 2.2 Reference Standard
 

--- a/cli-tool/components/agents/accessibility/accessibility-tester.md
+++ b/cli-tool/components/agents/accessibility/accessibility-tester.md
@@ -21,7 +21,7 @@ Use CLI tools to identify programmatic violations efficiently:
 
 Parse tool output and deduplicate findings before reporting.
 
-Confirm the `axe-core` version actually used by each tool is ≥4.5 (ideally current, e.g. 4.11) before trusting WCAG 2.2 coverage — `npx @axe-core/cli --version` only reports the CLI's own bundled version, not pa11y's or `@axe-core/playwright`'s independently-resolved axe-core, which can lag behind. Check each tool's bundled version separately since older pinned/cached versions silently omit WCAG 2.2 rules even when `wcag22aa` is requested.
+Confirm the `axe-core` version actually used by each tool is ≥4.5 (ideally current, e.g. 4.11) before trusting WCAG 2.2 coverage — `npx @axe-core/cli --version` only reports the CLI's own bundled version, not pa11y's or `@axe-core/playwright`'s independently-resolved axe-core, which can lag behind. Check each tool's bundled version separately (e.g. `npm ls axe-core` against the project's lockfile, or inspect `node_modules/axe-core/package.json`) since older pinned/cached versions silently omit WCAG 2.2 rules even when `wcag22aa` is requested.
 
 **Track 1b — Scripted interaction testing (where test infra exists)**
 For repeatable checks of tab order, focus trapping in modals, `aria-expanded`/`aria-selected` state changes, and focus restoration on close, use Deque's official Playwright integration rather than relying solely on the manual checklist:

--- a/cli-tool/components/agents/accessibility/accessibility-tester.md
+++ b/cli-tool/components/agents/accessibility/accessibility-tester.md
@@ -17,9 +17,11 @@ Automated tools typically catch 30–40% of WCAG violations industry-wide (axe-c
 Use CLI tools to identify programmatic violations efficiently:
 - `npx @axe-core/cli <url> --exit` — catches ARIA errors, missing labels, contrast failures; add `--tags wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa` to explicitly request WCAG 2.2 rule coverage
 - `npx lighthouse <url> --only-categories=accessibility` — Lighthouse accessibility score with opportunities
-- `npx pa11y <url>` — WCAG 2.1/2.2 rule-set with detailed failure messages
+- `npx pa11y <url> --runner axe --standard WCAG2AA` — pa11y's default runner is `htmlcs` (HTML_CodeSniffer), which is WCAG 2.0-era and does not reliably surface WCAG 2.1/2.2 violations; pass `--runner axe` explicitly to get axe-core-backed, WCAG 2.1/2.2-aligned results
 
 Parse tool output and deduplicate findings before reporting.
+
+Confirm the resolved `axe-core` version is ≥4.5 (ideally current, e.g. 4.11) before trusting WCAG 2.2 coverage — run `npx @axe-core/cli --version` — since older pinned/cached versions silently omit WCAG 2.2 rules even when `wcag22aa` is requested.
 
 **Track 1b — Scripted interaction testing (where test infra exists)**
 For repeatable checks of tab order, focus trapping in modals, `aria-expanded`/`aria-selected` state changes, and focus restoration on close, use Deque's official Playwright integration rather than relying solely on the manual checklist:
@@ -44,6 +46,8 @@ Run after automated scan to surface human-judgement violations:
 - Images: meaningful images have descriptive alt text; decorative images use `alt=""`
 - Forms: all inputs have associated labels; error messages are specific and programmatically linked
 - Live regions: dynamic content updates announced via `aria-live` with appropriate politeness
+- Documents: linked PDFs/Office files are tagged, have a logical reading order, and include alt text for embedded images (Section 508 and EAA scope commonly extends to downloadable documents, not just rendered web pages)
+- Forced colors: UI remains usable and all information is conveyed when Windows High Contrast / `forced-colors: active` is enabled; no information conveyed by background-image or box-shadow alone
 
 ## WCAG 2.2 Reference Standard
 
@@ -64,6 +68,8 @@ WCAG 3.0 remains a W3C Working Draft (not expected before ~2029) and will not re
 | 3.3.7 | A | Redundant Entry | Previously entered information is auto-populated or available for selection |
 | 3.3.8 | AA | Accessible Authentication (Minimum) | No cognitive function test required unless an alternative or assistance is provided |
 | 3.3.9 | AAA | Accessible Authentication (Enhanced) | No cognitive function test required at all during authentication |
+
+Of these 9 criteria, only **2.5.8 Target Size (Minimum)** has a dedicated automated check today — axe-core's `target-size` rule (axe-core ≥4.5, only fires when the `wcag22aa` tag is requested). The remaining 8 criteria have no reliable automated coverage and must be verified via the Track 2 manual checklist.
 
 ## ARIA Patterns and Screen Reader Guidance
 
@@ -113,6 +119,19 @@ Element: <CSS selector or component name>
 Issue: <Clear description of the barrier and its impact on users>
 Remediation: <Specific code-level fix or pattern>
 Verification: <How to confirm the fix resolves the issue>
+```
+
+**Worked example:**
+
+```
+ID: A11Y-001
+WCAG: 1.4.3 Contrast (Minimum) (Level AA)
+Severity: High
+Source: Automated (axe-core)
+Element: button.checkout-submit
+Issue: Button text color (#999999) on white background yields 2.85:1 contrast, below the 4.5:1 minimum for normal text.
+Remediation: Change text color to #595959 or darker (yields 7:1) to meet WCAG 1.4.3.
+Verification: Re-run axe-core color-contrast rule; confirm ratio ≥4.5:1 with a contrast checker.
 ```
 
 **Severity definitions:**

--- a/cli-tool/components/agents/accessibility/accessibility-tester.md
+++ b/cli-tool/components/agents/accessibility/accessibility-tester.md
@@ -17,11 +17,11 @@ Automated tools typically catch 30–40% of WCAG violations industry-wide (axe-c
 Use CLI tools to identify programmatic violations efficiently:
 - `npx @axe-core/cli <url> --exit` — catches ARIA errors, missing labels, contrast failures; add `--tags wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa` to explicitly request WCAG 2.2 rule coverage
 - `npx lighthouse <url> --only-categories=accessibility` — Lighthouse accessibility score with opportunities
-- `npx pa11y <url> --runner axe --standard WCAG2AA` — pa11y's default runner is `htmlcs` (HTML_CodeSniffer), which is WCAG 2.0-era and does not reliably surface WCAG 2.1/2.2 violations; pass `--runner axe` explicitly to get axe-core-backed, WCAG 2.1/2.2-aligned results
+- `npx pa11y <url> --runner axe --standard WCAG2AA` — pa11y's default runner is `htmlcs` (HTML_CodeSniffer), which is WCAG 2.0-era; pass `--runner axe` explicitly to get axe-core-backed WCAG 2.1 results. Note: pa11y's `WCAG2AA` standard maps only to the `wcag2a`/`wcag21a`/`wcag2aa`/`wcag21aa` axe tags (no `--tags` CLI flag exists) — it does **not** cover WCAG 2.2. For WCAG 2.2 rule coverage, add `wcag22aa` to `runnerConfig.axe.runOnly` in `.pa11yrc`, or rely on the `@axe-core/cli` command above.
 
 Parse tool output and deduplicate findings before reporting.
 
-Confirm the resolved `axe-core` version is ≥4.5 (ideally current, e.g. 4.11) before trusting WCAG 2.2 coverage — run `npx @axe-core/cli --version` — since older pinned/cached versions silently omit WCAG 2.2 rules even when `wcag22aa` is requested.
+Confirm the `axe-core` version actually used by each tool is ≥4.5 (ideally current, e.g. 4.11) before trusting WCAG 2.2 coverage — `npx @axe-core/cli --version` only reports the CLI's own bundled version, not pa11y's or `@axe-core/playwright`'s independently-resolved axe-core, which can lag behind. Check each tool's bundled version separately since older pinned/cached versions silently omit WCAG 2.2 rules even when `wcag22aa` is requested.
 
 **Track 1b — Scripted interaction testing (where test infra exists)**
 For repeatable checks of tab order, focus trapping in modals, `aria-expanded`/`aria-selected` state changes, and focus restoration on close, use Deque's official Playwright integration rather than relying solely on the manual checklist:


### PR DESCRIPTION
## Summary

Automated Component Review Loop improvements for `cli-tool/components/agents/accessibility/accessibility-tester.md`, based on research into current (2026) accessibility-testing tooling and WCAG 2.2 automation coverage.

- Fixed pa11y CLI guidance to explicitly use `--runner axe --standard WCAG2AA` — pa11y's default `htmlcs` runner is WCAG 2.0-era and does not reliably surface WCAG 2.1/2.2 violations
- Added a note to verify the resolved `axe-core` version is ≥4.5 before trusting WCAG 2.2 rule coverage (older pinned/cached versions silently omit 2.2 rules even when the `wcag22aa` tag is requested)
- Annotated the WCAG 2.2 new-criteria table to clarify that only 2.5.8 (Target Size Minimum) is automatable today, via axe-core's `target-size` rule; the other 8 criteria require manual verification via Track 2
- Added a fully worked example finding after the Finding Format template, to anchor severity/remediation phrasing
- Added a manual checklist item for document/PDF accessibility (PDF tagging, reading order, alt text — Section 508/EAA scope covers downloadable documents, not just rendered pages)
- Added a manual checklist item for forced-colors / `prefers-contrast` (Windows High Contrast Mode) testing

Validated against the `component-reviewer` checklist: valid YAML frontmatter, all required fields present, kebab-case name matches filename, no hardcoded secrets, no absolute paths, correct category placement, tools scoped correctly (audit-only, no `Write`/`Edit`).

## Follow-up needed (not addressed in this PR — out of scope for a single-component review)

`cli-tool/components/agents/development-tools/accessibility-tester.md` declares the same `name: accessibility-tester`, which violates the "unique within type" naming rule in `.claude/agents/component-reviewer.md`. That version is lower quality (WCAG 2.1-only, no WCAG 2.2 criteria, and includes an "Implementation Phase" that contradicts the audit-only philosophy of this agent). A maintainer should rename or deprecate the `development-tools` copy in a separate change.

## Test plan

- [x] Reviewed frontmatter and content against `.claude/agents/component-reviewer.md` checklist
- [ ] `python scripts/generate_components_json.py` (catalog regen — maintainer step after merge)

---

Generated by the automated Component Review Loop (cycle 83, Linear [CLA-125](https://linear.app/claude-code-templates/issue/CLA-125/review-accessibility-tester)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QTTuf1dEt7QW83eyAPV7Lm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the accessibility-tester component to axe-backed scanning and tightens WCAG 2.2 and high-contrast guidance. Previously audits could use `pa11y`’s default `htmlcs` runner and test one contrast mode; now we require `pa11y --runner axe`, per-tool `axe-core` ≥4.5 verification, and testing both `forced-colors` and `prefers-contrast`.

- Area: components (`cli-tool/components/`); no new components; regenerate `docs/components.json` after merge; no new environment variables or secrets; aligns with Linear CLA-125.
- Tooling: use `pa11y --runner axe --standard WCAG2AA`; note `pa11y` does not include WCAG 2.2 without `.pa11yrc` `runnerConfig.axe.runOnly` including `wcag22aa`, or use `@axe-core/cli` with `--tags wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa`.
- Versions: require `axe-core` ≥4.5 for WCAG 2.2 rules; check per-tool resolution with `npm ls axe-core` (do not rely on `@axe-core/cli --version` for other tools).
- Coverage: only WCAG 2.2 2.5.8 (Target Size Minimum) is automatable via `axe-core`’s `target-size`; verify other 2.2 criteria manually.
- Manual checks: require both Windows High Contrast (`forced-colors`) and `prefers-contrast` testing; add document/PDF accessibility to the checklist.

<sup>Written for commit c34a572661ccc3aaf9dd8b9866a043bbddddbd32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

