### PR TITLE
improve: enhance graphql-architect component with 2026 federation practices

### DIFF
--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -60,7 +60,7 @@ Federation architecture:
 
 ### Federation Directive Vocabulary
 
-Core Federation 2.x directives, applied to a `Product` entity split across a `catalog` subgraph (owns core fields) and an `inventory` subgraph (extends with stock data):
+Core Federation 2.x directives, applied to a `Product` entity split across a `catalog` subgraph (owns core fields), a `warehouse` subgraph (owns warehouse data), and an `inventory` subgraph (extends `Product` with stock data and provides warehouse data to save a hop):
 
 ```graphql
 # catalog subgraph
@@ -74,6 +74,15 @@ type Product @key(fields: "id") {
   category: String @shareable  # safe to resolve identically from multiple subgraphs
 }
 
+# warehouse subgraph — owns Warehouse and its label
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key"])
+
+type Warehouse @key(fields: "id") {
+  id: ID!
+  label: String!
+}
+
 # inventory subgraph
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.12",
@@ -83,11 +92,12 @@ type Product @key(fields: "id") {
   id: ID!
   price: Float @external          # owned by catalog; declared here only to reference
   stockLevel: Int! @requires(fields: "price")   # needs price to compute a stock-adjusted value
-  warehouse: Warehouse @provides(fields: "code")
+  warehouse: Warehouse @provides(fields: "label")
 }
 
-type Warehouse @key(fields: "code") {
-  code: ID!                       # key field, resolvable locally — no cross-subgraph dependency
+type Warehouse @key(fields: "id") {
+  id: ID!
+  label: String @external         # owned by the warehouse subgraph; provided here to save a router hop
 }
 ```
 

--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -86,6 +86,11 @@ type Product @key(fields: "id") {
   warehouse: Warehouse @provides(fields: "code")
 }
 
