### PR TITLE
feat(mcps): add Sicex trade intelligence MCP server

### DIFF
--- a/cli-tool/components/mcps/web-data/sicex.json
+++ b/cli-tool/components/mcps/web-data/sicex.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "sicex": {
+      "description": "Sicex MCP — global trade intelligence: search and analyze customs import/export records and maritime shipment data for Latin American markets. Tools cover data-source and filter discovery, trade-data search/aggregation, company profiles, and report generation, plus interactive widgets (trade-flow charts, shipment tables, company cards) on hosts that support them. Requires a Sicex account (sicex.com) with an active data subscription. Uses OAuth 2.1 authentication (dynamic client registration + consent screen) — no API key needed, the MCP client will prompt you to sign in on first use.",
+      "type": "http",
+      "url": "https://api.sicex.com/mcp"
+    }
+  }
+}

--- a/cli-tool/components/mcps/web-data/sicex.json
+++ b/cli-tool/components/mcps/web-data/sicex.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "sicex": {
-      "description": "Sicex MCP — global trade intelligence: search and analyze customs import/export records and maritime shipment data for Latin American markets. Tools cover data-source and filter discovery, trade-data search/aggregation, company profiles, and report generation, plus interactive widgets (trade-flow charts, shipment tables, company cards) on hosts that support them. Requires a Sicex account (sicex.com) with an active data subscription. Uses OAuth 2.1 authentication (dynamic client registration + consent screen) — no API key needed, the MCP client will prompt you to sign in on first use.",
+      "description": "Sicex MCP — global trade intelligence: search and analyze customs import/export records and maritime shipment data across markets in the Americas, the European Union, and Asia. Tools cover data-source and filter discovery, trade-data search/aggregation, company profiles, and report generation, plus interactive widgets (trade-flow charts, shipment tables, company cards) on hosts that support them. Requires a Sicex account (sicex.com) with an active data subscription. Uses OAuth 2.1 authentication (dynamic client registration + consent screen) — no API key needed, the MCP client will prompt you to sign in on first use.",
       "type": "http",
       "url": "https://api.sicex.com/mcp"
     }


### PR DESCRIPTION
## Summary
- Adds Sicex (sicex.com) as a new remote MCP server component under `cli-tool/components/mcps/web-data/`
- Sicex is a global trade intelligence platform: customs import/export records and maritime shipment data search/aggregation, company profiles, and report generation for Latin American markets
- Remote server over Streamable HTTP (`"type": "http"`), authenticated via OAuth 2.1 (dynamic client registration + consent screen) — no API key required, client prompts sign-in on first use
- Requires an active Sicex account/data subscription to use

## Test plan
- [x] Validated the JSON file parses correctly
- [x] Followed the existing MCP file convention (matched against `web/tinyfish.json`, `web/web-reader.json`, `devtools/postman.json` for the remote-HTTP + OAuth 2.1 shape)
- [x] Placed under the existing `web-data` category rather than introducing a new one, per repo convention of reusing categories where the fit is reasonable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Sicex trade intelligence MCP server, enabling MCP-enabled clients to search customs and maritime shipment data across the Americas, the EU, and Asia. Previously no Sicex integration; now available over HTTP with OAuth 2.1 sign-in; no API key required.

- Area: components (`cli-tool/components/`); added `cli-tool/components/mcps/web-data/sicex.json`.
- New component: `sicex` remote MCP (`type: "http"`, url `https://api.sicex.com/mcp`); requires an active Sicex account/subscription.
- Catalog: regenerate `docs/components.json` to include `sicex`.
- Env/secrets: none; OAuth 2.1 consent flow handles auth.

<sup>Written for commit 9b8e531bc123437332542c555b037ccd49a35e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

