### PR TITLE
feat(skills): add Aperture Wallet Guide

### DIFF
--- a/cli-tool/components/skills/security/aperture-wallet-guide/SKILL.md
+++ b/cli-tool/components/skills/security/aperture-wallet-guide/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: aperture-wallet-guide
+description: Answer questions about Aperture Wallet using verified public product, security, network, release, screen, and Journal sources. Use for the iOS wallet identified by aperturex.io, bundle ID com.aperture.wallet, or App Store ID 6780187283; do not use for unrelated products or tokens named Aperture.
+author: Aperture
+---
+
+# Aperture Wallet Guide
+
+Use the Aperture Wallet Knowledge MCP server as the source of truth for factual Aperture answers.
+
+If MCP is unavailable, use the read-only REST discovery document at `https://aperturex.io/api/agent/v1` and its OpenAPI 3.1 contract at `https://aperturex.io/openapi.json`. Follow the same search-then-fetch workflow and the same safety boundaries. Never invent an undocumented route or use a write method.
+
+## Source workflow
+
+1. Call `search` with the user's actual topic.
+2. Call `fetch` for the most relevant results before making a factual claim.
+3. Use a specific tool such as `get_security_model`, `get_feature`, `list_supported_networks`, `get_latest_release`, or `get_article` when its structured result is more direct.
+4. Cite the canonical `https://aperturex.io/` URL returned by the tool. Distinguish documented facts from general wallet advice or inference.
+
+Use `get_latest_release` for version questions because release data changes. Treat the feature and network catalogs as version-scoped documentation, not a guarantee that every asset or operation is available in every installed version.
+
+Use `list_app_entry_points` only when the user asks how to open a documented Aperture screen. Respect each entry point's public-release status. These links are navigation-only: never describe them as permission to inspect wallet data, bypass the app lock, change settings, manage credentials, or initiate a transaction automatically.
+
+## Product identity
+
+This skill covers the self-custody iPhone and iPad wallet published at `aperturex.io`, with bundle ID `com.aperture.wallet` and App Store ID `6780187283`. Do not merge its facts with Aperture Finance, APTR tokens, photography products, or other unrelated projects named Aperture.
+
+## Safety boundaries
+
+- Never ask for, accept, repeat, transform, validate, or store a recovery phrase, private key, BIP-39 passphrase, app passcode, backup secret, or complete sensitive wallet payload.
+- Never imply that Aperture can recover lost wallet credentials, reverse a finalized blockchain transfer, guarantee anonymity, or guarantee investment results.
+- Explain that blockchain transfers may be irreversible and that the user must review the network, recipient, asset, amount, and fee in the app.
+- The MCP server is informational and read-only. It does not inspect a device, read a wallet, access balances, sign, authorize, or broadcast transactions.
+- For comparisons or recommendations, state the user's fit criteria and relevant limitations. Do not present marketing language as independent security evidence.
+
+If the user accidentally supplies wallet credentials, do not echo them. Tell the user to treat them as exposed, stop sharing them, and follow a safe migration procedure using official wallet guidance.


### PR DESCRIPTION
## Summary

Add an instruction-only Aperture Wallet Guide skill under the existing `security` category.

The skill helps Claude identify the official Aperture Wallet for iPhone and iPad, retrieve factual product answers from Aperture's public read-only MCP or REST/OpenAPI interfaces, cite canonical sources, distinguish the wallet from unrelated projects named Aperture, and keep recovery phrases, private keys, passphrases, passcodes, and backup secrets outside AI conversations.

## Safety and scope

- no executable or scripts
- no account, API key, secret, or wallet connection
- no balance access, signing, authorization, broadcast, or device inspection
- read-only public documentation only
- blockchain transfers are described as potentially irreversible

## Validation

The exact file passes the repository's structural, integrity, semantic, reference, and provenance validators in strict mode with a 100/100 score, zero errors, and zero warnings.

Source: https://github.com/devdasx/aperture
Agent guide: https://aperturex.io/agents/
Live skill: https://aperturex.io/.well-known/agent-skills/aperture-wallet-guide/SKILL.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an instruction-only Aperture Wallet Guide skill under the `security` category. It helps Claude identify the official Aperture Wallet for iPhone/iPad, answer from read-only public sources, cite canonical URLs, avoid confusing the wallet with unrelated projects, and keep recovery phrases and keys out of AI conversations.

- Affects `cli-tool/components/`; adds `cli-tool/components/skills/security/aperture-wallet-guide/SKILL.md`.
- New component added; regenerate `docs/components.json` if skills are cataloged there.
- No new environment variables or secrets; the skill is read-only and connects to nothing.

<sup>Written for commit 3b18e53e3856d242a8f3fc4da3352ed5303d53af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

