### PR TITLE
Add eval-genius supporting resources (references, templates, scripts, evals)

### DIFF
--- a/cli-tool/components/skills/development/eval-genius/evals/evals.json
+++ b/cli-tool/components/skills/development/eval-genius/evals/evals.json
@@ -1,0 +1,23 @@
+[
+  {"query": "I built a small chatbot on top of an LLM. Do I even need evals for this?", "should_trigger": true},
+  {"query": "Where do evals fit in my development process, and at which step should I add one?", "should_trigger": true},
+  {"query": "I have never done this before. How do I know what eval to run for my summarizer?", "should_trigger": true},
+  {"query": "I ran my first eval and got 31/40. How do I tell if that's good, and what do I do next?", "should_trigger": true},
+  {"query": "Build an eval for our RAG pipeline so we can tell if the new chunking is better", "should_trigger": true},
+  {"query": "Set up a regression gate in CI for our agent's task success rate", "should_trigger": true},
+  {"query": "Should we use a public benchmark for long-context retrieval or make our own?", "should_trigger": true},
+  {"query": "Is SWE-bench a good fit to evaluate our code-repair agent?", "should_trigger": true},
+  {"query": "Our LLM judge gives the new prompt 9/10 but users complain. How do I calibrate the judge?", "should_trigger": true},
+  {"query": "The benchmark jumped from 40% to 97% after a one-line change. Is that real?", "should_trigger": true},
+  {"query": "Design an eval harness for our summarization feature", "should_trigger": true},
+  {"query": "Write up the results of our retrieval benchmark for the release notes", "should_trigger": true},
+  {"query": "What metric should we use to measure whether the classifier is better?", "should_trigger": true},
+  {"query": "How many test items do we need to detect a 3-point improvement?", "should_trigger": true},
+  {"query": "Write unit tests for the date parsing function", "should_trigger": false},
+  {"query": "Set up an A/B test for the new checkout button color", "should_trigger": false},
+  {"query": "Tune the learning rate and batch size for fine-tuning", "should_trigger": false},
+  {"query": "Fix the failing pytest in the auth module", "should_trigger": false},
+  {"query": "Benchmark the database query latency with pgbench", "should_trigger": false},
+  {"query": "Write a blog post about why evals matter", "should_trigger": false},
+  {"query": "Evaluate whether we should hire a second backend engineer", "should_trigger": false}
+]

--- a/cli-tool/components/skills/development/eval-genius/references/00-start-here.md
+++ b/cli-tool/components/skills/development/eval-genius/references/00-start-here.md
@@ -1,0 +1,88 @@
+# Start here: do I need an eval, and where does it go?
+
+For the reader who has never built one. Read this when the ask is "I think I might
+need evals", "where do evals fit in my process", or "which eval should I run". It ends
+with a concrete first-eval recipe; everything else in the skill deepens one step of it.
+
+## What an eval is, in one paragraph
+
+An eval is a repeatable check on a system whose outputs vary: a fixed set of inputs,
+a written rule for what a good output looks like, and a score (usually a pass rate).
+It is the test suite for the part of the product a unit test cannot pin down, because
+a model, prompt, or retriever produces different text on different days. Where a
+unit test says "equal or not", an eval says "how often, and is that enough".
+
+## Do I need one? Three questions
+
+1. **Does the output vary?** A model, a prompt, a retriever, a ranking, anything
+   you will keep tuning. No: ordinary tests, stop here.
+2. **Will you change it again and want to know if the change helped?** Or would a
+   quiet regression cost you something (a wrong answer to a user, a broken agent
+   action, a public number that turns out false)?
+3. **Is a decision or a claim coming?** Model A vs B, ship or hold, a number in a
+   README or a pitch.
+
+No to all three: spot check by hand and move on. Yes to any: an eval, sized to the
+stakes. Most projects reach "yes" the first time a prompt change breaks something
+that used to work.
+
+## Where evals sit in a development lifecycle
+
+| Stage | What you are doing | Instrument | Smallest useful version | Fine to skip when |
+|---|---|---|---|---|
+| **Exploring** | Trying prompts and models, nothing fixed yet | Spot check | 10 hand-picked inputs, eyeball the outputs | Always; nothing to measure yet |
+| **First working version** | It basically works and you are about to iterate | Smoke eval | 20 to 50 real inputs, code-checked, one pass rate. **This run is the baseline.** | The prototype is being thrown away |
+| **Changing one thing** | Prompt tweak, model swap, retrieval setting | Paired eval vs baseline | Same items through old and new, per-item diff, bar written before the run | The change is cosmetic and untestable |
+| **Merging or shipping** | Deciding whether this goes out | Gate in CI | Held-out items, PASS / FAIL / CANNOT-MEASURE, a known-bad item that must fail | Personal prototype, no users |
+| **Comparing or claiming** | Versus a rival, an older version, or a public number | Benchmark | Versioned dataset plus harness, interval on every number, written report | No comparison, no claim |
+| **Running in production** | Real traffic, real drift | Monitor | The same per-item scorer on a sampled slice of live traffic | Not launched yet |
+
+Timing rule: build the first eval at **first working version**. Earlier, there is
+nothing stable to measure; later, every change since is unattributable and the eval
+is built under pressure. Each later stage reuses the same items and scorer, heavier
+only in what surrounds them.
+
+## Which eval do I run? Four forks
+
+1. **What does one output look like?** An exact answer (a label, a number, a
+   file), a structured object (JSON, a table), free text (a summary, a reply), or a
+   sequence of actions (an agent). Name it; the grader follows from it.
+2. **Can code check it?** Exact answers, structured objects, and end states of an
+   agent: yes, and that is the whole grader. Free text: decompose first (required
+   facts present, forbidden content absent, length and format) and only the
+   remainder needs a model or human judge (`02-grading-and-metrics.md`).
+3. **What is the metric?** Pick from the family that matches the promise: retrieval
+   wants recall@k, classification wants precision and recall, generation wants fact
+   coverage plus a judged layer, agents want task success plus trajectory
+   (`02-grading-and-metrics.md`). Always record cost and latency next to it.
+4. **How many items?** 20 to 50 to start; enough to see a change of the size that
+   matters before trusting a delta (`08-statistics.md`). Include items where the
+   right output is "refuse" or "nothing found".
+
+Any existing public benchmark that measures the same promise beats building one
+(`04-search-vs-build.md`); most first evals are private and small, and that is fine.
+
+## The first-eval recipe (one afternoon)
+
+1. **Collect 30 real inputs.** From logs, support tickets, or hand-written cases that
+   look like real use. Five of them where the correct behavior is to refuse or return
+   nothing.
+2. **Write the expected result per item in a form code can check.** A string, a set
+   of required facts, a schema, a final state. If an item resists, split it or park it
+   for the judged layer later.
+3. **Run the current system.** Save per-item results, not just the total. That number,
+   with its n, is the baseline. Write down what version produced it.
+4. **Write the bar before the next change.** "Accept if no item that passed now fails,
+   and the pass rate is up by at least X." Also what would prove the change useless.
+5. **Change one thing, run again on the same items, diff per item.** Read the result
+   with `11-reading-results.md`.
+
+Fill `templates/preregistration.md` with steps 3 and 4; it is the same five fields the
+rest of the skill relies on, and a first-time user needs only the promise, the lever,
+the baseline, and the bar.
+
+## Output of this file
+
+A yes/no on whether an eval is needed, the stage it belongs to, the instrument for that
+stage, the grader type and metric family, and a baseline run with per-item results.
+Nothing downstream needs more than that to start.

--- a/cli-tool/components/skills/development/eval-genius/references/01-foundation.md
+++ b/cli-tool/components/skills/development/eval-genius/references/01-foundation.md
@@ -1,0 +1,111 @@
+# Foundation: what to measure, and why, before any benchmark exists
+
+Most bad eval work comes from skipping straight to "let's build a benchmark." This file
+is the part everyone skips. Read it when the ask is vague ("make retrieval better"),
+when a metric was chosen before a goal, or when a team cannot say what a number is for.
+
+## 1. Start with the promise, not the metric
+
+Write the promise the system makes, in plain language a non-expert would sign off on:
+
+- "Users find the right document in the first three results."
+- "The agent completes the task without breaking anything it did not touch."
+- "The summary keeps every decision and drops every pleasantry."
+
+The metric comes *from* the promise. When the promise cannot be stated, measurement is
+premature. When two people state different promises, that disagreement is the first
+finding, and it costs nothing to resolve now versus a month of measuring the wrong thing.
+
+## 2. Name the variables
+
+Every measurement is a small experiment with three kinds of variable:
+
+| Kind | Meaning | Examples |
+|---|---|---|
+| **Lever** (independent) | What changes on purpose | Prompt, model, retrieval setting, threshold, chunk size, a pipeline stage |
+| **Outcome** (dependent) | What is watched | Pass rate, recall@k, latency p95, cost per task, judged quality |
+| **Control** (held constant) | Everything else | Data, corpus, snapshot, seed policy, judge version, hardware class |
+
+Rules:
+
+- One lever per comparison. Two levers moved together give a result nobody can act on.
+- Every outcome gets a direction and a unit written down (higher-is-better recall@5,
+  lower-is-better p95 ms).
+- Controls are enumerated, not assumed. Anything not on the list is a suspect when a
+  delta appears.
+
+## 3. Decide where a measurement belongs
+
+Measurements go at three places:
+
+- **Decision points.** Model A vs B, config X vs Y, ship vs hold. A decision without a
+  measurement is a guess in a lab coat.
+- **Risky seams.** Where a mistake is expensive or invisible: data integrity, security,
+  anything a user would silently suffer from.
+- **Public claims.** Any number destined for a README, a pitch, or a blog post.
+
+Everywhere else, a spot check or nothing. Over-measuring low-stakes surface burns the
+budget that the risky seams needed.
+
+## 4. Pick the weight
+
+| Instrument | Use when | Lives | Cost |
+|---|---|---|---|
+| **Spot check** | "Does this look right?" during development | Nowhere | Seconds |
+| **Eval** | A repeatable check on one capability that keeps changing | In the repo, runs on every change | Cheap |
+| **Benchmark** | A standardized, versioned, comparable measurement across versions or systems | Versioned dataset + harness | Real setup |
+| **Monitor** | Continuous measurement of live behavior | Production | Ongoing |
+
+Decision walk:
+
+1. Will it run more than once? No: spot check.
+2. Will results be compared across time or systems? No: eval. Yes: benchmark.
+3. Is the thing being measured live traffic rather than a fixed set? Monitor.
+
+A benchmark run once was an eval. An eval running forever in production is a monitor
+and needs sampling, alerting, and drift handling that an eval never had. Monitors
+are out of this skill's scope beyond one rule: the offline eval's per-item scorer is
+reused on a sampled slice of live traffic, so the offline and online numbers share a
+definition and drift between them is itself a finding.
+
+## 5. Define "better" as a threshold before looking
+
+Write the bar in numbers, in advance:
+
+- "Accept only if every metric is at or above baseline and recall@5 is up by at least
+  0.02 with a 95% interval excluding zero."
+- "Accept if pass rate is unchanged within noise and p95 latency drops 20%."
+
+Then write the **falsifier**: the result that would prove the change useless, and what
+would be concluded from it. Then the **outlier rule**: how a single dominating item is
+handled (capped, excluded with disclosure, or reported separately).
+
+A bar set after the result is known is how people talk themselves into shipping noise.
+All three go into `templates/preregistration.md` before the first run.
+
+## 6. Match the metric to the promise, not to convenience
+
+Prefer the harder end-to-end outcome over the intermediate proxy:
+
+| Promise | Convenient proxy | Real outcome |
+|---|---|---|
+| "Finds the right answer" | Embedding similarity | Answer present in top-k, judged correct |
+| "Agent finishes the task" | Tool calls succeeded | Final state passes the acceptance test |
+| "Summary keeps what matters" | ROUGE overlap | Every pre-listed key fact present, no fabricated fact |
+
+The proxy is allowed as a *diagnostic* alongside the outcome, never as its replacement.
+Rename metrics into plain words in every report so a reader knows what moved.
+
+## When no baseline exists yet
+
+The first eval of anything has no prior run. The baseline is then the current
+production configuration, run first through the same harness on the same fixture,
+and its run id goes into the pre-registration before the treatment arm runs. The
+first result is the baseline; there is no comparison until a second arm exists. A
+brand-new system with no predecessor gets a stated floor instead (a trivial or
+off-the-shelf configuration), and the report says the comparison is against a floor.
+
+## Output of this file
+
+A filled `templates/preregistration.md` with promise, variables, placement, weight, bar,
+falsifier, outlier rule, and the named baseline. Nothing downstream starts without it.

