### PR TITLE
feat: add optional MuAPI text-to-speech backend

### DIFF
--- a/cli-tool/components/skills/media/speech/SKILL.md
+++ b/cli-tool/components/skills/media/speech/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "speech"
-description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation. OpenAI remains the default; Atlas Cloud is an explicit optional backend for asynchronous multilingual speech. Custom voice creation is out of scope."
+description: "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation. OpenAI remains the default; MuAPI and Atlas Cloud are explicit optional backends for asynchronous speech. Custom voice creation is out of scope."
 author: openai
 ---
 
@@ -10,7 +10,7 @@ author: openai
 Generate spoken audio for the current project (narration, product demo voiceover, IVR prompts, accessibility reads). OpenAI remains the default with `gpt-4o-mini-tts-2025-12-15`; Atlas Cloud is available only when the user explicitly selects it. Prefer the bundled CLIs for deterministic, reproducible runs.
 
 MuAPI is also available as an explicitly selected optional asynchronous speech
-backend through `scripts/muapi_text_to_speech.py`.
+backend through `scripts/muapi-text-to-speech.py`.
 
 ## When to use
 - Generate a single spoken clip from text
@@ -26,7 +26,7 @@ backend through `scripts/muapi_text_to_speech.py`.
 3. If batch: write a temporary JSONL under tmp/ (one job per line), run once, then delete the JSONL.
 4. Augment instructions into a short labeled spec without rewriting the input text.
 5. Run `scripts/text_to_speech.py` for the default OpenAI path, or `scripts/atlas_text_to_speech.py` only when Atlas Cloud was selected (see `references/cli.md`).
-   When MuAPI is explicitly selected, use `scripts/muapi_text_to_speech.py`.
+   When MuAPI is explicitly selected, use `scripts/muapi-text-to-speech.py`.
 6. For important clips, validate: intelligibility, pacing, pronunciation, and adherence to constraints.
 7. Iterate with a single targeted change (voice, speed, or instructions), then re-check.
 8. Save/return final outputs and note the final text + instructions + flags used.
@@ -57,7 +57,7 @@ The Atlas Cloud backend uses only the Python standard library.
 
 If the selected provider key is missing, give the user these steps:
 1. Create an API key in that provider's console.
-2. Set `OPENAI_API_KEY` or `ATLASCLOUD_API_KEY` as an environment variable in their system.
+2. Set `OPENAI_API_KEY`, `MUAPI_API_KEY`, or `ATLASCLOUD_API_KEY` as an environment variable in their system.
 3. Offer to guide them through setting the environment variable for their OS/shell if needed.
 - Keep provider credentials out of chat. Direct the user to set the selected key locally and confirm when ready.
 

--- a/cli-tool/components/skills/media/speech/SKILL.md
+++ b/cli-tool/components/skills/media/speech/SKILL.md
@@ -9,6 +9,9 @@ author: openai
 
 Generate spoken audio for the current project (narration, product demo voiceover, IVR prompts, accessibility reads). OpenAI remains the default with `gpt-4o-mini-tts-2025-12-15`; Atlas Cloud is available only when the user explicitly selects it. Prefer the bundled CLIs for deterministic, reproducible runs.
 
+MuAPI is also available as an explicitly selected optional asynchronous speech
+backend through `scripts/muapi_text_to_speech.py`.
+
 ## When to use
 - Generate a single spoken clip from text
 - Generate a batch of prompts (many lines, many files)
