### PR TITLE
fix(scripts): stop generate_plugins_json.py from silently dropping plugins when rate-limited

### DIFF
--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -77,62 +77,112 @@ GH_CLI = shutil.which("gh") or "gh"
 # --- GitHub API helpers (uses gh CLI) ---
 
 _request_count = 0
+_rate_limited_events = 0
+
+
+def _is_rate_limited(stderr):
+    """Detect primary/secondary rate limit errors in gh CLI stderr."""
+    low = (stderr or "").lower()
+    return (
+        "rate limit" in low
+        or "abuse detection" in low
+        or "too many requests" in low
+    )
+
+
+def _rate_limit_reset_wait():
+    """Sleep until the primary rate limit window resets (capped at 15 min)."""
+    try:
+        result = subprocess.run(
+            [GH_CLI, "api", "rate_limit", "--jq", ".rate.reset"],
+            capture_output=True, text=True, timeout=10, env=_GH_ENV
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            wait = int(result.stdout.strip()) - int(time.time()) + 5
+            wait = max(1, min(wait, 900))
+            print(f"  ⏳ Rate limited. Waiting {wait}s for window reset...")
+            time.sleep(wait)
+            return
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        pass
+    # Fallback: fixed escalating wait
+    global _rate_limited_events
+    wait = 30 * (_rate_limited_events + 1)
+    print(f"  ⏳ Rate limited. Waiting {wait}s...")
+    time.sleep(wait)
+
+
+def _run_gh_api(args, timeout=30):
+    """Run `gh api` and return (stdout_or_None, is_404, is_rate_limited)."""
+    global _request_count, _rate_limited_events
+    _request_count += 1
+    try:
+        result = subprocess.run(
+            [GH_CLI, "api"] + args,
+            capture_output=True, text=True, timeout=timeout, env=_GH_ENV
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"  ⚠️  gh CLI failed: {e}")
+        return None, False, False
+
+    stderr = result.stderr or ""
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout, False, False
+    if "Not Found" in stderr or "404" in stderr:
+        return None, True, False
+    if _is_rate_limited(stderr):
+        _rate_limited_events += 1
+        return None, False, True
+    return None, False, False
 
 
 def gh_api(endpoint, retries=3):
-    """Call GitHub API via gh CLI subprocess."""
-    global _request_count
-
+    """Call GitHub API via gh CLI, waiting out rate limits instead of
+    returning None (which callers would treat as 'not found')."""
+    endpoint = endpoint.lstrip("/")
     for attempt in range(retries):
-        _request_count += 1
         # Respect rate limits
-        if _request_count % 50 == 0:
+        if _request_count and _request_count % 50 == 0:
             time.sleep(1)
 
-        try:
-            cmd = [GH_CLI, "api", endpoint.lstrip("/")]
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30, env=_GH_ENV
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return json.loads(result.stdout)
-            if "Not Found" in result.stderr or "404" in result.stderr:
+        stdout, is_404, is_rate_limited = _run_gh_api([endpoint])
+        if stdout is not None:
+            try:
+                return json.loads(stdout)
+            except json.JSONDecodeError:
                 return None
-            if "rate limit" in result.stderr.lower():
-                wait = 30 * (attempt + 1)
-                print(f"  ⏳ Rate limited. Waiting {wait}s...")
-                time.sleep(wait)
-                continue
-            if result.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2 ** attempt)
-                    continue
-                return None
-        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-            if attempt < retries - 1:
-                time.sleep(2 ** attempt)
-            else:
-                print(f"  ⚠️  gh CLI failed: {e}")
-                return None
+        if is_404:
+            return None
+        if is_rate_limited:
+            _rate_limit_reset_wait()
+            continue
+        if attempt < retries - 1:
+            time.sleep(2 ** attempt)
     return None
 
 
