### PR TITLE
Add Cohesivity plugin marketplace listing

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -23512,5 +23512,37 @@
         "author": "anthropics"
       }
     ]
+  },
+  {
+    "slug": "cohesivity-plugin",
+    "name": "Cohesivity Plugin",
+    "author": "cohesivity-org",
+    "description": "cohesivity.ai offers free agent native backend services. Annonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.",
+    "github": "https://github.com/cohesivity-org/cohesivity-plugin",
+    "stars": 0,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "mcps"
+    ],
+    "contains": {
+      "skills": 1,
+      "mcps": 2
+    },
+    "highlights": [
+      "Web UI: https://cohesivity.ai"
+    ],
+    "website": "https://cohesivity.ai",
+    "marketplace_name": "cohesivity",
+    "plugin_name": "cohesivity",
+    "plugin_manifest": {
+      "skills": [
+        "cohesivity"
+      ],
+      "mcpServers": [
+        "cohesivity",
+        "cohesivity-local"
+      ]
+    }
   }
 ]

--- a/dashboard/src/pages/plugins/[slug].astro
+++ b/dashboard/src/pages/plugins/[slug].astro
@@ -50,7 +50,8 @@ const pluginCount = containsObj.plugins ?? 0;
 // Install commands
 const repoPath = plugin.github.replace('https://github.com/', '');
 const addMarketplaceCmd = `/plugin marketplace add ${repoPath}`;
-const marketplaceName = repoPath.replace('/', '-');
+const marketplaceName = plugin.marketplace_name ?? repoPath.replace('/', '-');
+const pluginName = plugin.plugin_name ?? plugin.slug;
 ---
 
 <DashboardLayout
@@ -178,7 +179,7 @@ const marketplaceName = repoPath.replace('/', '-');
           {isMarketplace && pluginsList.length > 0 ? (
             <pre class="p-4 rounded-xl bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-secondary)] overflow-x-auto font-mono"><code>{`/plugin install <plugin-name>@${marketplaceName}`}</code></pre>
           ) : (
-            <pre class="p-4 rounded-xl bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-secondary)] overflow-x-auto font-mono"><code>{`/plugin install ${plugin.slug}@${marketplaceName}`}</code></pre>
+            <pre class="p-4 rounded-xl bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-secondary)] overflow-x-auto font-mono"><code>{`/plugin install ${pluginName}@${marketplaceName}`}</code></pre>
           )}
         </div>
 

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -67,7 +67,7 @@ REPOS = [
 ]
 
 DESCRIPTION_OVERRIDES = {
-    "cohesivity-org/cohesivity-plugin": "cohesivity.ai offers free agent native backend services. Annonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.",
+    "cohesivity-org/cohesivity-plugin": "cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.",
 }
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -14,6 +14,8 @@ Requires:
 
 import json
 import os
+import posixpath
+import shutil
 import sys
 import time
 import subprocess
@@ -61,9 +63,15 @@ REPOS = [
     ("chu2bard/pinion-os", None),
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
+    ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
 ]
 
+DESCRIPTION_OVERRIDES = {
+    "cohesivity-org/cohesivity-plugin": "cohesivity.ai offers free agent native backend services. Annonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.",
+}
+
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")
+GH_CLI = shutil.which("gh") or "gh"
 
 # --- GitHub API helpers (uses gh CLI) ---
 
@@ -81,7 +89,7 @@ def gh_api(endpoint, retries=3):
             time.sleep(1)
 
         try:
-            cmd = ["/usr/local/bin/gh", "api", endpoint.lstrip("/")]
+            cmd = [GH_CLI, "api", endpoint.lstrip("/")]
             result = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=30, env=_GH_ENV
             )
@@ -115,7 +123,7 @@ def gh_file_content(repo, path):
 
     try:
         result = subprocess.run(
-            ["/usr/local/bin/gh", "api", f"repos/{repo}/contents/{path}", "--jq", ".content"],
+            [GH_CLI, "api", f"repos/{repo}/contents/{path}", "--jq", ".content"],
             capture_output=True, text=True, timeout=30, env=_GH_ENV
         )
         if result.returncode != 0 or not result.stdout.strip():
@@ -151,7 +159,7 @@ def parse_json_safe(text):
             return None
 
 
-def extract_plugin_components(plugin_json):
+def extract_plugin_components(plugin_json, repo=None, dir_path=""):
     """Extract component counts from a plugin.json manifest."""
     if not plugin_json:
         return {}
@@ -176,11 +184,21 @@ def extract_plugin_components(plugin_json):
         elif isinstance(hooks, str):
             counts["hooks"] = 1
     # MCPs
