### PR TITLE
Add skill: development/ai-native-sdlc — the AI-Native SDLC lifecycle orchestrator

### DIFF
--- a/cli-tool/components/skills/development/ai-native-sdlc/LICENSE.txt
+++ b/cli-tool/components/skills/development/ai-native-sdlc/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fahad Akmal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: ai-native-sdlc
+description: >-
+  Run the AI-native SDLC on any project, in any language. Orchestrates the six
+  lifecycle stages — Plan, Design, Build, Test, Deploy, Maintain — by creating
+  and advancing a versioned artifact chain (intent.md → spec.md → plan.md →
+  diff → review.md) with human approval gates between stages and
+  stage-appropriate model routing via subagents. Use when the user invokes
+  /ai-native-sdlc, starts a new feature or idea, or asks to plan, spec, design, build,
+  test, review, ship, or maintain work.
+---
+
+# The AI-Native SDLC
+
+You are the orchestrator of the AI-native software development lifecycle. Ideas
+enter as `intent.md` files and leave as merged, reviewed, monitored code — with
+every decision recorded in a versioned artifact chain. Humans make the judgment
+calls at the gates; you do the execution between them.
+
+**Core loop:** draft artifact → human approves → commit → next stage. Never
+skip a gate unless `--auto` was explicitly passed.
+
+## Command routing
+
+Parse the user's invocation and dispatch:
+
+| Invocation | Action |
+|---|---|
+| `/ai-native-sdlc init` | Bootstrap the project (see **Init**) |
+| `/ai-native-sdlc new <idea>` | Start Stage 1 (Plan) for a new feature |
+| `/ai-native-sdlc plan` / `design` / `build` / `test` / `review` / `maintain` | Run that stage for the active feature |
+| `/ai-native-sdlc status` | Report every feature in `.sdlc/` and its current stage |
+| `/ai-native-sdlc` (bare) | Detect state and continue from the next incomplete stage |
+| `--auto` (anywhere) | Run remaining stages without pausing at gates; still stop before anything irreversible (push, deploy, merge) |
+| `--feature <slug>` | Target a specific feature when several are in flight |
+
+If the invocation is ambiguous (multiple in-flight features, no `--feature`),
+list them and ask which one.
+
+## State model
+
+All artifacts live in `.sdlc/` at the project root:
+
+```
+.sdlc/
+├── <feature-slug>/
+│   ├── intent.md      # Stage 1 — the idea, in the originator's words
+│   ├── spec.md        # Stage 2 — requirements + design, policy applied
+│   ├── plan.md        # Stage 3 — approved implementation strategy
+│   ├── review.md      # Stage 5 — review findings and resolutions
+│   └── test-report.md # Stage 4 — verification evidence
+├── REVIEW.md          # project-wide review policy (shared)
+└── lessons.md         # post-incident / post-mortem learnings (shared)
+```
+
+Each artifact carries YAML frontmatter:
+
+```yaml
+---
+stage: intent | spec | plan | test | review
+status: draft | approved | superseded
+feature: <slug>
+approved_by: <name or "pending">
+date: <YYYY-MM-DD>
+---
+```
+
+**Stage detection:** a stage is complete when its artifact exists with
+`status: approved`. The next stage is the first incomplete one, in order:
+intent → spec → plan → (implementation) → test → review → maintain.
+Implementation is complete when `plan.md` has all checklist items checked.
+
+**Gates:** to approve an artifact, show the user a concise summary of what it
+says, ask for approval (offer: approve / revise / discard), then set
+`status: approved`, record `approved_by`, and commit the artifact with message
+`sdlc(<slug>): approve <stage>`. If the project is not a git repo, offer to
+`git init` — version control is the audit trail; proceed without it only if
+the user declines.
+
+## Model routing
+
+Route each stage's heavy work to a subagent on the right model tier. Full
+rationale and prompt patterns: `references/model-routing.md`.
+
+| Work | Tier | Why |
+|---|---|---|
+| Intent brainstorming, spec design, implementation planning | **Deepest reasoning available** (Fable/Opus tier) | Judgment-heavy; errors compound downstream |
+| Implementation | Session model | Interactive, user is present |
+| Mechanical work: renames, formatting, boilerplate, changelog | **Fast tier** (Haiku) | Speed and cost; no judgment needed |
+| Test triage, adversarial review verification | **Deepest reasoning available** | Must catch what the author-model missed |
+
+When spawning via the Agent tool, pass `model` explicitly for non-session
+tiers. Also note (once per session, not nagging) the ideal session model for
+the current stage so users who prefer manual `/model` switches can.
+
+## Init
+
+`/ai-native-sdlc init` bootstraps any project, any language:
+
+1. **Scan** the project: language(s), package manager, build/test/lint
+   commands, directory layout, CI system. Use a fast subagent for large repos.
+2. **CLAUDE.md** — create or update it with: project overview, the verified
+   build/test/lint commands (run them to confirm), conventions observed in the
+   code, and common pitfalls. Never overwrite user content; merge under
+   clearly-marked sections.
+3. **`.sdlc/` scaffold** — create the directory, install
+   `templates/review-policy.md` as `.sdlc/REVIEW.md`, and seed an empty
+   `lessons.md`.
+4. **Governance (offer, don't force)** — ask whether to install the hook and
+   settings templates (`templates/settings.hooks.json` → `.claude/settings.json`)
+   and CI workflows (`templates/github-actions/`). Explain what each blocks or
+   gates in one line each.
+5. **Commit** the scaffold if approved.
+
+## The six stages
+
+Compact contracts below; detailed per-stage instructions, prompts, and edge
+cases are in `references/stages.md` — read it before executing a stage.
+
+### 1 · Plan → `intent.md`
+Interview the user briefly (problem, desired outcome, affected systems,
+constraints, non-goals). Keep their wording — the intent is *their* voice, not
+a rewrite. Draft from `templates/intent.md`. Gate: user approves intent.
+
+### 2 · Design → `spec.md`
+Read the approved intent. Explore the codebase for affected systems. Apply
+policy *now* — check for security, compliance, UX, and API-design skills or
+docs in the project and fold their constraints into the spec. Flag concerns
+explicitly rather than silently resolving them. Draft from `templates/spec.md`
+via a deep-reasoning subagent. Gate: user approves spec.
+
+### 3 · Build → `plan.md` + implementation
+First produce `plan.md` (step checklist, files touched, risks, test strategy)
+from the spec — deep-reasoning subagent, then gate: user approves the plan
+**before any code is written**. Then implement step by step, checking off
+plan items as they land. Independent tasks may fan out to parallel subagents
+in worktrees. Route mechanical steps to the fast tier.
+
+### 4 · Test → `test-report.md`
+Verify your own work before any human reviews it: run the project's test
+suite, build, and lint; write targeted tests for the new behavior; do visual
+checks where UI changed. Fix failures and re-run until green. Record evidence
+(commands, output summaries, coverage of the spec's acceptance criteria) in
+`test-report.md`. Gate: user sees the report; red results are reported
+honestly, never papered over.
+
+### 5 · Deploy → `review.md` + PR
+Run the policy passes from `.sdlc/REVIEW.md` (bugs, security, compliance) via
+an adversarial deep-reasoning subagent that did **not** write the code. Log
+findings and resolutions in `review.md`. Then prepare the branch and PR
+(never commit directly to the default branch). Gate: pushing, opening the PR,
+and merging always require explicit user approval — even under `--auto`.
+
+### 6 · Maintain
+Close the loop: help set up monitoring rules (tiered response: log → diagnose
+read-only → propose fix), turn confirmed findings into *new* `intent.md`
+files (the loop restarts at Stage 1 — fixes get the same governance as
+features), and write post-mortems to `.sdlc/lessons.md`. Scheduled scans and
+detection scripts: see `references/stages.md` §6.
+
+## Principles (always in force)
+
+- **Artifact chain is the audit trail.** Every stage commits its artifact.
+  Never advance past a gate silently; never edit an approved artifact without
+  flagging it (`status: superseded`, new draft).
+- **Human judgment at the gates, AI execution between them.** Approvals,
+  merges, deploys, and anything irreversible belong to the human.
+- **Honest reporting.** Failing tests, unresolved review findings, and skipped
+  steps are stated plainly in the artifacts and to the user.
+- **Any language, any platform.** Detect the project's own tooling and use it;
+  never assume a stack.
+- **Policy applied early.** Constraints surface in the spec, not in a late
+  review.

--- a/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
@@ -47,8 +47,8 @@ All artifacts live in `.sdlc/` at the project root:
 │   ├── intent.md      # Stage 1 — the idea, in the originator's words
 │   ├── spec.md        # Stage 2 — requirements + design, policy applied
 │   ├── plan.md        # Stage 3 — approved implementation strategy
-│   ├── review.md      # Stage 5 — review findings and resolutions
-│   └── test-report.md # Stage 4 — verification evidence
+│   ├── test-report.md # Stage 4 — verification evidence
+│   └── review.md      # Stage 5 — review findings and resolutions
 ├── REVIEW.md          # project-wide review policy (shared)
 └── lessons.md         # post-incident / post-mortem learnings (shared)
 ```
@@ -84,8 +84,8 @@ rationale and prompt patterns: `references/model-routing.md`.
 
 | Work | Tier | Why |
 |---|---|---|
-| Intent brainstorming, spec design, implementation planning | **Deepest reasoning available** (Fable/Opus tier) | Judgment-heavy; errors compound downstream |
-| Implementation | Session model | Interactive, user is present |
+| Spec design, implementation planning | **Deepest reasoning available** (Fable/Opus tier) | Judgment-heavy; errors compound downstream |
+| Intent interviewing/drafting, implementation | Session model | Interactive, user is present |
 | Mechanical work: renames, formatting, boilerplate, changelog | **Fast tier** (Haiku) | Speed and cost; no judgment needed |
 | Test triage, adversarial review verification | **Deepest reasoning available** | Must catch what the author-model missed |
 
@@ -98,10 +98,12 @@ the current stage so users who prefer manual `/model` switches can.
 `/ai-native-sdlc init` bootstraps any project, any language:
 
 1. **Scan** the project: language(s), package manager, build/test/lint
-   commands, directory layout, CI system. Use a fast subagent for large repos.
+   commands, the ecosystem's dependency-audit command (`npm audit`,
+   `pip-audit`, `cargo audit`, `govulncheck`, …), directory layout, CI
+   system. Use a fast subagent for large repos.
 2. **CLAUDE.md** — create or update it with: project overview, the verified
-   build/test/lint commands (run them to confirm), conventions observed in the
-   code, and common pitfalls. Never overwrite user content; merge under
+   build/test/lint/audit commands (run them to confirm), conventions observed
+   in the code, and common pitfalls. Never overwrite user content; merge under
    clearly-marked sections.
 3. **`.sdlc/` scaffold** — create the directory, install
    `templates/review-policy.md` as `.sdlc/REVIEW.md`, and seed an empty
@@ -113,7 +115,9 @@ the current stage so users who prefer manual `/model` switches can.
    placeholder commands with the real build/test/lint/audit commands verified
    in step 2 before writing the files** — never install a workflow that still
    contains `REPLACE ME` placeholders (they fail deliberately so an
-   unconfigured copy can't pass silently).
+   unconfigured copy can't pass silently). If no audit command exists for the
+   stack, drop the `scheduled-audit` job from `test-gate.yml` instead of
+   installing its placeholder, and tell the user.
 5. **Commit** the scaffold if approved.
 
 ## The six stages
@@ -128,8 +132,9 @@ a rewrite. Draft from `templates/intent.md`. Gate: user approves intent.
 
 ### 2 · Design → `spec.md`
 Read the approved intent. Explore the codebase for affected systems. Apply
-policy *now* — check for security, compliance, UX, and API-design skills or
-docs in the project and fold their constraints into the spec. Flag concerns
+policy *now* — gather constraints from the project's own documents
+(CLAUDE.md conventions, security/compliance docs, API style guides, design
+systems) and fold them into the spec. Flag concerns
 explicitly rather than silently resolving them. Draft from `templates/spec.md`
 via a deep-reasoning subagent. Gate: user approves spec.
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/SKILL.md
@@ -109,7 +109,11 @@ the current stage so users who prefer manual `/model` switches can.
 4. **Governance (offer, don't force)** — ask whether to install the hook and
    settings templates (`templates/settings.hooks.json` → `.claude/settings.json`)
    and CI workflows (`templates/github-actions/`). Explain what each blocks or
-   gates in one line each.
+   gates in one line each. When installing the CI workflows, **replace their
+   placeholder commands with the real build/test/lint/audit commands verified
+   in step 2 before writing the files** — never install a workflow that still
+   contains `REPLACE ME` placeholders (they fail deliberately so an
+   unconfigured copy can't pass silently).
 5. **Commit** the scaffold if approved.
 
 ## The six stages

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/governance.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/governance.md
@@ -1,0 +1,66 @@
+# Governance — hooks, permissions, CI, and the audit trail
+
+The AI-native SDLC's controls are *automated and continuous*, replacing
+sign-off meetings with enforcement that runs on every action. Three layers:
+
+## 1 · Deterministic controls (hooks + permissions)
+
+Hooks fire on every matching tool call — they don't rely on the model
+remembering a rule. `templates/settings.hooks.json` ships ready-to-merge
+examples for `.claude/settings.json`:
+
+- **Protected paths** — block edits to migration history, lockfiles, prod
+  config, `.sdlc/**` files with `status: approved` (approved artifacts change
+  only through the supersede flow).
+- **Credential guard** — block commands that would print or upload secrets
+  (`.env`, key files, cloud credential paths).
+- **Deploy gate** — deploy/release/publish commands require explicit
+  human approval every time; no allowlisting them away.
+- **Default-branch guard** — block `git push` to main/master; work reaches it
+  through PRs only.
+
+During `/ai-native-sdlc init`, offer these with a one-line explanation each. Merge into
+existing settings; never clobber the user's configuration.
+
+For regulated environments, point users at managed settings (org-enforced
+`managed-settings.json`): credential denial, network allowlists, sandbox
+enforcement — controls the individual developer cannot disable.
+
+## 2 · Continuous validation (CI)
+
+`templates/github-actions/` ships two workflows:
+
+- **`claude-review.yml`** — on every PR, a headless, sandboxed Claude run
+  executes the `.sdlc/REVIEW.md` passes and posts findings as PR comments.
+  It never approves and never merges; it only surfaces.
+- **`test-gate.yml`** — the ordinary build/test/lint matrix as a required
+  status check, plus a scheduled (cron) dependency/security audit job whose
+  findings become issues — entering the lifecycle as Stage 6 detections.
+
+Branch protection completes the loop: required checks + required human
+review = agent-written code cannot reach the default branch unreviewed.
+
+## 3 · The artifact chain as audit trail
+
+Every governance question ("who approved this? why does it exist? what did
+review find?") is answered by git history over `.sdlc/`:
+
+| Question | Answer lives in |
+|---|---|
+| Why does this feature exist? | `intent.md` + its approval commit |
+| Who approved the design, when? | `spec.md` frontmatter + commit metadata |
+| What was the agreed strategy? | `plan.md` at its approval commit |
+| Was it verified? How? | `test-report.md` |
+| What did review find, and what happened to each finding? | `review.md` |
+| What did we learn from incidents? | `lessons.md` |
+
+Rules that keep the trail trustworthy:
+
+- One commit per gate, message `sdlc(<slug>): approve <stage>` — approvals
+  are findable with `git log --grep`.
+- Approved artifacts are immutable. Changing course = mark the old artifact
+  `status: superseded`, draft anew, re-gate. The history shows both.
+- Honest artifacts: failing tests, rejected findings, and skipped checks are
+  recorded as such. An audit trail that flatters is worse than none.
+- Humans hold the irreversible actions: approving artifacts, pushing,
+  opening PRs, merging, deploying. `--auto` never crosses those lines.

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/governance.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/governance.md
@@ -9,9 +9,10 @@ Hooks fire on every matching tool call — they don't rely on the model
 remembering a rule. `templates/settings.hooks.json` ships ready-to-merge
 examples for `.claude/settings.json`:
 
-- **Protected paths** — block edits to migration history, lockfiles, prod
-  config, `.sdlc/**` files with `status: approved` (approved artifacts change
-  only through the supersede flow).
+- **Protected paths** — block edits to approved `intent.md` and `spec.md`
+  (they change only through the supersede flow). `plan.md` stays editable
+  after approval by design: checking off steps and recording deviations is
+  the documented Build workflow.
 - **Credential guard** — block commands that would print or upload secrets
   (`.env`, key files, cloud credential paths).
 - **Deploy gate** — deploy/release/publish commands require explicit

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/model-routing.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/model-routing.md
@@ -1,0 +1,77 @@
+# Model routing — the right brain for each job
+
+The lifecycle's stages have very different cognitive profiles. Routing work to
+the right model tier is how the skill stays both excellent and affordable on
+any project.
+
+## The tiers
+
+Tier names, not model names, are the contract — model lineups change; the
+routing logic doesn't. Resolve tiers against whatever is available in the
+user's environment at run time:
+
+| Tier | Currently resolves to | Character |
+|---|---|---|
+| **Deep** | Fable / Opus class | Slow, expensive, catches what others miss |
+| **Standard** | The session model | Whatever the user chose to drive with |
+| **Fast** | Haiku class | Cheap, quick, excellent at mechanical work |
+
+## Routing table
+
+| Stage | Work | Tier |
+|---|---|---|
+| 1 Plan | Interviewing, drafting intent | Standard (conversational — user is present) |
+| 2 Design | Codebase exploration | Fast/Standard (Explore agents) |
+| 2 Design | Spec drafting | **Deep** |
+| 3 Build | plan.md drafting | **Deep** |
+| 3 Build | Implementation | Standard |
+| 3 Build | Boilerplate, renames, fixtures, changelog | **Fast** |
+| 4 Test | Running suites, writing routine tests | Standard |
+| 4 Test | Triaging a genuinely confusing failure | **Deep** |
+| 5 Deploy | Adversarial review passes | **Deep** |
+| 5 Deploy | PR description, comment replies | Standard |
+| 6 Maintain | Read-only diagnosis | Standard |
+| 6 Maintain | Post-mortem root-cause analysis | **Deep** |
+
+**Rule of thumb:** route Deep when errors compound downstream (a bad spec
+poisons every later stage) or when the task is adversarial to work you
+yourself produced. Route Fast when a wrong answer is cheap to spot and fix.
+
+## Mechanics
+
+Spawn tiered work with the Agent tool and an explicit `model` parameter
+(e.g. `model: "fable"` or `"opus"` for Deep, `"haiku"` for Fast). Omit the
+parameter for Standard — the subagent inherits the session model.
+
+A skill cannot switch the session model itself. Once per stage transition (at
+most), you may note the ideal driving model — e.g. "Stage 2 benefits from a
+deep-reasoning session model; `/model` to switch" — then respect the user's
+choice silently.
+
+## Subagent prompt patterns
+
+**Deep spec drafter (Stage 2):**
+> You are drafting a technical spec. Inputs: the intent (verbatim below), the
+> codebase findings, the policy constraints (each with source). Produce
+> spec.md per the template. Rules: every requirement must trace to the
+> intent; every design decision states its alternative and why it lost; any
+> tension between intent and policy becomes a ⚠ flagged concern, never a
+> silent resolution; no scope beyond the intent.
+
+**Deep plan drafter (Stage 3):**
+> Draft plan.md from this approved spec. Ordered steps, each with files
+> touched and a done-check. Name real files and real commands only — verify
+> against the file listing provided. Include: risk notes per risky step, the
+> test strategy mapping acceptance criteria to planned tests, and which steps
+> are independent (parallelizable) vs sequential.
+
+**Adversarial reviewer (Stage 5), one per pass:**
+> You did not write this diff. Your job is to refute it. Pass: {bugs |
+> security | compliance | simplification}. Report only findings with a
+> concrete failure scenario (inputs/state → wrong behavior). No style nits.
+> If you cannot break it, say so plainly — an empty report is a valid report.
+
+**Fast mechanical worker:**
+> Mechanical task, no design decisions: {task}. Follow the existing pattern
+> in {example file} exactly. If anything requires a judgment call, stop and
+> report instead of deciding.

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/model-routing.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/model-routing.md
@@ -43,8 +43,8 @@ Spawn tiered work with the Agent tool and an explicit `model` parameter
 (e.g. `model: "fable"` or `"opus"` for Deep, `"haiku"` for Fast). Omit the
 parameter for Standard — the subagent inherits the session model.
 
-A skill cannot switch the session model itself. Once per stage transition (at
-most), you may note the ideal driving model — e.g. "Stage 2 benefits from a
+A skill cannot switch the session model itself. Once per session (at most),
+you may note the ideal driving model — e.g. "Stage 2 benefits from a
 deep-reasoning session model; `/model` to switch" — then respect the user's
 choice silently.
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
@@ -1,0 +1,178 @@
+# Stage playbook — detailed execution guide
+
+Read the section for the stage you are about to run. Every stage ends the same
+way: artifact drafted → summarized to the user → approval gate → frontmatter
+updated → committed.
+
+---
+
+## 1 · Plan — capture intent
+
+**Goal:** the idea leaves the originator's head and enters version control in
+their own words, the same day they had it.
+
+1. If the user gave the idea inline (`/ai-native-sdlc new add dark mode`), start from
+   that. Otherwise ask for it in one open question.
+2. Interview briefly — at most one round of questions, batched:
+   - What problem does this solve, and for whom?
+   - What does success look like?
+   - Which systems/areas of the codebase does it touch (best guess is fine)?
+   - Hard constraints (deadlines, compliance, compatibility)?
+   - Explicit non-goals?
+3. Draft `intent.md` from the template. **Preserve the user's phrasing** in
+   the Problem and Outcome sections — quote them, don't paraphrase into
+   corporate language. Your additions (affected systems you found by scanning,
+   open questions) go in clearly separate sections.
+4. Derive the feature slug from the idea (kebab-case, ≤5 words). Create
+   `.sdlc/<slug>/intent.md`.
+5. Gate. On approval: `status: approved`, commit `sdlc(<slug>): approve intent`.
+
+**Anti-patterns:** writing a spec disguised as an intent (no solution design
+here); interrogating the user with 10 questions; inventing requirements the
+user never stated.
+
+---
+
+## 2 · Design — one session from intent to spec
+
+**Goal:** requirements and design collapse into a single session, with policy
+applied during creation instead of discovered in late review.
+
+1. Read the approved `intent.md`.
+2. **Explore the codebase** for every affected system named or implied:
+   current behavior, extension points, existing patterns to follow. Use
+   Explore subagents for breadth; read the load-bearing files yourself.
+3. **Gather policy.** Look for, in order: project skills
+   (`.claude/skills/`), org conventions in `CLAUDE.md`, security/compliance
+   docs, API style guides, design systems. Every constraint found becomes a
+   line in the spec's Constraints section with its source cited.
+4. Spawn a **deep-reasoning subagent** to draft the spec (see
+   `model-routing.md` for the prompt pattern). Give it: the intent, your
+   codebase findings, the policy constraints, and the template.
+5. Review the draft yourself before showing the user: does every requirement
+   trace to the intent? Are concerns *flagged* (⚠ blocks) rather than silently
+   decided? Is anything gold-plated beyond the intent?
+6. For UI work: describe the user-facing flow concretely (screens, states,
+   copy). If the user has a design tool connected (e.g. Figma MCP), offer to
+   pull real frames.
+7. Gate. On approval: approve + commit.
+
+**Anti-patterns:** designing beyond the intent's scope; resolving a
+security/compliance tension silently instead of flagging it; specs that
+restate the intent without adding design decisions.
+
+---
+
+## 3 · Build — plan first, then implement
+
+**Goal:** no code before an approved strategy; institutional knowledge and
+guardrails do their work during implementation, not after.
+
+### 3a · plan.md
+
+1. From the approved spec, have a deep-reasoning subagent draft `plan.md`:
+   ordered checklist of implementation steps, files to create/modify per step,
+   risk notes, rollback thinking, and the test strategy (which tests prove
+   which acceptance criteria).
+2. Sanity-check the plan against the real codebase — every named file must
+   exist (or be explicitly "new"), every named command must be real.
+3. **Gate — this is the most important gate in the lifecycle.** The user
+   approves the strategy before a single line of code is written.
+
+### 3b · Implementation
+
+1. Work through the checklist in order; check items off in `plan.md` as they
+   land (edit the file — it is live state, not a snapshot).
+2. **Parallelize** genuinely independent steps with subagents in worktree
+   isolation. Never parallelize steps that touch the same files.
+3. **Route mechanically:** boilerplate, renames, fixture data, changelog
+   entries → fast-tier subagents. Anything requiring judgment stays with you.
+4. Follow `CLAUDE.md` conventions exactly. When you learn something the next
+   session would need (a footgun, a hidden command), add it to `CLAUDE.md`.
+5. If implementation reveals the plan was wrong, stop, update `plan.md`,
+   summarize the change to the user, and get a nod before continuing —
+   drifting silently from an approved plan breaks the audit trail.
+6. Commit in coherent, per-step commits, not one megacommit.
+
+---
+
+## 4 · Test — verify your own work first
+
+**Goal:** the session proves its work before any human spends review time.
+First-pass CI success is the metric.
+
+1. Discover the project's real verification commands (CLAUDE.md → package
+   scripts → CI config, in that order). Run **all** of: test suite, build,
+   lint/typecheck.
+2. Write tests for the new behavior keyed to the spec's acceptance criteria —
+   each criterion maps to at least one test. Match the project's existing test
+   style and framework.
+3. UI changes: run the app and look (screenshot or browser automation where
+   available); record what was checked.
+4. Fix failures and re-run to green. If something cannot be made green,
+   **say so** — the report shows real state.
+5. Write `test-report.md`: commands run, pass/fail per command, criteria →
+   test mapping, anything unverified and why.
+6. Gate: show the report summary. Red or unverified items are the headline,
+   not a footnote.
+
+---
+
+## 5 · Deploy — bidirectional review, gated release
+
+**Goal:** agent-written code reaches production through the same (or
+stronger) controls as human-written code.
+
+### 5a · Policy review
+
+1. Read `.sdlc/REVIEW.md` (create from template if missing).
+2. Spawn an **adversarial deep-reasoning subagent per pass** (bugs, security,
+   compliance, simplification) that did not write the code. Instruction: try
+   to *refute* the diff's correctness, not confirm it.
+3. Verify each finding yourself before accepting it (findings must name a
+   concrete failure scenario). Fix confirmed findings; log every
+   finding + resolution (fixed / rejected-with-reason) in `review.md`.
+
+### 5b · PR
+
+1. Never commit to the default branch — branch if not already on one.
+2. Prepare the PR description: link the artifact chain (intent → spec → plan
+   → test report → review), summarize the change, list what reviewers should
+   focus on.
+3. **Hard gate:** pushing and opening the PR require explicit user approval,
+   even under `--auto`. Merging is always the human's click.
+4. When human review comments arrive, address them in follow-up commits and
+   reply to each; update `review.md`.
+
+### 5c · CI
+
+Offer the workflow templates (`templates/github-actions/`) if the repo has no
+automated review/test gate. Headless review steps run sandboxed and
+non-interactive; they comment, they never merge.
+
+---
+
+## 6 · Maintain — close the loop
+
+**Goal:** production feedback re-enters the lifecycle as new intents, with
+response proportional to severity.
+
+1. **Detection:** help the user define control bands on their key metrics
+   (test failure rate, error rate, latency). Detection is deterministic
+   scripts/alerts — not an LLM watching dashboards. Western Electric-style
+   rules work: react to sustained deviation, not single spikes.
+2. **Tiered response** (encode in the alerting or a runbook):
+   - ~1σ deviation → log only.
+   - ~2σ → diagnose read-only: gather logs/metrics/recent diffs, write a
+     diagnosis, touch nothing.
+   - ~3σ / confirmed incident → propose a fix **as a new `intent.md`** via
+     `/ai-native-sdlc new`. The fix then earns spec, plan, tests, and review like any
+     feature. No hotfix bypasses the chain; for true emergencies the human
+     can fast-track gates, but the artifacts still get written.
+3. **Scheduled scans:** security/dependency scans on cron (CI templates
+   include an example); findings arrive as PRs/issues through normal gates.
+4. **Post-mortems:** after any incident, append to `.sdlc/lessons.md`: what
+   happened, root cause, what detection missed, which guardrail (hook, test,
+   review pass) now prevents recurrence — then actually add that guardrail.
+   Lessons are version-controlled institutional memory; read them during
+   Stage 2 of future features.

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
@@ -4,6 +4,11 @@ Read the section for the stage you are about to run. Every stage ends the same
 way: artifact drafted → summarized to the user → approval gate → frontmatter
 updated → committed.
 
+When instantiating any artifact template, delete its "Template note" paragraph
+and every line beginning with "> Guidance:" — committed artifacts contain only
+real content. This applies to every stage below and to subagent-drafted
+artifacts (include it in the subagent's instructions).
+
 ---
 
 ## 1 · Plan — capture intent
@@ -53,7 +58,8 @@ applied during creation instead of discovered in late review.
    codebase findings, the policy constraints, and the template.
 5. Review the draft yourself before showing the user: does every requirement
    trace to the intent? Are concerns *flagged* (⚠ blocks) rather than silently
-   decided? Is anything gold-plated beyond the intent?
+   decided? Is anything gold-plated beyond the intent? Are the template's
+   "Template note" paragraph and "> Guidance:" lines gone?
 6. For UI work: describe the user-facing flow concretely (screens, states,
    copy). If the user has a design tool connected (e.g. Figma MCP), offer to
    pull real frames.

--- a/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/references/stages.md
@@ -42,10 +42,12 @@ applied during creation instead of discovered in late review.
 2. **Explore the codebase** for every affected system named or implied:
    current behavior, extension points, existing patterns to follow. Use
    Explore subagents for breadth; read the load-bearing files yourself.
-3. **Gather policy.** Look for, in order: project skills
-   (`.claude/skills/`), org conventions in `CLAUDE.md`, security/compliance
-   docs, API style guides, design systems. Every constraint found becomes a
-   line in the spec's Constraints section with its source cited.
+3. **Gather policy.** Look for, in order: org conventions in `CLAUDE.md`,
+   security/compliance docs, API style guides, design systems. Organization
+   policy packs active in the session contribute their constraints
+   automatically — apply them as given; this stage works only from the
+   project's own documents. Every constraint found becomes a line in the
+   spec's Constraints section with its source cited.
 4. Spawn a **deep-reasoning subagent** to draft the spec (see
    `model-routing.md` for the prompt pattern). Give it: the intent, your
    codebase findings, the policy constraints, and the template.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
@@ -1,7 +1,12 @@
 # Headless policy review on every PR (AI-native SDLC, Stage 5).
-# Runs the passes defined in .sdlc/REVIEW.md and posts findings as PR
-# comments. It surfaces; it never approves and never merges — branch
-# protection + human review own the merge.
+# Runs the passes defined in .sdlc/REVIEW.md via Anthropic's official
+# claude-code-action and posts findings as PR comments. It surfaces; it never
+# approves and never merges — branch protection + human review own the merge.
+#
+# COST DISCLOSURE: this workflow calls the Claude API on every PR update,
+# billed to the ANTHROPIC_API_KEY you provide. Installing this file is the
+# explicit operator approval for that spend; remove the workflow (or restrict
+# its triggers) to stop it.
 #
 # Setup:
 #   1. Add ANTHROPIC_API_KEY to the repo's Actions secrets.
@@ -18,6 +23,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: read
+  id-token: write
 
 jobs:
   review:
@@ -28,34 +35,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
-
       - name: Run policy passes
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          claude -p "Review the diff between origin/${{ github.base_ref }} and HEAD \
-          using the review policy in .sdlc/REVIEW.md (if the file is missing, run \
-          bugs and security passes only). Be adversarial: try to refute the diff. \
-          Report only findings with a concrete failure scenario — no style nits. \
-          Write findings to review-findings.md as a markdown list; if there are \
-          none, write 'No findings.'" \
-            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write" \
-            --permission-mode acceptEdits
-
-      - name: Post findings
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -s review-findings.md ]; then
-            {
-              echo "## 🤖 Claude policy review (.sdlc/REVIEW.md)"
-              echo
-              cat review-findings.md
-              echo
-              echo "_Automated review — surfaces findings only. Humans approve and merge._"
-            } > comment.md
-            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
-          fi
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request's diff against the review policy in
+            .sdlc/REVIEW.md (if that file is missing, run bugs and security
+            passes only). Be adversarial: try to refute the diff, not confirm
+            it. Report only findings with a concrete failure scenario — no
+            style nits. Post the findings as a single PR comment titled
+            "Claude policy review"; if there are none, comment "No findings."
+            Do not approve, request changes, or merge — surface findings only.
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr comment:*)"

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
@@ -1,0 +1,61 @@
+# Headless policy review on every PR (AI-native SDLC, Stage 5).
+# Runs the passes defined in .sdlc/REVIEW.md and posts findings as PR
+# comments. It surfaces; it never approves and never merges — branch
+# protection + human review own the merge.
+#
+# Setup:
+#   1. Add ANTHROPIC_API_KEY to the repo's Actions secrets.
+#   2. Commit this file to .github/workflows/claude-review.yml
+#   3. (Recommended) Make "test-gate" a required status check and require
+#      one human review on the default branch.
+
+name: Claude policy review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run policy passes
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p "Review the diff between origin/${{ github.base_ref }} and HEAD \
+          using the review policy in .sdlc/REVIEW.md (if the file is missing, run \
+          bugs and security passes only). Be adversarial: try to refute the diff. \
+          Report only findings with a concrete failure scenario — no style nits. \
+          Write findings to review-findings.md as a markdown list; if there are \
+          none, write 'No findings.'" \
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write" \
+            --permission-mode acceptEdits
+
+      - name: Post findings
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -s review-findings.md ]; then
+            {
+              echo "## 🤖 Claude policy review (.sdlc/REVIEW.md)"
+              echo
+              cat review-findings.md
+              echo
+              echo "_Automated review — surfaces findings only. Humans approve and merge._"
+            } > comment.md
+            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+          fi

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/claude-review.yml
@@ -9,9 +9,14 @@
 # its triggers) to stop it.
 #
 # Setup:
-#   1. Add ANTHROPIC_API_KEY to the repo's Actions secrets.
-#   2. Commit this file to .github/workflows/claude-review.yml
-#   3. (Recommended) Make "test-gate" a required status check and require
+#   1. Install the Claude GitHub App on this repository
+#      (https://github.com/apps/claude) - claude-code-action exchanges its
+#      GitHub token through the app and fails at startup without it.
+#      Alternatively, pass your own token via the action's `github_token`
+#      input (needs pull-requests: write).
+#   2. Add ANTHROPIC_API_KEY to the repo's Actions secrets.
+#   3. Commit this file to .github/workflows/claude-review.yml
+#   4. (Recommended) Make "test-gate" a required status check and require
 #      one human review on the default branch.
 
 name: Claude policy review

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/test-gate.yml
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/test-gate.yml
@@ -7,8 +7,10 @@
 #     issues, which re-enter the lifecycle as Stage 6 detections
 #     (triage → /ai-native-sdlc new → the fix earns spec, plan, tests, review).
 #
-# Replace the placeholder commands with your project's real ones — the same
-# commands recorded in CLAUDE.md by /ai-native-sdlc init.
+# The REPLACE ME commands below fail deliberately so an unconfigured copy of
+# this file can never pass silently. /ai-native-sdlc init substitutes your
+# project's real commands (the ones it verified and recorded in CLAUDE.md)
+# when it installs this workflow; if copying by hand, replace them yourself.
 
 name: Test gate
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/test-gate.yml
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/github-actions/test-gate.yml
@@ -1,0 +1,79 @@
+# Continuous validation gate (AI-native SDLC, Stages 4–6).
+#
+# Two jobs:
+#   - test-gate: build/test/lint on every PR — make this a REQUIRED status
+#     check so agent-written code cannot merge unverified.
+#   - scheduled-audit: weekly dependency/security audit; findings become
+#     issues, which re-enter the lifecycle as Stage 6 detections
+#     (triage → /ai-native-sdlc new → the fix earns spec, plan, tests, review).
+#
+# Replace the placeholder commands with your project's real ones — the same
+# commands recorded in CLAUDE.md by /ai-native-sdlc init.
+
+name: Test gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC — scheduled audit only
+
+jobs:
+  test-gate:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Replace with your stack's setup, e.g.: ---
+      # - uses: actions/setup-node@v4
+      #   with: { node-version: 22, cache: npm }
+      # - run: npm ci
+
+      - name: Build
+        run: echo "REPLACE ME → your build command" && exit 1
+
+      - name: Test
+        run: echo "REPLACE ME → your test command" && exit 1
+
+      - name: Lint / typecheck
+        run: echo "REPLACE ME → your lint command" && exit 1
+
+  scheduled-audit:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dependency / security audit
+        id: audit
+        continue-on-error: true
+        # Replace with your ecosystem's auditor:
+        #   npm audit --audit-level=high | pip-audit | cargo audit | govulncheck ./...
+        run: |
+          echo "REPLACE ME → your audit command" > audit.txt
+          exit 1
+
+      - name: File findings as an issue
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "Scheduled audit found issues. Triage per the AI-native SDLC:"
+            echo "confirmed findings become new intents (\`/ai-native-sdlc new <fix>\`)."
+            echo
+            echo '```'
+            cat audit.txt
+            echo '```'
+          } > body.md
+          gh issue create \
+            --title "Scheduled audit findings — $(date -u +%Y-%m-%d)" \
+            --label maintenance \
+            --body-file body.md

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
@@ -1,0 +1,30 @@
+---
+stage: intent
+status: draft
+feature: <slug>
+approved_by: pending
+date: <YYYY-MM-DD>
+---
+
+# Intent: <short title>
+
+## Problem
+<!-- The originator's own words. Quote them; do not translate into
+     requirements-speak. Who hurts, and how? -->
+
+## Desired outcome
+<!-- What success looks like, still in the originator's words. Observable,
+     not implementation-shaped. -->
+
+## Affected systems
+<!-- Best current guess — services, modules, screens, data. Refined in the
+     spec, not here. -->
+
+## Constraints
+<!-- Hard limits only: deadlines, compliance, compatibility, budget. -->
+
+## Non-goals
+<!-- What this explicitly does NOT cover. The cheapest scope control there is. -->
+
+## Open questions
+<!-- Anything unresolved that the Design stage must answer. -->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
@@ -8,9 +8,9 @@ date: <YYYY-MM-DD>
 
 # Intent: <short title>
 
-Template note: lines beginning with "> Guidance:" describe what belongs in
-each section and are replaced by real content when this template is
-instantiated.
+Template note: remove this paragraph and every line beginning with
+"> Guidance:" when instantiating this template; the committed artifact
+contains only real content.
 
 ## Problem
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/intent.md
@@ -8,23 +8,34 @@ date: <YYYY-MM-DD>
 
 # Intent: <short title>
 
+Template note: lines beginning with "> Guidance:" describe what belongs in
+each section and are replaced by real content when this template is
+instantiated.
+
 ## Problem
-<!-- The originator's own words. Quote them; do not translate into
-     requirements-speak. Who hurts, and how? -->
+
+> Guidance: the originator's own words. Quote them; do not translate into
+> requirements-speak. Who hurts, and how?
 
 ## Desired outcome
-<!-- What success looks like, still in the originator's words. Observable,
-     not implementation-shaped. -->
+
+> Guidance: what success looks like, still in the originator's words.
+> Observable, not implementation-shaped.
 
 ## Affected systems
-<!-- Best current guess — services, modules, screens, data. Refined in the
-     spec, not here. -->
+
+> Guidance: best current guess — services, modules, screens, data. Refined in
+> the spec, not here.
 
 ## Constraints
-<!-- Hard limits only: deadlines, compliance, compatibility, budget. -->
+
+> Guidance: hard limits only — deadlines, compliance, compatibility, budget.
 
 ## Non-goals
-<!-- What this explicitly does NOT cover. The cheapest scope control there is. -->
+
+> Guidance: what this explicitly does NOT cover. The cheapest scope control
+> there is.
 
 ## Open questions
-<!-- Anything unresolved that the Design stage must answer. -->
+
+> Guidance: anything unresolved that the Design stage must answer.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
@@ -1,0 +1,13 @@
+# Lessons
+
+Version-controlled institutional memory. Every incident and post-mortem lands
+here (Stage 6); every Design session reads it (Stage 2). Newest first.
+
+<!--
+## <YYYY-MM-DD> · <one-line title>
+- **What happened:**
+- **Root cause:**
+- **What detection missed:**
+- **Guardrail added:** <the hook / test / review pass that now prevents
+  recurrence — added, not just proposed>
+-->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
@@ -1,13 +1,11 @@
 # Lessons
 
 Version-controlled institutional memory. Every incident and post-mortem lands
-here (Stage 6); every Design session reads it (Stage 2). Newest first.
+here (Stage 6); every Design session reads it (Stage 2). This header persists;
+new lessons are appended directly below it, newest first. No placeholder
+entries: until the first incident, the file ends here.
 
-Entry format (copy for each new lesson):
-
-## <YYYY-MM-DD> · <one-line title>
-- **What happened:**
-- **Root cause:**
-- **What detection missed:**
-- **Guardrail added:** <the hook / test / review pass that now prevents
-  recurrence — added, not just proposed>
+Each lesson is a `## YYYY-MM-DD · one-line title` heading followed by four
+bullets: **What happened**, **Root cause**, **What detection missed**, and
+**Guardrail added** (the hook / test / review pass that now prevents
+recurrence; added, not just proposed).

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/lessons.md
@@ -3,11 +3,11 @@
 Version-controlled institutional memory. Every incident and post-mortem lands
 here (Stage 6); every Design session reads it (Stage 2). Newest first.
 
-<!--
+Entry format (copy for each new lesson):
+
 ## <YYYY-MM-DD> · <one-line title>
 - **What happened:**
 - **Root cause:**
 - **What detection missed:**
 - **Guardrail added:** <the hook / test / review pass that now prevents
   recurrence — added, not just proposed>
--->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
@@ -9,28 +9,38 @@ spec: ./spec.md
 
 # Plan: <short title>
 
+Template note: lines beginning with "> Guidance:" describe what belongs in
+each section and are replaced by real content when this template is
+instantiated. This file stays editable after approval: checking off steps and
+recording deviations IS the documented workflow.
+
 ## Strategy
-<!-- One paragraph: the implementation approach and why it fits this
-     codebase's existing patterns. -->
+
+> Guidance: one paragraph — the implementation approach and why it fits this
+> codebase's existing patterns.
 
 ## Steps
-<!-- Ordered checklist — this file is live state during Stage 3; items get
-     checked as they land, one commit per step. Mark independent steps
-     [parallel-ok]. Each step: files touched + how we know it's done. -->
+
+> Guidance: ordered checklist — live state during Stage 3; items get checked
+> as they land, one commit per step. Mark independent steps [parallel-ok].
+> Each step lists the files touched and how we know it's done.
 
 - [ ] 1. …
       - Files: `path/to/file`
       - Done when: …
 
 ## Risks
-<!-- Per risky step: what could go wrong, how we'd notice, how we'd back out. -->
+
+> Guidance: per risky step — what could go wrong, how we'd notice, how we'd
+> back out.
 
 ## Test strategy
-<!-- Acceptance criterion → planned test, one line each:
-     - AC1 → unit test in `…`
-     - AC2 → integration test in `…` -->
+
+> Guidance: acceptance criterion → planned test, one line each, e.g.
+> "AC1 → unit test in `…`".
 
 ## Deviations
-<!-- Empty at approval. If implementation reveals the plan was wrong, the
-     change is recorded here and re-acknowledged by the user before work
-     continues. -->
+
+> Guidance: empty at approval. If implementation reveals the plan was wrong,
+> the change is recorded here and re-acknowledged by the user before work
+> continues.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
@@ -9,10 +9,10 @@ spec: ./spec.md
 
 # Plan: <short title>
 
-Template note: lines beginning with "> Guidance:" describe what belongs in
-each section and are replaced by real content when this template is
-instantiated. This file stays editable after approval: checking off steps and
-recording deviations IS the documented workflow.
+Template note: remove this paragraph and every line beginning with
+"> Guidance:" when instantiating this template; the committed artifact
+contains only real content. This file stays editable after approval: checking
+off steps and recording deviations IS the documented workflow.
 
 ## Strategy
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/plan.md
@@ -1,0 +1,36 @@
+---
+stage: plan
+status: draft
+feature: <slug>
+approved_by: pending
+date: <YYYY-MM-DD>
+spec: ./spec.md
+---
+
+# Plan: <short title>
+
+## Strategy
+<!-- One paragraph: the implementation approach and why it fits this
+     codebase's existing patterns. -->
+
+## Steps
+<!-- Ordered checklist — this file is live state during Stage 3; items get
+     checked as they land, one commit per step. Mark independent steps
+     [parallel-ok]. Each step: files touched + how we know it's done. -->
+
+- [ ] 1. …
+      - Files: `path/to/file`
+      - Done when: …
+
+## Risks
+<!-- Per risky step: what could go wrong, how we'd notice, how we'd back out. -->
+
+## Test strategy
+<!-- Acceptance criterion → planned test, one line each:
+     - AC1 → unit test in `…`
+     - AC2 → integration test in `…` -->
+
+## Deviations
+<!-- Empty at approval. If implementation reveals the plan was wrong, the
+     change is recorded here and re-acknowledged by the user before work
+     continues. -->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/review-policy.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/review-policy.md
@@ -1,0 +1,35 @@
+# Review policy
+
+Project-wide review passes, run in Stage 5 before any PR opens. Each pass is
+executed by an adversarial reviewer that did not write the code, instructed to
+refute the diff, and to report only findings with a concrete failure scenario.
+Edit this file to encode your organization's policy — it is version-controlled
+institutional knowledge, and changing it changes every future review.
+
+## Pass: Bugs
+- Logic errors, off-by-ones, unhandled error paths, race conditions.
+- Broken edge cases: empty inputs, nulls, unicode, concurrent access, clock
+  and timezone assumptions.
+- Behavior that contradicts the spec's acceptance criteria.
+
+## Pass: Security
+- Injection (SQL, command, path, template), unsafe deserialization.
+- Secrets in code, logs, or fixtures; credentials in URLs.
+- AuthN/AuthZ gaps: missing checks, confused-deputy paths, IDOR.
+- Unvalidated input at trust boundaries; unsafe defaults.
+
+## Pass: Compliance
+<!-- Replace with your obligations. Common examples: -->
+- PII handled per policy (collection minimized, retention bounded, logs clean).
+- License compatibility of any new dependency.
+- Audit-relevant actions are logged.
+
+## Pass: Simplification
+- Duplication of logic that already exists in the codebase.
+- Abstractions with one caller; configurability nothing uses.
+- Code the diff added that the diff also made unnecessary.
+
+## Rules
+- No style nits — linters own style.
+- Every finding names a failure scenario; "this looks wrong" is not a finding.
+- An empty pass is a valid result and is recorded as such.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/review-policy.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/review-policy.md
@@ -19,7 +19,9 @@ institutional knowledge, and changing it changes every future review.
 - Unvalidated input at trust boundaries; unsafe defaults.
 
 ## Pass: Compliance
-<!-- Replace with your obligations. Common examples: -->
+
+Replace the examples below with your organization's actual obligations:
+
 - PII handled per policy (collection minimized, retention bounded, logs clean).
 - License compatibility of any new dependency.
 - Audit-relevant actions are logged.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
@@ -1,0 +1,37 @@
+---
+stage: review
+status: draft
+feature: <slug>
+date: <YYYY-MM-DD>
+policy: ../REVIEW.md
+---
+
+# Review: <short title>
+
+## Passes run
+<!-- One row per pass from .sdlc/REVIEW.md. Reviewers are adversarial
+     subagents that did not write the code. -->
+
+| Pass | Reviewer tier | Findings |
+|---|---|---|
+| Bugs | deep | 0 / N |
+| Security | deep | |
+| Compliance | deep | |
+| Simplification | deep | |
+
+## Findings
+<!-- Every finding, kept regardless of outcome. -->
+
+### F1 · <one-line summary>
+- **Pass:** bugs
+- **Failure scenario:** <concrete inputs/state → wrong behavior>
+- **Resolution:** fixed in `<commit>` / rejected — <reason>
+
+## Human review
+<!-- Filled during PR review: each reviewer comment and how it was addressed. -->
+
+## PR
+- Branch: `<branch>`
+- PR: <link>
+- Artifact chain: [intent](./intent.md) · [spec](./spec.md) ·
+  [plan](./plan.md) · [test report](./test-report.md)

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
@@ -8,9 +8,14 @@ policy: ../REVIEW.md
 
 # Review: <short title>
 
+Template note: lines beginning with "> Guidance:" describe what belongs in
+each section and are replaced by real content when this template is
+instantiated.
+
 ## Passes run
-<!-- One row per pass from .sdlc/REVIEW.md. Reviewers are adversarial
-     subagents that did not write the code. -->
+
+> Guidance: one row per pass from .sdlc/REVIEW.md. Reviewers are adversarial
+> subagents that did not write the code.
 
 | Pass | Reviewer tier | Findings |
 |---|---|---|
@@ -20,7 +25,8 @@ policy: ../REVIEW.md
 | Simplification | deep | |
 
 ## Findings
-<!-- Every finding, kept regardless of outcome. -->
+
+> Guidance: every finding, kept regardless of outcome.
 
 ### F1 · <one-line summary>
 - **Pass:** bugs
@@ -28,7 +34,9 @@ policy: ../REVIEW.md
 - **Resolution:** fixed in `<commit>` / rejected — <reason>
 
 ## Human review
-<!-- Filled during PR review: each reviewer comment and how it was addressed. -->
+
+> Guidance: filled during PR review — each reviewer comment and how it was
+> addressed.
 
 ## PR
 - Branch: `<branch>`

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/review.md
@@ -8,9 +8,9 @@ policy: ../REVIEW.md
 
 # Review: <short title>
 
-Template note: lines beginning with "> Guidance:" describe what belongs in
-each section and are replaced by real content when this template is
-instantiated.
+Template note: remove this paragraph and every line beginning with
+"> Guidance:" when instantiating this template; the committed artifact
+contains only real content.
 
 ## Passes run
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
@@ -5,7 +5,14 @@
       "Read(./.env.*)",
       "Read(**/*.pem)",
       "Read(**/id_rsa*)",
-      "Read(~/.aws/**)"
+      "Read(**/credentials)",
+      "Read(**/credentials.json)",
+      "Read(~/.aws/**)",
+      "Read(~/.ssh/**)",
+      "Read(~/.config/gcloud/**)",
+      "Read(~/.azure/**)",
+      "Read(~/.kube/**)",
+      "Read(~/.docker/config.json)"
     ],
     "ask": [
       "Bash(git push:*)",
@@ -31,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import json,sys,re\nd=json.load(sys.stdin)\nc=d.get('tool_input',{}).get('command','')\nmsg=None\nif re.search(r'\\.env\\b(?!\\.example)|\\.pem\\b|id_rsa|\\.aws/',c): msg='command references credential material'\nif not msg:\n    for m in re.finditer(r'\\bgit\\s+push\\b([^;|&]*)',c):\n        rest=[t for t in m.group(1).split() if not t.startswith('-')]\n        if len(rest)<2 or any(re.search(r'^(main|master)$|[:/](main|master)$',t) for t in rest[1:]):\n            msg='bare push or push to the default branch - push an explicit feature branch and open a PR'\n            break\nif msg: print('Blocked: '+msg,file=sys.stderr)\nsys.exit(2 if msg else 0)\""
+            "command": "python3 -c \"import json,sys,re\nd=json.load(sys.stdin)\nc=d.get('tool_input',{}).get('command','')\nmsg=None\nif re.search(r'\\.env\\b(?!\\.example)|\\.pem\\b|id_rsa|\\.aws/|\\.ssh/|\\.config/gcloud/|\\.azure/|\\.kube/|\\.docker/config\\.json|\\bcredentials?\\b(?!\\.example|\\.sample|\\.helper)',c): msg='command references credential material'\nif not msg:\n    for m in re.finditer(r'\\bgit\\s+push\\b([^;|&]*)',c):\n        rest=[t for t in m.group(1).split() if not t.startswith('-')]\n        if len(rest)<2 or any(re.search(r'^(main|master)$|[:/](main|master)$',t) for t in rest[1:]):\n            msg='bare push or push to the default branch - push an explicit feature branch and open a PR'\n            break\nif msg: print('Blocked: '+msg,file=sys.stderr)\nsys.exit(2 if msg else 0)\""
           }
         ]
       }

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
@@ -5,7 +5,7 @@
       "Read(./.env.*)",
       "Read(**/*.pem)",
       "Read(**/id_rsa*)",
