### PR TITLE
fix: repair invalid YAML frontmatter in six skills

### DIFF
--- a/cli-tool/components/skills/ai-research/data-processing-ray-data/SKILL.md
+++ b/cli-tool/components/skills/ai-research/data-processing-ray-data/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 tags: [Data Processing, Ray Data, Distributed Computing, ML Pipelines, Batch Inference, ETL, Scalable, Ray, PyTorch, TensorFlow]
-dependencies: [ray[data], pyarrow, pandas]
+dependencies: ["ray[data]", pyarrow, pandas]
 ---
 
 # Ray Data - Scalable ML Data Processing

--- a/cli-tool/components/skills/ai-research/distributed-training-ray-train/SKILL.md
+++ b/cli-tool/components/skills/ai-research/distributed-training-ray-train/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 tags: [Ray Train, Distributed Training, Orchestration, Ray, Hyperparameter Tuning, Fault Tolerance, Elastic Scaling, Multi-Node, PyTorch, TensorFlow]
-dependencies: [ray[train], torch, transformers]
+dependencies: ["ray[train]", torch, transformers]
 ---
 
 # Ray Train - Distributed Training Orchestration

--- a/cli-tool/components/skills/development/agirails-agent-payments/SKILL.md
+++ b/cli-tool/components/skills/development/agirails-agent-payments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agirails-agent-payments
-+description: "AI agent payment infrastructure — ACTP escrow, x402 instant payments, USDC settlement on Base L2. Interactive onboarding: asks your preferences, generates customized agent code, and verifies setup. Covers provider/requester patterns, adapter routing, 8-state machine, pricing, disputes, and identity."
+description: "AI agent payment infrastructure — ACTP escrow, x402 instant payments, USDC settlement on Base L2. Interactive onboarding: asks your preferences, generates customized agent code, and verifies setup. Covers provider/requester patterns, adapter routing, 8-state machine, pricing, disputes, and identity."
 license: MIT
 ---
 

--- a/cli-tool/components/skills/doordash/doordash-group-orders/SKILL.md
+++ b/cli-tool/components/skills/doordash/doordash-group-orders/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doordash-group-orders
-description: Group food ordering through the DoorDash CLI (dd-cli) from a persistent team roster. One request ("lunch for the team") fans out into a single merged cart with every line attributed to its eater via a person-to-cart-item-id ledger, per-person cost split with fee proration, payer rotation history, and a checkout gate that re-derives allergen conflicts against the roster live. Use when ordering for multiple people — team lunch, incident-response food, "collect orders from the thread" — or for /whose-turn payer rotation questions. Handles paste-a-thread intake: paste a Slack/chat thread and it builds the order ledger from it.
+description: "Group food ordering through the DoorDash CLI (dd-cli) from a persistent team roster. One request (\"lunch for the team\") fans out into a single merged cart with every line attributed to its eater via a person-to-cart-item-id ledger, per-person cost split with fee proration, payer rotation history, and a checkout gate that re-derives allergen conflicts against the roster live. Use when ordering for multiple people — team lunch, incident-response food, \"collect orders from the thread\" — or for /whose-turn payer rotation questions. Handles paste-a-thread intake: paste a Slack/chat thread and it builds the order ledger from it."
 allowed-tools: Bash(dd-cli:*), Bash(command -v:*), Bash(mkdir:*), Bash(cat:*), Bash(jq:*), Read, Write, Edit
 tags: [DoorDash, Team Lunch, Group Orders, Cost Split, CLI, Coordination]
 ---

--- a/cli-tool/components/skills/scientific/scholar-evaluation/SKILL.md
+++ b/cli-tool/components/skills/scientific/scholar-evaluation/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scholar-evaluation
+description: "Apply the ScholarEval framework to systematically evaluate scholarly and research work. This skill provides structured evaluation methodology based on peer-reviewed research assessment criteria, enabling comprehensive analysis of academic papers, research proposals, literature reviews, and scholarly writing across multiple quality dimensions."
+---
+
 # Scholar Evaluation
 
 ## Overview