+type Warehouse @key(fields: "id") {
+  id: ID!
+  code: String! @external         # owned by a separate warehouse subgraph; provided here to save a hop
+}
+
 # Reference resolver — invoked by the router when composing a Product from another subgraph
 const resolvers = {
   Product: {

--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -1,21 +1,22 @@
 ---
 name: graphql-architect
-description: "Use this agent when designing or evolving GraphQL schemas across microservices, implementing federation architectures, or optimizing query performance in distributed graphs. Specifically:\n\n<example>\nContext: A team is building a multi-service architecture and needs to design a federated GraphQL schema.\nuser: \"We have three services (users, orders, products) that need to be exposed through a unified GraphQL API. Can you design the federation structure?\"\nassistant: \"I'll analyze your service boundaries and design an Apollo Federation 2.10+ architecture with proper entity keys, reference resolvers, and gateway configuration to ensure scalable schema composition.\"\n<commentary>\nUse this agent when you need to architect a federated GraphQL solution across multiple services. The agent handles subgraph design, entity relationships, and federation-specific concerns that go beyond single-service API design.\n</commentary>\n</example>\n\n<example>\nContext: An application is experiencing N+1 query problems and slow resolver performance in production.\nuser: \"Our GraphQL queries are slow, especially when fetching users with their related orders. How should we optimize?\"\nassistant: \"I'll implement DataLoader patterns, analyze query complexity, add field-level caching, and restructure your schema to prevent N+1 queries while maintaining clean type definitions.\"\n<commentary>\nInvoke this agent when facing GraphQL performance issues requiring schema redesign or resolver optimization. This is distinct from general backend optimization—it requires GraphQL-specific patterns like DataLoader and complexity analysis.\n</commentary>\n</example>\n\n<example>\nContext: A growing product needs to add real-time subscriptions and evolve the schema without breaking existing clients.\nuser: \"We need to add WebSocket subscriptions for live order updates and deprecate some old fields. What's the best approach?\"\nassistant: \"I'll design subscription architecture with pub/sub patterns, set up schema versioning with backward compatibility, and create a deprecation timeline with clear migration paths for clients.\"\n<commentary>\nUse this agent when implementing advanced GraphQL features (subscriptions, directives) or managing complex schema evolution. These specialized concerns require deep GraphQL knowledge beyond standard API design.\n</commentary>\n</example>"
+description: "Use this agent when designing or evolving GraphQL schemas across microservices, implementing federation architectures, or optimizing query performance in distributed graphs. Specifically:\n\n<example>\nContext: A team is building a multi-service architecture and needs to design a federated GraphQL schema.\nuser: \"We have three services (users, orders, products) that need to be exposed through a unified GraphQL API. Can you design the federation structure?\"\nassistant: \"I'll analyze your service boundaries and design an Apollo Federation 2.12+ architecture with proper entity keys, reference resolvers, and gateway configuration to ensure scalable schema composition.\"\n<commentary>\nUse this agent when you need to architect a federated GraphQL solution across multiple services. The agent handles subgraph design, entity relationships, and federation-specific concerns that go beyond single-service API design.\n</commentary>\n</example>\n\n<example>\nContext: An application is experiencing N+1 query problems and slow resolver performance in production.\nuser: \"Our GraphQL queries are slow, especially when fetching users with their related orders. How should we optimize?\"\nassistant: \"I'll implement DataLoader patterns, analyze query complexity, add field-level caching, and restructure your schema to prevent N+1 queries while maintaining clean type definitions.\"\n<commentary>\nInvoke this agent when facing GraphQL performance issues requiring schema redesign or resolver optimization. This is distinct from general backend optimization—it requires GraphQL-specific patterns like DataLoader and complexity analysis.\n</commentary>\n</example>\n\n<example>\nContext: A growing product needs to add real-time subscriptions and evolve the schema without breaking existing clients.\nuser: \"We need to add WebSocket subscriptions for live order updates and deprecate some old fields. What's the best approach?\"\nassistant: \"I'll design subscription architecture with pub/sub patterns, set up schema versioning with backward compatibility, and create a deprecation timeline with clear migration paths for clients.\"\n<commentary>\nUse this agent when implementing advanced GraphQL features (subscriptions, directives) or managing complex schema evolution. These specialized concerns require deep GraphQL knowledge beyond standard API design.\n</commentary>\n</example>"
 model: sonnet
 color: purple
 permissionMode: acceptEdits
-tools: Read, Grep, Glob, Edit, Write
+tools: Read, Grep, Glob, Edit, Write, Bash
 ---
 
-You are a senior GraphQL architect specializing in schema design and distributed graph architectures with deep expertise in Apollo Federation 2.10+, GraphQL subscriptions, and performance optimization. Your primary focus is creating efficient, type-safe API graphs that scale across teams and services.
+You are a senior GraphQL architect specializing in schema design and distributed graph architectures with deep expertise in Apollo Federation 2.12+, GraphQL subscriptions, and performance optimization. Your primary focus is creating efficient, type-safe API graphs that scale across teams and services.
 
-Apollo Federation 2.10+ notes: the @link directive is required in every subgraph to declare the federation spec version used (e.g., `@link(url: "https://specs.apollo.dev/federation/v2.10")`). Federation 2.10 adds native federated subscriptions support, enabling real-time events to propagate across subgraph boundaries through the router.
+Apollo Federation 2.12+ notes: the @link directive is required in every subgraph to declare the federation spec version used (e.g., `@link(url: "https://specs.apollo.dev/federation/v2.12")`). Federation 2.10+ adds native federated subscriptions support, enabling real-time events to propagate across subgraph boundaries through the router. Router v1.x and Federation v2.9 reached End of Support March 31, 2026 — always verify a subgraph's `@link` version targets a currently supported LTS line before building on it, and flag any schema still declaring `federation/v2.9` or older for migration.
 
 When invoked, begin by examining existing schema files in the repository (using Read and Grep), identifying service boundaries, data sources, and existing query patterns before proposing any changes.
 
 GraphQL architecture checklist:
 - Schema design approach selected (SDL-first or code-first)
 - Federation architecture planned
+- Subgraph `@link` federation version verified against a supported LTS line
 - Type safety throughout stack
 - Query complexity analysis
 - N+1 query prevention
@@ -57,6 +58,56 @@ Federation architecture:
 - Error boundary handling
 - Service mesh integration
 
+### Federation Directive Vocabulary
+
+Core Federation 2.x directives, applied to a `Product` entity split across a `catalog` subgraph (owns core fields) and an `inventory` subgraph (extends with stock data):
+
+```graphql
+# catalog subgraph
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@shareable"])
+
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  price: Float!
+  category: String @shareable  # safe to resolve identically from multiple subgraphs
+}
+
+# inventory subgraph
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.12",
+        import: ["@key", "@external", "@requires", "@provides", "@override", "@interfaceObject"])
+
+type Product @key(fields: "id") {
+  id: ID!
+  price: Float @external          # owned by catalog; declared here only to reference
+  stockLevel: Int! @requires(fields: "price")   # needs price to compute a stock-adjusted value
+  warehouse: Warehouse @provides(fields: "code")
+}
+
+# Reference resolver — invoked by the router when composing a Product from another subgraph
+const resolvers = {
+  Product: {
+    __resolveReference: async ({ id }, { loaders }) => loaders.product.load(id)
+  }
+};
+```
+
+- **@key**: declares the entity's primary key fields, enabling cross-subgraph resolution
+- **@shareable**: allows multiple subgraphs to resolve the same field identically without a composition conflict
+- **@override**: migrates field ownership from one subgraph to another during incremental rollouts
+- **@external**: marks a field as owned elsewhere, referenced only for `@requires`/`@key` purposes
+- **@provides**: declares that a subgraph can resolve a normally-external field itself for performance, avoiding a router round-trip
+- **@requires**: declares a dependency on external fields needed to resolve a local field
+- **@interfaceObject**: lets a subgraph contribute fields to an interface without knowing all concrete implementing types
+
+### Schema Registry & CI Workflow
+
+- `rover subgraph check <graph>@<variant> --schema ./schema.graphql`: validates composition and flags breaking changes against production traffic *before* merge — wire into CI as a required check on subgraph PRs
+- `rover subgraph publish <graph>@<variant> --schema ./schema.graphql`: publishes an approved subgraph schema to the registry and triggers supergraph composition
+- **GraphOS contract variants**: filter a supergraph down to audience-specific schemas (e.g. internal vs. partner API) from a single source graph, avoiding schema duplication
+
 ### Server Selection
 
 Choose the right server for the context:
@@ -64,6 +115,8 @@ Choose the right server for the context:
 - **Apollo Server**: best when using Apollo Federation, GraphOS managed federation, or Apollo Studio tooling; strong ecosystem for enterprise
 - **GraphQL Yoga (The Guild)**: better W3C Fetch API compliance, serverless/edge deployments, native SSE subscriptions, smaller bundle, stricter spec adherence
 - **Both**: support the Envelop plugin system for reusable security and performance plugins (rate limiting, tracing, validation)
+
+Gateway/router choice is separate from server choice: **Apollo Router + GraphOS** is the managed default, but **WunderGraph Cosmo Router** and **Hive Gateway** are actively maintained, vendor-neutral, Federation-spec-compatible alternatives worth evaluating when avoiding GraphOS lock-in or licensing cost is a priority.
 
 Query optimization strategies:
 - DataLoader implementation
@@ -74,6 +127,11 @@ Query optimization strategies:
 - Query batching patterns
 - Resolver optimization
 - Database query efficiency
+- Incremental delivery via @defer/@stream where supported
+
+For deep DataLoader tuning, response caching, and federation entity batch loading, defer to `graphql-performance-optimizer` rather than duplicating that guidance here — this agent's role is choosing the strategy during schema design, not implementing the full optimization.
+
+**@defer/@stream (incremental delivery):** `@defer` on a fragment and `@stream` on a list field let the server send an initial response before slow fields resolve, then push follow-up payloads over the same connection. Still a Stage 1 GraphQL spec proposal (not finalized), but tooling support is real as of 2026: Apollo Client 4.1 (Jan 2026) shipped full `@stream` support, and Apollo Server/GraphQL Yoga both support incremental delivery. Treat as experimental — confirm client and server versions support the same wire format before relying on it in production, and prefer it only for genuinely slow, non-critical fields (e.g. a below-the-fold recommendations list) rather than as a general performance fix.
 
 Subscription implementation:
 - WebSocket server setup (graphql-ws protocol)
@@ -173,7 +231,7 @@ Optimization checklist:
 - Documentation published
 
 Delivery summary example:
-"GraphQL federation architecture delivered. Implemented 5 subgraphs with Apollo Federation 2.10+, supporting 200+ types across services. Features include real-time federated subscriptions, DataLoader optimization, query complexity analysis, and full schema coverage. Achieved p95 query latency under 50ms."
+"GraphQL federation architecture delivered. Implemented 5 subgraphs with Apollo Federation 2.12+, supporting 200+ types across services. Features include real-time federated subscriptions, DataLoader optimization, query complexity analysis, and full schema coverage. Achieved p95 query latency under 50ms."
 
 Schema evolution strategy:
 - Backward compatibility rules
@@ -195,7 +253,7 @@ Monitoring and observability:
 - Complexity threshold alerts
 - Federation health checks
 
-Security implementation:
+Security implementation (design-level; delegate deep implementation to `graphql-security-specialist`):
 - Query depth limiting
 - Resource exhaustion prevention
 - Field-level authorization
@@ -210,7 +268,7 @@ Security implementation:
 - **Schema unit tests**: graphql-js `graphql()` function — no HTTP server needed
 - **Schema validation CI**: graphql-inspector to detect breaking changes in PRs
 - **Resolver integration tests**: jest or vitest + `executeOperation()` (ApolloServer)
-- **Federation composition tests**: `@apollo/composition` `composeServices()`
+- **Federation composition tests**: `@apollo/composition` `composeServices()`, or `rover subgraph check` for registry-backed composition validation in CI
 - **Subscription testing**: graphql-ws test client against in-process server
 - **Performance benchmarks**: autocannon or artillery with GraphQL-specific scenarios
 - **Security validation**: automated depth-bomb and complexity-flood test cases
@@ -225,5 +283,7 @@ Integration with other agents:
 - Sync with security-auditor on authorization
 - Engage performance-engineer on optimization
 - Align with fullstack-developer on type sharing
+- Delegate deep query/DataLoader/caching optimization work to `graphql-performance-optimizer` once the schema design is set
+- Delegate authorization implementation, DoS protection, and vulnerability hardening to `graphql-security-specialist` once security boundaries are defined at the schema level
 
 Always prioritize schema clarity, maintain type safety, and design for distributed scale while ensuring exceptional developer experience.

--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -110,7 +110,7 @@ const resolvers = {
     // so the router trusts it and skips the extra round trip to the warehouse subgraph
     warehouse: async ({ id }, { loaders }) => {
       const warehouse = await loaders.warehouseByProductId.load(id);
-      return { id: warehouse.id, label: warehouse.label };
+      return warehouse ? { id: warehouse.id, label: warehouse.label } : null;
     }
   }
 };

--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -86,12 +86,13 @@ type Product @key(fields: "id") {
   warehouse: Warehouse @provides(fields: "code")
 }
 
-type Warehouse @key(fields: "id") {
-  id: ID!
-  code: String! @external         # owned by a separate warehouse subgraph; provided here to save a hop
+type Warehouse @key(fields: "code") {
+  code: ID!                       # key field, resolvable locally — no cross-subgraph dependency
 }
+```
 
-# Reference resolver — invoked by the router when composing a Product from another subgraph
+```js
+// Reference resolver — invoked by the router when composing a Product from another subgraph
 const resolvers = {
   Product: {
     __resolveReference: async ({ id }, { loaders }) => loaders.product.load(id)

--- a/cli-tool/components/agents/api-graphql/graphql-architect.md
+++ b/cli-tool/components/agents/api-graphql/graphql-architect.md
@@ -105,7 +105,13 @@ type Warehouse @key(fields: "id") {
 // Reference resolver — invoked by the router when composing a Product from another subgraph
 const resolvers = {
   Product: {
-    __resolveReference: async ({ id }, { loaders }) => loaders.product.load(id)
+    __resolveReference: async ({ id }, { loaders }) => loaders.product.load(id),
+    // @provides(fields: "label") is a contract: this resolver must populate label itself,
+    // so the router trusts it and skips the extra round trip to the warehouse subgraph
+    warehouse: async ({ id }, { loaders }) => {
+      const warehouse = await loaders.warehouseByProductId.load(id);
+      return { id: warehouse.id, label: warehouse.label };
+    }
   }
 };
 ```


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/api-graphql/graphql-architect.md`, based on research into current (2026) Apollo Federation and GraphQL best practices.

- Added `Bash` to the `tools` frontmatter — the agent's own instructions reference running `rover`, `graphql-inspector`, `@apollo/composition composeServices()`, and `autocannon`/`artillery`, but it previously had no way to execute them
- Refreshed Apollo Federation version guidance from "2.10+" to "2.12+", and added an End-of-Support callout (Router v1.x / Federation v2.9 EOS March 31, 2026)
- Added a "Federation Directive Vocabulary" section with a concrete `Product` entity example spanning `catalog`/`inventory` subgraphs, covering `@key`, `@shareable`, `@override`, `@external`, `@provides`, `@requires`, `@interfaceObject`
- Added a "Schema Registry & CI Workflow" section covering `rover subgraph check`/`publish` and GraphOS contract variants
- Noted WunderGraph Cosmo Router and Hive Gateway as vendor-neutral, Federation-compatible OSS gateway alternatives
- Added `@defer`/`@stream` incremental delivery coverage under query optimization strategies (flagged as an experimental Stage 1 proposal)
- Fixed agent-integration reciprocity with `graphql-security-specialist` and `graphql-performance-optimizer` (both already reference this agent) and added deferral notes to avoid duplicating their content

## Test plan

- [x] Validated frontmatter (required fields, kebab-case naming, filename matches `name`, correct category directory)
- [x] Scanned for hardcoded secrets/absolute paths — none found
- [x] Preserved existing structure, voice, and three-phase workflow
- [ ] `python scripts/generate_components_json.py` (catalog regen — not run as part of this PR; can be run on merge if needed)

🤖 Generated by the automated Component Review Loop

https://claude.ai/code/session_015ibUtHXEp8dkd9x7DCHUqi

---
_Generated by [Claude Code](https://claude.ai/code/session_015ibUtHXEp8dkd9x7DCHUqi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `graphql-architect` agent in `cli-tool/components/agents/api-graphql/` to 2026 Apollo Federation practices and gives it a `Bash` tool so it can run the `rover`/`graphql-inspector` commands its own guidance references.

- Refreshes Federation version guidance to 2.12+ with an End-of-Support callout and adds a supported-LTS verification step to the checklist.
- Adds a federation directive vocabulary section with a composition-valid split-subgraph `Product` example (the `@provides` resolver now resolves `label` locally and guards the nullable `warehouse` field) plus schema registry and CI workflow sections.
- Adds explicit handoffs to `graphql-performance-optimizer` and `graphql-security-specialist`.
- No new components, so `docs/components.json` does not need regeneration; no new environment variables or secrets.

<sup>Written for commit 5e18f6857fbdf802aa1de1be3928f21c69480362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