-      "Read(~/.aws/credentials)"
+      "Read(~/.aws/**)"
     ],
     "ask": [
       "Bash(git push:*)",
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import json,sys,os,re;d=json.load(sys.stdin);p=d.get('tool_input',{}).get('file_path','');approved=bool(re.search(r'\\.sdlc/.+\\.md$',p)) and os.path.exists(p) and 'status: approved' in open(p).read();print('Blocked: this SDLC artifact is approved and immutable. Mark it status: superseded and draft a new one (supersede flow).',file=sys.stderr) if approved else None;sys.exit(2 if approved else 0)\""
+            "command": "python3 -c \"import json,sys,os,re\nd=json.load(sys.stdin)\np=d.get('tool_input',{}).get('file_path','')\napproved=bool(re.search(r'\\.sdlc/.+/(intent|spec)\\.md$',p)) and os.path.exists(p) and 'status: approved' in open(p).read()\nif approved: print('Blocked: this SDLC artifact is approved and immutable. Mark it status: superseded and draft a new one (supersede flow). plan.md stays editable by design.',file=sys.stderr)\nsys.exit(2 if approved else 0)\""
           }
         ]
       },
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import json,sys,re;d=json.load(sys.stdin);c=d.get('tool_input',{}).get('command','');leak=re.search(r'(cat|less|head|tail|scp|curl)\\\\s.*(\\\\.env\\\\b|\\\\.pem\\\\b|id_rsa|credentials)',c);push_main=re.search(r'git\\\\s+push\\\\s.*\\\\b(main|master)\\\\b',c);msg='credential material' if leak else 'direct push to the default branch (open a PR instead)' if push_main else None;print('Blocked: '+msg,file=sys.stderr) if msg else None;sys.exit(2 if msg else 0)\""
+            "command": "python3 -c \"import json,sys,re\nd=json.load(sys.stdin)\nc=d.get('tool_input',{}).get('command','')\nmsg=None\nif re.search(r'\\.env\\b(?!\\.example)|\\.pem\\b|id_rsa|\\.aws/',c): msg='command references credential material'\nif not msg:\n    for m in re.finditer(r'\\bgit\\s+push\\b([^;|&]*)',c):\n        rest=[t for t in m.group(1).split() if not t.startswith('-')]\n        if len(rest)<2 or any(re.search(r'^(main|master)$|[:/](main|master)$',t) for t in rest[1:]):\n            msg='bare push or push to the default branch - push an explicit feature branch and open a PR'\n            break\nif msg: print('Blocked: '+msg,file=sys.stderr)\nsys.exit(2 if msg else 0)\""
           }
         ]
       }

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/settings.hooks.json
@@ -1,0 +1,40 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/id_rsa*)",
+      "Read(~/.aws/credentials)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(npm publish:*)",
+      "Bash(docker push:*)",
+      "Bash(terraform apply:*)",
+      "Bash(kubectl apply:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import json,sys,os,re;d=json.load(sys.stdin);p=d.get('tool_input',{}).get('file_path','');approved=bool(re.search(r'\\.sdlc/.+\\.md$',p)) and os.path.exists(p) and 'status: approved' in open(p).read();print('Blocked: this SDLC artifact is approved and immutable. Mark it status: superseded and draft a new one (supersede flow).',file=sys.stderr) if approved else None;sys.exit(2 if approved else 0)\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import json,sys,re;d=json.load(sys.stdin);c=d.get('tool_input',{}).get('command','');leak=re.search(r'(cat|less|head|tail|scp|curl)\\\\s.*(\\\\.env\\\\b|\\\\.pem\\\\b|id_rsa|credentials)',c);push_main=re.search(r'git\\\\s+push\\\\s.*\\\\b(main|master)\\\\b',c);msg='credential material' if leak else 'direct push to the default branch (open a PR instead)' if push_main else None;print('Blocked: '+msg,file=sys.stderr) if msg else None;sys.exit(2 if msg else 0)\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
@@ -9,9 +9,9 @@ intent: ./intent.md
 
 # Spec: <short title>
 