@@ -23,6 +26,7 @@ Generate spoken audio for the current project (narration, product demo voiceover
 3. If batch: write a temporary JSONL under tmp/ (one job per line), run once, then delete the JSONL.
 4. Augment instructions into a short labeled spec without rewriting the input text.
 5. Run `scripts/text_to_speech.py` for the default OpenAI path, or `scripts/atlas_text_to_speech.py` only when Atlas Cloud was selected (see `references/cli.md`).
+   When MuAPI is explicitly selected, use `scripts/muapi_text_to_speech.py`.
 6. For important clips, validate: intelligibility, pacing, pronunciation, and adherence to constraints.
 7. Iterate with a single targeted change (voice, speed, or instructions), then re-check.
 8. Save/return final outputs and note the final text + instructions + flags used.
@@ -48,6 +52,7 @@ The Atlas Cloud backend uses only the Python standard library.
 
 ## Environment
 - Default OpenAI calls require `OPENAI_API_KEY`.
+- Optional MuAPI calls require `MUAPI_API_KEY`.
 - Optional Atlas Cloud calls require `ATLASCLOUD_API_KEY`.
 
 If the selected provider key is missing, give the user these steps:
@@ -60,6 +65,8 @@ If installation isn't possible in this environment, tell the user which dependen
 
 ## Defaults & rules
 - Keep OpenAI as the default provider. Do not switch to Atlas Cloud unless the user requests it.
+- Do not switch to MuAPI unless the user requests it. Use the bundled MuAPI CLI
+  and its fixed, verified text-to-audio model when selected.
 - Use `gpt-4o-mini-tts-2025-12-15` unless the user requests another model.
 - Default voice: `cedar`. If the user wants a brighter tone, prefer `marin`.
 - Built-in voices only. Custom voices are out of scope for this skill.
@@ -70,6 +77,9 @@ If installation isn't possible in this environment, tell the user which dependen
 - For Atlas Cloud, default to `xai/tts-v1`, voice `eve`, language `auto`, and require `ATLASCLOUD_API_KEY`.
 - Atlas generation submits exactly one POST. Only prediction GET requests may retry, and polling must stay finite.
 - Download Atlas outputs without an Authorization header and reject non-HTTPS or private-network targets.
+- MuAPI generation submits exactly one POST. Only prediction GET requests may
+  retry, and polling must stay finite. Download MuAPI outputs without the API
+  key and reject non-HTTPS or private-network targets.
 - Provide a clear disclosure to end users that the voice is AI-generated.
 - Use the OpenAI Python SDK (`openai` package) for default OpenAI calls; the dedicated Atlas CLI uses its asynchronous HTTP contract.
 - Prefer the matching bundled CLI over writing new one-off scripts.
@@ -135,6 +145,7 @@ Use these modules when the request is for a specific delivery style. They provid
 ## CLI + environment notes
 - CLI commands + examples: `references/cli.md`
 - API parameter quick reference: `references/audio-api.md`
+- MuAPI asynchronous workflow and safeguards: `references/muapi.md`
 - Atlas Cloud asynchronous workflow and safeguards: `references/atlas-cloud.md`
 - Instruction patterns + examples: `references/voice-directions.md`
 - If network approvals / sandbox settings are getting in the way: `references/codex-network.md`
@@ -142,6 +153,7 @@ Use these modules when the request is for a specific delivery style. They provid
 ## Reference map
 - **`references/cli.md`**: how to run speech generation/batches via `scripts/text_to_speech.py` (commands, flags, recipes).
 - **`references/audio-api.md`**: API parameters, limits, voice list.
+- **`references/muapi.md`**: optional MuAPI model, CLI, polling, and download contract.
 - **`references/atlas-cloud.md`**: optional Atlas Cloud model, CLI, polling, and download contract.
 - **`references/voice-directions.md`**: instruction patterns and examples.
 - **`references/prompting.md`**: instruction best practices (structure, constraints, iteration patterns).

--- a/cli-tool/components/skills/media/speech/references/audio-api.md
+++ b/cli-tool/components/skills/media/speech/references/audio-api.md
@@ -2,6 +2,7 @@
 
 This page documents the default OpenAI backend. For the optional asynchronous
 Atlas Cloud backend, use `references/atlas-cloud.md` and its dedicated CLI.
+For the optional MuAPI backend, use `references/muapi.md` and its dedicated CLI.
 
 ## Endpoint
 - Create speech: `POST /v1/audio/speech`
@@ -32,3 +33,19 @@ Atlas Cloud backend, use `references/atlas-cloud.md` and its dedicated CLI.
 
 ## Compliance note
 - Provide a clear disclosure that the voice is AI-generated.
+
+## Optional MuAPI backend
+
+- Model: `elevenlabs-tts-turbo-2-5`
+- Endpoint: `POST /api/v1/elevenlabs-tts-turbo-2-5`
+- Required input: `prompt` (up to 40,000 characters)
+- Optional inputs: `voice_id`, `stability` (0 to 1), `similarity_boost` (0 to 1),
+  `speed` (0.7 to 1.2), and `language_code` (`en`, `fr`, `de`, `ja`, `vi`,
+  `hu`, or `no`)
+- Authentication: `x-api-key` from `MUAPI_API_KEY`
+- Result: asynchronous prediction with an `output.audio_url`
+
+Use the MuAPI CLI only after explicit provider selection. See the official
+[MuAPI text-to-speech page](https://muapi.ai/text-to-speech) for the current
+capability and [music and speech documentation](https://muapi.ai/docs/music-and-speech)
+for provider guidance.

--- a/cli-tool/components/skills/media/speech/references/cli.md
+++ b/cli-tool/components/skills/media/speech/references/cli.md
@@ -20,6 +20,7 @@ Set a stable path to the skill CLI (default `CODEX_HOME` is `~/.codex`):
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 export TTS_GEN="$CODEX_HOME/skills/speech/scripts/text_to_speech.py"
 export ATLAS_TTS_GEN="$CODEX_HOME/skills/speech/scripts/atlas_text_to_speech.py"
+export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi_text_to_speech.py"
 ```
 
 Dry-run (no API call; no network required; does not require the `openai` package):
@@ -35,6 +36,15 @@ python "$ATLAS_TTS_GEN" speak \
   --input "Test" \
   --voice eve \
   --language auto \
+  --dry-run
+```
+
+MuAPI dry-run (only when MuAPI is explicitly selected):
+
+```bash
+python "$MUAPI_TTS_GEN" speak \
+  --input "Test" \
+  --language-code en \
   --dry-run
 ```
 
@@ -58,8 +68,11 @@ python "$TTS_GEN" speak --input "Hello" --voice cedar --out speech.mp3
 ## Guardrails (important)
 - Use `python "$TTS_GEN" ...` (or equivalent full path) for the default OpenAI workflow.
 - Use `python "$ATLAS_TTS_GEN" ...` only after the user selects Atlas Cloud.
+- Use `python "$MUAPI_TTS_GEN" ...` only after the user selects MuAPI.
 - Atlas generation POSTs are never retried. Its prediction GET polling is finite.
 - Atlas output downloads never receive the API key and reject private-network URLs.
+- MuAPI generation POSTs are never retried. Its prediction GET polling is finite.
+- MuAPI output downloads never receive the API key and reject private-network URLs.
 - Do **not** create one-off runners (e.g., `gen_audio.py`) unless the user explicitly asks.
 
 ## Defaults (unless overridden by flags)
@@ -71,6 +84,10 @@ python "$TTS_GEN" speak --input "Hello" --voice cedar --out speech.mp3
 
 Atlas Cloud defaults are model `xai/tts-v1`, multilingual voice `eve`, language
 `auto`, codec `mp3`, 2-second polling, and at most 120 polls.
+
+MuAPI defaults are model `elevenlabs-tts-turbo-2-5`, the published default voice
+ID, 2-second polling, and at most 120 polls. See `references/muapi.md` for its
+verified input fields and model links.
 
 ## Input limits
 - Input text must be <= 4096 characters per request.

--- a/cli-tool/components/skills/media/speech/references/cli.md
+++ b/cli-tool/components/skills/media/speech/references/cli.md
@@ -20,7 +20,7 @@ Set a stable path to the skill CLI (default `CODEX_HOME` is `~/.codex`):
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 export TTS_GEN="$CODEX_HOME/skills/speech/scripts/text_to_speech.py"
 export ATLAS_TTS_GEN="$CODEX_HOME/skills/speech/scripts/atlas_text_to_speech.py"
-export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi_text_to_speech.py"
+export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi-text-to-speech.py"
 ```
 
 Dry-run (no API call; no network required; does not require the `openai` package):
@@ -86,7 +86,7 @@ Atlas Cloud defaults are model `xai/tts-v1`, multilingual voice `eve`, language
 `auto`, codec `mp3`, 2-second polling, and at most 120 polls.
 
 MuAPI defaults are model `elevenlabs-tts-turbo-2-5`, the published default voice
-ID, 2-second polling, and at most 120 polls. See `references/muapi.md` for its
+ID, 2-second polling, and 60 polls, bounded at 120. See `references/muapi.md` for its
 verified input fields and model links.
 
 ## Input limits

--- a/cli-tool/components/skills/media/speech/references/muapi.md
+++ b/cli-tool/components/skills/media/speech/references/muapi.md
@@ -17,7 +17,7 @@ and set it in the local environment:
 ```bash
 export MUAPI_API_KEY="<your-key>"
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
-export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi_text_to_speech.py"
+export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi-text-to-speech.py"
 ```
 
 Keep the key in the environment; do not put it in prompts, JSONL files, shell
@@ -69,7 +69,8 @@ python "$MUAPI_TTS_GEN" speak-batch \
 - Speed, stability, and similarity boost values reject non-finite numbers and
   values outside the model's published ranges.
 - Output URLs must use HTTPS and resolve to public hosts. Redirects are checked
-  too, and downloads are written to a temporary file before atomic replacement.
+  too, DNS is revalidated and pinned at connection setup, and downloads are
+  written to a temporary file before atomic replacement.
 - The download request does not include `MUAPI_API_KEY`.
 - Generated speech is AI-generated; disclose that when sharing the audio.
 

--- a/cli-tool/components/skills/media/speech/references/muapi.md
+++ b/cli-tool/components/skills/media/speech/references/muapi.md
@@ -1,0 +1,78 @@
+# MuAPI speech backend
+
+Use this backend only when the user explicitly selects MuAPI. The default
+speech workflow and `scripts/text_to_speech.py` remain unchanged.
+
+The bundled CLI uses the current `elevenlabs-tts-turbo-2-5` text-to-audio
+capability through MuAPI's asynchronous API. It sends the text as `prompt`,
+supports the model's verified voice IDs and language codes, polls the prediction
+with a finite limit, and downloads the resulting audio without forwarding the
+API key.
+
+## Setup
+
+Create a MuAPI key from the [MuAPI access keys page](https://muapi.ai/access-keys)
+and set it in the local environment:
+
+```bash
+export MUAPI_API_KEY="<your-key>"
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export MUAPI_TTS_GEN="$CODEX_HOME/skills/speech/scripts/muapi_text_to_speech.py"
+```
+
+Keep the key in the environment; do not put it in prompts, JSONL files, shell
+history, source files, or generated metadata.
+
+## Commands
+
+Inspect the currently published model metadata (read-only):
+
+```bash
+python "$MUAPI_TTS_GEN" models
+python "$MUAPI_TTS_GEN" list-voices
+```
+
+Dry-run without network access or a key:
+
+```bash
+python "$MUAPI_TTS_GEN" speak \
+  --input "Welcome to the demo." \
+  --language-code en \
+  --dry-run
+```
+
+Generate one clip:
+
+```bash
+python "$MUAPI_TTS_GEN" speak \
+  --input "Welcome to the demo." \
+  --voice-id IKne3meq5aSn9XLyUdCD \
+  --out output/speech/welcome.mp3
+```
+
+Generate JSONL jobs. Each line may contain `input` (or `text`), `out`,
+`voice_id`, `language_code`, `stability`, `similarity_boost`, and `speed`:
+
+```bash
+python "$MUAPI_TTS_GEN" speak-batch \
+  --input tmp/speech/jobs.jsonl \
+  --out-dir output/speech
+```
+
+## Guardrails
+
+- MuAPI is opt-in; OpenAI remains the skill default.
+- The model and API origin are fixed to the verified MuAPI contract.
+- The generation POST is sent once. Only prediction GET polling is retried.
+- Polling is bounded to at most 120 attempts; the default is 60.
+- Input is limited to 40,000 characters, matching the published model schema.
+- Speed, stability, and similarity boost values reject non-finite numbers and
+  values outside the model's published ranges.
+- Output URLs must use HTTPS and resolve to public hosts. Redirects are checked
+  too, and downloads are written to a temporary file before atomic replacement.
+- The download request does not include `MUAPI_API_KEY`.
+- Generated speech is AI-generated; disclose that when sharing the audio.
+
+For the provider's current model and API details, see the official
+[MuAPI text-to-speech page](https://muapi.ai/text-to-speech) and
+[music and speech documentation](https://muapi.ai/docs/music-and-speech).

--- a/cli-tool/components/skills/media/speech/scripts/muapi-text-to-speech.py
+++ b/cli-tool/components/skills/media/speech/scripts/muapi-text-to-speech.py
@@ -10,6 +10,7 @@ the MuAPI credential.
 from __future__ import annotations
 
 import argparse
+import http.client
 import ipaddress
 import json
 import math
@@ -22,10 +23,11 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 
 API_BASE = "https://api.muapi.ai"
+API_HOST = "api.muapi.ai"
 MODEL_NAME = "elevenlabs-tts-turbo-2-5"
 MODEL_ENDPOINT = f"/api/v1/{MODEL_NAME}"
 MODEL_DETAIL_PATH = f"/api/v1/models/{MODEL_NAME}"
@@ -158,6 +160,32 @@ def _api_key(dry_run: bool) -> str:
     return ""
 
 
+def _is_api_origin(url: str) -> bool:
+    parsed = urllib.parse.urlsplit(url)
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and parsed.hostname is not None
+        and parsed.hostname.lower() == API_HOST
+        and port in {None, 443}
+    )
+
+
+class _FixedOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        if not _is_api_origin(newurl):
+            raise RuntimeError("MuAPI API redirect left the fixed API origin")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _open_api(request: urllib.request.Request):
+    opener = urllib.request.build_opener(_FixedOriginRedirectHandler())
+    return opener.open(request, timeout=60)
+
+
 def _request_json(
     url: str,
     *,
@@ -184,7 +212,7 @@ def _request_json(
     for attempt in range(1, attempts + 1):
         request = urllib.request.Request(url, data=body, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(request, timeout=60) as response:
+            with _open_api(request) as response:
                 result = json.loads(response.read().decode("utf-8"))
             if not isinstance(result, dict):
                 raise ValueError("MuAPI returned a non-object JSON response")
@@ -338,6 +366,73 @@ def _is_safe_ip(address: str, *, named_host: bool) -> bool:
     return ip.is_global
 
 
+def _resolve_public_addresses(
+    host: str, port: int
+) -> List[Tuple[int, int, int, Any]]:
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise OSError(f"Could not resolve MuAPI output host: {exc}") from exc
+    if not infos:
+        raise OSError("MuAPI output host did not resolve")
+
+    addresses: List[Tuple[int, int, int, Any]] = []
+    seen = set()
+    for family, socktype, protocol, _canonname, sockaddr in infos:
+        address = sockaddr[0]
+        try:
+            safe = _is_safe_ip(address, named_host=True)
+        except ValueError as exc:
+            raise OSError("MuAPI output host returned an invalid address") from exc
+        if not safe:
+            raise OSError("MuAPI output URL resolves to a non-public address")
+        key = (family, socktype, protocol, sockaddr)
+        if key not in seen:
+            seen.add(key)
+            addresses.append((family, socktype, protocol, sockaddr))
+    if not addresses:
+        raise OSError("MuAPI output host did not resolve to a usable address")
+    return addresses
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """Connect to the exact public address validated at connection setup."""
+
+    def connect(self):  # type: ignore[no-untyped-def]
+        addresses = _resolve_public_addresses(self.host, self.port)
+        last_error: Optional[OSError] = None
+        for family, socktype, protocol, sockaddr in addresses:
+            sock = socket.socket(family, socktype or socket.SOCK_STREAM, protocol)
+            try:
+                if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                    sock.settimeout(self.timeout)
+                sock.connect(sockaddr)
+                try:
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                except OSError:
+                    pass
+                self.sock = sock
+                if self._tunnel_host:
+                    self._tunnel()
+                server_hostname = self._tunnel_host or self.host
+                self.sock = self._context.wrap_socket(
+                    self.sock, server_hostname=server_hostname
+                )
+                return
+            except OSError as exc:
+                last_error = exc
+                sock.close()
+                self.sock = None
+        if last_error is not None:
+            raise OSError("Could not connect to MuAPI output host") from last_error
+        raise OSError("Could not connect to MuAPI output host")
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def https_open(self, req):  # type: ignore[no-untyped-def]
+        return self.do_open(_PinnedHTTPSConnection, req, context=self._context)
+
+
 def _validate_download_url(url: str) -> None:
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme.lower() != "https" or not parsed.hostname:
@@ -356,15 +451,10 @@ def _validate_download_url(url: str) -> None:
     if host.lower() == "localhost" or host.lower().endswith(".localhost"):
         _die("MuAPI output URL must not target localhost.")
     try:
-        addresses: Set[str] = {
-            item[4][0]
-            for item in socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
-        }
-    except socket.gaierror as exc:
-        _die(f"Could not resolve MuAPI output host: {exc}")
-        return
-    if not addresses or any(not _is_safe_ip(address, named_host=True) for address in addresses):
-        _die("MuAPI output URL resolves to a non-public address.")
+        port = parsed.port or 443
+        _resolve_public_addresses(host, port)
+    except (OSError, ValueError) as exc:
+        _die(str(exc))
 
 
 class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -384,7 +474,11 @@ def _download(url: str, out_path: Path, *, force: bool) -> None:
         headers={"Accept": "audio/*", "User-Agent": USER_AGENT},
         method="GET",
     )
-    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        _SafeRedirectHandler(),
+        _PinnedHTTPSHandler(),
+    )
     try:
         with tempfile.NamedTemporaryFile(
             prefix=f".{out_path.name}.",
@@ -439,7 +533,13 @@ def _payload(args: argparse.Namespace, text: str) -> Dict[str, Any]:
     return payload
 
 
-def _generate(payload: Mapping[str, Any], out_path: Path, args: argparse.Namespace) -> None:
+def _generate(
+    payload: Mapping[str, Any],
+    out_path: Path,
+    args: argparse.Namespace,
+    *,
+    model_details: Optional[Mapping[str, Any]] = None,
+) -> None:
     _poll_options(args)
     if out_path.exists() and not args.force and not args.dry_run:
         _die(f"Output already exists: {out_path} (use --force to overwrite)")
@@ -459,7 +559,8 @@ def _generate(payload: Mapping[str, Any], out_path: Path, args: argparse.Namespa
         )
         return
 
-    _discover_model()
+    if model_details is None:
+        _discover_model()
     prediction_id = _submit(payload, key)
     output_url = _poll(
         prediction_id,
@@ -500,7 +601,11 @@ def _run_speak(args: argparse.Namespace) -> int:
 
 def _run_batch(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
-    for index, job in enumerate(_read_jobs(args.input), 1):
+    jobs = _read_jobs(args.input)
+    model_details: Optional[Mapping[str, Any]] = None
+    if not args.dry_run:
+        model_details = _discover_model()
+    for index, job in enumerate(jobs, 1):
         child = argparse.Namespace(**vars(args))
         child.voice_id = job.get("voice_id", args.voice_id)
         child.stability = job.get("stability", args.stability)
@@ -513,7 +618,12 @@ def _run_batch(args: argparse.Namespace) -> int:
         text = _read_text(job_text, None)
         filename = str(job.get("out") or f"{index:03d}-speech.mp3")
         out_path = out_dir / Path(filename).name
-        _generate(_payload(child, text), out_path, child)
+        _generate(
+            _payload(child, text),
+            out_path,
+            child,
+            model_details=model_details,
+        )
     return 0
 
 

--- a/cli-tool/components/skills/media/speech/scripts/muapi-text-to-speech.py
+++ b/cli-tool/components/skills/media/speech/scripts/muapi-text-to-speech.py
@@ -599,9 +599,19 @@ def _run_speak(args: argparse.Namespace) -> int:
     return 0
 
 
+def _batch_output_path(out_dir: Path, index: int, job: Mapping[str, Any]) -> Path:
+    filename = str(job.get("out") or f"{index:03d}-speech.mp3")
+    return out_dir / Path(filename).name
+
+
 def _run_batch(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
     jobs = _read_jobs(args.input)
+    if not args.dry_run and not args.force:
+        for index, job in enumerate(jobs, 1):
+            out_path = _batch_output_path(out_dir, index, job)
+            if out_path.exists():
+                _die(f"Output already exists: {out_path} (use --force to overwrite)")
     model_details: Optional[Mapping[str, Any]] = None
     if not args.dry_run:
         model_details = _discover_model()
@@ -616,8 +626,7 @@ def _run_batch(args: argparse.Namespace) -> int:
         if not isinstance(job_text, str):
             _die(f"Batch job {index} must provide string input text.")
         text = _read_text(job_text, None)
-        filename = str(job.get("out") or f"{index:03d}-speech.mp3")
-        out_path = out_dir / Path(filename).name
+        out_path = _batch_output_path(out_dir, index, job)
         _generate(
             _payload(child, text),
             out_path,

--- a/cli-tool/components/skills/media/speech/scripts/muapi_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/scripts/muapi_text_to_speech.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Generate speech through MuAPI's asynchronous text-to-speech endpoint.
+
+This is an explicitly selected optional backend. The default speech workflow
+continues to use the OpenAI CLI. The MuAPI generation POST is sent once; only
+bounded prediction GET requests may be retried. Download requests never carry
+the MuAPI credential.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import math
+import os
+import socket
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
+
+
+API_BASE = "https://api.muapi.ai"
+MODEL_NAME = "elevenlabs-tts-turbo-2-5"
+MODEL_ENDPOINT = f"/api/v1/{MODEL_NAME}"
+MODEL_DETAIL_PATH = f"/api/v1/models/{MODEL_NAME}"
+DEFAULT_VOICE_ID = "21m00Tcm4TlvDq8ikWAM"
+DEFAULT_STABILITY = 0.5
+DEFAULT_SIMILARITY_BOOST = 0.75
+DEFAULT_SPEED = 1.0
+DEFAULT_POLL_INTERVAL = 2.0
+DEFAULT_POLL_ATTEMPTS = 60
+MAX_POLL_ATTEMPTS = 120
+MAX_INPUT_CHARS = 40_000
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+USER_AGENT = "claude-code-templates-speech/muapi-tts"
+
+LANGUAGE_CODES = ("en", "fr", "de", "ja", "vi", "hu", "no")
+VOICE_LABELS = {
+    "21m00Tcm4TlvDq8ikWAM": "Published model default",
+    "ZQe5CZNOzWyzPSCn5a3c": "James - Husky, Engaging and Bold",
+    "Z3R5wn05IrDiVCyEkUrK": "Arabella - Mysterious and Emotive",
+    "NNl6r8mD7vthiJatiJt1": "Bradford - Expressive and Articulate",
+    "YOq2y2Up4RgXP2HyXjE5": "Xavier - Dominating, Metallic Announcer",
+    "qDuRKMlYmrm8trt5QyBn": "Taksh - Calm, Serious and Smooth",
+    "iP95p4xoKVk53GoZ742B": "Monika Sogam - Deep and Natural",
+    "UgBBYS2sOqTuMpoF3BR0": "Mark - Casual, Relaxed and Light",
+    "5l5f8iK3YPeGga21rQIX": "Adeline - Feminine and Conversational",
+    "yoZ06aMxZJJ28mfd3POQ": "Sam - Support Agent",
+    "NOpBlnGInO9m6vDvFkFC": "Spuds Oxley - Wise and Approachable",
+    "scOwDtmlLZohaFMFCHFe": "Eve - Authentic, Energetic and Happy",
+    "N2lVS1w4EtoT3dr4eOWO": "Callum - Husky Trickster",
+    "FGY2WhTYpPnrIDTdsKH5": "Laura - Enthusiast, Quirky Attitude",
+    "zPhCVfO2NBER7bRLIdbq": "Brian - Deep, Resonant and Comforting",
+    "nPczCjzI2devNBz1zQrb": "Nathan - Virtual Radio Host",
+    "IKne3meq5aSn9XLyUdCD": "Charlie - Natural",
+    "JBFqnCBsd6RMkjVDRZzb": "George - Warm",
+    "EXAVITQu4vr4xnSDxMaL": "Sarah - Soft",
+    "XB0fDUnXU5powFXDhCwa": "Charlotte - Clear",
+    "tnSpp4vdxKPjI9w0GnoV": "Hope - Bubbly, Gossipy and Girly",
+    "DYkrAHD8iwork3YSUBbs": "Finn - Youthful, Eager and Energetic",
+    "56AoDkrOh6qfVPDXZ7Pt": "Tom - Conversations and Books",
+    "lcMyyd2HUfFzxdCaC4Ta": "Lucy - Fresh and Casual",
+    "6aDn1KB0hjpdcocrUkmq": "Tiffany - Natural and Welcoming",
+    "7ftFdxRlmR6Z9V3nTdUh": "Brock - Commanding and Loud Sergeant",
+    "bajNon13EdhNMndG3z05": "Viraj - Rich and Soft",
+}
+VOICE_IDS = tuple(VOICE_LABELS)
+TERMINAL_FAILURES = {"failed", "error", "canceled", "cancelled", "timeout"}
+AUDIO_URL_KEYS = {
+    "audio_url",
+    "audiourl",
+    "url",
+    "file_url",
+    "fileurl",
+    "output",
+    "outputs",
+    "data",
+}
+AUDIO_SUFFIXES = (".aac", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav")
+BENCHMARK_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+
+
+def _die(message: str) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _read_text(text: Optional[str], text_file: Optional[str]) -> str:
+    if text is not None and text_file is not None:
+        _die("Use --input or --input-file, not both.")
+    if text_file:
+        path = Path(text_file)
+        if not path.is_file():
+            _die("Input file was not found.")
+        try:
+            value = path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            _die(f"Could not read input file: {exc}")
+    elif text is not None:
+        value = text.strip()
+    else:
+        _die("Missing input. Use --input or --input-file.")
+        return ""
+    if not value:
+        _die("Input text is empty.")
+    if len(value) > MAX_INPUT_CHARS:
+        _die(f"Input text exceeds {MAX_INPUT_CHARS} characters.")
+    return value
+
+
+def _choice(value: str, allowed: Iterable[str], label: str) -> str:
+    if value not in allowed:
+        _die(f"{label} must be one of: {', '.join(allowed)}")
+    return value
+
+
+def _number(value: Any, minimum: float, maximum: float, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        _die(f"{label} must be a number.")
+    if not math.isfinite(number) or number < minimum or number > maximum:
+        _die(f"{label} must be finite and between {minimum:g} and {maximum:g}.")
+    return number
+
+
+def _poll_options(args: argparse.Namespace) -> tuple[int, float]:
+    attempts = args.poll_attempts
+    interval = args.poll_interval
+    if not isinstance(attempts, int) or attempts < 1 or attempts > MAX_POLL_ATTEMPTS:
+        _die(f"poll-attempts must be an integer from 1 to {MAX_POLL_ATTEMPTS}.")
+    interval = _number(interval, 0.0, 60.0, "poll-interval")
+    return attempts, interval
+
+
+def _output_path(value: Optional[str]) -> Path:
+    path = Path(value) if value else Path("speech.mp3")
+    if path.exists() and path.is_dir():
+        return path / "speech.mp3"
+    if not path.suffix:
+        return path.with_suffix(".mp3")
+    return path
+
+
+def _api_key(dry_run: bool) -> str:
+    key = os.getenv("MUAPI_API_KEY", "").strip()
+    if key:
+        return key
+    if dry_run:
+        return ""
+    _die("MUAPI_API_KEY is not set. Export it before running MuAPI speech generation.")
+    return ""
+
+
+def _request_json(
+    url: str,
+    *,
+    api_key: str,
+    method: str,
+    payload: Optional[Mapping[str, Any]] = None,
+    attempts: int = 1,
+) -> Dict[str, Any]:
+    """Make one fixed-origin JSON request; only GETs may be retried."""
+    if method not in {"GET", "POST"}:
+        raise ValueError("MuAPI requests must use GET or POST")
+    if attempts < 1:
+        raise ValueError("request attempts must be positive")
+    if method != "GET":
+        attempts = 1
+
+    body = None if payload is None else json.dumps(dict(payload)).encode("utf-8")
+    headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                result = json.loads(response.read().decode("utf-8"))
+            if not isinstance(result, dict):
+                raise ValueError("MuAPI returned a non-object JSON response")
+            return result
+        except urllib.error.HTTPError as exc:
+            if method == "GET" and exc.code in {408, 429, 500, 502, 503, 504} and attempt < attempts:
+                time.sleep(min(4.0, 2.0 ** (attempt - 1)))
+                continue
+            raise RuntimeError(f"MuAPI API returned HTTP {exc.code}") from exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+            if method == "GET" and attempt < attempts:
+                time.sleep(min(4.0, 2.0 ** (attempt - 1)))
+                continue
+            raise RuntimeError("MuAPI request failed") from exc
+    raise RuntimeError("MuAPI request failed")
+
+
+def _validate_model(details: Mapping[str, Any]) -> None:
+    if details.get("name") not in {None, MODEL_NAME}:
+        raise RuntimeError("MuAPI returned unexpected model metadata")
+    if str(details.get("category") or "").lower() != "text to audio":
+        raise RuntimeError("MuAPI model is not a text-to-audio capability")
+    if details.get("endpoint") != MODEL_ENDPOINT:
+        raise RuntimeError("MuAPI returned an unexpected model endpoint")
+    schema = details.get("input_schema")
+    properties = (
+        schema.get("schemas", {}).get("input_data", {}).get("properties", {})
+        if isinstance(schema, dict)
+        else {}
+    )
+    if not isinstance(properties, dict) or "prompt" not in properties:
+        raise RuntimeError("MuAPI model metadata did not include a prompt input")
+
+
+def _discover_model() -> Dict[str, Any]:
+    details = _request_json(
+        f"{API_BASE}{MODEL_DETAIL_PATH}",
+        api_key="",
+        method="GET",
+        attempts=3,
+    )
+    _validate_model(details)
+    return details
+
+
+def _request_id(response: Mapping[str, Any]) -> Optional[str]:
+    candidates: List[Any] = [response.get("request_id"), response.get("id")]
+    data = response.get("data")
+    if isinstance(data, dict):
+        candidates.extend([data.get("request_id"), data.get("id")])
+    for candidate in candidates:
+        if candidate is not None and str(candidate).strip():
+            return str(candidate).strip()
+    return None
+
+
+def _submit(payload: Mapping[str, Any], api_key: str) -> str:
+    response = _request_json(
+        f"{API_BASE}{MODEL_ENDPOINT}",
+        api_key=api_key,
+        method="POST",
+        payload=payload,
+        attempts=1,
+    )
+    prediction_id = _request_id(response)
+    if not prediction_id:
+        raise RuntimeError("MuAPI submission did not return a prediction ID")
+    return prediction_id
+
+
+def _audio_urls(value: Any, *, parent_key: str = "") -> List[str]:
+    if isinstance(value, str):
+        if not value.lower().startswith("https://"):
+            return []
+        key = parent_key.lower()
+        if key in AUDIO_URL_KEYS or value.lower().split("?", 1)[0].endswith(AUDIO_SUFFIXES):
+            return [value]
+        return []
+    if isinstance(value, list):
+        result: List[str] = []
+        for item in value:
+            result.extend(_audio_urls(item, parent_key=parent_key))
+        return result
+    if isinstance(value, dict):
+        result = []
+        for key, item in value.items():
+            if str(key).lower() in {"request_url", "status", "id", "created_at"}:
+                continue
+            result.extend(_audio_urls(item, parent_key=str(key)))
+        return result
+    return []
+
+
+def select_audio_url(result: Mapping[str, Any]) -> Optional[str]:
+    """Select the first HTTPS audio URL from a completed prediction response."""
+    for key in ("output", "outputs", "data"):
+        urls = _audio_urls(result.get(key), parent_key=key)
+        if urls:
+            return urls[0]
+    return None
+
+
+def _result_status(result: Mapping[str, Any]) -> str:
+    data = result.get("data")
+    output = result.get("output")
+    for value in (
+        result.get("status"),
+        data.get("status") if isinstance(data, dict) else None,
+        output.get("status") if isinstance(output, dict) else None,
+    ):
+        if value:
+            return str(value).lower()
+    return ""
+
+
+def _poll(
+    prediction_id: str,
+    api_key: str,
+    *,
+    attempts: int,
+    interval: float,
+    sleep_fn: Optional[Any] = None,
+) -> str:
+    if attempts < 1 or attempts > MAX_POLL_ATTEMPTS:
+        raise ValueError(f"poll attempts must be between 1 and {MAX_POLL_ATTEMPTS}")
+    if not math.isfinite(interval) or interval < 0:
+        raise ValueError("poll interval must be finite and non-negative")
+    sleep = sleep_fn or time.sleep
+    quoted_id = urllib.parse.quote(prediction_id, safe="")
+    url = f"{API_BASE}/api/v1/predictions/{quoted_id}/result"
+
+    for poll_number in range(1, attempts + 1):
+        result = _request_json(url, api_key=api_key, method="GET", attempts=3)
+        status = _result_status(result)
+        output_url = select_audio_url(result)
+        if output_url:
+            return output_url
+        if status in TERMINAL_FAILURES:
+            raise RuntimeError(f"MuAPI prediction ended with status '{status}'")
+        if status in {"completed", "succeeded", "success"}:
+            raise RuntimeError("MuAPI prediction completed without an audio URL")
+        if poll_number < attempts:
+            sleep(interval)
+    raise RuntimeError(f"MuAPI prediction did not finish after {attempts} polls")
+
+
+def _is_safe_ip(address: str, *, named_host: bool) -> bool:
+    ip = ipaddress.ip_address(address)
+    if named_host and ip in BENCHMARK_NETWORK:
+        return True
+    return ip.is_global
+
+
+def _validate_download_url(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        _die("MuAPI output URL must use HTTPS.")
+    if parsed.username or parsed.password:
+        _die("MuAPI output URL must not include user information.")
+    host = parsed.hostname
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if not _is_safe_ip(str(literal), named_host=False):
+            _die("MuAPI output URL resolves to a non-public address.")
+        return
+    if host.lower() == "localhost" or host.lower().endswith(".localhost"):
+        _die("MuAPI output URL must not target localhost.")
+    try:
+        addresses: Set[str] = {
+            item[4][0]
+            for item in socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
+        }
+    except socket.gaierror as exc:
+        _die(f"Could not resolve MuAPI output host: {exc}")
+        return
+    if not addresses or any(not _is_safe_ip(address, named_host=True) for address in addresses):
+        _die("MuAPI output URL resolves to a non-public address.")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        _validate_download_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _download(url: str, out_path: Path, *, force: bool) -> None:
+    _validate_download_url(url)
+    if out_path.exists() and not force:
+        _die(f"Output already exists: {out_path} (use --force to overwrite)")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Optional[Path] = None
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "audio/*", "User-Agent": USER_AGENT},
+        method="GET",
+    )
+    opener = urllib.request.build_opener(_SafeRedirectHandler())
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{out_path.name}.",
+            suffix=".part",
+            dir=out_path.parent,
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            with opener.open(request, timeout=60) as response:
+                content_length = response.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        if int(content_length) > MAX_DOWNLOAD_BYTES:
+                            raise RuntimeError("MuAPI output exceeds the 100 MiB download limit")
+                    except ValueError:
+                        pass
+                written = 0
+                while True:
+                    chunk = response.read(64 * 1024)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > MAX_DOWNLOAD_BYTES:
+                        raise RuntimeError("MuAPI output exceeds the 100 MiB download limit")
+                    temporary.write(chunk)
+                if written == 0:
+                    raise RuntimeError("MuAPI output download was empty")
+                temporary.flush()
+                os.fsync(temporary.fileno())
+        os.replace(temporary_path, out_path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    print(f"Wrote {out_path}")
+
+
+def _payload(args: argparse.Namespace, text: str) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "prompt": text,
+        "voice_id": _choice(args.voice_id, VOICE_IDS, "voice-id"),
+        "stability": _number(args.stability, 0.0, 1.0, "stability"),
+        "similarity_boost": _number(
+            args.similarity_boost, 0.0, 1.0, "similarity-boost"
+        ),
+        "speed": _number(args.speed, 0.7, 1.2, "speed"),
+    }
+    if args.language_code is not None:
+        payload["language_code"] = _choice(
+            args.language_code, LANGUAGE_CODES, "language-code"
+        )
+    return payload
+
+
+def _generate(payload: Mapping[str, Any], out_path: Path, args: argparse.Namespace) -> None:
+    _poll_options(args)
+    if out_path.exists() and not args.force and not args.dry_run:
+        _die(f"Output already exists: {out_path} (use --force to overwrite)")
+    key = _api_key(args.dry_run)
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "model": MODEL_NAME,
+                    "endpoint": MODEL_ENDPOINT,
+                    "payload": dict(payload),
+                    "output": str(out_path),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    _discover_model()
+    prediction_id = _submit(payload, key)
+    output_url = _poll(
+        prediction_id,
+        key,
+        attempts=args.poll_attempts,
+        interval=args.poll_interval,
+    )
+    _download(output_url, out_path, force=args.force)
+
+
+def _read_jobs(path: str) -> List[Dict[str, Any]]:
+    jobs: List[Dict[str, Any]] = []
+    try:
+        lines = Path(path).read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        _die(f"Could not read batch input: {exc}")
+    for line_number, raw in enumerate(lines, 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            job = json.loads(line)
+        except json.JSONDecodeError:
+            _die(f"Invalid JSON on batch line {line_number}.")
+        if not isinstance(job, dict):
+            _die(f"Invalid batch job on line {line_number}: expected an object.")
+        jobs.append(job)
+    if not jobs:
+        _die("No jobs found in batch input.")
+    return jobs
+
+
+def _run_speak(args: argparse.Namespace) -> int:
+    text = _read_text(args.input, args.input_file)
+    _generate(_payload(args, text), _output_path(args.out), args)
+    return 0
+
+
+def _run_batch(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    for index, job in enumerate(_read_jobs(args.input), 1):
+        child = argparse.Namespace(**vars(args))
+        child.voice_id = job.get("voice_id", args.voice_id)
+        child.stability = job.get("stability", args.stability)
+        child.similarity_boost = job.get("similarity_boost", args.similarity_boost)
+        child.speed = job.get("speed", args.speed)
+        child.language_code = job.get("language_code", args.language_code)
+        job_text = job.get("input", job.get("text"))
+        if not isinstance(job_text, str):
+            _die(f"Batch job {index} must provide string input text.")
+        text = _read_text(job_text, None)
+        filename = str(job.get("out") or f"{index:03d}-speech.mp3")
+        out_path = out_dir / Path(filename).name
+        _generate(_payload(child, text), out_path, child)
+    return 0
+
+
+def _add_provider_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--voice-id", default=DEFAULT_VOICE_ID)
+    parser.add_argument("--language-code", choices=LANGUAGE_CODES)
+    parser.add_argument("--stability", type=float, default=DEFAULT_STABILITY)
+    parser.add_argument(
+        "--similarity-boost", type=float, default=DEFAULT_SIMILARITY_BOOST
+    )
+    parser.add_argument("--speed", type=float, default=DEFAULT_SPEED)
+    parser.add_argument("--poll-interval", type=float, default=DEFAULT_POLL_INTERVAL)
+    parser.add_argument("--poll-attempts", type=int, default=DEFAULT_POLL_ATTEMPTS)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true")
+
+
+def _list_voices(_args: argparse.Namespace) -> int:
+    for voice_id, label in VOICE_LABELS.items():
+        print(f"{voice_id}\t{label}")
+    return 0
+
+
+def _show_model(_args: argparse.Namespace) -> int:
+    details = _discover_model()
+    print(
+        json.dumps(
+            {
+                "name": details.get("name", MODEL_NAME),
+                "category": details.get("category"),
+                "endpoint": details.get("endpoint"),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate speech using MuAPI.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    voices = subparsers.add_parser("list-voices", help="List supported voice IDs")
+    voices.set_defaults(func=_list_voices)
+
+    models = subparsers.add_parser("models", help="Check the current MuAPI TTS model")
+    models.set_defaults(func=_show_model)
+
+    speak = subparsers.add_parser("speak", help="Generate one audio file")
+    speak.add_argument("--input")
+    speak.add_argument("--input-file")
+    speak.add_argument("--out")
+    _add_provider_args(speak)
+    speak.set_defaults(func=_run_speak)
+
+    batch = subparsers.add_parser("speak-batch", help="Generate from JSONL jobs")
+    batch.add_argument("--input", required=True)
+    batch.add_argument("--out-dir", default="output/speech")
+    _add_provider_args(batch)
+    batch.set_defaults(func=_run_batch)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest import mock
 
 
-SCRIPT = Path(__file__).parents[1] / "scripts" / "muapi_text_to_speech.py"
+SCRIPT = Path(__file__).parents[1] / "scripts" / "muapi-text-to-speech.py"
 SPEC = importlib.util.spec_from_file_location("muapi_tts", SCRIPT)
 assert SPEC and SPEC.loader
 muapi_tts = importlib.util.module_from_spec(SPEC)
@@ -51,12 +51,12 @@ class MuapiTextToSpeechTests(unittest.TestCase):
     def test_submission_post_is_not_retried(self):
         calls = 0
 
-        def fail(_request, timeout):
+        def fail(_request):
             nonlocal calls
             calls += 1
             raise urllib.error.URLError("offline")
 
-        with mock.patch.object(muapi_tts.urllib.request, "urlopen", side_effect=fail):
+        with mock.patch.object(muapi_tts, "_open_api", side_effect=fail):
             with self.assertRaises(RuntimeError):
                 muapi_tts._submit({"prompt": "Hello"}, "key")
         self.assertEqual(calls, 1)
@@ -64,13 +64,11 @@ class MuapiTextToSpeechTests(unittest.TestCase):
     def test_generation_uses_muapi_header_without_bearer(self):
         seen = []
 
-        def respond(request, timeout):
+        def respond(request):
             seen.append(request)
             return _Response(b'{"request_id":"pred-1"}')
 
-        with mock.patch.object(
-            muapi_tts.urllib.request, "urlopen", side_effect=respond
-        ):
+        with mock.patch.object(muapi_tts, "_open_api", side_effect=respond):
             self.assertEqual(
                 muapi_tts._submit({"prompt": "Hello"}, "secret"), "pred-1"
             )
@@ -83,9 +81,7 @@ class MuapiTextToSpeechTests(unittest.TestCase):
             _Response(b'{"status":"completed","output":{"audio_url":"https://cdn.example/audio.mp3"}}'),
         ]
         with (
-            mock.patch.object(
-                muapi_tts.urllib.request, "urlopen", side_effect=responses
-            ),
+            mock.patch.object(muapi_tts, "_open_api", side_effect=responses),
             mock.patch.object(muapi_tts.time, "sleep"),
         ):
             output = muapi_tts._poll(
@@ -95,8 +91,8 @@ class MuapiTextToSpeechTests(unittest.TestCase):
 
     def test_poll_fails_without_extra_polls_after_terminal_status(self):
         with mock.patch.object(
-            muapi_tts.urllib.request,
-            "urlopen",
+            muapi_tts,
+            "_open_api",
             return_value=_Response(b'{"status":"failed"}'),
         ) as urlopen:
             with self.assertRaisesRegex(RuntimeError, "failed"):
@@ -130,6 +126,72 @@ class MuapiTextToSpeechTests(unittest.TestCase):
         ):
             with self.assertRaises(SystemExit):
                 muapi_tts._validate_download_url("https://cdn.example/audio.mp3")
+
+    def test_api_redirect_outside_fixed_origin_is_rejected(self):
+        handler = muapi_tts._FixedOriginRedirectHandler()
+        request = muapi_tts.urllib.request.Request(
+            "https://api.muapi.ai/api/v1/models/example",
+            headers={"x-api-key": "secret"},
+        )
+        with self.assertRaisesRegex(RuntimeError, "fixed API origin"):
+            handler.redirect_request(
+                request,
+                io.BytesIO(),
+                307,
+                "Temporary Redirect",
+                {},
+                "https://attacker.example/collect",
+            )
+
+    def test_download_rechecks_dns_before_connection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "speech.mp3"
+            with mock.patch.object(
+                muapi_tts.socket,
+                "getaddrinfo",
+                side_effect=[
+                    [(muapi_tts.socket.AF_INET, muapi_tts.socket.SOCK_STREAM, 6, "", ("8.8.8.8", 443))],
+                    [(muapi_tts.socket.AF_INET, muapi_tts.socket.SOCK_STREAM, 6, "", ("10.0.0.8", 443))],
+                ],
+            ):
+                with self.assertRaises(urllib.error.URLError):
+                    muapi_tts._download(
+                        "https://cdn.example/audio.mp3", output, force=True
+                    )
+
+    def test_batch_discovers_model_once(self):
+        with tempfile.TemporaryDirectory() as directory:
+            jobs = Path(directory) / "jobs.jsonl"
+            jobs.write_text(
+                '{"input":"One"}\n{"input":"Two"}\n',
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.dict("os.environ", {"MUAPI_API_KEY": "secret"}, clear=True),
+                mock.patch.object(muapi_tts, "_discover_model", return_value={}) as discover,
+                mock.patch.object(muapi_tts, "_submit", side_effect=["pred-1", "pred-2"]),
+                mock.patch.object(
+                    muapi_tts,
+                    "_poll",
+                    side_effect=["https://cdn.example/one.mp3", "https://cdn.example/two.mp3"],
+                ),
+                mock.patch.object(muapi_tts, "_download"),
+            ):
+                result = muapi_tts.main(
+                    [
+                        "speak-batch",
+                        "--input",
+                        str(jobs),
+                        "--out-dir",
+                        directory,
+                        "--poll-attempts",
+                        "1",
+                        "--poll-interval",
+                        "0",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        discover.assert_called_once_with()
 
     def test_batch_dry_run_uses_job_overrides(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
@@ -193,6 +193,24 @@ class MuapiTextToSpeechTests(unittest.TestCase):
         self.assertEqual(result, 0)
         discover.assert_called_once_with()
 
+    def test_batch_existing_output_stops_before_discovery(self):
+        with tempfile.TemporaryDirectory() as directory:
+            jobs = Path(directory) / "jobs.jsonl"
+            jobs.write_text('{"input":"One"}\n', encoding="utf-8")
+            (Path(directory) / "001-speech.mp3").write_bytes(b"existing")
+            with mock.patch.object(muapi_tts, "_discover_model") as discover:
+                with self.assertRaises(SystemExit):
+                    muapi_tts.main(
+                        [
+                            "speak-batch",
+                            "--input",
+                            str(jobs),
+                            "--out-dir",
+                            directory,
+                        ]
+                    )
+        discover.assert_not_called()
+
     def test_batch_dry_run_uses_job_overrides(self):
         with tempfile.TemporaryDirectory() as directory:
             jobs = Path(directory) / "jobs.jsonl"

--- a/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
+++ b/cli-tool/components/skills/media/speech/tests/test_muapi_text_to_speech.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "muapi_text_to_speech.py"
+SPEC = importlib.util.spec_from_file_location("muapi_tts", SCRIPT)
+assert SPEC and SPEC.loader
+muapi_tts = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(muapi_tts)
+
+
+class _Response:
+    def __init__(self, body: bytes, headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _size=-1):
+        body, self._body = self._body, b""
+        return body
+
+
+class MuapiTextToSpeechTests(unittest.TestCase):
+    def test_dry_run_does_not_require_key(self):
+        stdout = io.StringIO()
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            mock.patch("sys.stdout", stdout),
+        ):
+            result = muapi_tts.main(
+                ["speak", "--input", "Hello", "--language-code", "en", "--dry-run"]
+            )
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn('"model": "elevenlabs-tts-turbo-2-5"', output)
+        self.assertIn('"prompt": "Hello"', output)
+        self.assertNotIn("x-api-key", output)
+
+    def test_submission_post_is_not_retried(self):
+        calls = 0
+
+        def fail(_request, timeout):
+            nonlocal calls
+            calls += 1
+            raise urllib.error.URLError("offline")
+
+        with mock.patch.object(muapi_tts.urllib.request, "urlopen", side_effect=fail):
+            with self.assertRaises(RuntimeError):
+                muapi_tts._submit({"prompt": "Hello"}, "key")
+        self.assertEqual(calls, 1)
+
+    def test_generation_uses_muapi_header_without_bearer(self):
+        seen = []
+
+        def respond(request, timeout):
+            seen.append(request)
+            return _Response(b'{"request_id":"pred-1"}')
+
+        with mock.patch.object(
+            muapi_tts.urllib.request, "urlopen", side_effect=respond
+        ):
+            self.assertEqual(
+                muapi_tts._submit({"prompt": "Hello"}, "secret"), "pred-1"
+            )
+        self.assertEqual(seen[0].get_header("X-api-key"), "secret")
+        self.assertIsNone(seen[0].get_header("Authorization"))
+
+    def test_poll_retries_get_and_returns_audio_url(self):
+        responses = [
+            urllib.error.URLError("temporary"),
+            _Response(b'{"status":"completed","output":{"audio_url":"https://cdn.example/audio.mp3"}}'),
+        ]
+        with (
+            mock.patch.object(
+                muapi_tts.urllib.request, "urlopen", side_effect=responses
+            ),
+            mock.patch.object(muapi_tts.time, "sleep"),
+        ):
+            output = muapi_tts._poll(
+                "pred-1", "key", attempts=1, interval=0
+            )
+        self.assertEqual(output, "https://cdn.example/audio.mp3")
+
+    def test_poll_fails_without_extra_polls_after_terminal_status(self):
+        with mock.patch.object(
+            muapi_tts.urllib.request,
+            "urlopen",
+            return_value=_Response(b'{"status":"failed"}'),
+        ) as urlopen:
+            with self.assertRaisesRegex(RuntimeError, "failed"):
+                muapi_tts._poll("pred-1", "key", attempts=4, interval=0)
+        self.assertEqual(urlopen.call_count, 1)
+
+    def test_invalid_non_finite_speed_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            muapi_tts._number(float("nan"), 0.7, 1.2, "speed")
+
+    def test_invalid_voice_is_rejected(self):
+        args = mock.Mock(
+            voice_id="not-a-voice",
+            stability=0.5,
+            similarity_boost=0.75,
+            speed=1.0,
+            language_code=None,
+        )
+        with self.assertRaises(SystemExit):
+            muapi_tts._payload(args, "Hello")
+
+    def test_private_literal_download_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            muapi_tts._validate_download_url("https://127.0.0.1/audio.mp3")
+
+    def test_named_private_download_host_is_rejected(self):
+        with mock.patch.object(
+            muapi_tts.socket,
+            "getaddrinfo",
+            return_value=[(None, None, None, None, ("10.0.0.8", 443))],
+        ):
+            with self.assertRaises(SystemExit):
+                muapi_tts._validate_download_url("https://cdn.example/audio.mp3")
+
+    def test_batch_dry_run_uses_job_overrides(self):
+        with tempfile.TemporaryDirectory() as directory:
+            jobs = Path(directory) / "jobs.jsonl"
+            jobs.write_text(
+                '{"input":"Bonjour","language_code":"fr","speed":0.9}\n',
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with (
+                mock.patch.dict("os.environ", {}, clear=True),
+                mock.patch("sys.stdout", stdout),
+            ):
+                result = muapi_tts.main(
+                    [
+                        "speak-batch",
+                        "--input",
+                        str(jobs),
+                        "--out-dir",
+                        directory,
+                        "--dry-run",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        output = stdout.getvalue()
+        self.assertIn('"language_code": "fr"', output)
+        self.assertIn('"speed": 0.9', output)
+        self.assertIn("001-speech.mp3", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an optional standard-library MuAPI text-to-speech CLI for the published `elevenlabs-tts-turbo-2-5` capability.
- Document explicit provider selection, voice and language inputs, batch usage, and the `MUAPI_API_KEY` environment variable.
- Add mocked contract, polling, retry, URL-safety, and dry-run coverage.

## Safety

- The API origin and model endpoint are fixed.
- The generation POST is sent once; only bounded prediction GET polling may retry.
- API credentials are never sent to output-download URLs.
- HTTPS output URLs, public DNS targets, redirects, download size, and atomic output writes are checked.
- The existing default speech workflow remains unchanged.

## Validation

- Focused speech unittest suite: 21 passed.
- Python bytecode compilation passed.
- `npm test` completed.
- Read-only MuAPI model discovery and CLI dry-run passed.

Relevant provider documentation: [MuAPI text-to-speech](https://muapi.ai/text-to-speech) and [music and speech documentation](https://muapi.ai/docs/music-and-speech).