--- a/cli-tool/components/skills/development/eval-genius/references/02-grading-and-metrics.md
+++ b/cli-tool/components/skills/development/eval-genius/references/02-grading-and-metrics.md
@@ -1,0 +1,117 @@
+# Grading and metrics: deterministic first, judged last
+
+The first fork in any eval is who grades it. This choice drives cost, reproducibility,
+and how much the number can be trusted.
+
+## The fork
+
+| | **Deterministic** (code-graded) | **Non-deterministic** (model- or human-graded) |
+|---|---|---|
+| Grader | Exact match, normalized match, regex, schema/type check, test suite, numeric threshold, set overlap | LLM-as-judge, human rater, pairwise preference |
+| Use when | A checkable right answer exists | Quality is inherently a judgment: tone, helpfulness, faithfulness |
+| Cost | Free, instant | Slow, paid, noisy across runs |
+| Trust | High, if the check itself is correct | Only as good as the judge's calibration |
+
+**Governing rule:** push every check that can be deterministic down to code. Reserve
+judgment for the edge no assertion captures. Then report the layers separately: a
+deterministic pass rate and a judged score never share a denominator or a headline.
+
+## Making more things deterministic
+
+Before accepting "this needs a judge," try these moves in order:
+
+1. **Normalize then match.** Lowercase, strip whitespace and punctuation, canonicalize
+   numbers and dates. Most "fuzzy" answers become exact.
+2. **Extract then match.** Have the system emit a structured field (JSON, a final line,
+   a tagged span) and grade the field, not the prose.
+3. **Assert on state, not text.** For agents and code, grade the resulting filesystem,
+   database, or test suite, not the transcript.
+4. **Decompose the rubric.** "Is this a good summary" becomes "contains fact A," "contains
+   fact B," "contains no fact outside the source." The first two are set-membership
+   checks. Only the last may need a judge, and often a fact-list diff does it.
+5. **Use a reference set with tolerance.** Numeric answers within an interval; lists
+   graded by Jaccard overlap above a threshold.
+
+Only what survives all five becomes the judged layer.
+
+## Metric catalog by task family
+
+Pick from the family that matches the promise. Each entry names the failure mode of
+the metric so it can be caught.
+
+### Retrieval / search / memory
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| recall@k | Is the relevant item in the top k | Ignores rank inside k; pick k from the real UI |
+| MRR (mean reciprocal rank) | How high the first relevant item lands | Dominated by first hit; blind to second relevant item |
+| nDCG@k | Graded relevance with position discount | Needs graded labels; cheap labels make it meaningless |
+| precision@k | How much of the top k is relevant | Punishes systems that surface useful near-misses |
+
+Retrieval gates work best on a per-query diff, not the aggregate: a mean can hold
+steady while ten queries collapse and ten others improve.
+
+### Classification / routing / triggering
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| Precision / recall / F1 | Trade-off between false alarms and misses | Report both, never F1 alone; class imbalance hides in accuracy |
+| False-positive rate on benign input | The negative space | Requires an explicit benign set, which teams forget to build |
+| Confusion matrix | Which classes get confused | The only view that explains *why* F1 moved |
+
+### Generation / summarization / rewriting
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| Key-fact coverage | Fraction of pre-listed facts present | Needs a fact list per item, built before generation |
+| Fabrication count | Facts present that are not in the source | Best graded by fact-list diff, then a judge only on disputed items |
+| Constraint compliance | Length, format, forbidden terms, required sections | Fully deterministic; always run first |
+| Judged quality | Fluency, tone, helpfulness | The judged layer; calibrate per `03-judge-calibration.md` |
+
+Lexical overlap scores (ROUGE, BLEU) are diagnostics, not outcomes. They reward
+copying and punish good paraphrase.
+
+### Extraction / structured output
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| Schema validity rate | Output parses and conforms | Necessary, not sufficient |
+| Field-level exact match | Per-field correctness | Report per field; a single aggregate hides the one field that always fails |
+| Slot F1 | Precision/recall over extracted entities | Define matching rule (exact vs normalized) up front |
+
+### Code
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| Test pass rate | Hidden tests pass | Tests must be hidden from the system; leaked tests inflate |
+| pass@k | Any of k samples passes | Reports capability, not reliability |
+| pass^k | All k samples pass | Reports reliability; the number a user actually feels |
+| Diff scope | Files touched outside the task | Catches collateral damage that tests miss |
+
+### Agentic / multi-turn
+
+See `10-agentic-evals.md`. Outcome (final state) and trajectory (how it got there) are
+graded separately.
+
+### Cost and latency (always, alongside any of the above)
+
+| Metric | Measures | Watch for |
+|---|---|---|
+| Tokens in / out per item | Spend | Judge tokens count too; report them separately |
+| Cost per pass | Money spent per successful item | The metric that makes "more retries" honest |
+| Latency p50 / p95 | Typical and tail response time | Means hide tails; tails are what users feel |
+
+A quality gain that doubles cost or tail latency is a trade, not a win, and the report
+says so.
+
+## Choosing k, thresholds, and tolerances
+
+Pull them from the product surface, not from habit. If the interface shows five
+results, recall@5 is the metric. If a user waits at most two seconds, p95 under two
+seconds is the bar. Thresholds invented in the abstract get gamed by the abstract.
+
+## Output of this file
+
+A grader plan: which checks are deterministic (and their normalization rule), which
+items go to the judged layer and why, the metric per outcome with direction and unit,
+and cost/latency recorded next to quality.

--- a/cli-tool/components/skills/development/eval-genius/references/03-judge-calibration.md
+++ b/cli-tool/components/skills/development/eval-genius/references/03-judge-calibration.md
@@ -1,0 +1,105 @@
+# LLM-as-judge: an instrument that needs calibration
+
+A model judge is useful and biased. It is never an oracle. It is a ruler, and a ruler
+with no markings measures nothing. This file is the procedure for putting markings on
+it, checking they stay put, and being honest about what the ruler certifies.
+
+## When a judge is legitimate
+
+Only after every deterministic move in `02-grading-and-metrics.md` has been tried. The
+judge grades the residue: tone, helpfulness, faithfulness where a fact list cannot be
+built, "would a domain expert accept this." If a judge is grading whether a string is
+present, that is a bug, not a judgment.
+
+## The biases inherited for free
+
+| Bias | Effect | Mitigation |
+|---|---|---|
+| **Position** | Prefers whichever answer appears first (or last) regardless of quality; a judge can be highly self-consistent and still position-biased, so test-retest stability is not evidence against it | Run both orderings and count a win only when both agree; otherwise record a tie |
+| **Verbosity** | Rewards longer answers even when shorter is correct | State how length is treated in the rubric; report length alongside score; spot-check top-scored long answers |
+| **Self-preference** | Inflates outputs from its own model family | Judge with a different model family than the one under test |
+| **Authority / style** | Rewards confident tone, headers, and lists over correctness | Rubric grades substance items explicitly; strip formatting before judging when the task is not about formatting |
+| **Rubric-author** | The rubric encodes what its author, usually the system's builder, already believes matters | Have someone who did not build the system author or review half the rubric items; blind-swap rubric authorship across teams when possible |
+
+De-biasing a judge is not the same as validating that it measures what is claimed. A
+perfectly de-biased comprehension judge can still be measuring "text present" rather
+than "understood." Classify each instrument honestly: deterministic, calibrated model
+proxy, or human, and be precise about what it certifies.
+
+## Rubric design
+
+- **Anchored scale.** Describe what a 1, a 3, and a 5 look like with concrete examples.
+  A bare "rate 1-10" produces a judge that drifts run to run.
+- **Binary where possible.** "Does the answer state the deadline?" beats "how good is
+  the answer" on every reliability metric. Decompose a holistic score into binary
+  checks and let the aggregate be arithmetic, not judgment.
+- **Reason before score.** The judge writes its rationale first, then the score. Score
+  first and the rationale becomes a justification of a guess.
+- **Pairwise for preference, pointwise for gates.** Pairwise ("which is better, A or B")
+  is more reliable than absolute scores but only yields relative results and needs both
+  orderings. Gates need a pointwise pass/fail against a fixed bar.
+- **Blind it.** The judge sees no system names, no version labels, no "new" vs "old."
+
+## Calibration procedure
+
+Calibration is a measurement with its own pre-registration.
+
+1. **Build the human set.** Sample items from the same distribution the judge will
+   grade. Stratify by expected difficulty and include the negative space. Size: enough
+   that an agreement statistic has a usable interval; a few hundred binary labels is a
+   reasonable floor, fewer than fifty is anecdote.
+2. **Label with two or more humans.** Write a labeling guideline first. Measure
+   inter-annotator agreement (Cohen's kappa for two raters, Krippendorff's alpha for
+   more). If humans do not agree with each other, the judge cannot be expected to agree
+   with them; fix the guideline before continuing.
+3. **Run the judge** on the same set, blinded, with the exact prompt and model that
+   will be used in production, at the same temperature and settings.
+4. **Compute agreement** judge-vs-human with a chance-corrected statistic (kappa or
+   alpha), never raw agreement. Raw agreement is inflated by class imbalance; large
+   judge studies have found it overstating chance-corrected agreement by 30 to 40
+   percentage points. Also compute precision and recall of the judge's PASS against
+   the human PASS, because a judge that agrees 90% by always saying PASS on a 90%-PASS
+   set is useless.
+5. **Set the bar before step 4.** One floor table applies to humans-vs-humans and
+   judge-vs-humans alike: kappa or alpha at or above 0.67 for tentative or diagnostic
+   use, 0.8 for a gate or a headline claim, 0.9 where a wrong grade costs a user
+   something. Below the floor, the judge is a diagnostic, not a
+   grader, and the report says so.
+6. **Inspect disagreements.** Every disagreement is either a rubric defect, a label
+   defect, or a judge failure. Sort them. Fix the rubric or the guideline, then
+   re-run from step 3. Iterating the judge prompt against the calibration set makes
+   the set a training set; hold out a slice that is never used for prompt iteration
+   and report agreement on that slice.
+
+`scripts/judge_agreement.py` computes kappa, agreement rate, and the PASS precision /
+recall from two label files.
+
+## Pin the instrument
+
+A judge is part of the fixture. The run manifest records:
+
+- judge model identifier and snapshot / version string
+- judge prompt hash
+- temperature and any sampling settings
+- calibration set version and the agreement achieved
+
+When any of these changes, the judge is a new instrument and calibration re-runs.
+Scores from different judge versions are never placed side by side without that note.
+
+## Measuring disagreement as signal
+
+For high-stakes calls, run two judges (different families) or two prompt variants.
+Where they agree, there is a signal. Where they disagree, there is not; route those
+items to a human or report them as undetermined. Never average away a disagreement.
+
+## Cost discipline
+
+Judge tokens are eval cost. Report them separately from system cost. A judged layer
+that costs more than the deterministic layer catches is a candidate for decomposition
+into more binary checks.
+
+## Output of this file
+
+A calibrated judge: rubric with anchors, blinded and order-randomized protocol, a human
+calibration set with inter-annotator agreement, judge-vs-human agreement above a
+pre-set floor on a held-out slice, and the judge pinned in the run manifest.

--- a/cli-tool/components/skills/development/eval-genius/references/04-search-vs-build.md
+++ b/cli-tool/components/skills/development/eval-genius/references/04-search-vs-build.md
@@ -1,0 +1,81 @@
+# Search vs build: adopt an existing benchmark or make one
+
+Building a benchmark is expensive and its ground truth is homemade. Adopting one buys
+external validity and credibility, and can silently measure the wrong thing. The
+decision is made with a scorecard, not a hunch.
+
+## When to search first
+
+Always. Ten minutes of search precedes any build. The search finds one of three things:
+
+1. A benchmark that exercises the promise directly. Adopt it, possibly with a subset.
+2. A benchmark with the right plumbing but the wrong tasks. Reuse the harness, add
+   tasks.
+3. Nothing that stresses the mechanism. Build, and say in the report that no public
+   benchmark fit and why.
+
+## Search procedure
+
+1. Name the capability in the words the field uses, not product words. "Long-context
+   retrieval," "tool-use reliability," "faithful summarization," "code repair."
+2. Search the usual venues: benchmark aggregators and leaderboards, the major model
+   release reports (they list what they evaluated on), survey papers for the capability,
+   and open harness repositories, which bundle dozens of tasks with shared plumbing.
+3. For each candidate, read in this order: the task definition, five sample items, the
+   grading code, the known-issues or errata page, the last commit date.
+4. Fill `templates/benchmark-assessment-scorecard.md` for each candidate that survives
+   item 3.
+
+## The five questions (the scorecard)
+
+1. **What does it implicitly reward?** Every benchmark encodes a utility function.
+   State it in one sentence and compare it to the promise. A mismatch means the
+   benchmark will report progress on a neighbor's problem.
+2. **Is it contaminated?** Public benchmarks leak into training data. Check the
+   release date against the model's cutoff, look for a canary string or a rolling
+   held-out set, search for the items verbatim. A contaminated benchmark measures
+   memory, not capability.
+3. **What is its label-error ceiling?** Datasets have wrong labels. Sample fifty items
+   and grade them by hand. A 5% label-error rate means no system can honestly score
+   above about 95% and any delta under the error rate is noise.
+4. **Does it exercise *this* mechanism?** A famous benchmark that does not stress the
+   lever under test will report that the lever does nothing. Check that item difficulty
+   actually depends on the capability being changed.
+5. **Is it maintained and comparable?** Last commit, open issues, whether published
+   numbers were produced with the same harness version and settings. A stale
+   leaderboard offers no comparison.
+
+Two further checks that decide the weight of an adopted benchmark:
+
+- **Saturation.** If leading systems score near the ceiling, the benchmark no longer
+  separates them. Use it as a floor check, not a headline.
+- **Scale and cost.** Item count, runtime, and judge cost per full run. A benchmark
+  that cannot be run on every change belongs in a nightly or release tier
+  (`07-gates-and-ci.md`).
+
+## Adopting with modifications
+
+Allowed, with disclosure:
+
+- **Subsetting** by a pre-registered rule (random seed, or a stated category filter).
+  Never by "the ones that look relevant" after seeing scores.
+- **Re-grading** with a stricter or deterministic grader when the original grader is
+  weak. Report both numbers.
+- **Extending** with new items in the original format. Label them as an extension; do
+  not compare the extended score with published numbers.
+
+## Building a custom one
+
+Triggered when the scorecard fails question 1 or 4 for every candidate. Then:
+
+- Reuse public harness plumbing wherever it exists. New tasks, proven runner.
+- Follow `05-dataset-construction.md` for items, labels, negatives, and splits.
+- Say in every report that the benchmark is custom and self-run. A custom benchmark is
+  evidence; it is never independent validation, and the honest label is what keeps it
+  credible.
+- Publish the fixture fingerprint and harness version with every number.
+
+## Output of this file
+
+A filled scorecard per candidate and a one-line decision: adopt as is, adopt with
+stated modifications, reuse harness and add tasks, or build with a stated reason.