-    mcps = plugin_json.get("mcpServers")
+    mcps_value = plugin_json.get("mcpServers")
+    mcps = (
+        resolve_server_manifest(repo, dir_path, mcps_value, "mcpServers")
+        if repo
+        else mcps_value
+    )
     if isinstance(mcps, dict) and len(mcps) > 0:
         counts["mcps"] = len(mcps)
     # LSPs
-    lsps = plugin_json.get("lspServers")
+    lsps_value = plugin_json.get("lspServers")
+    lsps = (
+        resolve_server_manifest(repo, dir_path, lsps_value, "lspServers")
+        if repo
+        else lsps_value
+    )
     if isinstance(lsps, dict) and len(lsps) > 0:
         counts["lsps"] = len(lsps)
     # Rules
@@ -261,6 +279,30 @@ def extract_frontmatter_description(content):
     return ""
 
 
+def resolve_server_manifest(repo, dir_path, manifest_value, manifest_key):
+    """Resolve inline or file-backed MCP/LSP server maps from plugin.json."""
+    if isinstance(manifest_value, dict):
+        return manifest_value
+    if not isinstance(manifest_value, str):
+        return {}
+
+    relative_path = posixpath.normpath(manifest_value.replace("\\", "/"))
+    if (
+        relative_path in ("", ".")
+        or relative_path.startswith("../")
+        or relative_path.startswith("/")
+    ):
+        return {}
+
+    full_path = f"{dir_path.rstrip('/')}/{relative_path}".lstrip("/")
+    raw = gh_file_content(repo, full_path)
+    document = parse_json_safe(raw)
+    if not isinstance(document, dict):
+        return {}
+    servers = document.get(manifest_key)
+    return servers if isinstance(servers, dict) else {}
+
+
 def scan_plugin_dir_components(repo, dir_path, fetch_descriptions=True):
     """Scan a plugin directory for skills/, agents/, commands/, hooks/ subdirs
     and list the files inside each. Returns (counts, items) where `counts` is
@@ -310,12 +352,12 @@ def scan_plugin_dir_components(repo, dir_path, fetch_descriptions=True):
     if plugin_json_raw:
         pj = parse_json_safe(plugin_json_raw)
         if pj:
-            mcps = pj.get("mcpServers")
-            if isinstance(mcps, dict) and len(mcps) > 0:
+            mcps = resolve_server_manifest(repo, dir_path, pj.get("mcpServers"), "mcpServers")
+            if mcps:
                 components["mcps"] = len(mcps)
                 component_items["mcps"] = [{"name": k, "description": ""} for k in mcps.keys()]
-            lsps = pj.get("lspServers")
-            if isinstance(lsps, dict) and len(lsps) > 0:
+            lsps = resolve_server_manifest(repo, dir_path, pj.get("lspServers"), "lspServers")
+            if lsps:
                 components["lsps"] = len(lsps)
                 component_items["lsps"] = [{"name": k, "description": ""} for k in lsps.keys()]
 
@@ -499,7 +541,9 @@ def process_repo(repo_full, website_override=None):
     marketplace_component_totals = aggregate_marketplace_components(plugins_detail)
 
     # 6. Extract single plugin components
-    single_components = extract_plugin_components(plugin_json) if plugin_json else {}
+    single_components = (
+        extract_plugin_components(plugin_json, repo=repo_full) if plugin_json else {}
+    )
 
     # 7. Build contains
     if repo_type == "marketplace":
@@ -570,7 +614,7 @@ def process_repo(repo_full, website_override=None):
         "slug": slug,
         "name": display_name,
         "author": repo_owner,
-        "description": description or marketplace.get("description", ""),
+        "description": DESCRIPTION_OVERRIDES.get(repo_full, description or marketplace.get("description", "")),
         "github": f"https://github.com/{repo_full}",
         "stars": stars,
         "type": repo_type,
@@ -581,6 +625,15 @@ def process_repo(repo_full, website_override=None):
 
     if website:
         result["website"] = website
+
+    marketplace_name = marketplace.get("name")
+    if isinstance(marketplace_name, str) and marketplace_name:
+        result["marketplace_name"] = marketplace_name
+
+    if repo_type == "plugin" and len(plugins_detail) == 1:
+        install_name = plugins_detail[0].get("name")
+        if isinstance(install_name, str) and install_name:
+            result["plugin_name"] = install_name
 
     # 14. Add marketplace plugins list (for individual pages)
     if repo_type == "marketplace" and plugins_detail:
@@ -593,12 +646,35 @@ def process_repo(repo_full, website_override=None):
             val = plugin_json.get(key)
             if isinstance(val, list) and val:
                 plugin_detail[key] = val
-        mcps = plugin_json.get("mcpServers")
-        if isinstance(mcps, dict) and mcps:
+        mcps = resolve_server_manifest(
+            repo_full, "", plugin_json.get("mcpServers"), "mcpServers"
+        )
+        if mcps:
             plugin_detail["mcpServers"] = list(mcps.keys())
-        lsps = plugin_json.get("lspServers")
-        if isinstance(lsps, dict) and lsps:
+        lsps = resolve_server_manifest(
+            repo_full, "", plugin_json.get("lspServers"), "lspServers"
+        )
+        if lsps:
             plugin_detail["lspServers"] = list(lsps.keys())
+        if plugin_detail:
+            result["plugin_manifest"] = plugin_detail
+    elif repo_type == "plugin" and len(plugins_detail) == 1:
+        component_items = plugins_detail[0].get("components_items", {})
+        plugin_detail = {}
+        for source_key, output_key in (
+            ("skills", "skills"),
+            ("agents", "agents"),
+            ("commands", "commands"),
+            ("mcps", "mcpServers"),
+            ("lsps", "lspServers"),
+        ):
+            names = [
+                item.get("name")
+                for item in component_items.get(source_key, [])
+                if isinstance(item, dict) and item.get("name")
+            ]
+            if names:
+                plugin_detail[output_key] = names
         if plugin_detail:
             result["plugin_manifest"] = plugin_detail
 
@@ -614,7 +690,7 @@ def main():
     # Check gh CLI is available
     try:
         test = subprocess.run(
-            ["/usr/local/bin/gh", "api", "rate_limit", "--jq", ".rate.remaining"],
+            [GH_CLI, "api", "rate_limit", "--jq", ".rate.remaining"],
             capture_output=True, text=True, timeout=10, env=_GH_ENV
         )
         if test.returncode == 0:

--- a/scripts/test_generate_plugins_json.py
+++ b/scripts/test_generate_plugins_json.py
@@ -1,0 +1,140 @@
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).with_name("generate_plugins_json.py")
+SPEC = importlib.util.spec_from_file_location("generate_plugins_json", MODULE_PATH)
+generator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generator)
+
+
+class CohesivityPluginGenerationTest(unittest.TestCase):
+    def test_root_file_backed_mcp_manifest_is_resolved(self):
+        plugin_json = {"mcpServers": "./.mcp.json"}
+        manifest = json.dumps(
+            {
+                "mcpServers": {
+                    "remote": {"type": "http"},
+                    "local": {"type": "stdio"},
+                }
+            }
+        )
+
+        with patch.object(
+            generator,
+            "gh_file_content",
+            side_effect=lambda _repo, path: manifest if path == ".mcp.json" else None,
+        ):
+            counts = generator.extract_plugin_components(
+                plugin_json, repo="example/root-plugin"
+            )
+
+        self.assertEqual(counts, {"mcps": 2})
+
+    def test_file_backed_mcp_manifest_is_resolved(self):
+        files = {
+            "packages/claude/.claude-plugin/plugin.json": json.dumps(
+                {"skills": "./skills/", "mcpServers": "./.mcp.json"}
+            ),
+            "packages/claude/.mcp.json": json.dumps(
+                {
+                    "mcpServers": {
+                        "cohesivity": {"type": "http"},
+                        "cohesivity-local": {"type": "stdio"},
+                    }
+                }
+            ),
+            "packages/claude/skills/cohesivity/SKILL.md": (
+                "---\nname: cohesivity\ndescription: Cohesivity skill\n---\n"
+            ),
+        }
+        listings = {
+            "packages/claude": [{"name": "skills", "type": "dir"}],
+            "packages/claude/skills": [{"name": "cohesivity", "type": "dir"}],
+        }
+
+        with (
+            patch.object(generator, "gh_file_content", side_effect=lambda _repo, path: files.get(path)),
+            patch.object(generator, "gh_dir_listing", side_effect=lambda _repo, path: listings.get(path, [])),
+        ):
+            counts, items = generator.scan_plugin_dir_components(
+                "cohesivity-org/cohesivity-plugin", "packages/claude"
+            )
+
+        self.assertEqual(counts, {"skills": 1, "mcps": 2})
+        self.assertEqual([item["name"] for item in items["skills"]], ["cohesivity"])
+        self.assertEqual(
+            [item["name"] for item in items["mcps"]],
+            ["cohesivity", "cohesivity-local"],
+        )
+
+    def test_cohesivity_listing_uses_declared_install_names_and_components(self):
+        marketplace = {
+            "name": "cohesivity",
+            "description": generator.DESCRIPTION_OVERRIDES["cohesivity-org/cohesivity-plugin"],
+            "plugins": [
+                {
+                    "name": "cohesivity",
+                    "source": "./packages/claude",
+                    "description": generator.DESCRIPTION_OVERRIDES[
+                        "cohesivity-org/cohesivity-plugin"
+                    ],
+                }
+            ],
+        }
+        files = {
+            ".claude-plugin/marketplace.json": json.dumps(marketplace),
+            "packages/claude/.claude-plugin/plugin.json": json.dumps(
+                {"skills": "./skills/", "mcpServers": "./.mcp.json"}
+            ),
+            "packages/claude/.mcp.json": json.dumps(
+                {
+                    "mcpServers": {
+                        "cohesivity": {"type": "http"},
+                        "cohesivity-local": {"type": "stdio"},
+                    }
+                }
+            ),
+            "packages/claude/skills/cohesivity/SKILL.md": (
+                "---\nname: cohesivity\ndescription: Cohesivity skill\n---\n"
+            ),
+        }
+        listings = {
+            "packages/claude": [{"name": "skills", "type": "dir"}],
+            "packages/claude/skills": [{"name": "cohesivity", "type": "dir"}],
+        }
+        repo_info = {
+            "name": "cohesivity-plugin",
+            "description": "GitHub repository description",
+            "homepage": "https://cohesivity.ai",
+            "stargazers_count": 10,
+            "owner": {"login": "cohesivity-org"},
+        }
+
+        with (
+            patch.object(generator, "gh_api", return_value=repo_info),
+            patch.object(generator, "gh_file_content", side_effect=lambda _repo, path: files.get(path)),
+            patch.object(generator, "gh_dir_listing", side_effect=lambda _repo, path: listings.get(path, [])),
+        ):
+            result = generator.process_repo(
+                "cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"
+            )
+
+        self.assertEqual(result["marketplace_name"], "cohesivity")
+        self.assertEqual(result["plugin_name"], "cohesivity")
+        self.assertEqual(result["description"], marketplace["description"])
+        self.assertEqual(result["contains"], {"skills": 1, "mcps": 2})
+        self.assertEqual(
+            result["plugin_manifest"],
+            {
+                "skills": ["cohesivity"],
+                "mcpServers": ["cohesivity", "cohesivity-local"],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the official Cohesivity Claude plugin to the plugins marketplace catalog.

cohesivity.ai offers free agent native backend services. Annonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.

The plugin bundles:

- Skill: `cohesivity`
- Remote OAuth MCP: `cohesivity`
- Local project MCP: `cohesivity-local`

This change also teaches the catalog generator to resolve file-backed `mcpServers` and `lspServers` manifests and makes plugin pages use the marketplace and plugin names declared by the source manifest. Cohesivity therefore renders the working commands:

```
/plugin marketplace add cohesivity-org/cohesivity-plugin
/plugin install cohesivity@cohesivity
```

The generated catalog update is intentionally limited to the Cohesivity entry; live star counts and third-party repository changes from the full generation were excluded.

Source: https://github.com/cohesivity-org/cohesivity-plugin

Disclosure: This is an official Cohesivity submission. The standalone MCP and skill are submitted separately in #824.

## Verification

- Required component review passed with no code blockers.
- `python3 -m unittest scripts/test_generate_plugins_json.py`
- `python3 -m py_compile scripts/generate_plugins_json.py`
- Full plugin catalog generation: 34 repositories, zero errors; Cohesivity detected with one skill and two MCP servers.
- Dashboard production build passed and prerendered `/plugins/cohesivity-plugin/`.
- Isolated Claude Code 2.1.238 install passed: marketplace add, `cohesivity@cohesivity` install, component inventory, and plugin validation.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Cohesivity plugin to the marketplace and updates the generator and plugin page to use declared install names and resolve file-backed server manifests. Previously names were derived from the repo and `mcpServers`/`lspServers` had to be inline; now commands render as `cohesivity@cohesivity` and components load from referenced manifests.

- Area: website (`dashboard/`) and generator scripts; no CLI, API, or workers changes.
- Generator: resolves file-backed `mcpServers`/`lspServers`, sets `marketplace_name` and `plugin_name`, applies a description override for this repo, and uses `gh` from PATH.
- Catalog: adds `cohesivity-org/cohesivity-plugin` with 1 skill and 2 MCP servers; `dashboard/public/plugins.json` update is limited to this entry; no new components directory; no `docs/components.json` regeneration needed.
- Ops/Tests: no new environment variables or secrets; new unit tests cover manifest resolution, declared install names, and the description override.

<sup>Written for commit c51d20f6564ded25e61732a38667c7d830c9bd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

