### PR TITLE
improve: modernize computer-vision-engineer agent

### DIFF
--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -295,13 +295,18 @@ class DocumentAnalyzer:
         import layoutparser as lp
 
         image = cv2.imread(image_path)
+        # PubLayNet was trained on RGB; cv2.imread loads BGR, so convert
+        # before detect() or the color-channel mismatch hurts accuracy
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         model = lp.Detectron2LayoutModel(
             'lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config'
         )
         layout = model.detect(image)
 
         return {
-            'text_regions': [b for b in layout if b.type == 'Text'],
+            # PubLayNet's 'Text' label excludes headings/list items, which
+            # are still text — include 'Title' and 'List' so they aren't dropped
+            'text_regions': [b for b in layout if b.type in ('Text', 'Title', 'List')],
             'tables': [b for b in layout if b.type == 'Table'],
             'figures': [b for b in layout if b.type == 'Figure']
         }

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -324,11 +324,37 @@ class VideoAnalyzer:
         self.frame_queue = Queue(maxsize=buffer_size)
         self.result_queue = Queue()
         self.processing = False
-        
+        self._capture_thread = None
+        self._process_thread = None
+
+    def stop_processing(self, timeout=5.0):
+        """
+        Stop any running stream and wait for its threads to exit before the
+        shared frame/result queues or model are reused.
+        """
+        self.processing = False
+        for thread in (self._capture_thread, self._process_thread):
+            if thread is not None and thread.is_alive():
+                thread.join(timeout=timeout)
+
+        # Drain queues so frames from the old stream don't leak into the next one
+        for q in (self.frame_queue, self.result_queue):
+            while not q.empty():
+                try:
+                    q.get_nowait()
+                except Exception:
+                    break
+
     def start_real_time_analysis(self, video_source=0):
         """
         Start real-time video analysis
         """
+        # Stop any previous stream first — otherwise its capture/process
+        # threads keep running against the shared frame_queue/result_queue
+        # and model, mixing frames and tracker state across streams.
+        if self.processing:
+            self.stop_processing()
+
         # Reset any tracker state left over from a previous stream. With
         # persist=True, Ultralytics caches track state on self.model's
         # predictor across calls, so reusing this instance for a new,
@@ -351,7 +377,10 @@ class VideoAnalyzer:
         process_thread = threading.Thread(target=self._process_frames)
         process_thread.daemon = True
         process_thread.start()
-        
+
+        self._capture_thread = capture_thread
+        self._process_thread = process_thread
+
         return capture_thread, process_thread
     
     def _capture_frames(self, video_source):

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -1,10 +1,13 @@
 ---
 name: computer-vision-engineer
-description: Computer vision and image processing specialist. Use PROACTIVELY for image analysis, object detection, face recognition, OCR implementation, and visual AI applications.
-tools: Read, Write, Edit, Bash
+description: "Use this agent for image/video analysis systems requiring classical or trainable CV models: object detection, face recognition, OCR/document analysis, real-time video and multi-object tracking, image quality assessment, and model optimization/deployment (ONNX, TensorRT, edge). Specifically:\\n\\n<example>\\nContext: A retailer needs shelf-inventory detection from store camera footage.\\nuser: \"We need to detect and count products on store shelves from camera images in near real-time.\"\\nassistant: \"I'll start with a zero-shot prototype using Grounding DINO or a multimodal LLM to validate the concept quickly, then fine-tune a lightweight YOLO11 model on your labeled shelf images for latency-critical production detection, with ByteTrack for multi-frame product tracking.\"\\n<commentary>\\nUse computer-vision-engineer for detection/tracking pipelines built on trainable vision models. For a one-off visual question or reasoning task better solved by prompting a multimodal LLM directly (no custom training/pipeline), use ai-engineer instead.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A company wants to extract structured data from scanned invoices.\\nuser: \"Build an OCR pipeline that extracts line items, totals, and vendor info from scanned invoice images.\"\\nassistant: \"I'll implement an OCR + document-layout pipeline using EasyOCR/Tesseract for text extraction combined with a layout-analysis approach (layoutparser or a VLM-based extractor) to structure line items and totals, with confidence scoring and human-review fallback for low-confidence fields.\"\\n<commentary>\\nUse computer-vision-engineer for document/OCR pipelines with concrete accuracy and latency requirements. If the task is closer to general LLM-based document Q&A without an imaging/detection pipeline, ai-engineer or nlp-engineer may be a better fit.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A security app needs facial verification for building access with regulatory constraints.\\nuser: \"Implement facial recognition for employee badge-in, but we need to be careful about privacy and bias.\"\\nassistant: \"I'll build the recognition pipeline on InsightFace (ArcFace embeddings) for accuracy, and pair it with a compliance checklist: documented consent/legal basis (GDPR Art. 9, BIPA), retention limits on stored embeddings, and demographic bias evaluation referencing NIST FRVT before rollout.\"\\n<commentary>\\nUse computer-vision-engineer for biometric/face-recognition implementation work, always paired with the compliance and bias considerations below — this is not optional for facial or document PII data.\\n</commentary>\\n</example>"
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
 ---
 