--- a/cli-tool/components/skills/development/eval-genius/references/05-dataset-construction.md
+++ b/cli-tool/components/skills/development/eval-genius/references/05-dataset-construction.md
@@ -1,0 +1,138 @@
+# Dataset construction: items, labels, negatives, splits, contamination
+
+A benchmark is only as honest as its items. Famous public benchmarks have been
+re-audited and found to carry label-error rates near 10% overall and above 50% in
+some subsets, which means a perfect system could not score 100% and any delta under
+the error rate is noise. Homemade sets are not better by default; they are just
+un-audited.
+
+## Sourcing items
+
+- **From the real distribution.** Sample from real traffic, real documents, real tasks.
+  Synthetic items are allowed for coverage of rare cases and are labeled as synthetic.
+- **Stratify by difficulty and by category** before sampling, so the set does not
+  quietly become "the easy cases we had lying around." Record the strata in the
+  fixture manifest.
+- **Size from the statistics, not from convenience.** Decide the minimum effect that
+  matters, then size the set so that effect is detectable (`08-statistics.md`). A few
+  hundred items is a typical floor for a gate; fewer than fifty is a smoke test.
+- **Sample fifty items and grade them by hand** before trusting any source, including
+  a well-known public one. This is how the label-error ceiling is found.
+
+## Labeling
+
+1. Write the **labeling guideline** first: what counts, what does not, the edge cases,
+   worked examples of each label.
+2. **Two or more labelers** on at least a stratified subset. Measure inter-annotator
+   agreement with a chance-corrected statistic: Cohen's kappa for two raters,
+   Krippendorff's alpha for more. Working floors: 0.67 for tentative use, 0.8 for a
+   gate, 0.9 where a wrong label harms someone. Below the floor, the guideline is
+   ambiguous; fix it and re-label. Do not average the disagreement away.
+3. **Adjudicate** disagreements with a written reason, and feed the reason back into
+   the guideline.
+4. **Version the labels.** A relabel is a new fixture version with a new fingerprint.
+
+## The four defect classes of task-style items
+
+A large, human-verified re-curation of a coding benchmark found four recurring defects.
+They generalize to any task-style item:
+
+| Defect | What it looks like | Check |
+|---|---|---|
+| **Over-strict grader** | Tests enforce an implementation detail the task never stated | Would a correct alternative solution fail? |
+| **Under-specified prompt** | Hidden checks demand something the prompt never asked for | Can a careful human pass from the prompt alone? |
+| **Low-coverage grader** | The check passes solutions that miss the feature | Does a deliberately wrong solution fail? |
+| **Misleading prompt** | The prompt points toward the wrong behavior | Does the prompt contradict the grader? |
+
+Run all four on every item before it enters the set. The third check is the same
+"verify the verifier" rule the harness enforces at run time.
+
+## Negative space
+
+A benchmark that only walks the happy path tests half a promise. Build, on purpose:
+
+- **Benign negatives.** Inputs where the correct behavior is nothing: no trigger, no
+  retrieval, no action. Measure the false-positive rate on them.
+- **Verified-absent negatives.** For retrieval and memory, queries whose answer is
+  provably not in the corpus. Generate them from a source outside the corpus and
+  check absence mechanically; hand-written negatives leak into the corpus over time
+  and turn into positives without anyone noticing.
+- **Near-miss distractors.** Items that look like a positive but are not. These are
+  where precision actually gets measured.
+- **Refusal cases.** Where the right answer is "cannot" or "should not."
+
+## Splits
+
+- **Development set** for iterating on prompts, rubrics, and configs.
+- **Held-out gate set** that nobody iterates against. Tuning on the gate set turns the
+  gate into a training set and the number into fiction.
+- **Calibration set** for judges, with its own held-out slice (`03-judge-calibration.md`).
+
+Splits are random with a recorded seed, or by a pre-registered rule. Never by hand.
+
+## Contamination
+
+Public benchmarks leak into training data. The contaminated benchmark measures memory,
+not capability.
+
+Detection:
+
+- **Overlap search.** Look for long n-gram overlaps between benchmark items and any
+  corpus the system could have trained on. Published practice has used 13-gram
+  overlap, 50-character overlap, and 8-gram overlap above 80% coverage as flags.
+- **Canary strings.** Embed a unique random token in the dataset text. A system that
+  can reproduce the canary has seen the set.
+- **Date gating.** Tag every item with a creation date. Score systems only on items
+  created after their known training cutoff, and compare pre- and post-cutoff scores;
+  a large gap is contamination made visible.
+- **Rephrase probe.** A system that scores far higher on verbatim items than on
+  meaning-preserving rephrasings has memorized rather than understood.
+
+Prevention:
+
+- Keep a **private held-out set** that never leaves the team.
+- **Rotate.** Add fresh items on a schedule and retire old ones; report scores on the
+  fresh slice separately.
+- Never paste benchmark items into prompts, docs, or issue trackers that get crawled.
+
+## Overfitting the benchmark (Goodhart's law)
+
+Contamination is memorizing the answers. Overfitting is subtler and needs its own defense:
+iterate against one fixed set long enough and you tune the system, prompts, and rubric to
+that set's quirks, so the score climbs while the real capability stalls. "When a measure
+becomes a target, it ceases to be a good measure." No test-set leak is required, only
+repeated selection against the same items.
+
+Symptoms:
+
+- The gate score rises release over release, but user reports, spot checks, or a fresh
+  qualitative pass don't move with it.
+- Gains concentrate on the exact items or strata you looked at most, and vanish on new items.
+- A newly drawn set from the same distribution scores materially lower than the standing set.
+
+Defenses:
+
+- **Reserve a rarely-touched held-out set**, ideally opened only at release. The set you read
+  every iteration is the set you overfit; frequency of contact is the risk, not just leakage.
+- **Rotate and refresh** items on a schedule (see Contamination) so the target moves faster
+  than you can fit it; report the fresh slice separately and watch for a standing-vs-fresh gap.
+- **Cap look frequency.** Track how many times each set has been evaluated against; a set
+  looked at hundreds of times is a training set in disguise.
+- **Keep an ungameable qualitative pass**, a small human read no optimization loop can see.
+- **Judge a basket, not one number.** Optimizing a single headline metric is what invites
+  Goodhart; a basket (quality + cost + a negative-space check) makes gaming one surface in another.
+- **Watch metric-reality divergence explicitly.** When the number and reality disagree,
+  believe reality and suspect the benchmark, not the other way around.
+
+## Fixture manifest
+
+Every dataset version ships with a manifest: item count per stratum, label version,
+inter-annotator agreement, label-error audit result, split seed, content hash, creation
+dates, and known issues. The hash is what the harness compares before it agrees to
+compare two runs (`06-harness-design.md`).
+
+## Output of this file
+
+A versioned fixture with a manifest, a labeling guideline with measured agreement, a
+negative-space slice, held-out splits with a recorded seed, and a contamination check
+result.

--- a/cli-tool/components/skills/development/eval-genius/references/06-harness-design.md
+++ b/cli-tool/components/skills/development/eval-genius/references/06-harness-design.md
@@ -1,0 +1,160 @@
+# Harness design: the runner nobody has to trust
+
+The harness is the instrument. Every rule here exists because a harness once produced a
+confident number about something it never ran. Design it so that a wrong number is
+structurally hard to produce and easy to detect.
+
+## Architecture: four parts, one seam each
+
+```
+fixture  ->  runner  ->  scorer  ->  reporter
+(items,      (calls the    (grades each   (aggregates, diffs
+ labels,     system,       item, emits    against baseline,
+ manifest)   captures      per-item       decides PASS / FAIL /
+             raw output)   verdicts)      CANNOT-MEASURE)
+```
+
+- **Fixture** is data plus a manifest with a content hash. It is never mutated by a run.
+- **Runner** produces raw outputs and a run manifest. It knows nothing about scoring.
+- **Scorer** takes raw outputs and labels, emits one record per item. It knows nothing
+  about the system under test.
+- **Reporter** reads per-item records from two runs and produces the comparison. It
+  knows nothing about how outputs were produced.
+
+The separation means a scorer bug is fixed and re-applied to stored raw outputs without
+re-running the system, and a runner change cannot quietly alter grading.
+
+## Standardize the seams, not the harness
+
+The four-part architecture is a contract, not a prescribed framework. A RAG eval may
+need a frozen corpus and retrieval trace; a coding agent may need a disposable container
+and hidden tests; a customer-support agent may need a simulated conversation and final
+CRM state. Build the runner and scorer that exercise the real mechanism. Do not force
+all three through one provider SDK or one generic text-in/text-out loop.
+
+Whatever the use case, keep these portable seams:
+
+- fixture items have stable, unique ids and an immutable content hash;
+- the runner stores raw output, trace or state evidence before scoring;
+- the scorer emits one record per id and can abstain or error without calling it a fail;
+- the reporter consumes records rather than calling the system;
+- baseline and treatment use the same adapter, budget, timeout and item order policy;
+- cache mode, retries, concurrency and provider/model identity are explicit in the manifest.
+
+Existing eval tools can implement any seam. Reuse their provider adapters, task
+registries, metrics or trace capture when they fit; preserve this record contract around
+them so the comparison and gate remain auditable.
+
+## Per-item records, not aggregates
+
+The scorer emits one record per item:
+
+```json
+{"id": "q-0042", "verdict": "pass", "score": 1.0, "layer": "deterministic",
+ "expected": "...", "actual": "...", "latency_ms": 812, "tokens_in": 1930,
+ "tokens_out": 74, "error": null}
+```
+
+Aggregates are computed by the reporter from these records. A mean without the
+per-item records cannot be diffed, cannot be bisected, and cannot be audited. A gate
+compares per-item, because an aggregate can hold steady while ten items collapse and
+ten improve.
+
+## Three-way outcome
+
+Every run ends in exactly one of:
+
+| Outcome | Meaning | Exit code |
+|---|---|---|
+| **PASS** | Ran on the intended fixture with the intended arm; bar met | 0 |
+| **FAIL** | Ran correctly; bar not met | 1 |
+| **CANNOT-MEASURE** | Anything that prevents a valid comparison | 2 |
+
+CANNOT-MEASURE is raised for: harness crash, system crash on more than a pre-set
+fraction of items, fixture fingerprint mismatch with the baseline, missing baseline,
+treatment-arm liveness check failed, judge version mismatch, timeout on setup. It is
+never collapsed into FAIL (which would block a good change for a broken gauge) and
+never into PASS (which would ship a regression behind a crashed harness).
+
+`scripts/check_gate.py` implements this contract over two per-item JSON files.
+
+CI must treat exit 2 as "gate could not run" and surface it, not as green. A common
+real-world failure: a runner exits 0 after a setup timeout, the pipeline reads green,
+and a batch of errored tasks is reported as clean. Read the per-item error field, never
+the runner's own "done" log.
+
+## Fixture fingerprint
+
+The run manifest records the fixture content hash. The reporter refuses to compare two
+runs whose fingerprints differ, with a message naming both hashes. Comparing across
+corpora, caches, or snapshots is the most common way teams see an effect that is
+really a changed condition. A refused comparison is a feature.
+
+## Treatment-arm liveness
+
+Before the first item, the runner asserts that the arm under test is active: the flag
+is set, the config is loaded, the model identifier in the response matches the
+intended one, the feature's own instrumentation reports on. On failure the run ends
+CANNOT-MEASURE. Silent misconfiguration produces a confident, fake comparison, and it
+is common enough to deserve a dedicated check rather than a hope.
+
+## The cache trap
+
+Benchmarks are usually run against pre-built caches, indexes, or snapshots because
+building them is slow. That means the write path is never exercised: a change that
+corrupts what gets written (a zeroed vector, a dropped field) passes every cached
+benchmark. Any gate protecting a system with a write path includes at least one
+fresh-build run from raw inputs, on a schedule appropriate to its cost.
+
+## Reproducibility
+
+- **Temperature zero is not determinism.** On a shared inference server, output depends
+  on batch composition through the order of floating-point reductions in the kernels.
+  The same prompt run twice is itself a noisy measurement. Either pin the serving
+  stack and batch configuration, or treat repeated runs as the unit and report spread.
+- **Seeds.** Every random choice (sampling, split, item order, judge ordering) is
+  seeded and the seed is in the manifest.
+- **Fixed clock.** Any time-dependent logic (recency boosts, expiry) receives an
+  injected clock during the run; wall-clock reads make yesterday's baseline
+  incomparable.
+- **Single-thread for equality runs.** When the check is bit-for-bit equality, disable
+  parallelism that changes reduction or merge order.
+- **Pinned everything.** Model snapshot string, judge snapshot string, harness version,
+  dependency lockfile hash, hardware class.
+
+## Run manifest
+
+Written at the start of the run, completed at the end. Template in
+`templates/run-manifest.json`. Minimum fields: run id, timestamp, fixture hash,
+fixture version, arm name and liveness result, system version or commit, model
+snapshot, judge snapshot and prompt hash, seeds, harness version, environment
+summary, item count, error count, outcome, and cost/latency totals.
+
+Without the manifest a number cannot be reproduced or audited, and an unreproducible
+number is an anecdote.
+
+## Timeouts and partial failure
+
+- Per-item timeout, recorded as an item error, not as a fail-by-default score unless
+  the pre-registration says timeouts count as failures (for agents it usually should).
+- Setup timeout ends the run CANNOT-MEASURE.
+- A pre-set error budget (say 2% of items) above which the run is CANNOT-MEASURE
+  rather than a scored run with holes.
+
+## Reporter checks before it prints a number
+
+1. Fingerprints match.
+2. Both runs have the same item ids.
+3. Error counts within budget.
+4. Liveness passed on the treatment run.
+5. Judge versions match (if a judged layer exists).
+6. The negative-control item (a known-bad case) failed on both runs. A scorer that
+   passes the known-bad case is broken, and the run is CANNOT-MEASURE.
+
+Then, and only then, the per-item diff and the aggregate.
+
+## Output of this file
+
+A harness where fixture, runner, scorer, and reporter are separate; per-item records;
+a three-way exit; fingerprint refusal; a liveness assertion; a negative control; a
+run manifest; and a fresh-build run somewhere in the schedule.

