### PR TITLE
feat(dashboard): sponsored placement display (CCT Ads), inert behind PUBLIC_ADS_ENABLED

### DIFF
--- a/dashboard/src/components/ComponentGrid.tsx
+++ b/dashboard/src/components/ComponentGrid.tsx
@@ -85,7 +85,9 @@ export default function ComponentGrid({ initialType }: Props) {
         if (earlyAds) setAds(earlyAds);
         setLoading(false);
         if (!earlyAds) {
-          adsPromise.then((lateAds) => { if (!cancelled && lateAds.length > 0) setAds(lateAds); });
+          // Apply every late result — including [] — so stale placements from
+          // a previously viewed type get cleared.
+          adsPromise.then((lateAds) => { if (!cancelled) setAds(lateAds); });
         }
       } catch {
         if (!cancelled) { setError('Failed to load components'); setLoading(false); }

--- a/dashboard/src/components/ComponentGrid.tsx
+++ b/dashboard/src/components/ComponentGrid.tsx
@@ -8,6 +8,9 @@ import SaveToCollectionButton from './SaveToCollectionButton';
 
 type GridComponent = Component & { sponsored?: boolean };
 
+// Max time the initial render waits for the optional ads request.
+const ADS_FIRST_PAINT_WAIT_MS = 1500;
+
 interface Props {
   initialType: string;
 }
@@ -64,13 +67,26 @@ export default function ComponentGrid({ initialType }: Props) {
       try {
         setLoading(true);
         setError(null);
-        // Ads resolve with the components so the first paint already has the
-        // sponsored card pinned (no post-load reorder). fetchActiveAds never throws.
-        const [components, activeAds] = await Promise.all([
-          fetchComponentsByType(activeType),
-          fetchActiveAds(),
+        // Ads normally resolve with the components so the first paint already
+        // has the sponsored card pinned. They are optional though: the catalog
+        // never waits more than ADS_FIRST_PAINT_WAIT_MS for them — if the ads
+        // endpoint is slow or down, render without ads and apply them late.
+        const adsPromise = fetchActiveAds(); // never throws
+        const adsOrTimeout = Promise.race<ActiveAd[] | null>([
+          adsPromise,
+          new Promise((resolve) => setTimeout(() => resolve(null), ADS_FIRST_PAINT_WAIT_MS)),
         ]);
-        if (!cancelled) { setTypeComponents(components); setAds(activeAds); setLoading(false); }
+        const [components, earlyAds] = await Promise.all([
+          fetchComponentsByType(activeType),
+          adsOrTimeout,
+        ]);
+        if (cancelled) return;
+        setTypeComponents(components);
+        if (earlyAds) setAds(earlyAds);
+        setLoading(false);
+        if (!earlyAds) {
+          adsPromise.then((lateAds) => { if (!cancelled && lateAds.length > 0) setAds(lateAds); });
+        }
       } catch {
         if (!cancelled) { setError('Failed to load components'); setLoading(false); }
       }

--- a/dashboard/src/components/ComponentGrid.tsx
+++ b/dashboard/src/components/ComponentGrid.tsx
@@ -3,7 +3,10 @@ import type { Component } from '../lib/types';
 import { TYPE_CONFIG } from '../lib/icons';
 import { ITEMS_PER_PAGE } from '../lib/constants';
 import { fetchComponentsByType } from '../lib/data';
+import { fetchActiveAds, findSponsoredIndex, type ActiveAd } from '../lib/ads';
 import SaveToCollectionButton from './SaveToCollectionButton';
+
+type GridComponent = Component & { sponsored?: boolean };
 
 interface Props {
   initialType: string;
@@ -45,6 +48,7 @@ export default function ComponentGrid({ initialType }: Props) {
   const [showFilters, setShowFilters] = useState(false);
   const [minDownloads, setMinDownloads] = useState(0);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [ads, setAds] = useState<ActiveAd[]>([]);
 
   // Sync activeType when initialType changes (e.g. sidebar navigation)
   useEffect(() => {
@@ -60,8 +64,13 @@ export default function ComponentGrid({ initialType }: Props) {
       try {
         setLoading(true);
         setError(null);
-        const components = await fetchComponentsByType(activeType);
-        if (!cancelled) { setTypeComponents(components); setLoading(false); }
+        // Ads resolve with the components so the first paint already has the
+        // sponsored card pinned (no post-load reorder). fetchActiveAds never throws.
+        const [components, activeAds] = await Promise.all([
+          fetchComponentsByType(activeType),
+          fetchActiveAds(),
+        ]);
+        if (!cancelled) { setTypeComponents(components); setAds(activeAds); setLoading(false); }
       } catch {
         if (!cancelled) { setError('Failed to load components'); setLoading(false); }
       }
@@ -114,12 +123,23 @@ export default function ComponentGrid({ initialType }: Props) {
     }
     
     // Sort
-    const sorted = [...items];
+    const sorted: GridComponent[] = [...items];
     if (sortBy === 'downloads') sorted.sort((a, b) => (b.downloads ?? 0) - (a.downloads ?? 0));
     else if (sortBy === 'name') sorted.sort((a, b) => a.name.localeCompare(b.name));
-    
+
+    // Sponsored placement: if an active ad's component survived the current
+    // filters, pin it to the top of page 1 (reorder only — counts and
+    // pagination stay untouched).
+    const adIdx = findSponsoredIndex(ads, sorted);
+    if (adIdx > 0) {
+      const [sponsored] = sorted.splice(adIdx, 1);
+      sorted.unshift({ ...sponsored, sponsored: true });
+    } else if (adIdx === 0) {
+      sorted[0] = { ...sorted[0], sponsored: true };
+    }
+
     return sorted;
-  }, [typeComponents, category, selectedCategories, search, sortBy, minDownloads]);
+  }, [typeComponents, category, selectedCategories, search, sortBy, minDownloads, ads]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
   const paged = filtered.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE);
@@ -468,7 +488,11 @@ export default function ComponentGrid({ initialType }: Props) {
             return (
               <div
                 key={component.path ?? component.name}
-                className="group relative flex items-center gap-5 p-4 rounded-md bg-[var(--color-card-bg)] border border-[var(--color-border)] hover:bg-[var(--color-card-hover)] hover:border-[var(--color-accent)] transition-all duration-150 cursor-pointer animate-fade-in-up"
+                className={`group relative flex items-center gap-5 p-4 rounded-md bg-[var(--color-card-bg)] border hover:bg-[var(--color-card-hover)] transition-all duration-150 cursor-pointer animate-fade-in-up ${
+                  component.sponsored
+                    ? 'border-[var(--color-primary-500)] ring-1 ring-[var(--color-primary-500)]/40'
+                    : 'border-[var(--color-border)] hover:border-[var(--color-accent)]'
+                }`}
                 style={{
                   animationDelay: `${idx * 30}ms`,
                   animationFillMode: 'both'
@@ -501,6 +525,11 @@ export default function ComponentGrid({ initialType }: Props) {
 
                 {/* Badges */}
                 <div className="flex items-center gap-2 shrink-0">
+                  {component.sponsored && (
+                    <span className="font-mono text-[10px] font-semibold px-2 py-0.5 rounded border border-[var(--color-primary-500)]/40 bg-[var(--color-primary-500)]/10 text-[var(--color-primary-500)]">
+                      Sponsored
+                    </span>
+                  )}
                   {component.category && (
                     <span className="font-mono text-[10px] font-semibold px-2 py-0.5 rounded border border-[var(--color-border)] bg-[var(--color-surface-2)] text-[var(--color-text-tertiary)]">
                       {component.category}
@@ -552,7 +581,11 @@ export default function ComponentGrid({ initialType }: Props) {
           return (
             <div
               key={component.path ?? component.name}
-              className="group relative flex items-start gap-4 p-5 rounded-md bg-[var(--color-card-bg)] border border-[var(--color-border)] hover:bg-[var(--color-card-hover)] hover:border-[var(--color-accent)] transition-all duration-150 cursor-pointer animate-fade-in-up"
+              className={`group relative flex items-start gap-4 p-5 rounded-md bg-[var(--color-card-bg)] border hover:bg-[var(--color-card-hover)] transition-all duration-150 cursor-pointer animate-fade-in-up ${
+                component.sponsored
+                  ? 'border-[var(--color-primary-500)] ring-1 ring-[var(--color-primary-500)]/40'
+                  : 'border-[var(--color-border)] hover:border-[var(--color-accent)]'
+              }`}
               style={{
                 animationDelay: `${idx * 50}ms`,
                 animationFillMode: 'both'
@@ -582,6 +615,11 @@ export default function ComponentGrid({ initialType }: Props) {
                   {component.description || component.content?.slice(0, 120) || 'No description'}
                 </p>
                 <div className="flex items-center gap-2 mt-3">
+                  {component.sponsored && (
+                    <span className="font-mono text-[10px] font-semibold px-2 py-0.5 rounded border border-[var(--color-primary-500)]/40 bg-[var(--color-primary-500)]/10 text-[var(--color-primary-500)]">
+                      Sponsored
+                    </span>
+                  )}
                   {component.category && (
                     <span className="font-mono text-[10px] font-semibold px-2 py-0.5 rounded border border-[var(--color-border)] bg-[var(--color-surface-2)] text-[var(--color-text-tertiary)]">
                       {component.category}

--- a/dashboard/src/components/SearchModal.tsx
+++ b/dashboard/src/components/SearchModal.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { TYPE_CONFIG } from '../lib/icons';
 import TypeIcon from './TypeIcon';
 import { fetchSearchIndex, type SearchIndexEntry } from '../lib/data';
+import { fetchActiveAds, findSponsoredIndex, type ActiveAd } from '../lib/ads';
+
+type SearchResult = SearchIndexEntry & { sponsored?: boolean };
 
 function cleanPath(path: string): string {
   return path?.replace(/\.(md|json)$/, '') ?? '';
@@ -21,6 +24,7 @@ export default function SearchModal() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [data, setData] = useState<SearchIndexEntry[] | null>(null);
+  const [ads, setAds] = useState<ActiveAd[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -35,6 +39,14 @@ export default function SearchModal() {
       .then((entries) => setData(entries))
       .catch(() => {});
   }, [open, data]);
+
+  // Refresh ads on every open (the lib's 5-min cache dedupes network traffic)
+  useEffect(() => {
+    if (!open) return;
+    fetchActiveAds()
+      .then((activeAds) => setAds(activeAds))
+      .catch(() => {});
+  }, [open]);
 
   // Cmd+K listener
   useEffect(() => {
@@ -128,25 +140,39 @@ export default function SearchModal() {
   }, [open]);
 
   // Search results
-  const results = useMemo(() => {
+  const results = useMemo<SearchResult[]>(() => {
     if (!data || !query.trim()) return [];
 
     const q = query.toLowerCase();
 
-    return data
-      .filter(
-        (c) =>
-          c.name.toLowerCase().includes(q) ||
-          c.description?.toLowerCase().includes(q) ||
-          c.category?.toLowerCase().includes(q)
-      )
-      .slice(0, 20);
-  }, [data, query]);
+    const matched = data.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.description?.toLowerCase().includes(q) ||
+        c.category?.toLowerCase().includes(q)
+    );
 
-  // Keyboard navigation
+    const top: SearchResult[] = matched.slice(0, 20);
+
+    // Sponsored placement: first matching active ad jumps to position 0.
+    // The ad stays inside `results`, so keyboard navigation and
+    // scroll-into-view keep working untouched.
+    const adIdx = findSponsoredIndex(ads, matched);
+    if (adIdx !== -1) {
+      const sponsored: SearchResult = { ...matched[adIdx], sponsored: true };
+      const inTop = top.findIndex((c) => c.path === sponsored.path && c.type === sponsored.type);
+      if (inTop !== -1) top.splice(inTop, 1);
+      else if (top.length >= 20) top.pop();
+      top.unshift(sponsored);
+    }
+
+    return top;
+  }, [data, ads, query]);
+
+  // Keyboard navigation — also reset when ads arrive async and reorder results
   useEffect(() => {
     setSelectedIndex(0);
-  }, [query]);
+  }, [query, ads]);
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {
@@ -246,6 +272,10 @@ export default function SearchModal() {
                 key={component.path ?? `${component.name}-${i}`}
                 onClick={() => navigate(component)}
                 className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+                  component.sponsored
+                    ? 'border-l-2 border-[var(--color-primary-500)] bg-[var(--color-primary-500)]/5'
+                    : ''
+                } ${
                   i === selectedIndex
                     ? 'bg-[var(--color-primary-500)]/10'
                     : 'hover:bg-[var(--color-surface-2)]'
@@ -256,6 +286,11 @@ export default function SearchModal() {
                   <span className="text-sm text-[var(--color-text-primary)]">{formatName(component.name)}</span>
                   <span className="text-xs text-[var(--color-text-tertiary)] ml-2">{config?.label ?? component.type}</span>
                 </div>
+                {component.sponsored && (
+                  <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded border border-[var(--color-primary-500)]/40 bg-[var(--color-primary-500)]/10 text-[var(--color-primary-500)] shrink-0">
+                    Sponsored
+                  </span>
+                )}
                 {component.category && (
                   <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[var(--color-text-tertiary)] shrink-0">
                     {component.category}

--- a/dashboard/src/components/SearchModal.tsx
+++ b/dashboard/src/components/SearchModal.tsx
@@ -169,10 +169,26 @@ export default function SearchModal() {
     return top;
   }, [data, ads, query]);
 
-  // Keyboard navigation — also reset when ads arrive async and reorder results
+  // Keyboard navigation: reset on new queries; when the same query's results
+  // reorder (ads arriving async), re-anchor to the item that was highlighted
+  // instead of snapping back to the top.
+  const prevResultsRef = useRef<SearchResult[]>([]);
+  const lastQueryRef = useRef(query);
   useEffect(() => {
-    setSelectedIndex(0);
-  }, [query, ads]);
+    const prev = prevResultsRef.current;
+    prevResultsRef.current = results;
+    if (lastQueryRef.current !== query) {
+      lastQueryRef.current = query;
+      setSelectedIndex(0);
+      return;
+    }
+    setSelectedIndex((i) => {
+      const selected = prev[i];
+      if (!selected) return 0;
+      const newIndex = results.findIndex((r) => r.path === selected.path && r.type === selected.type);
+      return newIndex === -1 ? 0 : newIndex;
+    });
+  }, [query, results]);
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {

--- a/dashboard/src/lib/ads.ts
+++ b/dashboard/src/lib/ads.ts
@@ -5,8 +5,10 @@
  */
 
 export interface ActiveAd {
-  id: string;
-  component_type: string; // plural, e.g. 'agents'
+  // Contract with the (private) ads writer service: component_type is stored
+  // PLURAL ('agents', 'commands', ...) — unlike other tables in this repo,
+  // which store it singular. matchesAd() below relies on this.
+  component_type: string;
   component_path: string;
   component_name: string;
   ends_at: string;
@@ -14,6 +16,7 @@ export interface ActiveAd {
 
 const ADS_URL = '/api/ads/active';
 const CACHE_TTL = 5 * 60 * 1000;
+const STALE_MAX_MS = 15 * 60 * 1000;
 
 // Feature flag: sponsored placements are inert unless PUBLIC_ADS_ENABLED=true
 // is set at build time (dashboard/wrangler.toml [vars]). While off, no request
@@ -51,7 +54,12 @@ export async function fetchActiveAds(): Promise<ActiveAd[]> {
     return stillLive(data);
   } catch {
     clearTimeout(timeoutId);
-    return adsCache ? stillLive(adsCache.data) : [];
+    // Serve last-known-good during short outages, but never indefinitely:
+    // past STALE_MAX_MS a deactivated placement must stop showing.
+    if (adsCache && now - adsCache.ts < STALE_MAX_MS) {
+      return stillLive(adsCache.data);
+    }
+    return [];
   }
 }
 

--- a/dashboard/src/lib/ads.ts
+++ b/dashboard/src/lib/ads.ts
@@ -40,7 +40,7 @@ export async function fetchActiveAds(): Promise<ActiveAd[]> {
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
     const res = await fetch(ADS_URL, { signal: controller.signal });
     clearTimeout(timeoutId);

--- a/dashboard/src/lib/ads.ts
+++ b/dashboard/src/lib/ads.ts
@@ -1,0 +1,80 @@
+/**
+ * Client helpers for sponsored ads (CCT Ads). Active ads come from the
+ * dynamic /api/ads/active endpoint (never from the static catalog files).
+ * Failures always degrade to "no ads" so search and grids keep working.
+ */
+
+export interface ActiveAd {
+  id: string;
+  component_type: string; // plural, e.g. 'agents'
+  component_path: string;
+  component_name: string;
+  ends_at: string;
+}
+
+const ADS_URL = '/api/ads/active';
+const CACHE_TTL = 5 * 60 * 1000;
+
+// Feature flag: sponsored placements are inert unless PUBLIC_ADS_ENABLED=true
+// is set at build time (dashboard/wrangler.toml [vars]). While off, no request
+// is made and search/grid behave exactly as before.
+const ADS_ENABLED = import.meta.env.PUBLIC_ADS_ENABLED === 'true';
+
+let adsCache: { data: ActiveAd[]; ts: number } | null = null;
+
+/** Drop ads already past ends_at — edge/client caches can serve stale lists. */
+function stillLive(ads: ActiveAd[]): ActiveAd[] {
+  const now = Date.now();
+  return ads.filter((ad) => {
+    const end = Date.parse(ad.ends_at);
+    return Number.isNaN(end) || end > now;
+  });
+}
+
+export async function fetchActiveAds(): Promise<ActiveAd[]> {
+  if (!ADS_ENABLED) return [];
+
+  const now = Date.now();
+  if (adsCache && now - adsCache.ts < CACHE_TTL) {
+    return stillLive(adsCache.data);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(ADS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const payload = await res.json().catch(() => null);
+    const data: ActiveAd[] = Array.isArray(payload?.ads) ? payload.ads : [];
+    adsCache = { data, ts: now };
+    return stillLive(data);
+  } catch {
+    clearTimeout(timeoutId);
+    return adsCache ? stillLive(adsCache.data) : [];
+  }
+}
+
+function pluralType(type: string): string {
+  return type.endsWith('s') ? type : type + 's';
+}
+
+/** True when a component (any type form) matches an ad. */
+export function matchesAd(ad: ActiveAd, type: string, path: string): boolean {
+  return ad.component_type === pluralType(type) && ad.component_path === path;
+}
+
+/**
+ * First active ad (endpoint order = earliest buyer first) whose component is
+ * present in the given list. Returns the matching list index, or -1.
+ */
+export function findSponsoredIndex<T extends { type: string; path: string }>(
+  ads: ActiveAd[],
+  items: T[]
+): number {
+  for (const ad of ads) {
+    const idx = items.findIndex((item) => matchesAd(ad, item.type, item.path));
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}

--- a/dashboard/src/pages/api/ads/active.ts
+++ b/dashboard/src/pages/api/ads/active.ts
@@ -7,15 +7,21 @@ export const prerender = false;
 
 export const OPTIONS: APIRoute = async () => corsResponse();
 
+// Same build-time flag that gates the frontend: while off, the deployment is
+// fully inert — no database access even for direct requests to this route.
+const ADS_ENABLED = import.meta.env.PUBLIC_ADS_ENABLED === 'true';
+
 /**
  * Public list of currently active sponsored ads, ordered by activation date
  * (earliest buyer wins the slot). Exposes no user or payment data.
  */
 export const GET: APIRoute = async () => {
+  if (!ADS_ENABLED) return jsonResponse({ ads: [] });
+
   try {
     const sql = getNeonClient();
     const ads = await sql`
-      SELECT id, component_type, component_path, component_name, ends_at
+      SELECT component_type, component_path, component_name, ends_at
       FROM sponsored_ads
       WHERE status = 'active' AND ends_at > now()
       ORDER BY starts_at ASC

--- a/dashboard/src/pages/api/ads/active.ts
+++ b/dashboard/src/pages/api/ads/active.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+import { corsHeaders, corsResponse, jsonResponse } from '../../../lib/api/cors';
+import { getNeonClient } from '../../../lib/api/neon';
+import { captureApiError } from '../../../lib/api/error-tracking';
+
+export const prerender = false;
+
+export const OPTIONS: APIRoute = async () => corsResponse();
+
+/**
+ * Public list of currently active sponsored ads, ordered by activation date
+ * (earliest buyer wins the slot). Exposes no user or payment data.
+ */
+export const GET: APIRoute = async () => {
+  try {
+    const sql = getNeonClient();
+    const ads = await sql`
+      SELECT id, component_type, component_path, component_name, ends_at
+      FROM sponsored_ads
+      WHERE status = 'active' AND ends_at > now()
+      ORDER BY starts_at ASC
+    `;
+
+    return new Response(JSON.stringify({ ads }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=60, s-maxage=300',
+        ...corsHeaders,
+      },
+    });
+  } catch (error) {
+    await captureApiError(error, { route: '/api/ads/active' });
+    // Fail open with an empty list so search/grids never break on an ads outage
+    return jsonResponse({ ads: [] });
+  }
+};

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -9,6 +9,8 @@ pages_build_output_dir = "./dist"
 PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_live_Y2xlcmsuYWl0bXBsLmNvbSQ"
 PUBLIC_COMPONENTS_JSON_URL = "/components.json"
 PUBLIC_GITHUB_CLIENT_ID = "Ov23li3KjfA4cuLi5c0k"
+# Sponsored placements (CCT Ads) are inert until this is set to "true":
+# PUBLIC_ADS_ENABLED = "true"
 
 # Secrets are set via Cloudflare Dashboard or `wrangler secret put`:
 # CLERK_SECRET_KEY


### PR DESCRIPTION
## Summary

Read-only groundwork for sponsored component placements on the dashboard. **No behavior change on aitmpl.com with this PR**: everything is behind the `PUBLIC_ADS_ENABLED` build-time flag, which is not set.

- `SearchModal.tsx` (Cmd+K): when enabled, an active sponsored component matching the query is moved to position 1 with a left accent border and a "Sponsored" badge. Reorder only — keyboard navigation, scroll-into-view and result counts unchanged.
- `ComponentGrid.tsx`: when enabled, the active sponsored component of the current type is pinned to the first card (grid and list views) with a highlighted border + badge. Respects active filters; pagination untouched. Ads resolve together with the components so there is no post-load reorder.
- `src/lib/ads.ts`: client helper with 5-min cache, expiry filtering and fail-safe `[]` on any error. Returns `[]` without any request while the flag is off.
- `GET /api/ads/active`: public, cached (`max-age=60, s-maxage=300`) list of live placements from the `sponsored_ads` table. Exposes only component type/path/name and end date — no user or payment data. Fails open with `[]`.
- `wrangler.toml`: documents the flag (commented out).

Payments, checkout, webhooks and the admin panel are intentionally **not** in this repo — they live in a separate private service.

## Safety for production

- Flag off ⇒ `fetchActiveAds()` short-circuits to `[]`; search and grid code paths are identical to today.
- Flag on with an empty/unreachable table ⇒ still `[]` (endpoint and client both fail open).
- `dashboard` build passes locally (`npm run build`).

## Enabling later

Set `PUBLIC_ADS_ENABLED = "true"` in `dashboard/wrangler.toml [vars]` (and the GitHub Actions build env) and redeploy. Requires `NEON_DATABASE_URL` (already configured) and the `sponsored_ads` table (already migrated).

https://claude.ai/code/session_015ehgc17pAU4EcLbAjkzq7h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only sponsored placement display to the dashboard's Cmd+K search and type grid, fed by the new public `GET /api/ads/active` endpoint and gated behind the `PUBLIC_ADS_ENABLED` build-time flag. With the flag off — the current production state — no request is made and search/grid behavior is identical to today; when enabled, the first active sponsored component matching the query or current type moves to position 1 with a highlighted border and "Sponsored" badge.

- Affects the website (`dashboard/`); new files are `dashboard/src/lib/ads.ts` (5-min cache with expiry filter, 15-min stale-cache bound, fail-safe `[]`) and `dashboard/src/pages/api/ads/active.ts` (public, cached, exposes only component type/path/name and end date, and returns `[]` without touching Neon while the flag is off).
- No components-catalog regeneration needed — no new components; `PUBLIC_ADS_ENABLED` is documented (commented out) in `dashboard/wrangler.toml`, and no new secrets are required (`NEON_DATABASE_URL` and the `sponsored_ads` table already exist).
- Both endpoint and client fail open with `[]`; the grid's first paint waits at most 1.5s for ads, late responses (including empty) always apply so stale placements clear, and search keyboard navigation re-anchors to the highlighted item when ads reorder results.
- To enable later: set `PUBLIC_ADS_ENABLED = "true"` in `dashboard/wrangler.toml [vars]` and the GitHub Actions build env, then redeploy.

<sup>Written for commit 1567a56bce500005bbec7a641e8d22060dbbd94c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

