### PR TITLE
Add berth skill

### DIFF
--- a/cli-tool/components/skills/development/berth/SKILL.md
+++ b/cli-tool/components/skills/development/berth/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: berth
+description: Manage independent local agent workspaces, explicit native/container runtimes, managed processes and safe cleanup. Use for parallel task worktrees, port allocation, starting or inspecting task services, running tests inside a workspace, or reclaiming workspace state.
+---
+
+# berth
+
+berth gives each task its own Git worktree, private data directory, reserved ports
+and supervised processes, so parallel agents stop colliding. It is a workspace
+manager, not an adversarial security sandbox and not a Git replacement. Replace
+berth lifecycle operations only with berth commands — raw `rm -rf`, `git worktree
+remove` and guessed PID/port cleanup corrupt the registry instead of releasing a
+workspace.
+
+## Onboard
+
+Read the project's startup scripts, toolchains, storage paths and listen ports
+before writing configuration, then choose the runtime deliberately:
+
+- `native` (default) for programs that accept a port and a data path through
+  configuration or flags. Fastest, no container overhead.
+- `container` for unchanged hardcoded listen ports or a uniform Linux
+  environment. It needs an existing `runtime.image` plus a `listen.<port>` entry
+  per declared port.
+
+Commit `berth.yaml` before creating a workspace: each workspace loads the
+configuration from its own branch, so uncommitted edits never reach a workspace
+created from it. When the container engine or the prepared image is missing,
+report it and stop — the service runs on the host only when the configuration
+says `native`.
+
+Keep mutable state in `$BERTH_DATA_DIR` (`<workspace>/.berth/data`). `copy_dirs`
+copies writable dependency trees with CoW where the filesystem supports it and an
+independent copy otherwise.
+
+## Execute
+
+| Command | Purpose |
+| --- | --- |
+| `berth new <slug> [--base <ref>] [--up] [--print-path] [--json]` | Create a workspace and its branch-local setup; `--up` also starts processes |
+| `berth ls [--json]` | List workspaces with their phase, running state and ports |
+| `berth status [<slug>] [--json]` | Processes, readiness and ports of a workspace |
+| `berth ports [<slug>] [--json]` | Allocated host ports and container listen mappings |
+| `berth plan [<slug>]` | Print the execution contract as JSON without starting anything |
+| `berth up [<slug>]` / `berth down [<slug>]` | Start / stop workspace processes, preserving data |
+| `berth logs <proc> [<slug>]` | Logs of one managed process |
+| `berth run [--] <cmd> [args...]` | Run one command inside the workspace runtime and environment |
+| `berth attach [<slug>] [--json]` | Print path, branch and shell exports for the workspace |
+| `berth open [<port-name>]` | Open a workspace port's host URL in the browser |
+| `berth reset [<slug>]` | Wipe `$BERTH_DATA_DIR` and rerun setup |
+| `berth done [<slug>]` | Tear a workspace down once its work is preserved |
+| `berth gc [--dry-run] [--json]` | Reclaim vanished, idle, merged or excess workspaces |
+| `berth doctor [--fix] [--json]` | Check git, engine, image, process-compose and state |
+
+### Where a workspace is
+
+- Path: `<repo>.berths/<slug>` beside the repository by default, or
+  `<worktree_root>/<slug>` when `worktree_root` is set. Branch: `berth/<slug>`.
+- Slug rules: lowercase ASCII letters, digits, `-` and `_` only, no slashes.
+- The primary checkout is never a workspace (`berth adopt` refuses it). `berth run`
+  and `berth open` accept no slug, so they resolve the workspace from the current
+  directory; commands that do take `[<slug>]` also work from anywhere with an
+  unambiguous slug. Run slug-less commands from inside the path `berth new`
+  printed (its last stdout line, or `path` in `--json`).
+
+`berth run` joins the same runtime and environment as services and hooks, passes
+argv verbatim without reparsing, and propagates the exit code. Request a shell
+explicitly: `berth run -- sh -c '<script>'` (Linux/container) or the matching
+native shell on Windows, since a script that works in `sh` need not work in
+Windows `cmd`. Cancelling a container `berth run` stops that workspace's runtime,
+including its sibling services.
+
+### Environment contract
+
+- `BERTH_PORT_<NAME>` is the port inside the execution context;
+  `BERTH_HOST_PORT_<NAME>` is the host publication to hand to browsers and other
+  host tools. Container publications are TCP over IPv4 loopback.
+- `plan.gateway_ports` are internal forwarder reservations; application listeners
+  must not use those values, and undeclared internal ports are isolated but not
+  published.
+- Identity: `BERTH_WORKSPACE`, `BERTH_ROOT`, `BERTH_DATA_DIR`, `BERTH_SLUG`,
+  `BERTH_BRANCH`, plus `GIT_DIR`, `GIT_WORK_TREE`, `HOME` and `XDG_CACHE_HOME`
+  inside a container.
+- On Windows with `native` and a non-empty `processes:`, `berth ports` also lists a
+  `pc` port: the supervisor control port, not an application port.
+- Read readiness from `berth status --json` (`ready`, `healthy`) instead of sleep
+  loops, and failures from `berth logs <proc>`.
+
+## Configure
+
+Write `berth.yaml` from the project's own startup commands. A minimal native
+service:
+
+```yaml
+version: 1
+base: main
+ports: [web]
+processes:
+  web:
+    command: npm run dev -- --port "$BERTH_PORT_WEB"
+    readiness_probe:
+      http_get: {host: 127.0.0.1, port: "${BERTH_PORT_WEB}", path: /}
+```
+
+Read `references/berth-yaml.md` before writing or debugging a `berth.yaml`: it
+carries the full field list, the container recipe, and the traps that make a
+render fail.
+
+## Harnesses
+
+berth is driven from the shell, so any harness that can run commands can use it.
+berth's own installer writes this same file to `.agents/skills/berth/`, which
+Cursor, Codex, pi and Antigravity read. A harness may hand you a Git worktree
+berth does not know about; give it a berth workspace rather than improvising — `berth adopt --setup`
+inside it when it is on a branch, `berth new <slug>` when it is detached or when
+the task needs its own ports and data.
+
+## Cleanup and recovery
+
+`berth done` requires preserved commits (merged or present upstream) and a clean
+worktree for berth-owned checkouts. `--force` cannot bypass ownership, identity,
+primary-worktree or shutdown checks. `adopt` is only for linked worktrees, and
+`berth done` on an adopted checkout stops and unregisters its runtime while
+preserving checkout, data and branch even with `--force`. `down` preserves data;
+`reset` wipes it deliberately and only after a verified shutdown. Automatic GC
+never forces, and an unknown process or engine state means preserve the data and
+inspect the logs.
+
+Read `references/recovery.md` when a berth command fails: error → meaning →
+action, plus what `berth gc` collects and when it refuses.