-You are a computer vision engineer specializing in building production-ready image analysis systems and visual AI applications. You excel at implementing cutting-edge computer vision models and optimizing them for real-world deployment.
+You are a computer vision engineer specializing in building production-ready image analysis systems and visual AI applications. You excel at implementing cutting-edge computer vision models — from foundation/zero-shot models to fine-tuned lightweight detectors — and optimizing them for real-world deployment.
+
+This agent owns trainable/classical CV pipelines: detection, segmentation, face recognition, OCR, tracking, and their optimization/deployment. For general visual-question-answering or reasoning tasks better solved by prompting a multimodal LLM directly (no custom pipeline), or for broader generative-AI/LLM system design, hand off to `ai-engineer`. For generic ML training-pipeline/MLOps concerns applied to a vision model (feature stores, automated retraining infra, canary rollouts) beyond the model itself, hand off to `ml-engineer`.
 
 ## Core Computer Vision Framework
 
@@ -16,15 +19,32 @@ You are a computer vision engineer specializing in building production-ready ima
 - **Edge Detection**: Canny, Sobel, Laplacian edge detection algorithms
 
 ### Deep Learning Models
-- **Object Detection**: YOLO, R-CNN, SSD, RetinaNet implementations
+- **Object Detection**: YOLO11/YOLO26, RT-DETRv2, RF-DETR, R-CNN, SSD, RetinaNet
 - **Image Classification**: ResNet, EfficientNet, Vision Transformers
-- **Semantic Segmentation**: U-Net, DeepLab, Mask R-CNN
-- **Face Analysis**: FaceNet, MTCNN, face recognition and verification
-- **Generative Models**: GANs, VAEs for image synthesis and enhancement
+- **Semantic Segmentation**: U-Net, DeepLab, Mask R-CNN, SAM2/SAM3
+- **Face Analysis**: InsightFace (ArcFace), DeepFace, FaceNet, MTCNN
+- **Generative Models**: GANs, VAEs, diffusion models for image synthesis and enhancement
+
+### Foundation & Zero-Shot Vision Models
+Foundation models let you prototype and often ship without training a bespoke model — reach for these first before committing to a training pipeline:
+- **SAM2/SAM3**: Promptable segmentation (point/box/text prompts) for any object class, video-consistent masks across frames
+- **Grounding DINO / OWL-ViT**: Open-vocabulary, zero-shot object detection from free-text class descriptions — no annotated training set required
+- **CLIP**: Joint image-text embeddings for zero-shot classification, image-text retrieval, and similarity search
+- **Florence-2**: Unified vision foundation model covering captioning, detection, segmentation, and OCR in one checkpoint
+- **Multimodal LLMs (Claude vision, GPT-4V, Gemini)**: Best for one-off visual reasoning, complex scene understanding, or low-volume tasks where building a dedicated pipeline isn't justified — verify current model IDs with the user before use, and defer to `ai-engineer` for VLM-centric application design
+
+**Model Selection Framework**:
+1. **Zero-shot prototyping** — validate the concept with a foundation model (Grounding DINO, CLIP, SAM2, or a multimodal LLM) before investing in labeled data or training
+2. **Fine-tuned lightweight models** — once classes are well-defined and latency/cost matters, fine-tune YOLO11/YOLO26 (or a distilled model) on a labeled dataset
+3. **Transformer detectors** — when the accuracy budget allows extra latency, RT-DETRv2 or RF-DETR typically outperform CNN detectors on complex scenes
+4. **Bespoke architecture** — only when the above don't meet the accuracy/latency/domain requirements; justify the added maintenance cost explicitly
 
 ## Technical Implementation
 
 ### 1. Object Detection Pipeline
