### PR TITLE
Add WebMCP Kit plugin listing

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -23544,5 +23544,30 @@
         "cohesivity-local"
       ]
     }
+  },
+  {
+    "slug": "webmcp-kit",
+    "name": "WebMCP Kit",
+    "author": "nekuda-ai",
+    "description": "Coding-agent plugin that maps a web app's user journeys in a visual Explorer, proposes WebMCP tools for approval, implements them through the app's own logic, and verifies each tool in a real browser.",
+    "github": "https://github.com/nekuda-ai/webmcp-kit",
+    "stars": 2,
+    "type": "plugin",
+    "tags": [
+      "skills"
+    ],
+    "contains": {
+      "skills": 2
+    },
+    "highlights": [],
+    "website": "https://github.com/nekuda-ai/webmcp-kit",
+    "marketplace_name": "nekuda",
+    "plugin_name": "webmcp-kit",
+    "plugin_manifest": {
+      "skills": [
+        "implement",
+        "verify"
+      ]
+    }
   }
 ]

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -64,11 +64,15 @@ REPOS = [
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
     ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
+    ("nekuda-ai/webmcp-kit", "https://github.com/nekuda-ai/webmcp-kit"),
 ]
 
 DESCRIPTION_OVERRIDES = {
     "cohesivity-org/cohesivity-plugin": "cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. topups through x402.",
+    "nekuda-ai/webmcp-kit": "Coding-agent plugin that maps a web app's user journeys in a visual Explorer, proposes WebMCP tools for approval, implements them through the app's own logic, and verifies each tool in a real browser.",
 }
+
+DISPLAY_NAME_OVERRIDES = {"nekuda-ai/webmcp-kit": "WebMCP Kit"}
 
 OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "dashboard", "public", "plugins.json")
 GH_CLI = shutil.which("gh") or "gh"
@@ -612,7 +616,7 @@ def process_repo(repo_full, website_override=None):
     # 13. Build result
     result = {
         "slug": slug,
-        "name": display_name,
+        "name": DISPLAY_NAME_OVERRIDES.get(repo_full, display_name),
         "author": repo_owner,
         "description": DESCRIPTION_OVERRIDES.get(repo_full, description or marketplace.get("description", "")),
         "github": f"https://github.com/{repo_full}",


### PR DESCRIPTION
## Summary

Add WebMCP Kit to the source catalog that generates the aitmpl.com/plugins listing, including its visual Explorer and real-browser verification workflow.

## Fit

- **Real use case:** turns an existing website or web app into an agent-ready product by implementing WebMCP tools through the app's own logic instead of scraping the page.
- **Not duplicative:** a repository-wide search found no existing WebMCP implementation plugin listing.
- **Tested:** the plugin ships automated tests, its focused public test set passes 43 checks, and its workflow verifies each generated tool in a real browser before reporting it as verified.

## Validation

- `python3 -m unittest scripts/test_generate_plugins_json.py` (3 passed)
- generated WebMCP Kit record matches `dashboard/public/plugins.json`
- `git diff --check`
- WebMCP Kit repository link responds successfully


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `nekuda-ai/webmcp-kit` plugin to the generated plugins catalog so it appears on the website listing with the correct display name and description.

- Area: website — updates `dashboard/public/plugins.json` and the generator script to include `nekuda-ai/webmcp-kit`.
- Behavior: previously not listed; now listed with display name and description overrides; no runtime or API changes.
- Generator changes: adds repo to the source list and introduces `DISPLAY_NAME_OVERRIDES` usage to set "WebMCP Kit".
- Rollout/migration: no new components, no `docs/components.json` regeneration, and no new env vars or secrets.

<sup>Written for commit 8ef57fd2bf127f5ac7082a2246b76f2783537760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

