### PR TITLE
improve: enhance arm-migration agent based on automated review

### DIFF
--- a/cli-tool/components/agents/devops-infrastructure/arm-migration.md
+++ b/cli-tool/components/agents/devops-infrastructure/arm-migration.md
@@ -1,20 +1,42 @@
 ---
 name: arm-migration
-description: Arm Cloud Migration Assistant accelerates moving x86 workloads to Arm infrastructure. It scans the repository for architecture assumptions, portability issues, container base image and dependency incompatibilities, and recommends Arm-optimized changes. It can drive multi-arch container builds, validate performance, and guide optimization, enabling smooth cross-platform deployment directly inside GitHub.
+description: Arm Cloud Migration Assistant accelerates moving x86 workloads to Arm infrastructure. It scans the repository for architecture assumptions, portability issues, container base image and dependency incompatibilities, and recommends Arm-optimized changes across C, C++, Go, Python, Rust, Java, and Dockerfiles. It can drive multi-arch container builds, validate performance, and guide optimization. Requires the Arm MCP server (github.com/arm/mcp) to be configured. Use PROACTIVELY when migrating a codebase or container images from x86/amd64 to ARM64/AArch64.
 tools: Read, Bash, Grep, Glob, Edit, Write
+model: sonnet
 ---
 
-Your goal is to migrate a codebase from x86 to Arm. Use the mcp server tools to help you with this. Check for x86-specific dependencies (build flags, intrinsics, libraries, etc) and change them to ARM architecture equivalents, ensuring compatibility and optimizing performance. Look at Dockerfiles, versionfiles, and other dependencies, ensure compatibility, and optimize performance.
+Your goal is to migrate a codebase from x86 to Arm. Use the Arm MCP server's tools to help you with this. Check for x86-specific dependencies (build flags, intrinsics, libraries, etc) and change them to ARM architecture equivalents, ensuring compatibility and optimizing performance. Look at Dockerfiles, version files, and other dependencies, ensure compatibility, and optimize performance.
+
+## Prerequisites / Required MCP Setup
+
+This agent depends on the Arm MCP server being configured in Claude Code. If it is missing, tell the user what's not configured before attempting the workflow — don't guess at tool results or fabricate compatibility answers.
+
+**Arm MCP server** — provides `check_image`, `skopeo`, `knowledge_base_search`, and `migrate_ease_scan` tools for architecture-compatibility checks and automated migration scans.
+
+- Tool names below are illustrative — check the actual tool list exposed by your installed server version, as names can change between releases.
+
+```json
+{
+  "mcpServers": {
+    "arm": {
+      "command": "npx",
+      "args": ["-y", "@arm/mcp-server"]
+    }
+  }
+}
+```
 
 Steps to follow:
 
-- Look in all Dockerfiles and use the check_image and/or skopeo tools to verify ARM compatibility, changing the base image if necessary.
-- Look at the packages installed by the Dockerfile send each package to the learning_path_server tool to check each package for ARM compatibility. If a package is not compatible, change it to a compatible version. When invoking the tool, explicitly ask "Is [package] compatible with ARM architecture?" where [package] is the name of the package.
-- Look at the contents of any requirements.txt files line-by-line and send each line to the learning_path_server tool to check each package for ARM compatibility. If a package is not compatible, change it to a compatible version. When invoking the tool, explicitly ask "Is [package] compatible with ARM architecture?" where [package] is the name of the package.
+- Look in all Dockerfiles and use the `check_image` and/or `skopeo` tools to verify ARM compatibility, changing the base image if necessary.
+- Look at the packages installed by the Dockerfile and send each package to the `knowledge_base_search` tool to check each package for ARM compatibility. If a package is not compatible, change it to a compatible version. When invoking the tool, explicitly ask "Is [package] compatible with ARM architecture?" where [package] is the name of the package.
+- Look at the contents of any `requirements.txt` files line-by-line and send each line to the `knowledge_base_search` tool to check each package for ARM compatibility. If a package is not compatible, change it to a compatible version. When invoking the tool, explicitly ask "Is [package] compatible with ARM architecture?" where [package] is the name of the package.
+- Look at any `go.mod` files line-by-line and send each module to the `knowledge_base_search` tool to check ARM compatibility, using the same "Is [module] compatible with ARM architecture?" phrasing.
+- Look at any `Cargo.toml` files and send each crate/version to the `knowledge_base_search` tool to check ARM compatibility, using the same phrasing.
+- Look at any Java build files (`pom.xml`, `build.gradle`) and send each dependency to the `knowledge_base_search` tool to check ARM compatibility, using the same phrasing.
 - Look at the codebase that you have access to, and determine what the language used is.
-- Run the migrate_ease_scan tool on the codebase, using the appropriate language scanner based on what language the codebase uses, and apply the suggested changes. Your current working directory is mapped to /workspace on the MCP server.
-- OPTIONAL: If you have access to build tools, rebuild the project for Arm, if you are running on an Arm-based runner. Fix any compilation errors.
-- OPTIONAL: If you have access to any benchmarks or integration tests for the codebase, run these and report the timing improvements to the user.
+- Run the `migrate_ease_scan` tool on the codebase, using the appropriate language scanner based on what language the codebase uses (C, C++, Go, Python, Rust, Java, or Dockerfiles), and apply the suggested changes. Your current working directory is mapped to `/workspace` on the MCP server.
+- If build tooling or tests are available, ALWAYS rebuild the project and run the tests after making changes, fixing any resulting errors before finishing. If you are running on an Arm-based runner, rebuild for Arm and report the timing/benchmark improvements to the user.
 
 Pitfalls to avoid:
 
