### PR TITLE
Add swarmery to the plugins list

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -65,6 +65,7 @@ REPOS = [
     ("krasserm/ml-plugins", None),
     ("cohesivity-org/cohesivity-plugin", "https://cohesivity.ai"),
     ("iOSDevSK/html2wp-cc-plugin", "https://html2wp.dev/"),
+    ("atretyak1985/swarmery", "https://atretyak1985.github.io/swarmery/"),
 ]
 
 DESCRIPTION_OVERRIDES = {


### PR DESCRIPTION
Adds one entry to `REPOS` in `scripts/generate_plugins_json.py`.

**[atretyak1985/swarmery](https://github.com/atretyak1985/swarmery)** — a Claude Code plugin marketplace (`core` + 11 opt-in domain packs: web, infra, IoT, UAV, Jira, architecture, design, LSP, knowledge graph, multi-account, Claude engineering) that ships one vendor-neutral agent framework to every project; per-project flavor comes from the consumer's `.claude/project.json`.

The repo has `.claude-plugin/marketplace.json` at the root with 12 plugins, so the generator reads it exactly like the existing entries. `claude plugin validate .` passes.

`python3 scripts/test_generate_plugins_json.py` on this branch: `Ran 3 tests`, `OK`. `dashboard/public/plugins.json` is left untouched for the post-merge regeneration.

The same repo carries a local-first control plane for Claude Code: a single Go binary that indexes the transcripts Claude Code already writes, shows live tool calls, cost and diffs, routes permission prompts into one approvals queue, and dispatches board tasks to headless agents in git worktrees. No cloud, no account, no telemetry. Website: <https://atretyak1985.github.io/swarmery/>

Happy to adjust the entry if this is not the right place.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `atretyak1985/swarmery` to the plugin marketplace list in the CLI's `scripts/generate_plugins_json.py` so its plugins are picked up by the generator.

- The repo provides a Claude Code plugin marketplace with a core agent framework and 11 opt-in domain packs.
- `claude plugin validate` passes and the generator test suite remains green.
- No new components, environment variables, or secrets are introduced; `dashboard/public/plugins.json` is intentionally left for post-merge regeneration.

<sup>Written for commit 4ab4c243662574a1a29b5e22979f976925839563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