--- a/cli-tool/components/skills/development/eval-genius/references/07-gates-and-ci.md
+++ b/cli-tool/components/skills/development/eval-genius/references/07-gates-and-ci.md
@@ -1,0 +1,121 @@
+# Gates and CI: making the eval block the merge
+
+A gate is an eval with the power to say no. That power is only worth having if the
+gate is trusted, and a gate is trusted only when it is fast enough to run, honest about
+when it could not run, and impossible to argue with after the fact.
+
+## Tiers
+
+| Tier | Runs on | Budget | Content | On failure |
+|---|---|---|---|---|
+| **Smoke** | Every commit | Under a minute, no paid calls | Deterministic subset, negative control, liveness | Block |
+| **Gate** | Every pull request | Minutes, small paid budget | Full deterministic layer on the held-out set; judged layer on a fixed sample | Block |
+| **Nightly** | Scheduled | Up to an hour, moderate budget | Full judged layer, repeated trials, fresh-build run, cost and latency | Alert, block release |
+| **Release** | Before a version ships | Whatever it costs | Everything, plus any adopted public benchmark | Block ship |
+
+Anything that cannot fit a tier's budget moves up a tier; nothing is dropped silently.
+The tier a check runs in is written next to the check.
+
+## What a gate compares
+
+Per-item, against a committed baseline, on the same fixture fingerprint. The rule is
+written in the pre-registration and looks like one of:
+
+- **No regressions:** no item that passed in baseline fails now, tolerance zero. Strict
+  and right for deterministic layers.
+- **Aggregate with tolerance:** metric not below baseline minus a stated tolerance, and
+  the per-item diff attached so a masked collapse is visible.
+- **Interval rule:** the paired confidence interval on the delta excludes a regression
+  larger than the stated tolerance (`08-statistics.md`).
+
+A gate rule with no per-item diff is a gate that can be fooled by offsetting changes.
+
+## Baseline lifecycle
+
+- **Lives in the repo**, versioned, as per-item records plus the manifest, next to the
+  fixture hash it was produced on.
+- **Promotion** is a deliberate commit with a written reason: "baseline updated after
+  change X; delta +0.031 recall@5, 0 regressions, manifest attached." Nobody promotes a
+  baseline in the same change that needed it to pass.
+- **Re-baseline** whenever the fixture, the judge, or the harness version changes,
+  because the old numbers are no longer comparable. Say so in the commit.
+- **Never edit** a baseline by hand.
+
+## Flake policy
+
+A flaky gate is a broken gate. Retries hide regressions and train people to ignore red.
+
+1. Measure run-to-run variance on the same commit first (`08-statistics.md`). If the
+   variance exceeds the tolerance, the gate is not yet a gate; move the noisy items to
+   nightly with repeated trials, or widen the tolerance with a written reason.
+2. Allow at most one automatic retry, only for CANNOT-MEASURE outcomes (infrastructure
+   failures), never for FAIL.
+3. Quarantine an item that flips on identical inputs, with an issue and a deadline.
+   Quarantine is visible in the report, not silent.
+
+## Verifier verification, wired in
+
+Every gate run includes a negative control: an item known to be bad (a deliberately
+wrong output, a corrupted fixture entry, a disabled feature). The gate must fail it. If
+the negative control passes, the scorer is broken, the run is CANNOT-MEASURE, and
+nothing else the run says is trusted. This is the cheapest check in the system and the
+one that catches "the gate has been green for a month because it grades nothing."
+
+## Triage when the gate fails
+
+1. **Read the outcome.** CANNOT-MEASURE is an infrastructure or fixture problem; fix the
+   gauge, do not touch the system.
+2. **Read the per-item diff.** Which items flipped, in which direction, in which
+   stratum. Ten flips in one category is a real effect; ten flips scattered at random
+   on a noisy judge is variance.
+3. **Reproduce one flipped item by hand** before believing the aggregate.
+4. **Bisect** on the lever if the change contains more than one.
+5. **Decide: fix the system, fix the gauge, or accept with a written reason and a
+   baseline promotion.** Never the fourth option, which is loosening the bar until
+   green.
+
+## Cost and latency gates
+
+Quality gates that ignore cost let a change ship that doubles the bill. Add:
+
+- Tokens per item and cost per pass, with a tolerance.
+- p95 latency, with a tolerance.
+
+Both are per-item records already, so they ride the same diff.
+
+## Anti-patterns specific to gates
+
+- **Green by crash.** Runner exits 0 after a setup failure; CI reads green.
+- **Retry until green.** Any retry of a FAIL.
+- **Baseline drift.** Baseline promoted in the same PR that needed it.
+- **Gate-set tuning.** Prompts iterated against the held-out set.
+- **Silent tier drop.** A slow check removed from the gate and added nowhere.
+
+## Output of this file
+
+A gate definition: tier, fixture hash, comparison rule, tolerance, baseline location
+and promotion rule, flake policy, negative control, cost/latency limits, and the exit
+code contract CI honors.
+
+## CI shell contract
+
+A gate command has three meaningful exits. CI must preserve all of them even though
+the job UI ultimately shows only success or failure:
+
+```bash
+set +e
+python3 path/to/check_gate.py --baseline "$BASELINE" --treatment "$TREATMENT"
+code=$?
+set -e
+case "$code" in
+  0) echo "PASS: the measured bar was met" ;;
+  1) echo "FAIL: the run was valid and the bar was missed"; exit 1 ;;
+  2) echo "CANNOT-MEASURE: the instrument or comparison was invalid"; exit 2 ;;
+  *) echo "CANNOT-MEASURE: unexpected gate exit $code"; exit 2 ;;
+esac
+```
+
+In the project that integrates the gate, store the per-item records and manifest as CI
+artifacts on every outcome. A red job without the records cannot distinguish a product
+regression from a broken gauge. The skill repository's own workflow tests the utilities;
+it does not produce system-under-test run artifacts.

--- a/cli-tool/components/skills/development/eval-genius/references/08-statistics.md
+++ b/cli-tool/components/skills/development/eval-genius/references/08-statistics.md
@@ -1,0 +1,98 @@
+# Statistics: is the delta real
+
+An eval score is a sample statistic. The items are a draw from a larger population of
+possible items, and the model's output on each is itself a draw. Treat the score the
+way any other measurement is treated: with an interval, a paired design, and a sample
+size chosen before the run.
+
+## Report an interval with every number
+
+A point estimate without spread is not a result. The minimum is a standard error or a
+95% interval next to every aggregate, computed from the per-item records.
+
+For a pass rate p over n independent items, the standard error is roughly
+sqrt(p(1-p)/n). Table for orientation, 95% interval half-width:
+
+| n | p = 0.5 | p = 0.9 |
+|---|---|---|
+| 50 | ±0.14 | ±0.08 |
+| 200 | ±0.07 | ±0.04 |
+| 1000 | ±0.03 | ±0.02 |
+
+A "+2 points" improvement on 200 items is inside the noise. Say so.
+
+## Paired comparisons
+
+When two arms run on the same items, compare per item and analyze the differences.
+Paired analysis removes item difficulty from the noise and is far more powerful than
+comparing two unpaired means. The per-item records the harness already emits are the
+input.
+
+`scripts/paired_bootstrap.py` takes two per-item files, matches on id, and reports the
+mean delta with a bootstrap 95% interval and the count of items that improved,
+regressed, and held. The decision rule from the pre-registration is applied to the
+interval, not to the point estimate.
+
+## Clustering
+
+Items are often not independent: several questions per document, several tasks per
+repository, several turns per conversation. Naive standard errors on clustered items
+have been measured at a third of the true value. When items share a parent, compute
+the interval over parents (cluster bootstrap: resample parents, not items) or report
+the cluster count as the effective n.
+
+## Sample size and minimum detectable effect
+
+Decide the smallest effect worth acting on, then size the set so it can be seen. Rule
+of thumb for a paired pass/fail comparison where items flip with rate f: to detect a
+net shift of d with reasonable power, n is on the order of 8·f/d². A 2-point shift
+with 10% of items flipping needs roughly 2000 items; a 10-point shift needs about 80.
+If the set cannot be that large, either accept a coarser detectable effect in writing
+or repeat runs and pool.
+
+## Repeated runs
+
+The same prompt twice is a noisy measurement (`06-harness-design.md`). For any judged
+or sampled layer:
+
+- Run the same commit k times before trusting a delta; the run-to-run spread is the
+  noise floor. A delta smaller than the noise floor is not a result.
+- Report per-run aggregates and their spread, not only the pooled mean.
+- For agents, report pass^k (all k trials succeed) next to pass@k (any succeeds). The
+  first is what a user experiences.
+
+## Multiple comparisons and "run until green"
+
+Testing many variants, many metrics, or the same variant many times inflates the
+chance that something looks significant by luck. Mitigations:
+
+- Pre-register the primary metric and treat the others as secondary.
+- When many comparisons are unavoidable, tighten the threshold (divide the significance
+  level by the number of comparisons, or report which of many the winner was).
+- Repeating a noisy gate until one run passes is the same inflation by another name.
+  It is prohibited in `07-gates-and-ci.md`.
+
+## Aggregation rules
+
+- **Mean** for pass rates and scores where every item weighs equally.
+- **Median** and **p95** for latency and cost; means hide tails.
+- **Per-stratum reporting** whenever the fixture is stratified; a flat mean over
+  unequal strata is weighted by whatever the sampling happened to be.
+- **Outlier rule** from the pre-registration, applied as written: cap, exclude with
+  disclosure, or report separately. Never decided after seeing which item dominates.
+- **Per-layer**, always. Deterministic and judged scores are never blended.
+
+## What "significant" buys
+
+An interval excluding zero means the delta is unlikely to be noise on this fixture.
+It says nothing about whether the fixture measures the promise (`01-foundation.md`),
+whether the labels are right (`05-dataset-construction.md`), or whether the effect
+will hold on live traffic. Statistical significance is the entry ticket, not the
+verdict.
+
+## Output of this file
+
+Every reported number carries an interval; every two-arm comparison is paired with a
+bootstrap interval and per-item flip counts; clustered items are handled; the sample
+size was chosen from a stated minimum detectable effect; repeated runs establish the
+noise floor before any delta is claimed.

--- a/cli-tool/components/skills/development/eval-genius/references/09-reporting.md
+++ b/cli-tool/components/skills/development/eval-genius/references/09-reporting.md
@@ -1,0 +1,80 @@
+# Reporting: honesty is the deliverable
+
+The report is where the eval becomes a claim. A report that flatters is worse than no
+report, because it will be believed. Write the report that survives the hostile reader.
+
+## Pre-registration is the first half of the report
+
+The report begins by quoting the pre-registration verbatim (`templates/preregistration.md`):
+promise, variables, placement, weight, bar, falsifier, outlier rule, baseline. Then it
+shows the result against that bar. A reader can see at once whether the goalposts
+moved.
+
+## Tier every number
+
+| Tier | Meaning | Example |
+|---|---|---|
+| **Measured** | Produced by a run with a manifest | "recall@5 0.71 ± 0.03, n=400, manifest r-2031" |
+| **Estimated** | Derived, extrapolated, or from a smaller sample | "roughly 30% cost reduction, from 20 sampled items" |
+| **Aspirational** | A target, not a result | "aiming for p95 under 1.5 s" |
+
+Never sum or average across tiers. A measured number and an estimated number in the
+same sentence get their labels.
+
+## Separate the layers
+
+Deterministic pass rate and judged score are reported in separate lines with separate
+denominators, intervals, and n. Cost and latency get their own lines. A blended
+"quality score" is a refusal to say which half moved.
+
+## Disclose what weakens the number
+
+- The conservative setup, older snapshot, small sample, or subset used.
+- Whether the benchmark is **self-run** or independent. Self-run benchmarks are
+  evidence, not market validation.
+- The harder metric, even when the easier one looks better.
+- Label-error ceiling of the fixture, so the reader knows the cap.
+- Judge agreement with humans, so the reader knows how much the judged layer means.
+- Anything the falsifier said would matter, and whether it happened.
+
+The disclosure is what makes the number believable. A report with no caveats reads as
+a report where nobody looked.
+
+## Comparability rule
+
+Two numbers may sit side by side only when fixture hash, harness version, judge
+version, and metric definition match. Otherwise they appear in separate tables with a
+note, or the older one is re-run.
+
+## Negative and null results
+
+A change that did nothing is a result. Report it with the same manifest and interval,
+and record what was concluded from the falsifier. Null results retired in silence get
+re-attempted by the next person.
+
+## Retiring a benchmark
+
+A benchmark is retired when it saturates (leading systems near the ceiling), when its
+label-error ceiling is found to be above the deltas being chased, when it is
+contaminated, or when the promise it measured no longer matters. Retirement is a
+written note: what it measured, why it stopped being useful, what replaces it, and the
+last comparable numbers. Kill darlings on evidence, in writing.
+
+## Attack it before shipping it
+
+Before a number goes public, someone who did not build the system tries to break the
+benchmark's logic: find an item that passes for the wrong reason, an offset regression
+the aggregate hides, a fixture drift, a judge bias. Findings go in the report. A
+number that has survived an attack is worth more than one that has only been admired.
+
+## Template
+
+`templates/eval-report.md` carries the structure: pre-registration quoted, manifest
+reference, per-layer results with intervals, per-item flip summary, cost and latency,
+caveats, tier labels, decision, and what happens next.
+
+## Output of this file
+
+A report where the reader can find the bar before the result, the tier of every
+number, the layers separated, the caveats that weaken the claim, and a decision that
+follows from the pre-registered rule.

