### PR TITLE
Add DemoDay plugin listing

### DIFF
--- a/dashboard/public/plugins.json
+++ b/dashboard/public/plugins.json
@@ -23406,6 +23406,26 @@
     "highlights": []
   },
   {
+    "slug": "demoday-claude-plugin",
+    "name": "Demoday Claude Plugin",
+    "author": "mrieck",
+    "description": "Claude Code plugin that creates demo videos for your projects.  Claude is given tools to drive the browser/cli, make recordings, and uses FAL.ai, ElevenLabs, and remotion to build a demo video with scene transitions.   ",
+    "github": "https://github.com/mrieck/demoday-claude-plugin",
+    "stars": 2,
+    "type": "plugin",
+    "tags": [
+      "skills",
+      "commands"
+    ],
+    "contains": {
+      "skills": 5,
+      "commands": 1
+    },
+    "highlights": [],
+    "marketplace_name": "demoday",
+    "plugin_name": "demoday"
+  },
+  {
     "slug": "best-claude-skills",
     "name": "Best Claude Skills",
     "author": "Nyanbalaji28",

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -64,6 +64,7 @@ REPOS = [
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
     ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
+    ("mrieck/demoday-claude-plugin", None),
 ]
 
 DESCRIPTION_OVERRIDES = {


### PR DESCRIPTION
Adds **DemoDay** to the plugins catalog.

DemoDay is a Claude Code plugin that creates demo videos for your projects. Claude is given tools to drive the browser/CLI, make recordings, and uses FAL.ai, ElevenLabs and Remotion to build a demo video with scene transitions. Supports 16:9 promo/tutorial demos and 9:16 Short listicle/cohost cuts. macOS. Open source, MIT.

```
/plugin marketplace add mrieck/demoday-claude-plugin
/plugin install demoday@demoday
```

- `scripts/generate_plugins_json.py`: add `mrieck/demoday-claude-plugin` to `REPOS`
- `dashboard/public/plugins.json`: the entry produced by `process_repo()` for that repo; the generated update is limited to this entry (no star refreshes of other repos)

Source: https://github.com/mrieck/demoday-claude-plugin
