### PR TITLE
Add suede-creator-skills (74 agent skills marketplace) to the plugins list

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -65,6 +65,7 @@ REPOS = [
     ("krasserm/ml-plugins", None),
     ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
     ("iOSDevSK/html2wp-cc-plugin", "https://html2wp.dev/"),
+    ("JasonColapietro/suede-creator-skills", None),
 ]
 
 DESCRIPTION_OVERRIDES = {


### PR DESCRIPTION
Adds one entry to `REPOS` in `scripts/generate_plugins_json.py`.

**[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - a marketplace of 74 agent skills for Claude Code and Codex, covering multi-agent orchestration, code review and release gates, AI evals, design, copy, and SEO.

The repo has `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` at the root, so the generator reads it exactly like the existing entries. `claude plugin validate` passes.

Details:

- marketplace name `suede`, 4 plugins: `suede-skills`, `suede-agent-workflows`, `suede-code`, `suede-marketing`
- root plugin `suede-skills`, version 0.16.0
- license `MIT AND BSD-3-Clause` (the repo ships a `licenses/` directory and one skill carries a BSD-3-Clause notice)
- 74 skill directories, each with its own `SKILL.md`
- public repo, 129 stars

I left the second tuple element as `None` instead of passing a website override. The repo's GitHub homepage is already set to <https://skills.suedeai.ai/>, and `process_repo` falls back to `repo_info.get("homepage")` when no override is given, so the site still lands in `website` the same way it does for entries like `anthropics/claude-plugins-official`. An override would only be needed to point somewhere other than the repo homepage.

Following #845, this changes the script only. I did not regenerate `dashboard/public/plugins.json`.

Happy to adjust the entry or move it if this is not the right place.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `suede-creator-skills` marketplace to the plugin catalog generator, making 74 agent skills available in the catalog.

- Affects only the plugin catalog script (`scripts/generate_plugins_json.py`); no CLI, component, website, API, or worker code changed.
- Regenerating `dashboard/public/plugins.json` was not done in this PR and may be needed to publish the new entry.
- No new environment variables or secrets are required.

<sup>Written for commit 06dbe8bb3875aa646b62b9a33a1e9bf36325d1a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