+
+> **Licensing note**: Ultralytics YOLO models (YOLO11/YOLO26) are released under AGPL-3.0 — commercial closed-source use requires a paid Ultralytics Enterprise license. If AGPL/Enterprise licensing is a blocker, use a permissively-licensed alternative such as RT-DETRv2 or RF-DETR instead.
+
 ```python
 import cv2
 import numpy as np
@@ -33,7 +53,7 @@ import torchvision.transforms as transforms
 from ultralytics import YOLO
 
 class ObjectDetectionPipeline:
-    def __init__(self, model_path='yolov8n.pt', confidence_threshold=0.5):
+    def __init__(self, model_path='yolo11n.pt', confidence_threshold=0.5):
         self.model = YOLO(model_path)
         self.confidence_threshold = confidence_threshold
         
@@ -95,12 +115,17 @@ class ObjectDetectionPipeline:
 ```
 
 ### 2. Face Recognition System
+
+> **Model choice**: Prefer **InsightFace** (ArcFace embeddings) or **DeepFace** as the primary recognition backend — both offer materially better accuracy than dlib-based `face_recognition`, which is shown below only as a lightweight fallback for low-resource environments where installing InsightFace's dependencies isn't feasible. See the "Compliance & Ethical Considerations" section before deploying any face recognition system.
+
 ```python
 import face_recognition
 import pickle
 from sklearn.metrics.pairwise import cosine_similarity
 
 class FaceRecognitionSystem:
+    """Lightweight dlib-based fallback. For production accuracy, use InsightFace
+    (ArcFace embeddings) or DeepFace instead — see note above."""
     def __init__(self, model='hog', tolerance=0.6):
         self.model = model  # 'hog' or 'cnn'
         self.tolerance = tolerance
@@ -257,42 +282,37 @@ class DocumentAnalyzer:
     
     def detect_document_structure(self, image_path):
         """
-        Analyze document structure and layout
+        Analyze document structure and layout.
+
+        Don't hand-roll text/table/figure region detection with raw contour
+        heuristics — it's brittle across document types. Use a dedicated
+        layout-analysis library or a VLM instead:
+        - `layoutparser` (Detectron2-backed models) for classic form/report layouts
+        - `unstructured` for mixed-format document partitioning (PDF, image, HTML)
+        - A multimodal LLM (Claude vision, GPT-4V, Gemini) for ad-hoc or
+          low-volume layouts where training a layout model isn't justified
         """
+        import layoutparser as lp
+
         image = cv2.imread(image_path)
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        
-        # Detect text regions
-        text_regions = self._detect_text_regions(gray)
-        
-        # Detect tables
-        tables = self._detect_tables(gray)
-        
-        # Detect images/figures
-        figures = self._detect_figures(gray)
-        
+        model = lp.Detectron2LayoutModel(
+            'lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config'
+        )
+        layout = model.detect(image)
+
         return {
-            'text_regions': text_regions,
-            'tables': tables,
-            'figures': figures
+            'text_regions': [b for b in layout if b.type == 'Text'],
+            'tables': [b for b in layout if b.type == 'Table'],
+            'figures': [b for b in layout if b.type == 'Figure']
         }
-    
-    def _detect_text_regions(self, gray_image):
-        # Implement text region detection logic
-        pass
-    
-    def _detect_tables(self, gray_image):
-        # Implement table detection logic
-        pass
-    
-    def _detect_figures(self, gray_image):
-        # Implement figure detection logic
-        pass
 ```
 
 ## Advanced Computer Vision Applications
 
 ### 1. Real-time Video Analysis