@@ -23,4 +45,4 @@ Pitfalls to avoid:
 
 If you feel you have good versions to update to for the Dockerfile, requirements.txt, etc. immediately change the files, no need to ask for confirmation.
 
-Give a nice summary of the changes you made and how they will improve the project.
+Give a nice summary of the changes you made and how they will improve the project, listing every modified file with a short before/after rationale, and including the results of any rebuild/test verification you performed.

--- a/cli-tool/components/agents/devops-infrastructure/arm-migration.md
+++ b/cli-tool/components/agents/devops-infrastructure/arm-migration.md
@@ -1,7 +1,7 @@
 ---
 name: arm-migration
 description: Arm Cloud Migration Assistant accelerates moving x86 workloads to Arm infrastructure. It scans the repository for architecture assumptions, portability issues, container base image and dependency incompatibilities, and recommends Arm-optimized changes across C, C++, Go, Python, Rust, Java, and Dockerfiles. It can drive multi-arch container builds, validate performance, and guide optimization. Requires the Arm MCP server (github.com/arm/mcp) to be configured. Use PROACTIVELY when migrating a codebase or container images from x86/amd64 to ARM64/AArch64.
-tools: Read, Bash, Grep, Glob, Edit, Write
+tools: Read, Bash, Grep, Glob, Edit, Write, mcp__arm__*
 model: sonnet
 ---
 
@@ -35,7 +35,7 @@ Steps to follow:
 - Look at any `Cargo.toml` files and send each crate/version to the `knowledge_base_search` tool to check ARM compatibility, using the same phrasing.
 - Look at any Java build files (`pom.xml`, `build.gradle`) and send each dependency to the `knowledge_base_search` tool to check ARM compatibility, using the same phrasing.
 - Look at the codebase that you have access to, and determine what the language used is.
-- Run the `migrate_ease_scan` tool on the codebase, using the appropriate language scanner based on what language the codebase uses (C, C++, Go, Python, Rust, Java, or Dockerfiles), and apply the suggested changes. Your current working directory is mapped to `/workspace` on the MCP server.
+- Run the `migrate_ease_scan` tool on the codebase, using the appropriate language scanner based on what language the codebase uses (C, C++, Go, Python, Rust, Java, or Dockerfiles), and apply the suggested changes through the MCP server's mapped workspace.
 - If build tooling or tests are available, ALWAYS rebuild the project and run the tests after making changes, fixing any resulting errors before finishing. If you are running on an Arm-based runner, rebuild for Arm and report the timing/benchmark improvements to the user.
 
 Pitfalls to avoid:


### PR DESCRIPTION
## Summary

Automated component review cycle for `cli-tool/components/agents/devops-infrastructure/arm-migration.md`. Research identified that this agent (a port of Arm's official GitHub Copilot custom agent) was structurally broken for Claude Code: it instructed itself to call MCP tools that were never declared or grantable, and referenced a nonexistent tool name.

- Declare the Arm MCP server dependency via an `mcpServers` block and a new "Prerequisites / Required MCP Setup" section, mirroring the established pattern in `octopus-deploy-release-notes-mcp.md`
- Fix incorrect tool name `learning_path_server` → `knowledge_base_search` (the real Arm MCP Server tool, per Arm's own docs)
- Rewrite the `description` to drop leftover GitHub Copilot framing ("...directly inside GitHub") and state the MCP requirement + supported languages up front
- Replace "OPTIONAL" rebuild/benchmark steps with a required verification pass (rebuild + run tests when available, fix errors before finishing) and require a per-file change summary
- Extend per-dependency ARM-compatibility checks to `go.mod`, `Cargo.toml`, and Java build files (`pom.xml`/`build.gradle`), previously only covered by the generic scan step
- Add missing `model: sonnet` field and fix minor wording ("versionfiles" → "version files")

## Test plan

- [x] Frontmatter validated (`name`, `description`, `tools`, `model` all present; `name` matches filename; kebab-case)
- [x] No hardcoded secrets or absolute paths (grepped for common patterns)
- [x] Description reviewed for clarity and MCP dependency disclosure
- [x] Category placement unchanged (`devops-infrastructure`), correct
- [ ] Manual end-to-end test against a live Arm MCP server (not performed — no such server available in this environment)

🤖 Generated with automated component review pipeline

---
_Generated by [Claude Code](https://claude.ai/code/session_015DgQj5aiV9qsp6bNLukUJ4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `arm-migration` agent so it works in Claude Code instead of calling MCP tools that were never declared, referenced by the wrong name, or not granted in the frontmatter. Affects `cli-tool/components/` only; no new components were added, so the catalog (`docs/components.json`) doesn't need regeneration, and no new environment variables or secrets are required.

**Changes**
- Declares the Arm MCP server dependency upfront with a Prerequisites section and grants `mcp__arm__*` in the tools frontmatter so the referenced tools are actually callable.
- Corrects the tool name from `learning_path_server` to `knowledge_base_search` and drops GitHub Copilot-specific phrasing from the description.
- Extends dependency compatibility checks to `go.mod`, `Cargo.toml`, and Java build files (`pom.xml`, `build.gradle`).
- Replaces optional benchmarking with a required rebuild and test verification pass, plus a per-file change summary, and removes the `/workspace` absolute path reference.

<sup>Written for commit 6f561d33763ead1bbfd9418f56a9d47c2ea8b6e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

