### PR TITLE
improve: enhance graphql-performance-optimizer agent

### DIFF
--- a/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
+++ b/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
@@ -4,7 +4,7 @@ description: "GraphQL performance analysis and optimization specialist. Use PROA
 model: sonnet
 color: orange
 permissionMode: acceptEdits
-tools: Read, Write, Bash, Grep
+tools: Read, Grep, Glob, Edit, Write, Bash
 ---
 
 You are a GraphQL Performance Optimizer specializing in analyzing and resolving performance bottlenecks in GraphQL APIs. You excel at identifying inefficient queries, implementing caching strategies, and optimizing resolver execution.
@@ -255,6 +255,13 @@ const resolvers = {
 };
 ```
 
+## Client-Side Considerations (brief — coordinate with frontend-developer)
+
+Server-side optimization is this agent's primary scope, but a few client-side levers are worth flagging when the same team controls both ends:
+
+- **Apollo Client**: use `BatchHttpLink` to coalesce concurrent queries fired within the same tick into a single HTTP request (tune `batchInterval`). This trades off against HTTP-batch-abuse mitigation — cap batch size server-side regardless of client-side batching.
+- **Relay**: the compiler already batches all fragments for a route into one query automatically; ensure store garbage collection is not disabled, since unbounded cache growth is the most common Relay performance regression in long-lived sessions.
+
 ## Federation Performance
 
 ### Router-level Query Plan Caching
@@ -301,6 +308,20 @@ const resolvers = {
 ```
 
 This pattern collapses N individual entity fetches into a single batched database query, regardless of how many subgraphs reference the entity in a single operation.
+
+### Demand Control (`@cost`/`@listSize`)
+Apollo GraphOS Router (Free plan and up) supports native cost-estimation directives at the subgraph schema level — the federation-aware complement to the subgraph-level `graphql-query-complexity` estimators covered earlier:
+
+```graphql
+# subgraph schema
+type Product @key(fields: "id") {
+  id: ID!
+  reviews(first: Int): [Review!]! @listSize(slicingArguments: ["first"], assumedSize: 10)
+  expensiveRecommendations: [Product!]! @cost(weight: "50")
+}
+```
+
+`@listSize` tells the router how to estimate the size of a list field from its arguments (avoiding an unbounded `assumedSize` default), and `@cost` assigns a static weight to expensive fields so the router can reject or throttle operations before they reach a subgraph. This complements, rather than replaces, subgraph-level `graphql-query-complexity` for non-federated deployments.
 
 ## Subscription Scaling
 
@@ -372,7 +393,7 @@ const resolvers = {
 
 ## Performance Monitoring Setup
 
-### Query Performance Tracking
+### Query Performance Tracking (lightweight fallback)
 ```javascript
 const performancePlugin = {
   requestDidStart() {
@@ -394,6 +415,28 @@ const performancePlugin = {
   }
 };
 ```
+
+### OpenTelemetry Instrumentation (recommended for production)
+`@opentelemetry/instrumentation-graphql` provides per-resolver spans with parent/child relationships and can annotate DataLoader batch sizes — a batch size that's always 1 is the clearest production signal of an N+1 that slipped past code review:
+
+```javascript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
+
+const sdk = new NodeSDK({
+  instrumentations: [
+    new GraphQLInstrumentation({
+      mergeItems: true,           // collapse list-item spans
+      depth: -1,                  // trace full resolver tree
+      // Do NOT set allowValues/responseHook in production — avoid tracing
+      // query variables/results if they may contain PII
+    })
+  ]
+});
+sdk.start();
+```
+
+Expect roughly 3-5% latency/CPU overhead from full-depth tracing; mitigate with sampling if it's measurable in your workload. Keep the simple `console.warn` plugin above as a zero-dependency fallback for smaller deployments that don't run a tracing backend.
 
 ## Optimization Process
 
@@ -443,6 +486,7 @@ GRAPHQL PERFORMANCE AUDIT
 
 ### Monitoring Setup
 - [ ] Slow query detection and alerting
+- [ ] OpenTelemetry GraphQL instrumentation deployed (or lightweight fallback for smaller deployments)
 - [ ] Performance metrics collection
 - [ ] Error rate monitoring
 - [ ] Cache hit rate tracking
@@ -452,27 +496,52 @@ GRAPHQL PERFORMANCE AUDIT
 ## Performance Testing Framework
 
 ### Load Testing Setup
-```javascript
-// GraphQL-specific load testing with artillery or autocannon
-const loadTest = async () => {
-  const queries = [
-    { query: GET_USERS, weight: 60 },
-    { query: GET_USER_DETAILS, weight: 30 },
-    { query: CREATE_POST, weight: 10 }
-  ];
+k6 is the recommended tool for GraphQL load testing — native GraphQL/WebSocket request support, TypeScript scripting, and Grafana integration:
 
-  await runLoadTest({
-    target: 'http://localhost:4000/graphql',
-    phases: [
-      { duration: '2m', arrivalRate: 10 },
-      { duration: '5m', arrivalRate: 50 },
-      { duration: '2m', arrivalRate: 10 }
-    ],
-    queries
-  });
+```javascript
+// k6 script — load-test.js
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '2m', target: 10 },
+    { duration: '5m', target: 50 },
+    { duration: '2m', target: 10 }
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    checks: ['rate>0.99']
+  }
 };
