### PR TITLE
Add html2wp (HTML to WordPress converter) to the plugins list

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -64,6 +64,7 @@ REPOS = [
     ("Airtable/skills", None),
     ("krasserm/ml-plugins", None),
     ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
+    ("iOSDevSK/html2wp-cc-plugin", "https://html2wp.dev/"),
 ]
 
 DESCRIPTION_OVERRIDES = {


### PR DESCRIPTION
Adds one entry to `REPOS` in `scripts/generate_plugins_json.py`.

**[iOSDevSK/html2wp-cc-plugin](https://github.com/iOSDevSK/html2wp-cc-plugin)** — converts a static HTML site into a standalone WordPress block theme. Lovable, Bolt, v0, Claude artifacts, Next.js export, Vite, Astro or hand-written pages go in as a folder.

The repo has `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` at the root, so the generator reads it exactly like the existing entries. `claude plugin validate` passes.

What makes it different from other HTML-to-WordPress converters is that it verifies its own output: every page is composed side by side with its original at 1440, 820 and 390 pixels wide, and the generated theme is installed into a throwaway WordPress in Docker and driven there before handover.

That claim is checkable rather than just stated — <https://bruce.html2wp.dev> is a conversion whose Lovable original is still public at <https://bruce-banner.lovable.app>, and wp-admin is open on `demo`/`demo`.

Free tier needs no key and no sign-up. Website: <https://html2wp.dev/>

Happy to adjust the entry or add it elsewhere if this is not the right place.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds html2wp to the plugins list so the HTML-to-WordPress converter appears in generated plugin feeds.

- Modifies `scripts/generate_plugins_json.py` only.
- The target repo includes the required `.claude-plugin` files and passes `claude plugin validate`.
- No new environment variables or secrets needed.
- Run the generator after merging to refresh the published plugin list.

<sup>Written for commit 40c6a87457949d275342c5e05b17ab679a608489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

