### PR TITLE
Add OrcaReplay MCP component (devtools)

### DIFF
--- a/cli-tool/components/mcps/devtools/orcareplay.json
+++ b/cli-tool/components/mcps/devtools/orcareplay.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "orcareplay": {
+      "description": "Record, replay and fork debugger for coding agents. Exposes recorded runs to Claude Code: list runs, read a run's timeline, inspect the causal graph of what caused what, and replay a run offline byte-for-byte or fork it from a checkpoint onto a different model.",
+      "command": "npx",
+      "args": ["-y", "orcareplay", "mcp"]
+    }
+  }
+}

--- a/cli-tool/components/mcps/devtools/orcareplay.json
+++ b/cli-tool/components/mcps/devtools/orcareplay.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "orcareplay": {
-      "description": "Record, replay and fork debugger for coding agents. Exposes recorded runs to Claude Code: list runs, read a run's timeline, inspect the causal graph of what caused what, and replay a run offline byte-for-byte or fork it from a checkpoint onto a different model.",
+      "description": "Record, replay and fork debugger for coding agents. Exposes recorded runs to Claude Code: list runs, read a run's timeline, inspect the causal graph of what caused what, and replay a run offline byte-for-byte or fork it from a checkpoint onto a different model. Requires Node.js 20+.",
       "command": "npx",
       "args": ["-y", "orcareplay", "mcp"]
     }


### PR DESCRIPTION
## 🧩 New MCP component: OrcaReplay

Adds `cli-tool/components/mcps/devtools/orcareplay.json` — one new file, nothing else touched.

### What it does

[OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) records a coding-agent run and can replay it offline byte-for-byte or fork it from any checkpoint onto a different model. `orca mcp` serves that trace store to Claude Code over stdio, so Claude can read and re-run **its own** past sessions:

| tool | what it answers |
|---|---|
| `orca_list_runs` | which runs exist |
| `orca_show_run` | the timeline of one run |
| `orca_checkpoints` | where a run can be forked from |
| `orca_graph` | what caused what, with each edge labelled `recorded` or `inferred` |
| `orca_replay` | re-run it offline — free, no tokens |
| `orca_compare` | same task, several models (this one says in its own description that it spends real tokens) |

### Why it fits `devtools/`

It is a debugger for the agent itself, not an integration with an external service — the closest neighbours in that folder are `chrome-devtools` and `codacy`. Typical use is asking Claude "why did you delete that migration file yesterday" and having it read the recorded trace instead of guessing.

### Config

No API key, no environment variables. `npx -y orcareplay mcp` — [`orcareplay`](https://www.npmjs.com/package/orcareplay) is published on npm (v0.1.2, Apache-2.0, Node 20+) and exposes both `orca` and `orcareplay` bins. Replay is fully offline; only `orca_compare` reaches the network, and it says so in its tool description.

Disclosure: I work on OrcaReplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the OrcaReplay MCP component so Claude Code can read and replay its own recorded agent runs.

- Adds `cli-tool/components/mcps/devtools/orcareplay.json` with six stdio tools; the component requires Node.js 20+.
- Affects only `cli-tool/components/`; no API, website, or worker changes.
- Regenerate `docs/components.json` to include the new component.
- No new environment variables or secrets; only `orca_compare` spends tokens, the rest runs offline.

<sup>Written for commit 3675b5b3de17e4e57e98e1f29501dfa50f37f85d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