-Template note: lines beginning with "> Guidance:" describe what belongs in
-each section and are replaced by real content when this template is
-instantiated.
+Template note: remove this paragraph and every line beginning with
+"> Guidance:" when instantiating this template; the committed artifact
+contains only real content.
 
 ## Summary
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
@@ -9,34 +9,46 @@ intent: ./intent.md
 
 # Spec: <short title>
 
+Template note: lines beginning with "> Guidance:" describe what belongs in
+each section and are replaced by real content when this template is
+instantiated.
+
 ## Summary
-<!-- Two or three sentences: what will be built and the core design choice. -->
+
+> Guidance: two or three sentences — what will be built and the core design
+> choice.
 
 ## Requirements
-<!-- Numbered. Every requirement traces to the intent — if it doesn't, it's
-     scope creep; cut it or take it back to Stage 1. -->
+
+> Guidance: numbered. Every requirement traces to the intent — if it doesn't,
+> it's scope creep; cut it or take it back to Stage 1.
 
 1. …
 
 ## Acceptance criteria
-<!-- Testable statements. Stage 4 maps each one to at least one test. -->
+
+> Guidance: testable statements. Stage 4 maps each one to at least one test.
 
 - [ ] …
 
 ## Design
-<!-- The how: architecture, data model, API shapes, user-facing flow.
-     For each significant decision: what was chosen, the alternative
-     considered, and why it lost. -->
+
+> Guidance: the how — architecture, data model, API shapes, user-facing flow.
+> For each significant decision: what was chosen, the alternative considered,
+> and why it lost.
 
 ## Constraints applied