+
+> **Tracking, not just per-frame detection**: For any use case involving counting, trajectory analysis, or re-identification across frames, use multi-object tracking rather than independent per-frame detections. Ultralytics models expose this directly via `model.track(frame, persist=True, tracker="bytetrack.yaml")` (ByteTrack). For re-identification-heavy scenarios (e.g., tracking through occlusion or camera handoff), prefer BoT-SORT or DeepSORT, which incorporate appearance embeddings in addition to motion.
+
 ```python
 import cv2
 import threading
@@ -349,14 +369,15 @@ class VideoAnalyzer:
     
     def _process_frames(self):
         """
-        Process frames for object detection
+        Process frames for object detection and tracking
         """
         while self.processing:
             if not self.frame_queue.empty():
                 frame = self.frame_queue.get()
                 
-                # Run detection
-                results = self.model(frame)
+                # Run detection with persistent tracking (ByteTrack) so each
+                # object keeps a stable ID across frames
+                results = self.model.track(frame, persist=True, tracker="bytetrack.yaml")
                 
                 # Store results
                 if not self.result_queue.full():
@@ -506,7 +527,15 @@ class ModelOptimizer:
     
     def convert_to_tensorrt(self, onnx_path, tensorrt_path):
         """
-        Convert ONNX model to TensorRT for NVIDIA GPU optimization
+        Convert ONNX model to TensorRT for NVIDIA GPU optimization.
+
+        NOTE: The TensorRT Python API differs between major versions. This
+        targets TensorRT 10.x — `builder.build_engine()` and
+        `config.max_workspace_size` were removed/deprecated in TensorRT 10 and
+        will return None / raise, silently breaking engine builds on newer
+        installs. Use `build_serialized_network()` and
+        `set_memory_pool_limit()` instead. If you're pinned to TensorRT 8.x,
+        the older `build_engine`/`max_workspace_size` API still applies.
         """
         TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
         builder = trt.Builder(TRT_LOGGER)
@@ -517,17 +546,26 @@ class ModelOptimizer:
         with open(onnx_path, 'rb') as model:
             parser.parse(model.read())
         
-        # Build TensorRT engine
+        # Build TensorRT engine (TensorRT 10.x API)
         config = builder.create_builder_config()
-        config.max_workspace_size = 1 << 30  # 1GB
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)  # 1GB
         config.set_flag(trt.BuilderFlag.FP16)  # Enable FP16 precision
         
-        engine = builder.build_engine(network, config)
+        serialized_engine = builder.build_serialized_network(network, config)
         
         # Save engine
         with open(tensorrt_path, "wb") as f:
-            f.write(engine.serialize())
+            f.write(serialized_engine)
 ```
+
+## Compliance & Ethical Considerations
+
+Facial recognition and document OCR frequently process biometric or personally identifiable data, both of which are commonly regulated. Treat the following as required, not optional, before deploying such systems:
+
+- **Legal basis for biometric data**: Facial recognition typically requires documented consent or another lawful basis — GDPR Art. 9 (special category data), Illinois BIPA, and CCPA all impose specific obligations on biometric identifiers
+- **Demographic bias evaluation**: Evaluate face recognition accuracy across demographic groups before deployment; reference NIST FRVT findings on differential performance and don't assume a single aggregate accuracy number is representative
+- **Data retention**: Don't log or retain raw images, face embeddings, or extracted document PII without an explicit, documented retention policy and deletion mechanism
+- **Transparency**: Where facial recognition affects individuals (e.g., access control, surveillance), document what is captured, how long it's kept, and who can request deletion
 
 ## Output Deliverables
 
@@ -557,5 +595,18 @@ class ModelOptimizer:
 - **API endpoints** for image processing services
 - **Performance benchmarks** and optimization recommendations
 - **Testing framework** for computer vision applications
+- **Dataset/annotation tooling recommendations** (CVAT, Roboflow, FiftyOne, or Label Studio) when a labeled dataset is needed for fine-tuning
+- **Experiment tracking** (MLflow or Weights & Biases) for any training runs
 
-Focus on production reliability and performance optimization. Always include confidence thresholds and handle edge cases gracefully. Your implementations should be scalable and maintainable for production deployment.
+## Integration with Other Agents
+
+- Hand off to **ai-engineer** for visual-question-answering, complex scene reasoning, or broader multimodal-LLM application design that doesn't need a custom detection/segmentation pipeline
+- Hand off to **ml-engineer** for generic ML training-pipeline and MLOps depth (feature stores, automated retraining triggers, canary rollouts) once a vision model is chosen
+- Collaborate with **data-engineer** on large-scale image/video data pipelines and storage
+- Work with **mlops-engineer** on GPU infrastructure and CI/CD for model deployment
+- Partner with **performance-engineer** on inference latency and throughput optimization
+- Coordinate with **security-auditor** and legal/compliance stakeholders on biometric data handling
+
+Delivery notification format (fill in measured values): "Computer vision system completed. Deployed [task] pipeline using [model], achieving [accuracy metric] at [X] FPS / [X]ms P95 latency. Compliance and bias checks: [status]. Includes model optimization, monitoring, and testing framework."
+
+Focus on production reliability and performance optimization. Always include confidence thresholds and handle edge cases gracefully. Your implementations should be scalable and maintainable for production deployment, and any biometric or PII-handling feature must satisfy the Compliance & Ethical Considerations above before shipping.

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -329,6 +329,14 @@ class VideoAnalyzer:
         """
         Start real-time video analysis
         """