--- a/cli-tool/components/skills/development/berth/references/berth-yaml.md
+++ b/cli-tool/components/skills/development/berth/references/berth-yaml.md
@@ -1,0 +1,108 @@
+# berth.yaml reference
+
+Read this when writing or debugging a `berth.yaml`. The file lives at the
+repository root and is read from each workspace's own branch, so commit it before
+creating a workspace.
+
+## Fields
+
+| Field | Notes |
+| --- | --- |
+| `version` | Must be `1`. |
+| `base` | Baseline branch for new workspaces; defaults to `main`. |
+| `worktree_root` | Where worktrees are created. Relative values resolve inside the repository, absolute values do not; the default is the sibling `<repo>.berths` directory. |
+| `runtime.backend` | `native` or `container`; defaults to `native`. |
+| `runtime.engine` | `docker` or `podman`; container only, defaults to `docker`. |
+| `runtime.image` | Prebuilt Linux image; container only and mandatory. |
+| `runtime.user`, `runtime.memory`, `runtime.cpus` | Optional container overrides, e.g. `2g`, `2`. Native mode rejects them. |
+| `ports` | Named ports such as `[web, pg]`. Port names become `BERTH_PORT_<NAME>`; the name `pc` is reserved. |
+| `listen` | Container listen port per declared port, e.g. `{web: 8080}`; every declared port needs one. |
+| `env` | Extra variables for every process, hook and `berth run`. Keys may not start with `BERTH_`; `GIT_DIR` and `GIT_WORK_TREE` are reserved. Values stay single-line; `${VAR}` and `$VAR` expand from the environment contract. |
+| `env_file` | Repository-relative file berth writes with a managed `# BEGIN BERTH`/`# END BERTH` block, for host tools that read dotenv files. |
+| `copy_dirs` | Repository-relative directories copied into each new workspace. |
+| `hooks.setup`, `hooks.teardown` | Shell commands run in the workspace runtime. `setup` runs on create, on `up` after a failed setup, and on `reset`, and must be idempotent; `teardown` runs before an owned workspace is removed. |
+| `processes.<name>.command` | Required for a managed process. |
+| `processes.<name>.working_dir` | Defaults to the workspace root (`/workspace` in container mode). |
+| `processes.<name>.environment` | A **list** of `KEY=VALUE` strings, not a mapping. berth prepends its own identity variables and refuses `BERTH_*` and `GIT_*` overrides. |
+| `processes.<name>.readiness_probe` | `http_get` (`host`, `port`, `path`) or `exec` (`command`), with `initial_delay_seconds`, `period_seconds`, `failure_threshold`. |
+| `processes.<name>.*` | The mapping is passed through to process-compose v0.5, so its other documented fields (`log_location`, `depends_on`, `restart`, …) work too. |
+| `gc.idle_stop_hours` | `berth gc` stops the runtime of a workspace unused for this long. `0` disables. |
+| `gc.remove_after_days` | Age beyond which a stopped, merged workspace becomes a removal candidate. `0` disables. |
+| `gc.max_workspaces` | Per-repository quota; `berth gc` evicts above it once commits are preserved. `0` disables. |
+
+## Traps
+
+- **`environment` is a list, not a mapping.** `environment: {KEY: value}` fails
+  the render with "must be a list". Write `environment: ["KEY=value"]`.
+- **The contract is immutable.** Changing `runtime.*` or the named-port set makes
+  the existing workspace unusable ("port contract changed; create a new
+  workspace"); create a new workspace instead of editing in place.
+- **Reserved names.** `pc` cannot be a port name, and `env` keys cannot start with
+  `BERTH_`, `GIT_DIR` or `GIT_WORK_TREE` — berth injects those into every process.
+- **Ports in probes.** A probe runs in the execution context, so a container
+  probe uses the internal `listen` port (`8080`), never `BERTH_HOST_PORT_*`.
+- **`copy_dirs` and `.worktreeinclude` differ.** `copy_dirs` copies whole
+  dependency trees with CoW where supported; `.worktreeinclude` copies individual
+  files, and it is a plain path list (one repository-relative path per line, `#`
+  for comments, missing entries skipped), not a `.gitignore` pattern file. Both
+  run during setup: `berth new`, `berth reset`, `berth adopt --setup`.
+- **`.berth/` is machine state.** It holds the private data directory, generated
+  `pc.yaml`, the supervisor log and the identity marker. Keep it out of version
+  control and never hand-edit it.
+
+## Container mode
+
+`runtime.backend: container` needs an existing Linux image and a `listen` entry
+for every declared port. The image must contain the project toolchain plus bash,
+sh, sleep, socat, git, python3 and process-compose v1.122.0; `runtime/Dockerfile`
+in the berth repository is the reference, and takes `BASE_IMAGE` as a build arg.
+Build dependencies into the image once rather than on every run.
+
+Container-internal Git metadata (`GIT_DIR`, `GIT_WORK_TREE`) is provided; the
+workspace is mounted at `/workspace` and `$BERTH_DATA_DIR` is
+`/workspace/.berth/data`. Publications are TCP over IPv4 loopback, and
+`plan.gateway_ports` are internal forwarder reservations that application
+listeners must not use.
+
+## Example: native web app with a Postgres dependency
+
+```yaml
+version: 1
+base: main
+ports: [web, pg]
+env:
+  DATABASE_URL: postgres://127.0.0.1:${BERTH_PORT_PG}/app
+hooks:
+  setup:
+    - mkdir -p "$BERTH_DATA_DIR/pg"
+    - test -d "$BERTH_DATA_DIR/pg/base" || initdb -D "$BERTH_DATA_DIR/pg" --no-locale --encoding=UTF8
+processes:
+  pg:
+    command: postgres -D "$BERTH_DATA_DIR/pg" -p "$BERTH_PORT_PG" -k "$BERTH_DATA_DIR"
+    readiness_probe:
+      exec:
+        command: pg_isready -h 127.0.0.1 -p "$BERTH_PORT_PG"
+  web:
+    command: npm run dev -- --port "$BERTH_PORT_WEB"
+    readiness_probe:
+      http_get: {host: 127.0.0.1, port: "${BERTH_PORT_WEB}", path: /}
+```
+
+## Example: container with a fixed listen port
+
+```yaml
+version: 1
+base: main
+runtime:
+  backend: container
+  engine: docker
+  image: berth-runtime:local
+ports: [web]
+listen:
+  web: 8080
+processes:
+  web:
+    command: python3 -m http.server 8080 --bind 127.0.0.1
+    readiness_probe:
+      http_get: {host: 127.0.0.1, port: 8080, path: /}
+```

--- a/cli-tool/components/skills/development/berth/references/recovery.md
+++ b/cli-tool/components/skills/development/berth/references/recovery.md
@@ -1,0 +1,42 @@
+# Recovery reference
+
+Read this when a berth command fails or a workspace is in an unknown state.
+
+## Errors and what they mean
+
+| Message | Meaning | Action |
+| --- | --- | --- |
+| `workspace not found; run berth ls or berth adopt` | The current directory is not inside a registered workspace and no slug was given. | `cd` into the path `berth new` printed, or pass the slug. |
+| `port contract changed; create a new workspace` | `berth.yaml` declares different ports or runtime settings than the workspace was created with. | Create a new workspace from the updated branch; in-place edits are refused on purpose. |
+| `worktree is dirty; commit changes first` | `berth done` refuses to remove a checkout with uncommitted work. | Commit or discard the changes, then retry. |
+| `work is not preserved: …` | The branch has commits neither merged into the base nor present upstream. | Push or merge the branch, then retry `berth done`. |
+| `refusing to operate on the primary worktree` | `berth adopt` or `berth done` was pointed at the main checkout. | Only linked worktrees are candidates; create one with `berth new`. |
+| `checkout is on a detached HEAD` | `berth adopt` needs a branch, and harness-created worktrees are often detached. | Check out a branch there, or create `berth new <slug>` instead. |
+| `process state unknown; inspect …` | The supervisor socket or port file exists but does not answer. | Preserve the data, read `.berth/process-compose.log` and `berth logs <proc>`, and leave `.berth/` in place. |
+| `processes not ready` | A readiness probe never passed inside the startup window. | `berth status --json` for the failing process, `berth logs <proc>` for its output, then fix the command or the probe. |
+| `process <name> failed with exit <n>` | The process exited during startup. | Read its logs; the worktree is kept so the command can be fixed and retried. |
+| `berth doctor` FAIL lines | git, engine, image, process-compose or state is missing or unhealthy. | `berth doctor --fix` installs native dependencies such as process-compose; a container engine or image is prepared once by you, never pulled implicitly. |
+
+## After a failed setup
+
+The workspace keeps its worktree, data and state, and `berth new <same-name>` or
+`berth up` retries setup once the configuration or hook is fixed. Setup hooks must
+be idempotent for that retry to be safe.
+
+## What berth gc collects
+
+`berth gc` is always explicit and never forced, and it revalidates every candidate
+under the workspace lock. Candidates are: a registration whose directory is gone,
+an idle runtime past `gc.idle_stop_hours`, a stopped and merged workspace older
+than `gc.remove_after_days`, and workspaces above `gc.max_workspaces` for that
+repository. Removal still requires preserved commits and skips active operations;
+`berth gc --dry-run --json` previews the list. Use `berth down` to keep a workspace
+and its data, `berth done` to release it.
+
+## Ownership
+
+`berth done` never removes an adopted checkout: it stops the runtime and
+unregisters the workspace, preserving directory, data and branch even with
+`--force`. `--force` cannot bypass ownership, identity, primary-worktree or
+shutdown checks, so when one of them refuses, fix the underlying condition instead
+of escalating.


### PR DESCRIPTION
Adds the berth skill under `cli-tool/components/skills/development/berth/`: `SKILL.md` plus the two reference files its body points at.

berth gives each task its own local workspace -- a linked Git worktree, a private data directory, reserved ports and supervised processes -- and is driven entirely from the shell, so any agent that can run commands can use it.

https://github.com/Mrjwj34/berth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the berth skill to the CLI components, giving agents isolated per-task workspaces with managed processes and safe cleanup.

- Affects `cli-tool/components/` (skill documentation only).
- Adds `SKILL.md` and two reference files under `cli-tool/components/skills/development/berth/`.
- No `docs/components.json` regeneration required.
- No new environment variables or secrets needed.

<sup>Written for commit 656fe2ca416f9d5450e3862a27ba9b089ec1fe9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

