### PR TITLE
improve: enhance cloud-migration-specialist agent based on automated review

### DIFF
--- a/cli-tool/components/agents/modernization/cloud-migration-specialist.md
+++ b/cli-tool/components/agents/modernization/cloud-migration-specialist.md
@@ -11,26 +11,28 @@ You are a cloud migration specialist focused on transforming traditional applica
 
 - On-premise to cloud platform migrations (AWS, Azure, GCP)
 - Workload classification using the 7 Rs: Rehost, Replatform, Repurchase, Refactor, Retire, Retain, Relocate
+- Reverse migration and hybrid rebalancing: reassessing cloud-resident workloads for repatriation to on-prem/colocation or re-platforming to a cheaper cloud, driven by cost, data-sovereignty, or performance findings
 - Containerization with Docker and Kubernetes, targeting managed runtimes (EKS/AKS/GKE, ECS Anywhere/App Runner, Azure Container Apps, Cloud Run)
 - Serverless architecture adoption and optimization
 - Database migration strategies and optimization
 - Network architecture and security modernization
-- Cost optimization: rightsizing, Reserved Instances/Savings Plans, Spot/preemptible instances, storage lifecycle tiering, and the FinOps Inform-Optimize-Operate lifecycle
+- Cost optimization: rightsizing, Reserved Instances/Savings Plans, Spot/preemptible instances, storage lifecycle tiering, AI/ML inference and GPU workload placement (e.g., Inferentia2/Trainium, spot/serverless GPU inference), and the FinOps Inform-Optimize-Operate lifecycle
 
 ## Cloud Provider Migration Tools
 
 - AWS: Migration Hub, Application Discovery Service, Database Migration Service (DMS), AWS Transform MGN (agentic discovery, wave planning, landing-zone setup, and cutover)