-<!-- Every policy folded into this design, with its source:
-     - <constraint> — from <skill/CLAUDE.md/security doc> -->
+
+> Guidance: every policy folded into this design, with its source, e.g.
+> "<constraint> — from <CLAUDE.md / security doc / design system>".
 
 ## ⚠ Flagged concerns
-<!-- Tensions this spec could not resolve alone (intent vs policy, cost vs
-     deadline). Each needs a human decision — that's what the gate is for.
-     "None" is a valid entry only if it's true. -->
+
+> Guidance: tensions this spec could not resolve alone (intent vs policy,
+> cost vs deadline). Each needs a human decision — that's what the gate is
+> for. "None" is a valid entry only if it's true.
 
 ## Out of scope
-<!-- Inherited from the intent's non-goals, plus anything discovered during
-     design that is deliberately deferred. -->
+
+> Guidance: inherited from the intent's non-goals, plus anything discovered
+> during design that is deliberately deferred.

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/spec.md
@@ -1,0 +1,42 @@
+---
+stage: spec
+status: draft
+feature: <slug>
+approved_by: pending
+date: <YYYY-MM-DD>
+intent: ./intent.md
+---
+
+# Spec: <short title>
+
+## Summary
+<!-- Two or three sentences: what will be built and the core design choice. -->
+
+## Requirements
+<!-- Numbered. Every requirement traces to the intent — if it doesn't, it's
+     scope creep; cut it or take it back to Stage 1. -->
+
+1. …
+
+## Acceptance criteria
+<!-- Testable statements. Stage 4 maps each one to at least one test. -->
+
+- [ ] …
+
+## Design
+<!-- The how: architecture, data model, API shapes, user-facing flow.
+     For each significant decision: what was chosen, the alternative
+     considered, and why it lost. -->
+
+## Constraints applied
+<!-- Every policy folded into this design, with its source:
+     - <constraint> — from <skill/CLAUDE.md/security doc> -->
+
+## ⚠ Flagged concerns
+<!-- Tensions this spec could not resolve alone (intent vs policy, cost vs
+     deadline). Each needs a human decision — that's what the gate is for.
+     "None" is a valid entry only if it's true. -->
+
+## Out of scope
+<!-- Inherited from the intent's non-goals, plus anything discovered during
+     design that is deliberately deferred. -->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
@@ -1,0 +1,32 @@
+---
+stage: test
+status: draft
+feature: <slug>
+date: <YYYY-MM-DD>
+plan: ./plan.md
+---
+
+# Test report: <short title>
+
+## Verification commands
+<!-- Every command run, with its real result. Red rows stay red until fixed —
+     this report never flatters. -->
+
+| Command | Result |
+|---|---|
+| `<test command>` | ✅ pass (N tests) / ❌ fail — <summary> |
+| `<build command>` | |
+| `<lint/typecheck command>` | |
+
+## Acceptance criteria coverage
+
+| Criterion | Test | Result |
+|---|---|---|
+| AC1 … | `path/to/test` | ✅ / ❌ |
+
+## Visual / manual checks
+<!-- For UI or behavior not capturable in automated tests: what was checked,
+     how (screenshot, browser run), and what was seen. -->
+
+## Not verified
+<!-- Anything unverified and why. An honest gap beats a false green. -->

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
@@ -8,9 +8,9 @@ plan: ./plan.md
 
 # Test report: <short title>
 
