### PR TITLE
feat(mcps): add Serply search MCP server (web)

### DIFF
--- a/cli-tool/components/mcps/web/serply.json
+++ b/cli-tool/components/mcps/web/serply.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "serply": {
+      "description": "Serply MCP Server - Google web, news, scholar, maps, jobs and video search, Bing search, Amazon product search and URL scraping through the Serply.io API. Hosted Streamable HTTP endpoint, no local install required; get an API key at https://serply.io and see https://serply.io/docs for the API reference.",
+      "type": "http",
+      "url": "https://api.serply.io/mcp",
+      "headers": {
+        "X-Api-Key": "<your-serply-api-key>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a `web/serply` MCP component (`cli-tool/components/mcps/web/serply.json`) for the [Serply](https://serply.io) MCP server. It is a hosted Streamable HTTP server, so the entry uses the same `type: http` + `headers` shape as `web/web-search-prime.json`: users install it with `npx claude-code-templates@latest --mcp web/serply` and replace `<your-serply-api-key>` with their key.

The server exposes Google web, news, scholar, maps, jobs and video search, Bing search, Amazon product search and URL scraping as MCP tools. API reference: https://serply.io/docs.

## Why

The `web` category currently has search servers for Z.AI, SearXNG and TinyFish, but nothing that returns Google SERP results or the Google News / Scholar verticals. Serply fills that gap with a single API key and no local install.

## Notes

- One new JSON file, no changes to the CLI, the generated catalog (`docs/components.json`) or the dashboard assets, which the daily bot commit regenerates.
- Follows the existing HTTP MCP entry shape (`description`, `type`, `url`, `headers`) used by `web/web-search-prime.json`.
- Nothing changes for users who do not install this component.

## Testing

```text
$ python3 -c "import json; d=json.load(open('cli-tool/components/mcps/web/serply.json')); print(list(d['mcpServers']['serply'].keys()))"
['description', 'type', 'url', 'headers']

$ node -e "const d=require('./cli-tool/components/mcps/web/serply.json'); console.log(Object.keys(d.mcpServers))"
[ 'serply' ]
```

Endpoint check (2026-08-26): `https://api.serply.io/mcp` answers MCP `initialize` over Streamable HTTP with an `X-Api-Key` header (server `serply-mcp-server`, tools `google_search`, `google_news_search`, `google_scholar_search`, `google_maps_search`, `google_jobs_search`, `google_video_search`, `bing_search`, `amazon_product_search`, `scrape_url`).

Disclosure: I work with Serply. Happy to adjust the category, description, or drop this entirely if it isn't a direction you want for the catalog.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Serply MCP server as a new web component, exposing Google web/news/scholar/maps/jobs/video search, Bing, Amazon product search, and URL scraping tools through a hosted HTTP endpoint.

- Adds `cli-tool/components/mcps/web/serply.json` using the same `type: http` + `headers` shape as `web/web-search-prime.json`; no other files change.
- Install with `npx claude-code-templates@latest --mcp web/serply` and replace `<your-serply-api-key>` with a key from https://serply.io.
- `docs/components.json` needs no manual regeneration; the daily bot commit handles it.
- No new environment variables or secrets; behavior is unchanged for anyone who doesn't install the component.

<sup>Written for commit b3aa7fafb12aaef2074f0d87535769f0109d2dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