--- a/cli-tool/components/skills/development/eval-genius/references/10-agentic-evals.md
+++ b/cli-tool/components/skills/development/eval-genius/references/10-agentic-evals.md
@@ -1,0 +1,80 @@
+# Agentic evals: outcome, trajectory, reliability
+
+Agents produce a trajectory (tool calls, intermediate states, messages) and an
+outcome (the final state of the world). The two are graded separately, because many
+correct trajectories reach one correct outcome, and a lucky trajectory can reach it
+too.
+
+## Outcome grading first
+
+Grade the end state, deterministically:
+
+- The resulting files, database rows, or API state match an annotated goal state.
+- Hidden tests pass. Tests are hidden from the agent; leaked tests inflate.
+- Nothing outside the task scope changed. Diff the world before and after; collateral
+  damage is a failure even when the task passed.
+
+The transcript is not consulted for the outcome verdict. That removes the temptation
+to award credit for "trying hard."
+
+## Trajectory grading second, and separately
+
+Trajectory checks catch what outcome grading cannot:
+
+- **Forbidden actions.** Destructive commands, out-of-scope writes, credential reads.
+  Deterministic: pattern-match the tool log.
+- **Efficiency.** Tool calls, tokens, wall time, retries. Deterministic.
+- **Process quality.** Did it verify before claiming done, did it read before writing.
+  Usually judged; calibrate per `03-judge-calibration.md`, and keep it out of the
+  headline.
+
+Report trajectory metrics next to the outcome metric, never blended into it.
+
+## Reliability: pass^k beside pass@k
+
+- **pass@k**: at least one of k independent trials succeeds. Rises with k. Measures
+  capability.
+- **pass^k**: all k trials succeed. Falls with k. Measures reliability, which is what a
+  user experiences when they run the agent once and trust it.
+
+An agent with pass@1 near 60% can have pass^8 under 25%. Report both. A gate on a
+production agent uses pass^k with a pre-registered k.
+
+## Sandboxing and infrastructure failure
+
+- Every trial runs in a fresh, isolated environment with a pinned image. State leaking
+  between trials is fixture drift.
+- Setup timeouts, image pull failures, and container crashes are CANNOT-MEASURE for
+  that item, recorded in the error field, never scored as a fail. A harness that
+  reports 0% on a task the agent never entered is measuring infrastructure.
+- Per-trial timeout is pre-registered and usually counts as a failure, because a user
+  would experience it as one. Say which.
+
+## The harness is a lever
+
+Two agents on the same model with different scaffolds score differently. When the
+comparison is between models, freeze the scaffold, tool set, budgets, and timeouts.
+When the comparison is between scaffolds, freeze the model. Moving both is the
+two-lever mistake from `01-foundation.md`.
+
+## Items for agent tasks
+
+Follow `05-dataset-construction.md`, with the four defect classes applied hard: an
+over-strict hidden test fails a correct alternative solution; an under-specified prompt
+makes the hidden test a guessing game. Every task gets a known-good reference solution
+that passes and a known-bad one that fails, both run in the harness before the task is
+admitted.
+
+## Multi-turn and simulated users
+
+When the task needs a user in the loop, the simulated user is part of the fixture:
+pinned model, pinned persona script, pinned seed. A simulated user that changes
+between runs is a control that moved. Grade the outcome state, not the conversation's
+tone, unless tone is the promise.
+
+## Output of this file
+
+An agent eval with deterministic outcome grading on end state, separate trajectory
+metrics, pass^k beside pass@k with pre-registered k, isolated per-trial sandboxes,
+infrastructure failures recorded as CANNOT-MEASURE, and a frozen scaffold when the
+model is the lever.

--- a/cli-tool/components/skills/development/eval-genius/references/11-reading-results.md
+++ b/cli-tool/components/skills/development/eval-genius/references/11-reading-results.md
@@ -1,0 +1,97 @@
+# Reading results from scratch
+
+For the reader holding their first output file. Read in order; each check gates the
+next. The deeper material sits in `07-gates-and-ci.md` (triage) and `08-statistics.md`
+(noise), and this file stays at the level of "what does this number let me say".
+
+## 1. Did it run? (before the number means anything)
+
+Every run ends one of three ways: **PASS**, **FAIL**, or **CANNOT-MEASURE**. A crash,
+a timeout, an item that errored, a fixture that did not match, a treatment arm that was
+not actually switched on: all CANNOT-MEASURE, which is a plumbing problem to fix and not
+a verdict on the system. `scripts/check_gate.py` exits 2 for this; read that exit code
+before reading any score. Also check the known-bad item failed. A verifier that passes
+a plant grades nothing, and every green above it is meaningless.
+
+## 2. Compare to the bar you wrote, not to your hopes
+
+Open the pre-registration. The bar says what "better" means in numbers; the falsifier
+says what "useless" looks like. Put the result next to those two lines. A result that
+is above the bar is a candidate win; one below the falsifier is a rejected change; one
+in between is "not established". Deciding the bar now, with the number in view, is the
+single most common way a team ships noise, and the reason the bar was written first.
+
+## 3. Is the difference bigger than the noise?
+
+A pass rate on n items carries an error bar. Orientation, 95% half-width:
+
+| n | around 50% pass | around 90% pass |
+|---|---|---|
+| 50 | about ±14 points | about ±8 points |
+| 200 | about ±7 points | about ±4 points |
+| 1000 | about ±3 points | about ±2 points |
+
+So on 50 items, a 4-point rise is inside the noise. `scripts/paired_bootstrap.py`
+gives the honest version: run both arms on the same items, it reports the mean delta
+and a 95% interval. Plain reading: the interval is the range of true deltas the data is
+consistent with. If it includes zero, the change may have done nothing; say "not
+established", not "no effect". If it excludes zero and clears the bar, the delta is
+real on this fixture. That is the entry ticket, not the verdict; it says nothing about
+whether the items measure the promise.
+
+Judged layers and anything with sampling are noisier than that table: run the same
+version twice first. The spread between two identical runs is the noise floor, and a
+delta smaller than it is not a result.
+
+## 4. Look at the items, not the average
+
+The per-item diff has three counts: improved, regressed, held. Read the regressions
+before the total; an aggregate can climb while a category collapses. Ten flips in one
+category is a real effect, in one direction. Ten flips scattered across categories on
+a judged score is variance. Reproduce one flipped item by hand before believing any
+of it; the reproduction is where most "wins" and most "regressions" turn out to be a
+scorer that changed its mind.
+
+## 5. Surprised? Suspect the harness first
+
+A 0%, a 99%, a jump of thirty points from a one-line change: harness bug until proven
+otherwise. Confirm the run used the fixture it claims, the version it claims, and the
+arm it claims. The one forbidden move is changing the system until a suspect gauge
+reads nicely; fix the gauge or stop.
+
+## 6. Read the layers separately, then cost
+
+Deterministic pass rate and judged score have different denominators and different
+noise; one number that blends them hides which half moved. Then read tokens per item,
+cost per pass, and p95 latency. A quality gain that doubled cost or tail latency is a
+trade to state, not a win to announce.
+
+## 7. What you are allowed to say
+
+Three sentences, each tagged **measured** (from a run with a manifest), **estimated**
+(derived or from a smaller sample), or **aspirational** (a target):
+
+1. The bar, quoted, and whether it was met.
+2. The primary delta with its interval and n, and the improved / regressed / held counts.
+3. The caveat that most weakens the claim: sample size, subset, self-run, judge
+   agreement, or a surprising number that was not fully explained.
+
+Everything the report template asks for (`templates/eval-report.md`) is an expansion
+of those three. A write-up with no third sentence reads as one where nobody looked.
+
+## Worked example (hypothetical numbers)
+
+Baseline 31 of 40 pass, treatment 34 of 40. Per item: 4 improved, 1 regressed, 35
+held. Bar was "no regressions and pass rate up by at least 5 points". Reading:
+
+- Ran cleanly, negative control failed: measurable.
+- The bar's first clause fails on one regression; open that item before anything else.
+- +7.5 points on 40 items sits inside a noise band of more than ten points; the
+  paired interval will likely include zero. Verdict: **promising, not established**. Next
+  step is more items or repeated runs, not a promotion of the baseline.
+
+## Output of this file
+
+A three-way outcome read before any score; the result placed against the written bar;
+a delta with an interval and a stated noise floor; regressions inspected by hand;
+layers and cost read separately; and three tagged sentences a hostile reader can check.

--- a/cli-tool/components/skills/development/eval-genius/scripts/check_gate.py
+++ b/cli-tool/components/skills/development/eval-genius/scripts/check_gate.py
@@ -120,15 +120,19 @@ def main():
     if live not in ("passed", "not-applicable"):
         die(f"treatment liveness is {live!r}; must be 'passed' or 'not-applicable'. Assert the arm under test is active before scoring.")
 
-    # If a judged layer is present, the two runs must share the same judge instrument.
-    # Comparing runs graded by different judge prompts or models is fixture drift in
-    # the grader. Checked only when both manifests declare the field; absent = skip.
-    base_judge = base["manifest"].get("judge") or {}
-    treat_judge = treat["manifest"].get("judge") or {}
+    # If either run declares a judge fingerprint, both runs must declare the same value.
+    # Missing metadata is not evidence that the instrument matched, so compare fail-closed.
+    base_judge = base["manifest"].get("judge")
+    treat_judge = treat["manifest"].get("judge")
+    for role, judge in (("baseline", base_judge), ("treatment", treat_judge)):
+        if judge is not None and not isinstance(judge, dict):
+            die(f"{role} judge metadata must be an object or null.")
+    base_judge = base_judge or {}
+    treat_judge = treat_judge or {}
     for field in ("prompt_hash", "model_snapshot"):
         b_val, t_val = base_judge.get(field), treat_judge.get(field)