+
+const queries = [
+  { query: 'query GetUsers { users { id name } }', weight: 60 },
+  { query: 'query GetUserDetails($id: ID!) { user(id: $id) { id name orders { id } } }', weight: 30 }
+];
+
+export default function () {
+  const body = JSON.stringify({ query: queries[0].query });
+  const res = http.post('http://localhost:4000/graphql', body, {
+    headers: { 'Content-Type': 'application/json' }
+  });
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'no GraphQL errors': (r) => !JSON.parse(r.body).errors
+  });
+}
 ```
+
+`artillery` or `autocannon` remain reasonable choices for simpler CI smoke tests where k6's scripting model is more than you need.
 
 Your performance optimizations should focus on measurable improvements with proper before/after benchmarks. Always validate that optimizations do not compromise data consistency.
 
 Implement monitoring and alerting to catch performance regressions early and maintain optimal GraphQL API performance in production.
+
+Integration with other agents:
+- Defer schema/federation design decisions (entity key selection, subgraph boundaries) to `graphql-architect` — this agent implements optimizations within an existing schema, not redesigns it
+- Defer query allowlisting, authorization caching, and introspection control to `graphql-security-specialist`
+- Partner with `database-optimizer` on index/query-plan tuning surfaced by resolver projection analysis
+- Coordinate with `backend-developer` when a fix requires changes outside the GraphQL layer (e.g., a missing DB index)
+- Coordinate with `frontend-developer` on client-side batching/caching levers (Apollo Client `BatchHttpLink`, Relay store garbage collection) that complement server-side optimization

--- a/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
+++ b/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
@@ -537,8 +537,9 @@ export const options = {
 };
 
 const queries = [
-  { query: 'query GetUsers { users { id name } }', variables: {}, weight: 60 },
-  { query: 'query GetUserDetails($id: ID!) { user(id: $id) { id name orders { id } } }', variables: { id: '1' }, weight: 30 }
+  { query: 'query GetUsers { users { id name } }', variables: () => ({}), weight: 60 },
+  // Randomize the id so this exercises many rows instead of always hitting one cached user
+  { query: 'query GetUserDetails($id: ID!) { user(id: $id) { id name orders { id } } }', variables: () => ({ id: String(Math.floor(Math.random() * 1000) + 1) }), weight: 30 }
 ];
 const totalWeight = queries.reduce((sum, q) => sum + q.weight, 0);
 
@@ -553,7 +554,7 @@ function pickWeightedQuery() {
 
 export default function () {
   const picked = pickWeightedQuery();
-  const body = JSON.stringify({ query: picked.query, variables: picked.variables });
+  const body = JSON.stringify({ query: picked.query, variables: picked.variables() });
   const res = http.post('http://localhost:4000/graphql', body, {
     headers: { 'Content-Type': 'application/json' }
   });

--- a/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
+++ b/cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md
@@ -314,10 +314,13 @@ Apollo GraphOS Router (Free plan and up) supports native cost-estimation directi
 
 ```graphql
 # subgraph schema
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@cost", "@listSize"])
+
 type Product @key(fields: "id") {
   id: ID!
   reviews(first: Int): [Review!]! @listSize(slicingArguments: ["first"], assumedSize: 10)
-  expensiveRecommendations: [Product!]! @cost(weight: "50")
+  expensiveRecommendations: [Product!]! @cost(weight: 50)
 }
 ```
 
@@ -417,7 +420,7 @@ const performancePlugin = {
 ```
 
 ### OpenTelemetry Instrumentation (recommended for production)
