### PR TITLE
Add nable: local-first FinOps MCP for cloud and AI spend

### DIFF
--- a/cli-tool/components/mcps/devtools/nable.json
+++ b/cli-tool/components/mcps/devtools/nable.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "nable": {
+      "description": "Local-first FinOps server for cloud and AI spend. Answers cost questions across AWS, Azure, GCP, Kubernetes and 15+ SaaS and AI providers, detects anomalies against a rolling baseline, tracks LLM spend by model, and drafts the Terraform fix as a pull request a human reviews. Runs on your machine: credentials stay in your OS keyring and cost data caches in a local SQLite database. Propose-only, so it never changes your cloud on its own.",
+      "command": "uvx",
+      "args": ["nable"]
+    }
+  }
+}


### PR DESCRIPTION
Adds one component: `cli-tool/components/mcps/devtools/nable.json`.

**Why this one.** There is no cost or FinOps MCP in the catalog today. Cloud spend is a question people ask inside Claude Code constantly and currently have to leave for a console to answer.

**What nable does.** Answers cost questions across AWS, Azure, GCP, Kubernetes and 15+ SaaS and AI providers, detects anomalies against a rolling baseline, tracks LLM spend by model, and drafts the Terraform fix as a pull request a human reviews.

**Config notes.** Runs with `uvx`, matching the nine existing uvx components. No API key in the config, so no placeholder for users to fill: it reads the cloud credentials already on the machine, and they stay in the OS keyring. Propose-only, so it never changes cloud resources on its own.

Open source (Apache-2.0) at [getnable/finopsmcp](https://github.com/getnable/finopsmcp), on PyPI as `finops-mcp`. I did not touch `components.json`, since that is generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `nable` as a new MCP component to provide local‑first FinOps for cloud and AI spend, filling the gap of no cost tooling in the catalog. Previously there was no FinOps MCP; now users can query spend, detect anomalies, and get Terraform fix proposals locally without modifying cloud resources.

- Area: components (`cli-tool/components/`); adds `cli-tool/components/mcps/devtools/nable.json`.
- Catalog: new component added; regenerate `docs/components.json`.
- Runtime: starts via `uvx` (entrypoint `nable`, PyPI `finops-mcp`); no API key in config; reads existing cloud credentials from the OS keyring; caches cost data locally; propose‑only (no resource changes).
- No new environment variables or secrets; no impact to existing components.

<sup>Written for commit d54b2c27b1d21808e49b23b72d5a5c7926150e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