-def gh_file_content(repo, path):
-    """Fetch and decode a file from a GitHub repo using gh CLI."""
-    global _request_count
-    _request_count += 1
-
-    try:
-        result = subprocess.run(
-            [GH_CLI, "api", f"repos/{repo}/contents/{path}", "--jq", ".content"],
-            capture_output=True, text=True, timeout=30, env=_GH_ENV
+def gh_file_content(repo, path, retries=3):
+    """Fetch and decode a file from a GitHub repo using gh CLI.
+    Rate-limit failures are waited out and retried so they are never
+    confused with a missing file."""
+    import base64
+    for attempt in range(retries):
+        stdout, is_404, is_rate_limited = _run_gh_api(
+            [f"repos/{repo}/contents/{path}", "--jq", ".content"]
         )
-        if result.returncode != 0 or not result.stdout.strip():
+        if stdout is not None and stdout.strip():
+            try:
+                return base64.b64decode(stdout.strip()).decode("utf-8")
+            except Exception:
+                return None
+        if is_404:
             return None
-        import base64
-        return base64.b64decode(result.stdout.strip()).decode("utf-8")
-    except Exception:
-        return None
+        if is_rate_limited:
+            _rate_limit_reset_wait()
+            continue
+        if attempt < retries - 1:
+            time.sleep(2 ** attempt)
+    return None
 
 
 def gh_dir_listing(repo, path):
@@ -716,6 +766,24 @@ def main():
             print(f"  ❌ Error processing {repo_full}: {e}")
             errors.append(repo_full)
 
+    # Retry repos that failed on the first pass (e.g. transient or rate-limit
+    # failures) so a single rate-limited window doesn't silently drop plugins.
+    if errors:
+        print(f"\n🔁 Retrying {len(errors)} failed repo(s): {errors}")
+        still_failed = []
+        website_by_repo = dict(REPOS)
+        for repo_full in errors:
+            try:
+                data = process_repo(repo_full, website_by_repo.get(repo_full))
+                if data:
+                    results.append(data)
+                else:
+                    still_failed.append(repo_full)
+            except Exception as e:
+                print(f"  ❌ Error processing {repo_full}: {e}")
+                still_failed.append(repo_full)
+        errors = still_failed
+
     # Sort by stars descending
     results.sort(key=lambda x: x["stars"], reverse=True)
 
@@ -737,6 +805,14 @@ def main():
     print(f"\n   📊 {len(marketplaces)} marketplaces | {len(plugins)} individual plugins")
     total_stars = sum(r["stars"] for r in results)
     print(f"   ⭐ {total_stars:,} total stars across all repos")
+
+    # Refuse to silently publish a partial plugins.json: fail the run so CI
+    # keeps the previous (complete) file instead of committing stale data.
+    if errors:
+        print(f"\n❌ {len(errors)} repo(s) failed even after retry: {errors}")
+        print("   Not all plugins could be fetched; exiting with error to avoid")
+        print("   writing an incomplete plugins.json.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem (fixes #847)

`generate_plugins_json.py` silently drops plugins when GitHub rate-limits it:

1. **`gh_file_content()` had zero rate-limit handling** — a rate-limit error returned `None`, which is indistinguishable from "file not found", so `process_repo()` treated the repo as having no `marketplace.json` and dropped it entirely.
2. `gh_api()` retried rate limits with fixed 30/60/90s waits but gave up and returned `None` — again looking like a missing repo.
3. `main()` wrote a partial `plugins.json` and exited 0 regardless, so CI committed stale/incomplete data with no signal.

## Fix

- New shared `_run_gh_api()` helper classifies every `gh api` call outcome as success / 404 / rate-limited / other — a rate-limit failure can never be confused with a missing file.
- New `_rate_limit_reset_wait()`: on rate limit, query `.rate.reset` and sleep until the window actually resets (capped at 15 min), with an escalating fallback if that probe fails.
- `gh_api()` and `gh_file_content()` now wait out rate limits and retry instead of returning `None`; genuine 404s still return `None` immediately (no retry storm).
- `main()` retries failed repos once after the first pass.
- If repos still fail, the script **exits 1** so CI fails loudly instead of silently committing an incomplete `plugins.json`.

## Testing

- `python -m py_compile` passes.
- Unit-tested with a stubbed `subprocess.run`: a rate-limited file fetch waits out the window and retries successfully; a genuine 404 returns `None` immediately (0.00s); `gh_api` waits out a rate limit and returns parsed JSON.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #847: `generate_plugins_json.py` in `scripts/` previously treated GitHub rate-limit responses like file-not-found errors, silently dropping plugins from `plugins.json` and exiting 0.

**Bug Fixes**
- Rate limits are now detected separately from 404s; the script waits out the reset window (up to 15 min) and retries instead of returning `None`.
- Repos that fail the first pass are retried once; if any still fail, the script exits 1 and leaves the last complete `plugins.json` intact so CI never commits partial data.
- No new components, catalog regeneration, or environment variables are required.

<sup>Written for commit 530dbaacb6898a2331910398c7b23260738c868b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

