### PR TITLE
Add Scavio MCP component (web-data)

### DIFF
--- a/cli-tool/components/mcps/web-data/scavio.json
+++ b/cli-tool/components/mcps/web-data/scavio.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "scavio": {
+      "description": "Real-time structured web data across 32 platforms with one API key: Google search, YouTube, Amazon, Walmart, eBay, Target, TikTok, Instagram, LinkedIn, X, Reddit, Zillow, Indeed, SEC EDGAR and more, plus extract-any-URL to Markdown.",
+      "command": "npx",
+      "args": ["-y", "@scavio/mcp-server"],
+      "env": {
+        "SCAVIO_API_KEY": "<your-scavio-api-key>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds [Scavio](https://scavio.dev) to `components/mcps/web-data/`.

Scavio is a unified web data API: one key returns structured JSON from Google search (SERP, News, Maps, Shopping, Trends, Flights, Hotels, AI Mode), YouTube, Amazon, Walmart, eBay, Target, TikTok, TikTok Shop, Instagram, LinkedIn, X, Reddit, Zillow, Redfin, Indeed, Glassdoor, SEC EDGAR and more, plus an extract endpoint that turns any URL into Markdown. 191 tools across 32 platforms.

- Published on npm as `@scavio/mcp-server` (v0.13.1), stdio transport, no build step
- Also in the official MCP registry as `io.github.scavio-ai/scavio-mcp`
- Free tier on signup, no credit card, so the component is testable without payment

One file added, matching the shape of the neighbouring `apify.json` and `brightdata.json`. JSON validated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Scavio MCP component for web data so users can fetch structured results from major platforms and extract any URL via a single API key.

- Area: components (`cli-tool/components/`); adds `cli-tool/components/mcps/web-data/scavio.json`.
- Invokes external runtime via `npx` with `@scavio/mcp-server` (unpinned); reviewers should confirm trust/versioning.
- Requires new env var: `SCAVIO_API_KEY`.
- New component added; regenerate `docs/components.json` if the catalog needs to include it.

<sup>Written for commit 19a0d2a9bed683c4063129cca71fe268f09b9ad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

