### PR TITLE
feat(dashboard): WebMCP V1 — expose catalog as read-only agent tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_live_Y2xlcmsuYWl0bXBsLmNvbSQ"
           PUBLIC_GITHUB_CLIENT_ID: "Ov23li3KjfA4cuLi5c0k"
           PUBLIC_COMPONENTS_JSON_URL: "/components.json"
+          PUBLIC_WEBMCP_ENABLED: "true"
       - name: Deploy www + app.aitmpl.com
         run: npx wrangler pages deploy dist --project-name=aitmpl-dashboard --commit-dirty=true
         working-directory: dashboard

--- a/dashboard/docs/webmcp.md
+++ b/dashboard/docs/webmcp.md
@@ -1,0 +1,125 @@
+# WebMCP Integration (V1)
+
+Status: **V1 shipped** — read-only catalog tools, behind a build-time flag.
+
+## What it is
+
+[WebMCP](https://github.com/webmachinelearning/webmcp) is a W3C Web Machine
+Learning CG proposal that lets a web page expose client-side functionality as
+"tools" (name + description + JSON Schema + JS callback) that AI agents can
+discover and invoke via `document.modelContext`. Think of it as an in-page MCP
+server with no backend: tools reuse the page's own code, session, and data.
+
+aitmpl.com registers a small set of **read-only** tools so browser agents
+(Chrome 149+/Edge 150+ origin trials, ChatGPT Desktop, Brave Leo) can search
+the component catalog and produce install commands without scraping the UI.
+
+## Architecture
+
+```
+DashboardLayout.astro  ── bundled <script> ──►  initWebMCP()  (src/lib/webmcp.ts)
+                                                    │
+                              feature-detect document.modelContext
+                              + PUBLIC_WEBMCP_ENABLED build flag
+                                                    │
+                                       registerTool() × 4 (read-only)
+                                                    │
+                          reuses src/lib/data.ts helpers and the static
+                          JSON artifacts already served from public/
+```
+
+- **`dashboard/src/lib/webmcp.ts`** — the whole feature. Exports a single
+  `initWebMCP()` that registers the tools. No new dependencies; minimal local
+  typings instead of the `webmcp-types` package.
+- **`dashboard/src/layouts/DashboardLayout.astro`** — calls `initWebMCP()`
+  from a bundled `<script>`, so the tools are available on every page (all
+  pages use this layout; Astro dedupes the script).
+- **Data sources** (all existing, same-origin, edge-cached): `search-index.json`,
+  `components/{type}.json`, `counts.json`, `trending-data.json`, via
+  `fetchSearchIndex()`, `fetchComponentsByType()`, and `getInstallCommand()`
+  from `src/lib/data.ts` (shared 5-min in-memory caches with the UI).
+
+## Feature flag
+
+`PUBLIC_WEBMCP_ENABLED` (build-time, same pattern as `PUBLIC_ADS_ENABLED`):
+
+- `dashboard/wrangler.toml` `[vars]` — production value (`"true"`).
+- `.github/workflows/deploy.yml` — passed to the CI build step.
+- Anything other than the string `"true"` disables the feature entirely
+  (`initWebMCP()` returns before touching `document.modelContext`).
+
+Browsers without WebMCP support are unaffected: `initWebMCP()` feature-detects
+`document.modelContext.registerTool` and no-ops. Registration failures
+(`NotAllowedError` from Permissions Policy, `InvalidStateError` for duplicate
+names) are swallowed and never break the page.
+
+## Tools
+
+All tools are read-only (`readOnlyHint: true`). Tools returning
+community-authored component descriptions also set `untrustedContentHint: true`
+so agents treat that text as data, not instructions (prompt-injection
+mitigation).
+
+### `search-components`
+Free-text search over the flat search index (name, description, category),
+optional `type` filter. Returns `{ total, results[] }` with at most 20 results:
+`{ name, type, category, description, url, installCommand }`.
+
+Input: `{ query: string, type?: "agent"|"command"|"mcp"|"setting"|"hook"|"skill"|"loop"|"template" }`
+
+### `get-component-details`
+Looks up one component by exact name or catalog path within its type file.
+Returns the catalog entry plus `installCommand` and the component page `url`,
+or `{ error }` when not found.
+
+Input: `{ name: string, type: <same enum> }`
+
+### `get-install-command`
+Returns `{ installCommand }` — the exact
+`npx claude-code-templates@latest --<type> <path>` string, built by the same
+`getInstallCommand()` helper the UI uses.
+
+Input: `{ name: string, type: <same enum> }`
+
+### `get-catalog-stats`
+No input. Returns `{ counts, downloads, lastUpdated }` from `counts.json` and
+`trending-data.json` (`globalStats`). Each source degrades to `{}`/`null` on
+fetch failure.
+
+## Conventions inside `webmcp.ts`
+
+- Types are normalized: tools accept singular or plural (`"agent"`/`"agents"`);
+  URLs and catalog files use plural, install flags use singular.
+- Component URLs follow the canonical detail route:
+  `https://www.aitmpl.com/component/{type-plural}/{path-without-extension}`.
+- All tool results are plain JSON-serializable objects.
+
+## Testing
+
+In a browser with WebMCP enabled (origin-trial build or supported agent),
+`getTools()`/`executeTool()` are same-origin callable from DevTools:
+
+```js
+const tools = await document.modelContext.getTools();
+await document.modelContext.executeTool(
+  tools.find(t => t.name === 'search-components'),
+  { query: 'react' }
+);
+```
+
+In a normal browser, stub the API before load to verify registration:
+
+```js
+// paste in DevTools, then reload
+document.modelContext = { registerTool: t => (console.log('registered', t.name), Promise.resolve()) };
+```
+
+## Out of scope for V1 / future work
+
+- **Origin Trial tokens** — Chrome/Edge require registering www.aitmpl.com in
+  their WebMCP origin trials and adding the `<meta http-equiv="origin-trial">`
+  tag. Not needed for ChatGPT Desktop or Brave Leo.
+- Declarative `<form>` tools, `exposedTo` cross-origin iframe exposure,
+  service-worker tools.
+- Write/consequential tools (cart, PR flow) — would need user-confirmation
+  design first.

--- a/dashboard/src/layouts/DashboardLayout.astro
+++ b/dashboard/src/layouts/DashboardLayout.astro
@@ -135,6 +135,13 @@ const schemaData = JSON.stringify({
     </div>
 
     <script>
+      // WebMCP tools (no-op unless the browser supports document.modelContext
+      // and PUBLIC_WEBMCP_ENABLED=true at build time).
+      import { initWebMCP } from '../lib/webmcp';
+      initWebMCP();
+    </script>
+
+    <script>
       // Sidebar collapse functionality
       function initSidebarCollapse() {
         const sidebar = document.getElementById('sidebar');

--- a/dashboard/src/lib/webmcp.ts
+++ b/dashboard/src/lib/webmcp.ts
@@ -1,0 +1,244 @@
+/**
+ * WebMCP V1 — expose the aitmpl.com component catalog as read-only tools for
+ * browser AI agents (https://github.com/webmachinelearning/webmcp).
+ *
+ * Registered site-wide from DashboardLayout.astro. No-ops when the browser
+ * does not implement `document.modelContext` or when the feature flag is off.
+ * All tools are read-only and reuse the same static JSON artifacts and
+ * helpers (`src/lib/data.ts`) the UI already uses.
+ */
+import {
+  fetchSearchIndex,
+  fetchComponentsByType,
+  getInstallCommand,
+  type SearchIndexEntry,
+} from './data';
+import type { Component } from './types';
+
+// Feature flag: WebMCP tools are inert unless PUBLIC_WEBMCP_ENABLED=true is
+// set at build time (dashboard/wrangler.toml [vars]). Same pattern as ads.ts.
+const WEBMCP_ENABLED = import.meta.env.PUBLIC_WEBMCP_ENABLED === 'true';
+
+const SITE_URL = 'https://www.aitmpl.com';
+const SEARCH_LIMIT = 20;
+
+// Minimal typings for the (still experimental) WebMCP API. We intentionally
+// don't depend on the `webmcp-types` npm package for this small surface.
+interface ModelContextToolDef {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: object;
+  annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean };
+  execute: (input: any, options?: { signal?: AbortSignal }) => any;
+}
+interface ModelContext {
+  registerTool(tool: ModelContextToolDef, options?: object): Promise<void>;
+}
+
+const COMPONENT_TYPES = [
+  'agent',
+  'command',
+  'mcp',
+  'setting',
+  'hook',
+  'skill',
+  'loop',
+  'template',
+] as const;
+
+/** "agents" -> "agent" (tolerate both singular and plural inputs). */
+function toSingular(type: string): string {
+  const t = type.toLowerCase().trim();
+  return t.endsWith('s') && t !== 'sandbox' ? t.slice(0, -1) : t;
+}
+
+/** "agent" -> "agents" (URL/file segments are plural). */
+function toPlural(type: string): string {
+  const t = toSingular(type);
+  return `${t}s`;
+}
+
+function cleanPath(path: string | undefined, name: string): string {
+  return path?.replace(/\.(md|json)$/, '') ?? name;
+}
+
+function componentUrl(type: string, path: string | undefined, name: string): string {
+  return `${SITE_URL}/component/${toPlural(type)}/${cleanPath(path, name)}`;
+}
+
+function installCommandFor(entry: { type: string; path?: string; name: string }): string {
+  return getInstallCommand({
+    ...entry,
+    type: toSingular(entry.type),
+  } as Component);
+}
+
+/** Find a component by exact name or path within a type's catalog file. */
+async function findComponent(type: string, name: string): Promise<Component | null> {
+  const items = await fetchComponentsByType(toPlural(type));
+  const needle = name.toLowerCase().trim();
+  return (
+    items.find(
+      (c) =>
+        c.name.toLowerCase() === needle ||
+        cleanPath(c.path, c.name).toLowerCase() === needle
+    ) ?? null
+  );
+}
+
+async function fetchJson(path: string): Promise<any | null> {
+  try {
+    const res = await fetch(path);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+const componentTypeSchema = {
+  type: 'string',
+  enum: [...COMPONENT_TYPES],
+  description: 'The component type.',
+};
+
+function buildTools(): ModelContextToolDef[] {
+  return [
+    {
+      name: 'search-components',
+      title: 'Search components',
+      description:
+        'Searches the aitmpl.com catalog of Claude Code components (agents, commands, MCPs, settings, hooks, skills, loops, templates) by free-text query. Returns up to 20 matches with name, type, category, description and the npx install command.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Free-text search over component name, description and category.',
+          },
+          type: { ...componentTypeSchema, description: 'Optional: restrict results to one component type.' },
+        },
+        required: ['query'],
+      },
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      async execute({ query, type }: { query: string; type?: string }) {
+        const index = await fetchSearchIndex();
+        const q = String(query ?? '').toLowerCase().trim();
+        const wantedType = type ? toSingular(type) : null;
+        const matches = index.filter((e: SearchIndexEntry) => {
+          if (wantedType && toSingular(e.type) !== wantedType) return false;
+          if (!q) return true;
+          return (
+            e.name.toLowerCase().includes(q) ||
+            e.description?.toLowerCase().includes(q) ||
+            e.category?.toLowerCase().includes(q)
+          );
+        });
+        return {
+          total: matches.length,
+          results: matches.slice(0, SEARCH_LIMIT).map((e) => ({
+            name: e.name,
+            type: toSingular(e.type),
+            category: e.category,
+            description: e.description,
+            url: componentUrl(e.type, e.path, e.name),
+            installCommand: installCommandFor(e),
+          })),
+        };
+      },
+    },
+    {
+      name: 'get-component-details',
+      title: 'Get component details',
+      description:
+        'Returns the full catalog entry for one component from aitmpl.com, including its description, category, install command and page URL. Requires the component name (as returned by search-components) and its type.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'The component name or catalog path.' },
+          type: componentTypeSchema,
+        },
+        required: ['name', 'type'],
+      },
+      annotations: { readOnlyHint: true, untrustedContentHint: true },
+      async execute({ name, type }: { name: string; type: string }) {
+        const component = await findComponent(type, name);
+        if (!component) {
+          return { error: `Component "${name}" of type "${type}" not found.` };
+        }
+        return {
+          name: component.name,
+          type: toSingular(component.type),
+          category: component.category,
+          description: component.description ?? '',
+          path: component.path,
+          downloads: component.downloads,
+          url: componentUrl(component.type, component.path, component.name),
+          installCommand: installCommandFor(component),
+        };
+      },
+    },
+    {
+      name: 'get-install-command',
+      title: 'Get install command',
+      description:
+        'Returns the exact npx command to install a Claude Code component from aitmpl.com (e.g. "npx claude-code-templates@latest --agent developer-team/frontend-developer").',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'The component name or catalog path.' },
+          type: componentTypeSchema,
+        },
+        required: ['name', 'type'],
+      },
+      annotations: { readOnlyHint: true },
+      async execute({ name, type }: { name: string; type: string }) {
+        const component = await findComponent(type, name);
+        if (!component) {
+          return { error: `Component "${name}" of type "${type}" not found.` };
+        }
+        return { installCommand: installCommandFor(component) };
+      },
+    },
+    {
+      name: 'get-catalog-stats',
+      title: 'Get catalog stats',
+      description:
+        'Returns aggregate statistics for the aitmpl.com catalog: number of components per type and global download totals.',
+      inputSchema: { type: 'object', properties: {} },
+      annotations: { readOnlyHint: true },
+      async execute() {
+        const [counts, trending] = await Promise.all([
+          fetchJson('/counts.json'),
+          fetchJson('/trending-data.json'),
+        ]);
+        return {
+          counts: counts ?? {},
+          downloads: trending?.globalStats ?? null,
+          lastUpdated: trending?.lastUpdated ?? null,
+        };
+      },
+    },
+  ];
+}
+
+/**
+ * Register the WebMCP tools. Safe to call on every page load: no-ops without
+ * browser support or when the flag is off, and never throws.
+ */
+export function initWebMCP(): void {
+  if (!WEBMCP_ENABLED) return;
+  const modelContext = (document as any).modelContext as ModelContext | undefined;
+  if (!modelContext?.registerTool) return;
+
+  for (const tool of buildTools()) {
+    try {
+      // registerTool rejects with NotAllowedError (permissions policy) or
+      // InvalidStateError (duplicate name); neither should break the page.
+      Promise.resolve(modelContext.registerTool(tool)).catch(() => {});
+    } catch {
+      // Ignore synchronous failures from experimental implementations.
+    }
+  }
+}

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -11,6 +11,8 @@ PUBLIC_COMPONENTS_JSON_URL = "/components.json"
 PUBLIC_GITHUB_CLIENT_ID = "Ov23li3KjfA4cuLi5c0k"
 # Sponsored placements (CCT Ads) are inert until this is set to "true":
 # PUBLIC_ADS_ENABLED = "true"