-        if b_val is not None and t_val is not None and b_val != t_val:
-            die(f"judge {field} differs: baseline={b_val!r} treatment={t_val!r}. "
+        if b_val != t_val:
+            die(f"judge {field} differs or is missing on one arm: baseline={b_val!r} treatment={t_val!r}. "
                 "Re-grade both arms with one pinned judge before comparing the judged layer.")
 
     baseline_all = {item["id"]: item for item in base["items"]}

--- a/cli-tool/components/skills/development/eval-genius/scripts/check_gate.py
+++ b/cli-tool/components/skills/development/eval-genius/scripts/check_gate.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Compare a treatment run against a baseline run, per item, with a three-way outcome.
+
+Exit codes (CI must honor all three):
+  0  PASS            bar met on the same fixture with a live treatment arm
+  1  FAIL            ran correctly, bar not met
+  2  CANNOT-MEASURE  fingerprint mismatch, missing items, error budget blown,
+                     liveness failed, negative control passed, bad input
+
+Input: two files, each JSON {"manifest": {...}, "items": [{"id", "verdict", ...}]} or
+JSONL whose first line is {"manifest": {...}} followed by one item record per line.
+  manifest.fixture_hash        required, must match between runs
+  manifest.liveness            required on treatment: "passed" | "failed" | "not-applicable"
+  manifest.negative_control_id required unless --no-negative-control; both manifests must
+                               name the same id, which must fail in both runs
+  items[].id                   required non-empty string, unique within each run
+  items[].verdict              "pass" | "fail" | "error"
+
+Usage:
+  check_gate.py --baseline base.json --treatment treat.json [--tolerance 0.0]
+                [--error-budget 0.02] [--max-regressions 0] [--layer deterministic]
+                [--no-negative-control]
+  --tolerance          allowed drop in pass rate (0.0 = no aggregate regression)
+  --max-regressions N  fail if more than N items flip pass->fail (default 0)
+  --no-negative-control  waive the mandatory negative control (record the reason
+                       in the pre-registration)
+
+Behavior changes (stricter than earlier versions; each is CANNOT-MEASURE, never a
+silent PASS, so an archived pair can flip from scored to refused):
+  - the error budget applies to BOTH arms; a baseline over budget is refused too.
+  - negative_control_id must match between the two manifests (a one-sided control
+    is no longer honored).
+  - duplicate item ids are refused; ids must be unique within each run.
+"""
+import argparse
+import json
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+PASS, FAIL, CANNOT = 0, 1, 2
+
+
+def die(msg, code=CANNOT):
+    print(f"CANNOT-MEASURE: {msg}" if code == CANNOT else msg, file=sys.stderr)
+    sys.exit(code)
+
+
+def load(path, role):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        die(f"{role} file not found: {path}. Pass the per-item results JSON written by the scorer.")
+    except (OSError, UnicodeError) as exc:
+        die(f"cannot read {role} file {path} as UTF-8 ({exc}).")
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            lines = [json.loads(line) for line in text.splitlines() if line.strip()]
+            first = lines[0]
+            if not isinstance(first, dict):
+                raise TypeError("first JSONL record must be an object")
+            data = {"manifest": first.get("manifest", first), "items": lines[1:]}
+        except (json.JSONDecodeError, ValueError, IndexError, TypeError, AttributeError) as exc:
+            die(f"{role} file {path} is neither JSON {{'manifest','items'}} nor JSONL (manifest line then item lines) ({exc}).")
+    if not isinstance(data, dict) or "manifest" not in data or "items" not in data:
+        die(f"{role} file {path} must be an object with 'manifest' and 'items' keys.")
+    if not isinstance(data["manifest"], dict):
+        die(f"{role} manifest must be an object.")
+    if not isinstance(data["items"], list):
+        die(f"{role} items must be an array.")
+    if "fixture_hash" not in data["manifest"]:
+        die(f"{role} manifest has no 'fixture_hash'. Every run must record the fixture content hash; a run without one cannot be compared.")
+    fixture_hash = data["manifest"]["fixture_hash"]
+    if not isinstance(fixture_hash, str) or not fixture_hash.strip():
+        die(f"{role} fixture_hash must be a non-empty string.")
+    seen = set()
+    for item in data["items"]:
+        if not isinstance(item, dict):
+            die(f"{role} item {item!r} must be an object.")
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id.strip():
+            die(f"{role} item {item!r} needs a non-empty string 'id'.")
+        if item.get("verdict") not in ("pass", "fail", "error"):
+            die(f"{role} item {item!r} needs a verdict in pass|fail|error.")
+        if item_id in seen:
+            die(f"{role} contains duplicate item id {item_id!r}. Duplicate ids make per-item comparison ambiguous.")
+        seen.add(item_id)
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--treatment", required=True)
+    parser.add_argument("--tolerance", type=float, default=0.0)
+    parser.add_argument("--max-regressions", type=int, default=0)
+    parser.add_argument("--error-budget", type=float, default=0.02)
+    parser.add_argument("--layer", default=None, help="only compare items whose 'layer' field equals this")
+    parser.add_argument("--no-negative-control", action="store_true", help="waive the mandatory negative control (state the reason in the pre-registration)")
+    args = parser.parse_args()
+
+    if not 0.0 <= args.tolerance <= 1.0:
+        die("--tolerance must be between 0 and 1.")
+    if args.max_regressions < 0:
+        die("--max-regressions must be zero or greater.")
+    if not 0.0 <= args.error_budget <= 1.0:
+        die("--error-budget must be between 0 and 1.")
+
+    base, treat = load(args.baseline, "baseline"), load(args.treatment, "treatment")
+    baseline_hash = base["manifest"]["fixture_hash"]
+    treatment_hash = treat["manifest"]["fixture_hash"]
+    if baseline_hash != treatment_hash:
+        die(f"fixture fingerprint mismatch: baseline={baseline_hash} treatment={treatment_hash}. Runs on different fixtures are not comparable; re-run both on one fixture.")
+
+    live = treat["manifest"].get("liveness")
+    if live not in ("passed", "not-applicable"):
+        die(f"treatment liveness is {live!r}; must be 'passed' or 'not-applicable'. Assert the arm under test is active before scoring.")
+
+    # If a judged layer is present, the two runs must share the same judge instrument.
+    # Comparing runs graded by different judge prompts or models is fixture drift in
+    # the grader. Checked only when both manifests declare the field; absent = skip.
+    base_judge = base["manifest"].get("judge") or {}
+    treat_judge = treat["manifest"].get("judge") or {}
+    for field in ("prompt_hash", "model_snapshot"):
+        b_val, t_val = base_judge.get(field), treat_judge.get(field)
+        if b_val is not None and t_val is not None and b_val != t_val:
+            die(f"judge {field} differs: baseline={b_val!r} treatment={t_val!r}. "
+                "Re-grade both arms with one pinned judge before comparing the judged layer.")
+
+    baseline_all = {item["id"]: item for item in base["items"]}
+    treatment_all = {item["id"]: item for item in treat["items"]}
+    baseline_control = base["manifest"].get("negative_control_id")
+    treatment_control = treat["manifest"].get("negative_control_id")
+    if baseline_control != treatment_control:
+        die(f"negative_control_id mismatch: baseline={baseline_control!r} treatment={treatment_control!r}. Both arms must exercise the same control.")
+    control = baseline_control
+    if not control and not args.no_negative_control:
+        die("no negative_control_id in either manifest. Every gate run must include a known-bad item that the scorer fails; add one, or pass --no-negative-control to waive it with a written reason in the pre-registration.")
+    if control:
+        if not isinstance(control, str) or not control.strip():
+            die("negative_control_id must be a non-empty string.")
+        if control not in baseline_all or control not in treatment_all:
+            die(f"negative control item {control!r} must be present in both runs.")
+        if baseline_all[control]["verdict"] != "fail" or treatment_all[control]["verdict"] != "fail":
+            die(f"negative control {control!r} did not fail (baseline={baseline_all[control]['verdict']}, treatment={treatment_all[control]['verdict']}). The scorer is not catching a known-bad case; nothing else in this run is trusted.")
+
+    baseline_items = {item_id: item for item_id, item in baseline_all.items()
+                      if item_id != control and (args.layer is None or item.get("layer") == args.layer)}
+    treatment_items = {item_id: item for item_id, item in treatment_all.items()
+                       if item_id != control and (args.layer is None or item.get("layer") == args.layer)}
+    if not baseline_items or not treatment_items:
+        die("no scored items remain to compare (check --layer and the negative control).")
+    if set(baseline_items) != set(treatment_items):
+        only_base = sorted(set(baseline_items) - set(treatment_items))[:5]
+        only_treat = sorted(set(treatment_items) - set(baseline_items))[:5]
+        die(f"item id sets differ (baseline-only e.g. {only_base}, treatment-only e.g. {only_treat}). Both runs must cover the same items.")
+
+    item_count = len(treatment_items)
+    baseline_errors = sum(item["verdict"] == "error" for item in baseline_items.values())
+    treatment_errors = sum(item["verdict"] == "error" for item in treatment_items.values())
+    for role, errors in (("baseline", baseline_errors), ("treatment", treatment_errors)):
+        if errors / item_count > args.error_budget:
+            die(f"{errors}/{item_count} {role} items errored ({errors/item_count:.1%}) > error budget {args.error_budget:.1%}. Fix the harness; a run with holes is not a scored run.")
+
+    improved = sorted(item_id for item_id in treatment_items
+                      if baseline_items[item_id]["verdict"] != "pass" and treatment_items[item_id]["verdict"] == "pass")
+    regressed = sorted(item_id for item_id in treatment_items
+                       if baseline_items[item_id]["verdict"] == "pass" and treatment_items[item_id]["verdict"] != "pass")
+    baseline_rate = sum(item["verdict"] == "pass" for item in baseline_items.values()) / item_count
+    treatment_rate = sum(item["verdict"] == "pass" for item in treatment_items.values()) / item_count
+
+    print(f"fixture {treatment_hash}  items {item_count}  errors baseline {baseline_errors} treatment {treatment_errors}")
+    print(f"pass rate  baseline {baseline_rate:.4f}  treatment {treatment_rate:.4f}  delta {treatment_rate-baseline_rate:+.4f}")
+    print(f"improved {len(improved)}  regressed {len(regressed)}  held {item_count-len(improved)-len(regressed)}")
+    if regressed:
+        print("regressed ids: " + ", ".join(regressed[:20]) + (" ..." if len(regressed) > 20 else ""))
+    if len(regressed) > args.max_regressions:
+        print(f"FAIL: {len(regressed)} regressions > allowed {args.max_regressions}")
+        sys.exit(FAIL)
+    if treatment_rate < baseline_rate - args.tolerance:
+        print(f"FAIL: pass rate dropped {baseline_rate-treatment_rate:.4f} > tolerance {args.tolerance}")
+        sys.exit(FAIL)
+    print("PASS")
+    sys.exit(PASS)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-tool/components/skills/development/eval-genius/scripts/hash_fixture.py
+++ b/cli-tool/components/skills/development/eval-genius/scripts/hash_fixture.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Canonical content hash of a frozen fixture, for the manifest's fixture_hash.
+
+Every gate/bootstrap run is refused without a fixture_hash, and two runs are only
+comparable when their hashes match. This produces that hash the same way every time,
+so two people (or two tools) hashing the same fixture get the same string instead of
+each inventing a canonicalization and silently failing to compare.
+
+Canonicalization: parse the fixture, re-serialize with sorted keys and no incidental
+whitespace, UTF-8. Formatting, key order, and trailing newlines do not change the hash;
+content does. Accepts a JSON document ({"items":[...]} or a bare array) or JSONL
+(one record per line); both hash to the same value when they carry the same records.
+
+Usage:
+  hash_fixture.py path/to/fixture.json         # prints: sha256:<hex>
+  hash_fixture.py --raw path/to/fixture.json   # prints just <hex>
+Exit 0 on success, 2 on unreadable or non-JSON input.
+"""
+import argparse
+import hashlib
+import json
+import sys
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_records(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        die(f"file not found: {path}")
+    except (OSError, UnicodeError) as exc:
+        die(f"cannot read {path} as UTF-8 ({exc})")
+    if not text:
+        die(f"{path} is empty.")
+    try:
+        data = json.loads(text)
+        return data["items"] if isinstance(data, dict) and "items" in data else data
+    except (json.JSONDecodeError, ValueError):
+        try:
+            return [json.loads(line) for line in text.splitlines() if line.strip()]
+        except (json.JSONDecodeError, ValueError) as exc:
+            die(f"{path} is neither a JSON document nor JSONL ({exc}).")
+
+
+def canonical_hash(records):
+    if not isinstance(records, list):
+        die("fixture must be a list of records (or an object with an 'items' array).")
+    # Sort records by id when present so record order does not change the hash;
+    # a fixture is a set of items, not a sequence.
+    try:
+        ordered = sorted(records, key=lambda r: json.dumps(r.get("id") if isinstance(r, dict) else r,
+                                                            sort_keys=True, ensure_ascii=False))
+    except TypeError:
+        ordered = records
+    blob = json.dumps(ordered, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("fixture", help="path to the fixture (JSON or JSONL)")
+    parser.add_argument("--raw", action="store_true", help="print the bare hex, no 'sha256:' prefix")
+    args = parser.parse_args()
+    digest = canonical_hash(load_records(args.fixture))
+    print(digest if args.raw else f"sha256:{digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-tool/components/skills/development/eval-genius/scripts/judge_agreement.py
+++ b/cli-tool/components/skills/development/eval-genius/scripts/judge_agreement.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Measure agreement between judge and human labels on a calibration set.
+
+Input: JSON {"items":[{"id","label"}]}, JSONL, or CSV with id,label. IDs must be
+unique non-empty strings. Labels must be strings in --labels (default pass,fail).
+At least 50 shared IDs and 80% coverage of each file are required by default.
+
+Exit 0 when kappa meets the floor, 1 when measured agreement is below it, and 2 when
+the calibration cannot be measured safely.
+
+Behavior change: labels are now restricted to the --labels set (default pass,fail);
+a value outside it, or a non-string id, is CANNOT-MEASURE. For a multi-class rubric
+pass every class via --labels (e.g. --labels A,B,C); for numeric ids, stringify them
+in the file first (arbitrary numeric ids are no longer coerced silently).
+"""
+import argparse
+import csv
+import json
+import math
+import sys
+from collections import Counter
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
+def cannot(message):
+    print(f"CANNOT-MEASURE: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load(path, allowed_labels):
+    try:
+        with open(path, encoding="utf-8-sig") as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        cannot(f"file not found: {path}")
+    except (OSError, UnicodeError) as exc:
+        cannot(f"cannot read {path} as UTF-8 ({exc})")
+    try:
+        if text.lower().startswith("id,"):
+            rows = list(csv.DictReader(text.splitlines()))
+        else:
+            try:
+                data = json.loads(text)
+                if isinstance(data, dict):
+                    if "items" not in data:
+                        raise TypeError("JSON object needs an 'items' array")
+                    rows = data["items"]
+                else:
+                    rows = data
+            except (json.JSONDecodeError, ValueError):
+                rows = [json.loads(line) for line in text.splitlines() if line.strip()]
+    except (json.JSONDecodeError, ValueError, KeyError, TypeError, csv.Error) as exc:
+        cannot(f"{path} is not JSON/JSONL/CSV with id,label ({exc})")
+    if not isinstance(rows, list):
+        cannot(f"{path} items must be an array.")
+    result = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            cannot(f"record {row!r} in {path} must be an object.")
+        item_id, label = row.get("id"), row.get("label")
+        if not isinstance(item_id, str) or not item_id.strip():
+            cannot(f"record {row!r} in {path} needs a non-empty string 'id'.")
+        if not isinstance(label, str) or label.strip().lower() not in allowed_labels:
+            cannot(f"record {row!r} in {path} needs a string label in {sorted(allowed_labels)}.")
+        if item_id in result:
+            cannot(f"{path} contains duplicate item id {item_id!r}")
+        result[item_id] = label.strip().lower()
+    return result
+
+
+def kappa(pairs):
+    count = len(pairs)
+    observed = sum(human == judge for human, judge in pairs) / count
+    labels = set(human for human, _ in pairs) | set(judge for _, judge in pairs)
+    human_counts = Counter(human for human, _ in pairs)
+    judge_counts = Counter(judge for _, judge in pairs)
+    expected = sum((human_counts[label] / count) * (judge_counts[label] / count) for label in labels)
+    if math.isclose(expected, 1.0):
+        cannot("Cohen's kappa is undefined because expected agreement is 1; the calibration labels are degenerate.")
+    return observed, (observed - expected) / (1 - expected)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--human", required=True)
+    parser.add_argument("--judge", required=True)
+    parser.add_argument("--positive", default="pass")
+    parser.add_argument("--labels", default="pass,fail", help="comma-separated allowed labels (default: pass,fail)")
+    parser.add_argument("--floor", type=float, default=0.8, help="minimum Cohen's kappa (default: 0.8)")
+    parser.add_argument("--min-coverage", type=float, default=0.8, help="minimum shared-ID fraction of each file (default: 0.8)")
+    args = parser.parse_args()
+    if not -1.0 <= args.floor <= 1.0:
+        cannot("--floor must be between -1 and 1.")
+    if not 0.0 < args.min_coverage <= 1.0:
+        cannot("--min-coverage must be greater than 0 and at most 1.")
+    allowed = {label.strip().lower() for label in args.labels.split(",") if label.strip()}
+    if len(allowed) < 2:
+        cannot("--labels must name at least two distinct labels.")
+    positive = args.positive.strip().lower()
+    if positive not in allowed:
+        cannot("--positive must be one of --labels.")
+
+    human, judge = load(args.human, allowed), load(args.judge, allowed)
+    common = sorted(set(human) & set(judge))
+    if len(common) < 50:
+        cannot(f"only {len(common)} shared ids; a calibration set this small is anecdote, not agreement.")
+    human_coverage = len(common) / len(human) if human else 0.0
+    judge_coverage = len(common) / len(judge) if judge else 0.0
+    if min(human_coverage, judge_coverage) < args.min_coverage:
+        cannot(f"shared-id coverage is human {human_coverage:.1%}, judge {judge_coverage:.1%}; both must be at least {args.min_coverage:.1%}.")
+    pairs = [(human[item_id], judge[item_id]) for item_id in common]
+    if len({label for pair in pairs for label in pair}) < 2:
+        cannot("calibration contains only one label; chance-corrected agreement is undefined.")
+    observed, coefficient = kappa(pairs)
+    true_positive = sum(h == positive and j == positive for h, j in pairs)
+    false_positive = sum(h != positive and j == positive for h, j in pairs)
+    false_negative = sum(h == positive and j != positive for h, j in pairs)
+    precision = true_positive / (true_positive + false_positive) if true_positive + false_positive else float("nan")
+    recall = true_positive / (true_positive + false_negative) if true_positive + false_negative else float("nan")
+    missing = (set(human) | set(judge)) - set(common)
+    print(f"n {len(common)} shared items" + (f" ({len(missing)} unmatched ids ignored after coverage check)" if missing else ""))
+    print(f"coverage  human {human_coverage:.3f}   judge {judge_coverage:.3f}")
+    print(f"human positive rate {sum(h == positive for h, _ in pairs)/len(pairs):.3f}   judge positive rate {sum(j == positive for _, j in pairs)/len(pairs):.3f}")
+    print(f"raw agreement {observed:.3f}   (inflated by class imbalance; do not use for the decision)")
+    print(f"Cohen's kappa {coefficient:.3f}   floor {args.floor}")
+    print(f"judge PASS precision {precision:.3f}   recall {recall:.3f}   (vs human PASS)")
+    disagreements = [item_id for item_id, pair in zip(common, pairs) if pair[0] != pair[1]]
+    if disagreements:
+        print("disagreements (first 20): " + ", ".join(disagreements[:20]))
+    if coefficient >= args.floor:
+        print("OK: judge meets the floor on this set; pin model + prompt hash in the manifest.")
+        sys.exit(0)
+    print("BELOW FLOOR: judge is a diagnostic, not a grader. Inspect disagreements, fix rubric or guideline, re-run on the held-out slice.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-tool/components/skills/development/eval-genius/scripts/paired_bootstrap.py
+++ b/cli-tool/components/skills/development/eval-genius/scripts/paired_bootstrap.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Paired bootstrap interval on per-item deltas from two harness-agnostic result files.
+
+Input: JSON {"items":[...]}, a JSON array, or JSONL. Records need a unique, non-empty
+string ``id`` and a finite numeric ``score``. Optional ``cluster`` values must be JSON
+scalars and must match between arms. Exit 0 on valid input and 1 on invalid input.
+"""
+import argparse
+import json
+import math
+import random
+import statistics
+import sys
+
+MAX_REPS = 100_000
+MAX_RESAMPLED_UNITS = 10_000_000
+
+
+def fail(message):
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_records(text):
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            if "items" not in data:
+                raise TypeError("JSON object needs an 'items' array")
+            return data["items"]
+        return data
+    except (json.JSONDecodeError, ValueError):
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def scalar(value):
+    return isinstance(value, (str, int, float)) and not isinstance(value, bool) and (not isinstance(value, float) or math.isfinite(value))
+
+
+def load(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read().strip()
+    except FileNotFoundError:
+        fail(f"file not found: {path}")
+    except (OSError, UnicodeError) as exc:
+        fail(f"cannot read {path} as UTF-8 ({exc})")
+    try:
+        items = parse_records(text)
+    except (json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+        fail(f"{path} is not a per-item JSON/JSONL file ({exc}). Need records with 'id' and finite numeric 'score'.")
+    if not isinstance(items, list):
+        fail(f"{path} items must be an array.")
+    result = {}
+    for item in items:
+        if not isinstance(item, dict):
+            fail(f"record {item!r} in {path} must be an object.")
+        item_id, score = item.get("id"), item.get("score")
+        if not isinstance(item_id, str) or not item_id.strip():
+            fail(f"record {item!r} in {path} needs a non-empty string 'id'.")
+        try:
+            finite_score = isinstance(score, (int, float)) and not isinstance(score, bool) and math.isfinite(score)
+        except OverflowError:
+            finite_score = False
+        if not finite_score:
+            fail(f"record {item!r} in {path} needs a finite numeric 'score'.")
+        cluster = item.get("cluster", item_id)
+        if not scalar(cluster):
+            fail(f"record {item!r} in {path} needs a scalar string or number 'cluster'.")
+        if item_id in result:
+            fail(f"{path} contains duplicate item id {item_id!r}.")
+        result[item_id] = item
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--a", required=True, help="baseline per-item file")
+    parser.add_argument("--b", required=True, help="treatment per-item file")
+    parser.add_argument("--reps", type=int, default=5000)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+    if not 1 <= args.reps <= MAX_REPS:
+        fail(f"--reps must be between 1 and {MAX_REPS}.")
+
+    a_items, b_items = load(args.a), load(args.b)
+    if set(a_items) != set(b_items):
+        fail(f"item ids differ ({len(set(a_items)-set(b_items))} only in a, {len(set(b_items)-set(a_items))} only in b). Paired analysis needs identical item sets.")
+    ids = sorted(a_items)
+    if len(ids) < 2:
+        fail("need at least 2 paired items.")
+    mismatches = [item_id for item_id in ids
+                  if a_items[item_id].get("cluster", item_id) != b_items[item_id].get("cluster", item_id)]
+    if mismatches:
+        fail("cluster assignments differ between arms for ids: " + ", ".join(mismatches[:20]))
+
+    deltas = {}
+    for item_id in ids:
+        delta = b_items[item_id]["score"] - a_items[item_id]["score"]
+        if not math.isfinite(delta):
+            fail(f"score delta for item {item_id!r} is not finite (values overflow or are too large).")
+        deltas[item_id] = delta
+    clusters = {}
+    for item_id in ids:
+        clusters.setdefault(a_items[item_id].get("cluster", item_id), []).append(deltas[item_id])
+    units = list(clusters.values())
+    if len(ids) * args.reps > MAX_RESAMPLED_UNITS:
+        fail(f"requested bootstrap work is too large: {len(ids)} items x {args.reps} reps exceeds {MAX_RESAMPLED_UNITS} resampled item values. Reduce --reps or the evaluation set size.")
+    unit_name = "clusters" if len(units) < len(ids) else "items"
+    rng = random.Random(args.seed)
+    means = []
+    for _ in range(args.reps):
+        flat = [delta for _unit in units for delta in rng.choice(units)]
+        sample_mean = sum(flat) / len(flat)
+        if not math.isfinite(sample_mean):
+            fail("bootstrap sample overflowed; scores are too large.")
+        means.append(sample_mean)
+    means.sort()
+    # Nearest-rank percentile: the 1-indexed rank ceil(p*reps) maps to the
+    # 0-indexed value ceil(p*reps)-1. Using int() truncated toward the middle,
+    # narrowing the interval (the anti-conservative direction) whenever p*reps
+    # landed on an integer or fractional boundary.
+    low = means[max(0, math.ceil(0.025 * args.reps) - 1)]
+    high = means[min(args.reps - 1, max(0, math.ceil(0.975 * args.reps) - 1))]
+    mean = statistics.fmean(deltas.values())
+    if not math.isfinite(mean):
+        fail("mean delta overflowed; scores are too large.")
+    improved = sum(delta > 0 for delta in deltas.values())
+    regressed = sum(delta < 0 for delta in deltas.values())
+    print(f"n {len(ids)} items, resampled over {len(units)} {unit_name}, {args.reps} reps, seed {args.seed}")
+    print(f"mean delta (b - a) {mean:+.4f}   95% interval [{low:+.4f}, {high:+.4f}]")
+    print(f"improved {improved}  regressed {regressed}  held {len(ids)-improved-regressed}")
+    print("interval includes zero: not distinguishable from noise on this fixture" if low <= 0 <= high else "interval excludes zero on this fixture (still subject to fixture validity and label error)")
+
+
+if __name__ == "__main__":
+    main()

--- a/cli-tool/components/skills/development/eval-genius/templates/benchmark-assessment-scorecard.md
+++ b/cli-tool/components/skills/development/eval-genius/templates/benchmark-assessment-scorecard.md
@@ -1,0 +1,34 @@
+# Benchmark assessment scorecard
+
+One per candidate. Filled from the task definition, five sample items, the grading
+code, the errata page, and the last commit date, in that order. Decision at the bottom.
+
+- **Candidate:**
+- **Version / commit / date accessed:**
+- **Promise it will be used to evidence:**
+
+| # | Question | Finding | Score (0-2) |
+|---|---|---|---|
+| 1 | What does it implicitly reward? Does that match the promise? | | |
+| 2 | Is it contaminated? (release date vs training cutoff, canary, verbatim search, rolling set?) | | |
+| 3 | What is its label-error ceiling? (50 items hand-graded: k wrong) | | |
+| 4 | Does it exercise this mechanism? (does item difficulty depend on the lever?) | | |
+| 5 | Is it maintained and comparable? (last commit, open issues, harness version behind published numbers) | | |
+
+Scoring: 2 = clearly fine, 1 = usable with a stated modification, 0 = disqualifying.
+A 0 on question 1 or 4 disqualifies regardless of the rest.
+
+## Weight checks
+- **Saturation:** leading systems score near ceiling? (yes = floor check only)
+- **Scale and cost per full run:** items, minutes, paid calls
+- **Tier it fits:** smoke / gate / nightly / release
+
+## Decision
+- [ ] Adopt as is
+- [ ] Adopt with modification: subset rule / re-grade / extension (state which, and that
+      modified scores are not compared with published numbers)
+- [ ] Reuse harness, add own tasks
+- [ ] Build custom, because: 
+
+- **Fixture hash of the version adopted:**
+- **Disclosure line for the report:** "Benchmark X vN, self-run, <modifications>, label-error ceiling ~k%."

--- a/cli-tool/components/skills/development/eval-genius/templates/eval-report.md
+++ b/cli-tool/components/skills/development/eval-genius/templates/eval-report.md
@@ -1,0 +1,52 @@
+# Eval report
+
+## 1. Pre-registration (quoted verbatim)
+> id, promise, lever, primary outcome, bar, falsifier, outlier rule, baseline
+
+## 2. Runs
+| Arm | Run id | Fixture hash | Liveness | Outcome | Errors / budget |
+|---|---|---|---|---|---|
+| baseline | | | | | |
+| treatment | | | | | |
+
+Negative control: failed on both runs (yes / no). If no, stop here: CANNOT-MEASURE.
+
+## 3. Results, per layer (never blended)
+
+**Deterministic layer**
+| Metric | Baseline | Treatment | Paired delta | 95% interval | Improved / regressed / held (items) | n |
+|---|---|---|---|---|---|---|
+
+**Judged layer** (judge snapshot, prompt hash, human agreement on held-out slice)
+| Metric | Baseline | Treatment | Paired delta | 95% interval | n |
+|---|---|---|---|---|---|
+
+**Cost and latency**
+| Metric | Baseline | Treatment | Delta |
+|---|---|---|---|
+| tokens per item | | | |
+| cost per pass | | | |
+| p50 / p95 ms | | | |
+
+**Per-stratum** (if stratified): one row per stratum for the primary metric.
+
+## 4. Noise floor
+Repeated runs on the same commit: k runs, spread of the primary metric.
+
+## 5. Decision against the bar
+Bar as written. Result. Decision: accept / reject / cannot measure. Falsifier
+triggered: yes / no, and what was concluded.
+
+## 6. Caveats that weaken the number
+Self-run or independent. Subset, snapshot, sample size. Label-error ceiling. Judge
+agreement. Anything the pre-registration said would matter.
+
+## 7. Tier labels
+Every number above is tagged measured / estimated / aspirational. List any estimated or
+aspirational number here so none hides in a table.
+
+## 8. Attack findings
+What an independent reader tried in order to break this, and what they found.
+
+## 9. What happens next
+Baseline promotion (with reason) / system fix / gauge fix / retire benchmark.

--- a/cli-tool/components/skills/development/eval-genius/templates/preregistration.md
+++ b/cli-tool/components/skills/development/eval-genius/templates/preregistration.md
@@ -1,0 +1,69 @@
+# Pre-registration
+
+Filled before the first run. Committed next to the fixture. Quoted verbatim at the top
+of the report. Nothing below changes after a number has been seen; a change is a new
+pre-registration with a new id.
+
+- **Id:** prereg-YYYYMMDD-short-name
+- **Author / date:**
+
+## Promise
+One plain sentence a non-expert understands. What does the system promise, and what
+does "better" mean for it?
+
+>
+
+## Variables
+| Kind | Name | Values / definition |
+|---|---|---|
+| Lever | | (exactly one per comparison) |
+| Outcome (primary) | | metric, direction, unit |
+| Outcome (secondary) | | |
+| Outcome (cost/latency) | | tokens per item, cost per pass, p95 ms |
+| Controls | | fixture hash, model snapshot, judge snapshot, seeds, clock, harness version |
+
+## Placement and weight
+- Where this measurement sits (decision point / risky seam / public claim):
+- Instrument (spot check / eval / benchmark / monitor):
+- Tier (smoke / gate / nightly / release):
+
+## Baseline
+- Baseline run id and manifest (if no run exists yet: "current production config,
+  to be run first on this fixture", or the stated floor for a brand-new system):
+- Fixture version and hash:
+
+## Bar (acceptance rule)
+Written as a rule the reporter can apply mechanically. Examples: "no per-item
+regressions on the deterministic layer"; "paired 95% interval on primary delta excludes
+values below -0.01"; "p95 latency not above baseline +10%".
+
+>
+
+## Falsifier
+The result that would show the change is useless or harmful, and what will be
+concluded and done if it appears.
+
+>
+
+## Outlier rule
+How a single item that dominates the aggregate is handled (cap / exclude with
+disclosure / report separately). Decided now.
+
+>
+
+## Noise floor
+How many repeated runs on the same commit establish run-to-run spread before a delta
+is claimed, and the minimum detectable effect the fixture size supports.
+
+>
+
+## Judged layer (if any)
+- Judge model and snapshot:
+- Rubric version and prompt hash:
+- Calibration set version, human agreement, judge-vs-human agreement on held-out slice:
+- Floor for the judge to count as a grader:
+
+## Negative control
+The known-bad case the gate must fail on every run.
+
+>

--- a/cli-tool/components/skills/development/eval-genius/templates/quality-checklist.md
+++ b/cli-tool/components/skills/development/eval-genius/templates/quality-checklist.md
@@ -1,0 +1,15 @@
+# Eval quality checklist
+
+Copy into the project. Nothing is "done" until every box is honestly checked.
+
+- [ ] Pre-registration filled: promise, variables, placement, weight, bar, falsifier
+- [ ] Grader is deterministic wherever a checkable answer exists
+- [ ] Judged layer (if any) has a human-labeled calibration set and an agreement score
+- [ ] Fixture fingerprinted; baseline pinned; run manifest written
+- [ ] Treatment-arm liveness assertion present
+- [ ] Negative cases included
+- [ ] Verifier shown to fail a known-bad case
+- [ ] Multiple trials with spread; paired comparison where possible
+- [ ] Run ended PASS / FAIL / CANNOT-MEASURE explicitly
+- [ ] Overfitting guarded: rarely-touched held-out reserved; metric-reality divergence watched
+- [ ] Report separates layers, labels tiers, discloses caveats

--- a/cli-tool/components/skills/development/eval-genius/templates/run-manifest.json
+++ b/cli-tool/components/skills/development/eval-genius/templates/run-manifest.json
@@ -1,64 +1,77 @@
 {
-  "run_id": "r-YYYYMMDD-HHMM-shortname",
-  "preregistration_id": "prereg-YYYYMMDD-short-name",
-  "started_at": "ISO-8601",
-  "finished_at": "ISO-8601",
-  "outcome": "PASS | FAIL | CANNOT-MEASURE",
-  "outcome_reason": "one line",
+  "manifest": {
+    "run_id": "r-YYYYMMDD-HHMM-shortname",
+    "preregistration_id": "prereg-YYYYMMDD-short-name",
+    "started_at": "ISO-8601",
+    "finished_at": "ISO-8601",
+    "outcome": "PASS | FAIL | CANNOT-MEASURE",
+    "outcome_reason": "one line",
 
-  "fixture": {
-    "name": "",
-    "version": "",
-    "content_hash": "sha256:...",
-    "item_count": 0,
-    "strata": {"stratum-name": 0},
-    "label_version": "",
-    "inter_annotator_agreement": null,
-    "label_error_audit": "n sampled, k wrong"
-  },
+    "fixture_hash": "sha256:...",
+    "liveness": "passed | failed | not-applicable",
+    "negative_control_id": "known-bad-item-id",
 
-  "arm": {
-    "name": "baseline | treatment-<lever>",
-    "lever_value": "",
-    "liveness_check": "passed | failed | not-applicable",
-    "liveness_evidence": "what was asserted and what it returned"
-  },
-
-  "system": {
-    "version_or_commit": "",
-    "model_snapshot": "",
-    "config_hash": "sha256:...",
-    "cache_state": "fresh-build | prebuilt:<hash>"
-  },
-
-  "judge": {
-    "model_snapshot": null,
-    "prompt_hash": null,
-    "temperature": null,
-    "calibration_set_version": null,
-    "agreement_with_humans": null
-  },
-
-  "reproducibility": {
-    "seeds": {"sampling": 0, "split": 0, "order": 0, "judge_order": 0},
-    "clock": "fixed:<ISO-8601> | wall",
-    "parallelism": "single-thread | n=<k>",
-    "harness_version": "",
-    "lockfile_hash": "sha256:...",
-    "hardware_class": ""
-  },
-
-  "results": {
-    "items_run": 0,
-    "items_errored": 0,
-    "error_budget": 0.02,
-    "negative_control": "failed-as-expected | PASSED-SCORER-BROKEN",
-    "per_item_records": "path/to/records.jsonl",
-    "layers": {
-      "deterministic": {"pass_rate": null, "n": 0, "ci95": [null, null]},
-      "judged": {"score": null, "n": 0, "ci95": [null, null]}
+    "fixture": {
+      "name": "",
+      "version": "",
+      "item_count": 0,
+      "strata": {"stratum-name": 0},
+      "label_version": "",
+      "inter_annotator_agreement": null,
+      "label_error_audit": "n sampled, k wrong"
     },
-    "cost": {"tokens_in": 0, "tokens_out": 0, "judge_tokens": 0, "cost_per_pass": null},
-    "latency_ms": {"p50": null, "p95": null}
-  }
+
+    "arm": {
+      "name": "baseline | treatment-<lever>",
+      "lever_value": "",
+      "liveness_evidence": "what was asserted and what it returned"
+    },
+
+    "system": {
+      "version_or_commit": "",
+      "model_snapshot": "",
+      "config_hash": "sha256:...",
+      "cache_state": "fresh-build | prebuilt:<hash>"
+    },
+
+    "judge": {
+      "model_snapshot": null,
+      "prompt_hash": null,
+      "temperature": null,
+      "calibration_set_version": null,
+      "agreement_with_humans": null
+    },
+
+    "reproducibility": {
+      "seeds": {"sampling": 0, "split": 0, "order": 0, "judge_order": 0},
+      "clock": "fixed:<ISO-8601> | wall",
+      "parallelism": "single-thread | n=<k>",
+      "harness_version": "",
+      "lockfile_hash": "sha256:...",
+      "hardware_class": ""
+    },
+
+    "results": {
+      "items_run": 0,
+      "items_errored": 0,
+      "error_budget": 0.02,
+      "negative_control": "failed-as-expected | PASSED-SCORER-BROKEN",
+      "per_item_records": "path/to/records.jsonl",
+      "layers": {
+        "deterministic": {"pass_rate": null, "n": 0, "ci95": [null, null]},
+        "judged": {"score": null, "n": 0, "ci95": [null, null]}
+      },
+      "cost": {"tokens_in": 0, "tokens_out": 0, "judge_tokens": 0, "cost_per_pass": null},
+      "latency_ms": {"p50": null, "p95": null}
+    }
+  },
+  "items": [
+    {
+      "id": "known-bad-item-id",
+      "verdict": "fail",
+      "score": 0.0,
+      "layer": "deterministic",
+      "error": null
+    }
+  ]
 }

--- a/cli-tool/components/skills/development/eval-genius/templates/run-manifest.json
+++ b/cli-tool/components/skills/development/eval-genius/templates/run-manifest.json
@@ -1,0 +1,64 @@
+{
+  "run_id": "r-YYYYMMDD-HHMM-shortname",
+  "preregistration_id": "prereg-YYYYMMDD-short-name",
+  "started_at": "ISO-8601",
+  "finished_at": "ISO-8601",
+  "outcome": "PASS | FAIL | CANNOT-MEASURE",
+  "outcome_reason": "one line",
+
+  "fixture": {
+    "name": "",
+    "version": "",
+    "content_hash": "sha256:...",
+    "item_count": 0,
+    "strata": {"stratum-name": 0},
+    "label_version": "",
+    "inter_annotator_agreement": null,
+    "label_error_audit": "n sampled, k wrong"
+  },
+
+  "arm": {
+    "name": "baseline | treatment-<lever>",
+    "lever_value": "",
+    "liveness_check": "passed | failed | not-applicable",
+    "liveness_evidence": "what was asserted and what it returned"
+  },
+
+  "system": {
+    "version_or_commit": "",
+    "model_snapshot": "",
+    "config_hash": "sha256:...",
+    "cache_state": "fresh-build | prebuilt:<hash>"
+  },
+
+  "judge": {
+    "model_snapshot": null,
+    "prompt_hash": null,
+    "temperature": null,
+    "calibration_set_version": null,
+    "agreement_with_humans": null
+  },
+
+  "reproducibility": {
+    "seeds": {"sampling": 0, "split": 0, "order": 0, "judge_order": 0},
+    "clock": "fixed:<ISO-8601> | wall",
+    "parallelism": "single-thread | n=<k>",
+    "harness_version": "",
+    "lockfile_hash": "sha256:...",
+    "hardware_class": ""
+  },
+
+  "results": {
+    "items_run": 0,
+    "items_errored": 0,
+    "error_budget": 0.02,
+    "negative_control": "failed-as-expected | PASSED-SCORER-BROKEN",
+    "per_item_records": "path/to/records.jsonl",
+    "layers": {
+      "deterministic": {"pass_rate": null, "n": 0, "ci95": [null, null]},
+      "judged": {"score": null, "n": 0, "ci95": [null, null]}
+    },
+    "cost": {"tokens_in": 0, "tokens_out": 0, "judge_tokens": 0, "cost_per_pass": null},
+    "latency_ms": {"p50": null, "p95": null}
+  }
+}


### PR DESCRIPTION
Follow-up to #880. The merged eval-genius SKILL.md routes work to supporting files under `references/`, `templates/`, and `scripts/`, but #880 shipped the SKILL.md alone - flagged in review as a P1 (routed workflows unusable).

This PR adds the complete supporting tree, copied verbatim from the canonical source (https://github.com/alexgreensh/eval-genius, Apache-2.0, path `skills/eval-genius/`):

- `references/` - 12 docs (00-start-here through 11-reading-results)
- `templates/` - preregistration, benchmark-assessment scorecard, eval report, quality checklist, run manifest
- `scripts/` - check_gate.py, judge_agreement.py, paired_bootstrap.py, hash_fixture.py (stdlib-only CLIs)
- `evals/` - the skill's own eval definitions

Every path the SKILL.md names now resolves in the component directory (verified mechanically against the merged SKILL.md). Layout follows the repo's existing skill-component convention (e.g. git-context-controller ships references/ + scripts/, telegram-bot-builder ships reference/).

Filed on behalf of the author (her assistant's machine account).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the supporting files for the eval-genius skill so every path its SKILL.md references resolves, fixing the broken workflows from the prior merge, and syncs them with the upstream eval-genius main.

- Adds `references/`, `templates/`, `scripts/`, and `evals/` under `cli-tool/components/skills/development/eval-genius/`, copied from the canonical Apache-2.0 source.
- `scripts/check_gate.py` and `scripts/judge_agreement.py` now fail closed: misconfigured runs exit 2 (CANNOT-MEASURE), and judge labels are restricted to the `--labels` set.
- This is a content-only change to an existing skill; no new components, so `docs/components.json` does not need regeneration, and no new environment variables or secrets are required.

<sup>Written for commit acbdab56db0b5ea0e64e87d5d0b32023eb6a039c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