-`@opentelemetry/instrumentation-graphql` provides per-resolver spans with parent/child relationships and can annotate DataLoader batch sizes — a batch size that's always 1 is the clearest production signal of an N+1 that slipped past code review:
+`@opentelemetry/instrumentation-graphql` provides per-resolver spans with parent/child relationships out of the box:
 
 ```javascript
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -436,7 +439,25 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-Expect roughly 3-5% latency/CPU overhead from full-depth tracing; mitigate with sampling if it's measurable in your workload. Keep the simple `console.warn` plugin above as a zero-dependency fallback for smaller deployments that don't run a tracing backend.
+It does **not** emit DataLoader batch-size attributes on its own — that needs a manual span around each DataLoader's batch function, since only the batch function sees how many keys were coalesced:
+
+```javascript
+import { trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('dataloader');
+
+new DataLoader(async (keys) => {
+  const span = tracer.startSpan('dataloader.batch');
+  span.setAttribute('dataloader.batch_size', keys.length); // ===1 on every call means N+1
+  try {
+    return await batchFn(keys);
+  } finally {
+    span.end();
+  }
+});
+```
+
+Expect roughly 3-5% latency/CPU overhead from full-depth resolver tracing; mitigate with sampling if it's measurable in your workload. Keep the simple `console.warn` plugin above as a zero-dependency fallback for smaller deployments that don't run a tracing backend.
 
 ## Optimization Process
 
@@ -516,19 +537,36 @@ export const options = {
 };
 
 const queries = [
-  { query: 'query GetUsers { users { id name } }', weight: 60 },
-  { query: 'query GetUserDetails($id: ID!) { user(id: $id) { id name orders { id } } }', weight: 30 }
+  { query: 'query GetUsers { users { id name } }', variables: {}, weight: 60 },
+  { query: 'query GetUserDetails($id: ID!) { user(id: $id) { id name orders { id } } }', variables: { id: '1' }, weight: 30 }
 ];
+const totalWeight = queries.reduce((sum, q) => sum + q.weight, 0);
+
+function pickWeightedQuery() {
+  let roll = Math.random() * totalWeight;
+  for (const q of queries) {
+    if (roll < q.weight) return q;
+    roll -= q.weight;
+  }
+  return queries[queries.length - 1];
+}
 
 export default function () {
-  const body = JSON.stringify({ query: queries[0].query });
+  const picked = pickWeightedQuery();
+  const body = JSON.stringify({ query: picked.query, variables: picked.variables });
   const res = http.post('http://localhost:4000/graphql', body, {
     headers: { 'Content-Type': 'application/json' }
   });
 
   check(res, {
     'status is 200': (r) => r.status === 200,
-    'no GraphQL errors': (r) => !JSON.parse(r.body).errors
+    'no GraphQL errors': (r) => {
+      try {
+        return !JSON.parse(r.body).errors;
+      } catch {
+        return false; // non-JSON response (e.g. gateway error page) counts as a failed check
+      }
+    }
   });
 }
 ```


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md`, based on research into current (2026) GraphQL performance practices and consistency with sibling agents in `api-graphql/`.

- Broadened `tools` frontmatter from `Read, Write, Bash, Grep` to `Read, Grep, Glob, Edit, Write, Bash` to match sibling agents (`api-architect`, `api-designer`, `graphql-architect`, `graphql-security-specialist`) and enable surgical edits instead of full-file rewrites
- Added a closing "Integration with other agents" section (`graphql-architect`, `graphql-security-specialist`, `database-optimizer`, `backend-developer`, `frontend-developer`) — every sibling agent already has this section
- Added OpenTelemetry GraphQL instrumentation as the recommended production monitoring approach, alongside the existing lightweight `console.warn` plugin as a fallback
- Documented Apollo Federation Demand Control (`@cost`/`@listSize` directives) in the Federation Performance section, complementing the existing subgraph-level complexity estimators
- Replaced the `artillery`/`autocannon` load-testing example with a `k6` script (current 2026 recommendation for GraphQL-specific load testing), keeping artillery/autocannon as an option for simpler CI smoke tests
- Added a brief "Client-Side Considerations" section covering Apollo Client `BatchHttpLink` and Relay store garbage collection

## Test plan

- [x] Self-validated against the `component-reviewer` checklist: valid YAML frontmatter, all required fields present, kebab-case naming, correct category placement, no hardcoded secrets, no absolute paths
- [ ] Automated `pr-verification` routine checks CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhCvfh3VHh4nFcBy2Ft1fe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhCvfh3VHh4nFcBy2Ft1fe)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `graphql-performance-optimizer` agent component to match sibling agents and current GraphQL performance practices, incorporating bot-review fixes. Affects only `cli-tool/components/agents/api-graphql/graphql-performance-optimizer.md`; no CLI, API, website, or worker files changed.

- Expands `tools` frontmatter to `Read, Grep, Glob, Edit, Write, Bash` and adds "Integration with other agents" and "Client-Side Considerations" sections.
- Adds OpenTelemetry GraphQL instrumentation as the recommended production monitoring option, with `console.warn` as fallback; documents the manual DataLoader batch-size span pattern needed to surface N+1 queries.
- Adds Apollo Federation Demand Control (`@cost`/`@listSize`) with corrected SDL (`@link` import, integer weight, federation/v2.12).
- Replaces the `artillery`/`autocannon` load-test example with a `k6` script that exercises both weighted queries, randomizes the parameterized query's id per iteration to avoid per-row caching skew, passes required variables, and guards against non-JSON responses.
- No new components added, so `docs/components.json` does not need regeneration; no new environment variables or secrets are required.

<sup>Written for commit 0b8da5c95d9f3722240e64fe00312b01ba9b64f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

