### PR TITLE
fix(dashboard): show Featured Integrations only on the home page

### DIFF
--- a/dashboard/src/pages/[...type].astro
+++ b/dashboard/src/pages/[...type].astro
@@ -1,7 +1,6 @@
 ---
 import DashboardLayout from '../layouts/DashboardLayout.astro';
 import TopBar from '../components/TopBar.astro';
-import FeaturedSection from '../components/FeaturedSection.astro';
 import ComponentGrid from '../components/ComponentGrid.tsx';
 import SearchModal from '../components/SearchModal.tsx';
 import CartSidebar from '../components/CartSidebar.tsx';
@@ -128,7 +127,6 @@ export function getStaticPaths() {
     </div>
   )}
 
-  <FeaturedSection />
   <ComponentGrid client:load initialType={activeType} />
   <SearchModal client:idle />
   <CartSidebar client:idle />


### PR DESCRIPTION
The Featured Integrations banner was rendered by `[...type].astro`, so it appeared on every category page (`/skills`, `/agents`, `/function-hooks`, ...) in addition to the home page.

This removes the `FeaturedSection` import and render from the category page template. The home page (`index.astro`) keeps it unchanged.

Verified with `npm run build` in `dashboard/` — all category pages build, including `/function-hooks`.

https://claude.ai/code/session_01WukNTAeqGd3VVkYqrCKyEC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the Featured Integrations banner only on the home page instead of on every category page.

- Removes the `FeaturedSection` import and render from the category page template (`dashboard/src/pages/[...type].astro`).
- Affects only the `dashboard` area; no new components, catalog regeneration, or environment variables required.
- Verified with `npm run build` in `dashboard/`, including the `/function-hooks` page.

<sup>Written for commit 081ed151eb61a9c22db3044909f1109d7d00b4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