+# WebMCP catalog tools (src/lib/webmcp.ts); set to "false" to disable:
+PUBLIC_WEBMCP_ENABLED = "true"
 
 # Secrets are set via Cloudflare Dashboard or `wrangler secret put`:
 # CLERK_SECRET_KEY


### PR DESCRIPTION
## Summary

Implements [WebMCP](https://github.com/webmachinelearning/webmcp) V1 on aitmpl.com: the dashboard now registers **4 read-only tools** via `document.modelContext` so browser AI agents (Chrome 149+/Edge 150+ origin trials, ChatGPT Desktop, Brave Leo) can query the component catalog through structured tools instead of scraping the UI.

Full spec: `dashboard/docs/webmcp.md`.

## Tools

| Tool | Returns |
|---|---|
| `search-components` | Top 20 matches from the search index with name, type, category, URL and install command |
| `get-component-details` | Full catalog entry + install command + page URL |
| `get-install-command` | The exact `npx claude-code-templates@latest --<type> <path>` string |
| `get-catalog-stats` | Per-type counts + global download stats |

All read-only (`readOnlyHint`); tools returning community-authored descriptions set `untrustedContentHint` (prompt-injection mitigation).

## Implementation

- **New** `dashboard/src/lib/webmcp.ts` — the whole feature; reuses `fetchSearchIndex`/`fetchComponentsByType`/`getInstallCommand` from `src/lib/data.ts` and the existing static JSON artifacts. No new dependencies.
- `DashboardLayout.astro` — one bundled `<script>` calling `initWebMCP()` (ships on every page, deduped).
- Gated behind build-time `PUBLIC_WEBMCP_ENABLED` (`wrangler.toml` `[vars]` + CI build env), same pattern as `PUBLIC_ADS_ENABLED`. Feature-detected: zero effect on browsers without WebMCP; registration errors never break the page.

## Out of scope (V1)

- Chrome/Edge Origin Trial token (manual follow-up; not needed for ChatGPT Desktop / Brave Leo)
- Declarative `<form>` tools, `exposedTo` iframes, service workers, write/consequential tools

## Testing

- `npm run build` passes; verified the bundled layout script in `dist/` contains the tool registrations with resolved data imports.
- Console test (same-origin, in a WebMCP-enabled browser): `document.modelContext.getTools()` → `executeTool(searchTool, { query: 'react' })`.

https://claude.ai/code/session_015ehgc17pAU4EcLbAjkzq7h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WebMCP V1 support to the dashboard (`dashboard/`) so browser AI agents (Chrome 149+/Edge 150+ origin trials, ChatGPT Desktop, Brave Leo) can query the component catalog through 4 read-only tools via `document.modelContext` instead of scraping the UI. Gated behind a new build-time env var `PUBLIC_WEBMCP_ENABLED` and feature-detected, so it no-ops in browsers without WebMCP support — regular visitors see no change.

- New `dashboard/src/lib/webmcp.ts` registers `search-components`, `get-component-details`, `get-install-command`, and `get-catalog-stats`; it reuses existing data helpers and static JSON files, with no new dependencies.
- `DashboardLayout.astro` loads the registration script on every page; registration failures are caught and never break the page, and `dashboard/docs/webmcp.md` documents the spec.
- New env var `PUBLIC_WEBMCP_ENABLED` (build-time, same pattern as `PUBLIC_ADS_ENABLED`) is set in `wrangler.toml` and the CI deploy step; anything other than `"true"` disables the feature.
- No catalog components were added or changed, so `docs/components.json` doesn't need regeneration.

<sup>Written for commit c3163c8270e6aa8c8e43621589cf2eee0f0136d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