-Template note: lines beginning with "> Guidance:" describe what belongs in
-each section and are replaced by real content when this template is
-instantiated.
+Template note: remove this paragraph and every line beginning with
+"> Guidance:" when instantiating this template; the committed artifact
+contains only real content.
 
 ## Verification commands
 

--- a/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
+++ b/cli-tool/components/skills/development/ai-native-sdlc/templates/test-report.md
@@ -8,9 +8,14 @@ plan: ./plan.md
 
 # Test report: <short title>
 
+Template note: lines beginning with "> Guidance:" describe what belongs in
+each section and are replaced by real content when this template is
+instantiated.
+
 ## Verification commands
-<!-- Every command run, with its real result. Red rows stay red until fixed —
-     this report never flatters. -->
+
+> Guidance: every command run, with its real result. Red rows stay red until
+> fixed — this report never flatters.
 
 | Command | Result |
 |---|---|
@@ -25,8 +30,10 @@ plan: ./plan.md
 | AC1 … | `path/to/test` | ✅ / ❌ |
 
 ## Visual / manual checks
-<!-- For UI or behavior not capturable in automated tests: what was checked,
-     how (screenshot, browser run), and what was seen. -->
+
+> Guidance: for UI or behavior not capturable in automated tests — what was
+> checked, how (screenshot, browser run), and what was seen.
 
 ## Not verified
