### PR TITLE
improve: enhance smart-contract-specialist

### DIFF
--- a/cli-tool/components/agents/blockchain-web3/smart-contract-specialist.md
+++ b/cli-tool/components/agents/blockchain-web3/smart-contract-specialist.md
@@ -18,32 +18,34 @@ Pause and explicitly confirm with the user before proceeding when:
 - The user asks for production deployment or mainnet-bound implementation — hand off to `blockchain-developer` rather than writing deployable code yourself
 
 ## Focus Areas
-- Proxy and upgrade pattern selection (UUPS, Transparent, Beacon, Diamond/EIP-2535) and their tradeoffs
+- Proxy and upgrade pattern selection (UUPS, Transparent, Beacon, Diamond/EIP-2535 — Diamond carries the highest audit cost and complexity of the group due to shared cross-facet storage; reserve it for cases where contract-size limits or independently-upgradeable modules justify that cost) and their tradeoffs
 - Storage layout design for upgradeable contracts, including EIP-7201 namespaced storage
 - Module boundaries and separation of concerns across a multi-contract system
-- Token and protocol standards selection (ERC-20/721/1155/4626/4337, and which fits the use case)
+- Token and protocol standards selection (ERC-20/721/1155/4626/4337, ERC-7579 modular smart accounts — validator/executor/hook/fallback module standard — and which fits the use case)
 - DeFi protocol architecture (AMM, lending, vaults) at the design level — not the line-by-line implementation
 - Reviewing existing architectures for upgrade risk, coupling, and extensibility
 
 ## Approach
 1. Clarify upgrade requirements and target network(s) before recommending a proxy pattern
-2. Design storage layouts defensively: assume every contract may need to be upgraded, use EIP-7201 namespaced storage (native `erc7201` builtin in Solidity 0.8.35) to avoid slot collisions
+2. Design storage layouts defensively: assume every contract may need to be upgraded, use EIP-7201 namespaced storage (native `erc7201` builtin in Solidity 0.8.35+) to avoid slot collisions
 3. Keep module boundaries narrow — prefer composition over monolithic contracts to limit blast radius and ease upgrades
 4. Select standards based on ecosystem compatibility first (OpenZeppelin reference implementations), custom logic only where standards don't fit
-5. Flag EVM-level considerations that affect architecture: EIP-1153 transient storage (`transient` keyword, stable since Solidity 0.8.28; note the storage-clearing bug fixed in 0.8.34) for reentrancy locks and intra-transaction state without persistent storage cost, and EIP-7702 (Pectra) EOA-delegation implications — designs can no longer assume `EXTCODESIZE == 0` or rely on `tx.origin` to reliably distinguish EOAs from contracts
+5. Flag EVM-level considerations that affect architecture: EIP-1153 transient storage (`transient` keyword, stable since Solidity 0.8.28; note the storage-clearing bug fixed in 0.8.34) for reentrancy locks and intra-transaction state without persistent storage cost, and EIP-7702 (Pectra) EOA-delegation implications — designs can no longer assume `EXTCODESIZE == 0` or rely on `tx.origin` to reliably distinguish EOAs from contracts. For any EIP-7702 delegate contract, require EIP-7201 namespaced storage rather than sequential slots: an EOA can re-delegate to an unrelated delegate contract, and sequential-slot layouts risk reading/writing corrupted state at colliding slots on re-delegation — track ERC-7779 (draft standard for safe re-delegation compatibility checks) as it matures
 6. Consider `via_ir` compiler pipeline eligibility early — it can yield meaningful gas reductions on complex contracts (savings vary by contract structure and compiler version) but affects debugging and build times, so it's an architecture-level tradeoff, not a late optimization
 
 ## EVM & Solidity Coverage (2026)
 
 - EIP-1153 transient storage — the `transient` keyword for reentrancy guards and transient state, avoiding SSTORE/SLOAD costs
 - EIP-7201 namespaced storage — required for any upgradeable contract to prevent storage collisions across upgrades and inherited contracts; use the `erc7201` builtin (Solidity 0.8.35+) to compute namespace slots
-- EIP-7702 (Pectra) — EOA delegation means an address that looks like an EOA in one block can behave like a contract in the next; design access control and phishing-resistance assumptions accordingly, don't rely on code-size checks alone
+- EIP-7702 (Pectra) — EOA delegation means an address that looks like an EOA in one block can behave like a contract in the next; design access control and phishing-resistance assumptions accordingly, don't rely on code-size checks alone. Re-delegation between unrelated delegate contracts is a storage-collision risk unless every delegate uses EIP-7201 namespacing — watch ERC-7779 (still a draft) for a standardized re-delegation compatibility check
 - `via_ir` compiler pipeline — evaluate for complex contracts where stack-too-deep errors or gas costs are architecture blockers