--- a/cli-tool/components/skills/video/motion-canvas/SKILL.md
+++ b/cli-tool/components/skills/video/motion-canvas/SKILL.md
@@ -6,7 +6,7 @@ author: motion-canvas
 repo: https://github.com/motion-canvas/motion-canvas
 license: MIT
 tags: [Video, TypeScript, Animation, Motion Canvas, Signals, Generators, Canvas API, Vector, Audio Sync, Vite, ESM]
-dependencies: [@motion-canvas/core>=3.0.0, @motion-canvas/2d>=3.0.0, @motion-canvas/ui>=3.0.0, @motion-canvas/vite-plugin>=3.0.0]
+dependencies: ["@motion-canvas/core>=3.0.0", "@motion-canvas/2d>=3.0.0", "@motion-canvas/ui>=3.0.0", "@motion-canvas/vite-plugin>=3.0.0"]
 ---
 
 # Motion Canvas - Production-Ready Video Creation with TypeScript


### PR DESCRIPTION
Six skills under `cli-tool/components/skills/` have frontmatter that a standard YAML parser rejects, so `npx skills add davila7/claude-code-templates --list` skips them:

```
⚠ Skipped .../ai-research/data-processing-ray-data/SKILL.md — YAML parse error: Missing , or : between flow sequence items
dependencies: [ray[data], pyarrow, pandas]
                  ^
⚠ Skipped .../ai-research/distributed-training-ray-train/SKILL.md — YAML parse error: Missing , or : between flow sequence items
⚠ Skipped .../development/agirails-agent-payments/SKILL.md — missing required frontmatter field(s): description
⚠ Skipped .../doordash/doordash-group-orders/SKILL.md — YAML parse error: Nested mappings are not allowed in compact mappings
⚠ Skipped .../scientific/scholar-evaluation/SKILL.md — missing required frontmatter field(s): name, description
⚠ Skipped .../video/motion-canvas/SKILL.md — YAML parse error: Plain value cannot start with reserved character @
dependencies: [@motion-canvas/core>=3.0.0, ...
               ^
```

| Skill | Problem | Fix |
|---|---|---|
| `doordash/doordash-group-orders` | unquoted `description:` contains `: ` | wrap in double quotes |
| `ai-research/data-processing-ray-data` | `[ray[data], ...]` nested brackets inside a flow sequence | `["ray[data]", pyarrow, pandas]` |
| `ai-research/distributed-training-ray-train` | same with `ray[train]` | `["ray[train]", torch, transformers]` |
| `video/motion-canvas` | `[@motion-canvas/core>=3.0.0, ...]`, `@` can't start a plain scalar | quote each entry |
| `development/agirails-agent-payments` | line reads `+description: ...` (stray `+` from a diff paste), so there is no `description` key | drop the `+` |
| `scientific/scholar-evaluation` | no frontmatter at all | add `name` + `description`, description copied from the existing Overview paragraph |

No description text changed apart from adding quotes. After the change `npx skills add . --list` reports 0 skipped (was 6).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid YAML frontmatter in six skills so the components catalog parses cleanly. Previously a standard YAML parser rejected these files and `npx skills add ... --list` skipped them; now all six parse and the command reports 0 skipped. Content is unchanged except quoting; `scientific/scholar-evaluation` gained minimal `name` and `description`.

- Area: components (`cli-tool/components/skills/*`). No new components added.
- Fixes: quote dependency items and descriptions; remove a stray `+` in `development/agirails-agent-payments`; add frontmatter to `scientific/scholar-evaluation`.
- Verify: run `npx skills add . --list` and confirm 0 skipped; optional YAML lint on the six `SKILL.md` files.
- Catalog: regenerate `docs/components.json` to include these skills. No new environment variables or secrets.

<sup>Written for commit efad65cad57c18044ca251b4ca2b040a2c513213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