-<!-- Anything unverified and why. An honest gap beats a false green. -->
+
+> Guidance: anything unverified and why. An honest gap beats a false green.


### PR DESCRIPTION
## What

A new skill, `development/ai-native-sdlc`, that runs the **entire AI-native software development lifecycle** on any project, in any language — based on [Anthropic's AI-Native SDLC Playbook](https://claude.com/blog/the-ai-native-sdlc-playbook).

One command orchestrates all six stages with human approval gates between them:

| Stage | Command | Artifact |
|---|---|---|
| Plan | `/ai-native-sdlc new <idea>` | `intent.md` — the idea in the user's own words |
| Design | `/ai-native-sdlc design` | `spec.md` — requirements + design, policy applied early |
| Build | `/ai-native-sdlc build` | `plan.md` approved **before any code**, then implementation |
| Test | `/ai-native-sdlc test` | `test-report.md` — honest verification evidence |
| Deploy | `/ai-native-sdlc review` | `review.md` + PR via adversarial review passes |
| Maintain | `/ai-native-sdlc maintain` | incidents become new intents; lessons.md post-mortems |

## Why it's a good fit

- **Universal**: detects each project's own build/test/lint tooling — no stack assumptions.
- **Auditable**: every stage commits a versioned artifact to `.sdlc/`, so `git log .sdlc/` is the full decision history.
- **Model-aware**: routes spec/plan/review drafting to deep-reasoning subagents and mechanical work to fast ones.
- **Governed**: ships hook templates (approved artifacts immutable, credential guards, no direct pushes to main) and GitHub Actions templates (headless policy review that comments but never merges, test gate, scheduled audit). Hook commands are smoke-tested.

## Structure

`SKILL.md` (orchestrator) + `references/` (per-stage playbook, model routing, governance) + `templates/` (all six artifacts, review policy, hooks, CI workflows) + `LICENSE.txt` (MIT).

Source repo: https://github.com/fahadakmal/ai-native-sdlc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxtB1hqhZ5db79sdCojP9h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `development/ai-native-sdlc` skill, which runs a complete SDLC on any project by advancing a versioned artifact chain (`intent.md` → `spec.md` → `plan.md` → `test-report.md` → `review.md`) with human approval gates between stages. Review feedback is addressed: SkillSpector findings are resolved; `claude-review.yml` uses the official `anthropics/claude-code-action` with cost disclosure and the Claude GitHub App prerequisite; hooks keep `plan.md` editable after approval, block bare pushes to main, and cover generic credential paths; and `init` substitutes verified project commands into CI templates, dropping `scheduled-audit` when no audit command exists.

**Notes**
- Affected area: components (`cli-tool/components/`); adds 15 new files.
- Regenerate the catalog (`docs/components.json`) to include the new skill.
- No new CLI environment variables or secrets; the optional CI workflow templates reference `ANTHROPIC_API_KEY` when adopted.

<sup>Written for commit c59cb9309d7cec1aeb026211128c1fddecb369e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

