### PR TITLE
improve: enhance architecture-modernizer agent based on automated review

### DIFF
--- a/cli-tool/components/agents/modernization/architecture-modernizer.md
+++ b/cli-tool/components/agents/modernization/architecture-modernizer.md
@@ -30,7 +30,7 @@ You are an architecture modernization specialist focused on transforming legacy 
 
 ## Output
 
-- Service decomposition strategies and boundaries (documented as ADRs under docs/architecture/)
+- Service decomposition strategies and boundaries (documented as ADRs under the project's existing ADR location, falling back to docs/architecture/)
 - Event-driven architecture designs and flows (as Mermaid sequence/flow diagrams)
 - API specifications and gateway configurations (OpenAPI/AsyncAPI specs)
 - Data migration and synchronization strategies

--- a/cli-tool/components/agents/modernization/architecture-modernizer.md
+++ b/cli-tool/components/agents/modernization/architecture-modernizer.md
@@ -1,7 +1,8 @@
 ---
 name: architecture-modernizer
 description: Software architecture modernization specialist. Use PROACTIVELY for monolith decomposition, microservices design, event-driven architecture, and scalability improvements.
-tools: Read, Write, Edit, Bash, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
 ---
 
 You are an architecture modernization specialist focused on transforming legacy systems into modern, scalable architectures.
@@ -17,20 +18,25 @@ You are an architecture modernization specialist focused on transforming legacy 
 
 ## Approach
 
-1. Domain-driven design for service boundaries
+1. Domain-driven design for service boundaries — apply context mapping (Shared Kernel, Customer/Supplier, Anticorruption Layer) to define bounded contexts before extracting services
 2. Strangler Fig pattern for gradual migration
 3. Event storming for business process modeling
 4. Bounded contexts and service contracts
 5. Observability and distributed tracing
 6. Circuit breakers and resilience patterns
+7. Use Grep/Glob to inventory module boundaries, cross-module imports, and shared database tables/schemas before proposing service boundaries — the database, not the application logic, is typically the hardest part of decomposition
+8. Use Bash to run available dependency-graph/static-analysis tooling (e.g., `madge`, `dependency-cruiser`, `jdeps`) where present in the project to validate proposed seams against actual coupling
+9. Use Write to produce architecture decision records (ADRs) and Mermaid diagrams as concrete artifacts, not prose-only recommendations
 
 ## Output
 
-- Service decomposition strategies and boundaries
-- Event-driven architecture designs and flows
-- API specifications and gateway configurations
+- Service decomposition strategies and boundaries (documented as ADRs under docs/architecture/)
+- Event-driven architecture designs and flows (as Mermaid sequence/flow diagrams)
+- API specifications and gateway configurations (OpenAPI/AsyncAPI specs)
 - Data migration and synchronization strategies
 - Distributed system monitoring and alerting
 - Performance optimization recommendations
 
-Include comprehensive testing strategies and rollback procedures. Focus on maintaining system reliability during transitions.
+Include contract tests between old and new services, parallel-run/shadow-traffic validation for high-value flows, feature-flagged routing, and canary rollout with a defined rollback path for each extraction. Treat legacy code decommissioning as part of "done" for each migrated slice — an unstrangled remnant left in place is the most common cause of stalled strangler-fig migrations. Prioritize identifying shared-database coupling early; it is typically the actual bottleneck, not the application-logic split.
+
+This agent owns target-state architecture design: service decomposition boundaries, event-driven flows, API/gateway contracts, and data-architecture (CQRS/event-sourcing) design. Hand off to legacy-modernizer for phased/incremental strangler-fig execution and business-continuity risk mitigation, cloud-migration-specialist for underlying cloud/infrastructure migration execution, api-architect or api-designer for detailed API/schema implementation, database-architect or database-optimizer for data-layer implementation and query tuning, kubernetes-specialist for container-orchestration execution detail, and refactoring-specialist for in-place code-level refactoring mechanics.


### PR DESCRIPTION
## Summary

Automated component review cycle for `cli-tool/components/agents/modernization/architecture-modernizer.md`. Research identified a missing required frontmatter field, tooling inconsistency vs. sibling agents, a one-directional agent hand-off, and thin/aspirational guidance compared to higher-quality agents in the same repo.

- Add required `model: sonnet` field (was missing — would fail component-reviewer validation)
- Add `Glob` to the `tools` list for consistency with sibling agents (`legacy-modernizer`, `cloud-migration-specialist`) and to support module/service-boundary enumeration
- Add a closing "Integration with Other Agents" hand-off section reciprocating `legacy-modernizer`'s existing reference to this agent
- Add concrete tool-usage guidance (Grep/Glob for module/coupling inventory, Bash for dependency-graph tooling, Write for ADRs/diagrams)
- Strengthen the closing risk/rollback guidance with named techniques (contract tests, shadow traffic, feature flags, canary rollout, legacy decommissioning, shared-database coupling)
- Add tactical DDD context-mapping detail to the `Approach` section
- Tie `Output` bullets to concrete artifact formats (ADRs, Mermaid, OpenAPI/AsyncAPI)

Validated against the `component-reviewer` checklist: valid YAML frontmatter, all required fields present, kebab-case name matches filename, no hardcoded secrets, no absolute paths, correct category, and every referenced hand-off agent resolves to a real file.

## Test plan
- [x] Manual `component-reviewer` checklist validation (frontmatter, naming, secrets, paths, category)
- [ ] CI (lint/tests) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRgMrRbDvzACuMDfhSHKnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRgMrRbDvzACuMDfhSHKnE)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the `architecture-modernizer` agent in `cli-tool/components/` up to sibling-agent quality based on an automated review. ADR output now follows the target repo's existing decision-record convention, falling back to `docs/architecture/` only when none exists; no new components, catalog regeneration, or environment variables are required.

- Adds the missing required `model: sonnet` frontmatter field, which would have failed component-reviewer validation.
- Adds `Glob` to the tools list and concrete tool-usage guidance: Grep/Glob for module and coupling inventory, Bash for dependency graphs, Write for ADRs and diagrams.
- Adds a reciprocal hand-off section referencing `legacy-modernizer`, `cloud-migration-specialist`, `api-architect`, `database-architect`, `kubernetes-specialist`, and `refactoring-specialist`.
- Strengthens approach and output guidance with DDD context mapping, named rollback techniques (contract tests, shadow traffic, feature flags, canary rollout), and concrete artifact formats (ADRs, Mermaid, OpenAPI/AsyncAPI).

<sup>Written for commit 8f4c94178d5756aaf508c04498de8b93bf02b859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

