### PR TITLE
feat(mcp): add driftlint — context-file drift checks for agents

### DIFF
--- a/cli-tool/components/mcps/devtools/driftlint.json
+++ b/cli-tool/components/mcps/devtools/driftlint.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "driftlint": {
+      "description": "Model Context Protocol (stdio) server for driftlint. Read-only tools (drift_scan, drift_check) that verify CLAUDE.md, AGENTS.md, skills and hooks against the actual repo, so an agent can check a context edit before writing it.",
+      "command": "npx",
+      "args": ["-y", "@alifurkangokce/driftlint-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
Adds `cli-tool/components/mcps/devtools/driftlint.json`.

### What it is

[driftlint](https://github.com/alifurkangokce/driftlint) checks whether a project's agent instruction files are still true. CLAUDE.md says "run `npm run test:unit`", someone renames the script, and nothing breaks — the agent just reads a false statement and acts on it. driftlint resolves every claim against the actual tree: path references, npm/make commands, markdown links and anchors, hook and MCP-server commands in `.claude/settings.json` and `.mcp.json`, plugin manifests, and skill listing budgets.

### Why the MCP server is useful here

The two tools are **read-only** — `drift_scan` (scan a path, optionally diff-scoped) and `drift_check` (verify one reference). There is no fix, write or shell tool on that surface. The point is that an agent can verify a context edit *before* writing it, rather than a human discovering months later that CLAUDE.md points at a deleted script.

### Notes

- Published as `@alifurkangokce/driftlint-mcp`, MIT, Node 20+.
- No API key or env var needed — nothing to configure, which is why the `env` block is omitted.
- The engine has zero runtime dependencies and no telemetry. Nothing leaves the machine (the one optional network feature lives behind a CLI flag and is not exposed over MCP at all).

Happy to adjust the category or the description wording.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the driftlint MCP server to the component catalog so agents can verify context-file claims against the actual repo before writing edits. `drift_scan` and `drift_check` are read-only tools that check paths, commands, markdown links/anchors, and hook/MCP-server commands in `CLAUDE.md`, `AGENTS.md`, skills, and `.claude/settings.json`.

- Affected area: `cli-tool/components/` — new component definition added.
- `docs/components.json` needs regeneration to pick up the new component.
- No new environment variables or secrets required; runs via `npx -y @alifurkangokce/driftlint-mcp`.

<sup>Written for commit 0284206f9097afdcc6a6395d258c793fa34df4a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