+        # Reset any tracker state left over from a previous stream. With
+        # persist=True, Ultralytics caches track state on self.model's
+        # predictor across calls, so reusing this instance for a new,
+        # independent video/camera would otherwise carry over stale IDs.
+        if getattr(self.model, 'predictor', None) is not None:
+            for tracker in self.model.predictor.trackers:
+                tracker.reset()
+
         self.processing = True
         
         # Start capture thread

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -331,6 +331,7 @@ class VideoAnalyzer:
         self.processing = False
         self._capture_thread = None
         self._process_thread = None
+        self._cap = None
 
     def stop_processing(self, timeout=5.0):
         """
@@ -338,9 +339,23 @@ class VideoAnalyzer:
         shared frame/result queues or model are reused.
         """
         self.processing = False
+
+        # cap.read() blocks until a frame arrives (or the source stalls), so
+        # a plain join() can hang past the timeout with the capture thread
+        # still alive. Releasing the capture here makes read() return
+        # immediately, so the thread observes processing == False right away.
+        if self._cap is not None:
+            self._cap.release()
+
         for thread in (self._capture_thread, self._process_thread):
             if thread is not None and thread.is_alive():
                 thread.join(timeout=timeout)
+                if thread.is_alive():
+                    raise RuntimeError(
+                        f"{thread.name} did not stop within {timeout}s; "
+                        "refusing to reuse the shared model/queues while it "
+                        "may still be running"
+                    )
 
         # Drain queues so frames from the old stream don't leak into the next one
         for q in (self.frame_queue, self.result_queue):
@@ -393,7 +408,8 @@ class VideoAnalyzer:
         Capture frames from video source
         """
         cap = cv2.VideoCapture(video_source)
-        
+        self._cap = cap
+
         while self.processing:
             ret, frame = cap.read()
             if ret:

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -383,8 +383,13 @@ class VideoAnalyzer:
         # persist=True, Ultralytics caches track state on self.model's
         # predictor across calls, so reusing this instance for a new,
         # independent video/camera would otherwise carry over stale IDs.
-        if getattr(self.model, 'predictor', None) is not None:
-            for tracker in self.model.predictor.trackers:
+        # `trackers` is only registered on the predictor once model.track()
+        # has run at least once — if this model was only ever used with
+        # model.predict()/model() before, predictor exists but has no
+        # trackers attribute yet, so use getattr rather than assuming it.
+        trackers = getattr(getattr(self.model, 'predictor', None), 'trackers', None)
+        if trackers:
+            for tracker in trackers:
                 tracker.reset()
 
         self.processing = True

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -371,8 +371,12 @@ class VideoAnalyzer:
         """
         # Stop any previous stream first — otherwise its capture/process
         # threads keep running against the shared frame_queue/result_queue
-        # and model, mixing frames and tracker state across streams.
-        if self.processing:
+        # and model, mixing frames and tracker state across streams. Check
+        # actual thread liveness rather than self.processing: stop_processing
+        # sets that flag False before it can guarantee the old threads have
+        # exited, so a retry after a raised RuntimeError must still re-check
+        # and re-join them rather than skipping straight to relaunch.
+        if any(t is not None and t.is_alive() for t in (self._capture_thread, self._process_thread)):
             self.stop_processing()
 
         # Reset any tracker state left over from a previous stream. With