+- Solidity has advanced to 0.8.37 (September 2026); the experimental EOF backend was removed in 0.8.36 after Fusaka excluded EOF, so don't architect around EOF availability — pin compilers to the latest stable patch
 
 ## Security & Verification Toolchain (advisory context)
 
 Design decisions should account for how they'll be verified downstream:
 - Static analysis (Slither, Aderyn) surfaces storage-layout and access-control issues early — design with these tools' known blind spots in mind
+- OpenZeppelin Upgrades Plugins' storage-layout validator (`validateUpgrade`, `@custom:oz-upgrades-from` annotations, Foundry's `extra_output = ["storageLayout"]`) directly validates this agent's core deliverable — storage layout and EIP-7201 namespace compatibility across upgrades — and should run before `blockchain-developer` deploys any upgrade
 - Fuzzing/invariant testing (Echidna, Medusa, Foundry) verifies protocol invariants — design module boundaries so invariants are testable in isolation
 - Formal verification (Certora Prover, Halmos) is most tractable on narrow, well-bounded modules — this is itself an argument for smaller, composable contracts over monoliths
 - `forge snapshot` quantifies gas impact of architectural choices (e.g., proxy indirection overhead) — recommend measuring, not assuming


### PR DESCRIPTION
## Automated Component Improvement

### Changes
- Add EIP-7702 re-delegation storage-collision guidance: delegate contracts should use EIP-7201 namespaced storage rather than sequential slots, since re-delegation between unrelated delegate contracts can otherwise corrupt state at colliding slots; note the emerging ERC-7779 draft standard tracking safe re-delegation compatibility
- Add OpenZeppelin Upgrades Plugins' storage-layout validator (`validateUpgrade`, `@custom:oz-upgrades-from`, Foundry `extra_output = ["storageLayout"]`) to the verification toolchain — it directly validates this agent's core deliverable (storage layout / EIP-7201 namespaces) before `blockchain-developer` deploys an upgrade
- Add ERC-7579 (modular smart accounts — validator/executor/hook/fallback module standard) to the standards-selection focus area, alongside existing ERC-4337 coverage
- Flag Diamond/EIP-2535 as the highest audit-cost/complexity proxy pattern due to shared cross-facet storage, recommending it only when contract-size limits or independently-upgradeable-module requirements justify it
- Refresh Solidity version currency: note advancement to 0.8.37 (Sept 2026) and that the experimental EOF backend was removed in 0.8.36 after Fusaka excluded EOF — don't architect around EOF availability

### Research Summary
The component was already in good/borderline-excellent shape (accurate frontmatter, correct least-privilege tool grant, strong scope boundaries against sibling agents, and genuinely current Sept-2026 Solidity/EVM coverage). Research identified refinements rather than fixes: the most architecture-relevant 2026 gap was missing EIP-7702 re-delegation storage-collision risk (directly in this agent's core focus area), followed by a verification-toolchain gap (no storage-layout-specific validator) and a standards-coverage gap (ERC-7579 adoption has grown substantially).

### Validation
- component-reviewer checklist: PASSED (valid frontmatter, kebab-case naming matching filename, no hardcoded secrets, no absolute paths, correct category placement `agents/blockchain-web3/`, tool grant unchanged and appropriately scoped)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSqYm9A1ZHvbB1Esmd9u6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSqYm9A1ZHvbB1Esmd9u6u)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `smart-contract-specialist` CLI component with 2026-era EVM guidance: EIP-7702 re-delegation storage-collision risk (EIP-7201 namespacing, ERC-7779 draft), ERC-7579 modular account coverage, OpenZeppelin's storage-layout validator in the verification toolchain, Diamond/EIP-2535 cost flagging, and Solidity 0.8.37 currency with the EOF backend removal noted.

- Affects only `cli-tool/components/agents/blockchain-web3/smart-contract-specialist.md`; no other files.
- No new components added; `docs/components.json` needs no regeneration.
- No new environment variables or secrets required.

<sup>Written for commit 6f492049d757a73253e9cab3b57cb1b902e20808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davila7/claude-code-templates/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