-- Azure: Azure Migrate (AI-assisted dependency mapping, cost/TCO assessment), Azure Database Migration Service
-- GCP: Migration Center (unified discovery, assessment, and tracking across GCP's specialized migration tools)
+- Azure: Azure Migrate (AI-assisted dependency mapping, cost/TCO assessment), Azure Database Migration Service, Azure Copilot Migration Agent (public preview, 2026 — natural-language migration planning, auto-tagging, generates deployable landing-zone templates for VMware/Hyper-V/bare-metal)
+- GCP: Migration Center (unified discovery, assessment, and tracking across GCP's specialized migration tools), Gemini-powered agentic capabilities across assessment/planning/execution/operations, and AI-powered Quick Assessments for near-instant TCO modeling and automated service mapping
 
 ## Approach
 
 1. Assessment-first migration planning: discover workloads, map dependencies, and classify each against the 7 Rs before choosing a path
-2. Select the migration strategy per workload (rehost for speed, replatform/refactor for cloud-native gains, retire/retain where migration isn't justified)
-3. Gradual refactoring to cloud-native patterns
-4. Infrastructure as Code implementation
-5. Automated testing and deployment pipelines
-6. Cost monitoring and optimization cycles
+2. Select the migration strategy per workload (rehost for speed, replatform/refactor for cloud-native gains, retire/retain where migration isn't justified); apply the same discovery-and-TCO rigor to repatriation/hybrid rebalancing candidates when the 7 Rs point away from the cloud
+3. Review and validate output from agentic discovery/planning tools (AWS Transform, Azure Copilot Migration Agent, GCP Migration Center's Gemini agent) before executing generated wave plans or landing-zone templates — these tools are increasingly autonomous and require human/architect sign-off
+4. Gradual refactoring to cloud-native patterns
+5. Infrastructure as Code implementation
+6. Automated testing and deployment pipelines
+7. Cost monitoring and optimization cycles, including a 14–30 day post-cutover right-sizing pass to catch the 30–50% of cloud spend commonly wasted immediately after migration
 
 ## Output
 
@@ -39,8 +41,9 @@ You are a cloud migration specialist focused on transforming traditional applica
 - Infrastructure as Code templates
 - Migration automation scripts and tools
 - Cost analysis and optimization reports
+- Post-cutover utilization and right-sizing report
 - Security and compliance validation frameworks
 
 Focus on minimizing downtime and maximizing cloud benefits. Include disaster recovery and multi-region strategies.
 
-This agent owns migration execution (assessment, waves, cutover, runbooks). Hand off to cloud-architect for target-state and multi-cloud architecture design, kubernetes-specialist for cluster-level orchestration detail, terraform-specialist for IaC authoring, database-architect for database migration specifics, and security-engineer for compliance/security review.
+This agent owns migration execution (assessment, waves, cutover, runbooks). Hand off to cloud-architect for target-state and multi-cloud architecture design, kubernetes-specialist for cluster-level orchestration detail, terraform-specialist for IaC authoring, database-architect for database migration specifics, mlops-engineer for AI/ML training and inference workload placement and cost management, and security-engineer for compliance/security review.

--- a/cli-tool/components/agents/modernization/cloud-migration-specialist.md
+++ b/cli-tool/components/agents/modernization/cloud-migration-specialist.md
@@ -32,7 +32,7 @@ You are a cloud migration specialist focused on transforming traditional applica
 4. Gradual refactoring to cloud-native patterns
 5. Infrastructure as Code implementation
 6. Automated testing and deployment pipelines
-7. Cost monitoring and optimization cycles, including a 14–30 day post-cutover right-sizing pass to catch the 30–50% of cloud spend commonly wasted immediately after migration
+7. Cost monitoring and optimization cycles, including a 14–30 day post-cutover right-sizing pass, since post-migration workloads are frequently over-provisioned and fresh utilization data enables right-sizing
 
 ## Output
 


### PR DESCRIPTION
## Summary

Automated component review of `cli-tool/components/agents/modernization/cloud-migration-specialist.md`, applying improvements identified by research into current (2026) cloud migration practices and consistency with sibling agents in the catalog.

- Added cloud repatriation / hybrid-rebalancing as a first-class Focus Area and Approach consideration (now a dominant 2026 migration pattern, not just forward on-prem→cloud)
- Updated Azure/GCP tool bullets with 2026 agentic assessment tools (Azure Copilot Migration Agent; GCP Gemini-powered agentic capabilities / AI-powered Quick Assessments)
- Added a governance/verification Approach step requiring human/architect sign-off before executing output from increasingly autonomous agentic migration tools (AWS Transform, Azure Copilot Migration Agent, GCP's Gemini agent)
- Added AI/ML inference/GPU workload cost-and-placement awareness to the cost optimization focus area, and extended the hand-off footer to route AI/ML infrastructure work to `mlops-engineer`
- Added a concrete post-migration cost-realization step (14–30 day right-sizing pass) to the Approach section, plus a matching Output deliverable

Only the target component file was modified; validated against the component-reviewer checklist (frontmatter valid, name matches filename, kebab-case, tools/model present, no hardcoded secrets, no absolute paths, correct category).

## Note for maintainers

The catalog has two distinct agents both named `security-engineer` (`devops-infrastructure/security-engineer.md` and `security/security-engineer.md`). This file's hand-off footer references `security-engineer` without a category qualifier, which is ambiguous. This is a catalog-wide naming collision outside the scope of this PR — flagging it here rather than unilaterally renaming either file.

## Test plan

- [x] Manual component-reviewer checklist (frontmatter, naming, security, paths, category) — passed
- [ ] `python scripts/generate_components_json.py` (catalog regeneration — not run per workflow; typically done separately before publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018X2hX39HZ4gXcCV8DJT2Hm

---
_Generated by [Claude Code](https://claude.ai/code/session_018X2hX39HZ4gXcCV8DJT2Hm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `cloud-migration-specialist` agent in `cli-tool/components/` to align with 2026 cloud migration practices and sibling agents in the catalog.

- Adds cloud repatriation/hybrid rebalancing as a first-class focus area and updates AWS/Azure/GCP tool bullets for 2026 agentic migration tools, with a human/architect sign-off step before executing generated wave plans.
- Adds AI/ML inference and GPU workload cost-and-placement awareness with an `mlops-engineer` hand-off and a post-cutover right-sizing pass.
- Removes the uncited 30–50% cost-waste figure flagged in review; the right-sizing rationale no longer relies on it.
- No new components were added, so `docs/components.json` does not need regeneration, and no new environment variables or secrets are required.

<sup>Written for commit de335d47b2da24c7fb17b34a7b260cd970356946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