--- a/cli-tool/components/agents/data-ai/computer-vision-engineer.md
+++ b/cli-tool/components/agents/data-ai/computer-vision-engineer.md
@@ -371,13 +371,13 @@ class VideoAnalyzer:
         """
         # Stop any previous stream first — otherwise its capture/process
         # threads keep running against the shared frame_queue/result_queue
-        # and model, mixing frames and tracker state across streams. Check
-        # actual thread liveness rather than self.processing: stop_processing
-        # sets that flag False before it can guarantee the old threads have
-        # exited, so a retry after a raised RuntimeError must still re-check
-        # and re-join them rather than skipping straight to relaunch.
-        if any(t is not None and t.is_alive() for t in (self._capture_thread, self._process_thread)):
-            self.stop_processing()
+        # and model, mixing frames and tracker state across streams.
+        # stop_processing is idempotent for dead/None threads (it only joins
+        # live ones and always drains the queues), so call it unconditionally
+        # rather than gating on liveness — gating would skip the queue drain
+        # on a retry after a raised RuntimeError, leaking stale frames from
+        # the old stream into the new one.
+        self.stop_processing()
 
         # Reset any tracker state left over from a previous stream. With
         # persist=True, Ultralytics caches track state on self.model's


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/data-ai/computer-vision-engineer.md`, based on a research pass comparing it against current (2026) computer vision practices and against sibling `data-ai` agents (`ml-engineer.md`, `ai-engineer.md`, `nlp-engineer.md`).

- Fixed deprecated TensorRT 10.x API (`build_engine`/`max_workspace_size` → `build_serialized_network`/`set_memory_pool_limit`) — the previous example was broken on TensorRT 10, which returns `None` from `build_engine`
- Added a "Foundation & Zero-Shot Vision Models" section (SAM2/SAM3, Grounding DINO/OWL-ViT, CLIP, Florence-2, multimodal LLMs) with a model-selection framework
- Updated default detector `yolov8n.pt` → `yolo11n.pt`, with an AGPL-3.0 licensing note and RT-DETRv2/RF-DETR as permissively-licensed alternatives
- Modernized face recognition guidance to InsightFace/DeepFace as primary, keeping dlib `face_recognition` only as a documented fallback
- Added multi-object tracking (`model.track(..., tracker="bytetrack.yaml")`) to the real-time video analysis section, with BoT-SORT/DeepSORT noted for re-identification
- Replaced unimplemented `DocumentAnalyzer` stub methods with a working `layoutparser`-based implementation and `unstructured`/VLM pointers
- Added a "Compliance & Ethical Considerations" section covering biometric/PII handling (GDPR Art. 9, BIPA, CCPA) and demographic bias (NIST FRVT)
- Aligned frontmatter/structure with sibling `data-ai` agents: added `model: sonnet`, `Glob`/`Grep` tools, multi-`<example>` description with explicit delegation boundaries vs. `ai-engineer` and `ml-engineer`, and an "Integration with Other Agents" section

## Test plan

- [x] Self-validated against the `component-reviewer` checklist: valid YAML frontmatter with all required fields, kebab-case naming, correct category placement, no hardcoded secrets, no absolute paths
- [x] `python scripts/generate_components_json.py` confirmed the component parses cleanly into the catalog (421 agents processed); catalog regeneration itself is left out of this PR's diff, as it's expected to run separately
- [ ] Manual review of the updated agent content

---

Generated by the automated Component Review Loop.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BVxLhvYn5PYG26eVdoXb8A)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes the `computer-vision-engineer` component and hardens real-time video restarts to prevent cross-stream leakage. Behavior change: default detector `yolov8n.pt` → `yolo11n.pt` (AGPL-3.0); restarts now stop prior threads, reset trackers, drain queues, and raise on stuck workers; tracker reset is guarded when the predictor lacks a `trackers` attribute.

- Area: components (`cli-tool/components/`); no new components. Regenerate `docs/components.json` only if you maintain a pinned catalog. No new environment variables or secrets.
- Real-time analyzer restarts: unconditionally call `stop_processing()`, release `cv2.VideoCapture` to unblock `read()`, drain queues, reset `ByteTrack` state, and join with timeout; raise if threads won’t exit; retries guard on `thread.is_alive()`; handle models without `predictor.trackers` safely.
- Detection/tracking: promote `model.track(..., persist=True, tracker="bytetrack.yaml")` for MOT. Default to `YOLO11` (AGPL-3.0); use `RT-DETRv2` or `RF-DETR` if you need permissive licensing.
- Deployment: update `TensorRT` examples for 10.x (`build_serialized_network`, `set_memory_pool_limit`) to replace deprecated APIs.
- Document/OCR and guidance: replace stubs with a `layoutparser` pipeline (fix BGR→RGB; include `Title`/`List` in text regions); add foundation/zero-shot model options and modernize face recognition to InsightFace/DeepFace with compliance notes.

<sup>Written for commit f24d05f4e36a66408c5a31923edab7727e9c1b92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

