### PR TITLE
feat: add AgentPlat documentation MCP

### DIFF
--- a/cli-tool/components/mcps/devtools/agentplat-docs.json
+++ b/cli-tool/components/mcps/devtools/agentplat-docs.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "agentplat-docs": {
+      "description": "Read-only AgentPlat documentation MCP for Agent Rooms, Agent Mesh, governed multi-agent runtimes, inference control, trust, and evidence boundaries.",
+      "command": "npx",
+      "args": ["-y", "@agentplat/mcp-docs"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the read-only AgentPlat documentation MCP to the `devtools` catalog
- configure installation through `npx -y @agentplat/mcp-docs`
- document AgentPlat Agent Rooms, Agent Mesh, governed multi-agent runtimes, inference control, trust, and evidence boundaries in the catalog description

## Validation

- validated the component JSON with `python3 -m json.tool`
- ran `git diff --check`
- confirmed `@agentplat/mcp-docs@0.3.0-beta.5` is published on npm

The MCP is read-only and does not require credentials.
